### PR TITLE
fix(gen): prefix numeric response / request structs with "R"

### DIFF
--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -50,6 +50,9 @@ func (g *schemaGen) generate(name string, schema *oas.Schema) (*ir.Type, error) 
 
 		name = pascal(strings.TrimPrefix(ref, "#/components/schemas/"))
 	}
+	if name[0] >= '0' && name[0] <= '9' {
+		name = "R" + name
+	}
 
 	switch {
 	case len(schema.AnyOf) > 0:


### PR DESCRIPTION
Since I am not familiar with the package (yet), I am not sure if this enough to fix this. There are no tests yet for this case. 

Fix #88 