### PR TITLE
fix(gen): do not copy body twice

### DIFF
--- a/examples/ex_ent/oas_client_gen.go
+++ b/examples/ex_ent/oas_client_gen.go
@@ -124,8 +124,8 @@ func (c *Client) CreatePet(ctx context.Context, request CreatePetReq) (res Creat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pets"
@@ -178,8 +178,8 @@ func (c *Client) CreatePetCategories(ctx context.Context, request CreatePetCateg
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pets/"
@@ -247,8 +247,8 @@ func (c *Client) CreatePetFriends(ctx context.Context, request CreatePetFriendsR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pets/"
@@ -316,8 +316,8 @@ func (c *Client) CreatePetOwner(ctx context.Context, request CreatePetOwnerReq, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pets/"
@@ -858,8 +858,8 @@ func (c *Client) UpdatePet(ctx context.Context, request UpdatePetReq, params Upd
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pets/"

--- a/examples/ex_ent/oas_req_enc_gen.go
+++ b/examples/ex_ent/oas_req_enc_gen.go
@@ -64,72 +64,42 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeCreatePetRequestJSON(req CreatePetReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreatePetRequestJSON(req CreatePetReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreatePetCategoriesRequestJSON(req CreatePetCategoriesReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreatePetCategoriesRequestJSON(req CreatePetCategoriesReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreatePetFriendsRequestJSON(req CreatePetFriendsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreatePetFriendsRequestJSON(req CreatePetFriendsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreatePetOwnerRequestJSON(req CreatePetOwnerReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreatePetOwnerRequestJSON(req CreatePetOwnerReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUpdatePetRequestJSON(req UpdatePetReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUpdatePetRequestJSON(req UpdatePetReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }

--- a/examples/ex_firecracker/oas_client_gen.go
+++ b/examples/ex_firecracker/oas_client_gen.go
@@ -132,8 +132,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, request SnapshotCreateParam
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/snapshot/create"
@@ -194,8 +194,8 @@ func (c *Client) CreateSyncAction(ctx context.Context, request InstanceActionInf
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/actions"
@@ -448,8 +448,8 @@ func (c *Client) LoadSnapshot(ctx context.Context, request SnapshotLoadParams) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/snapshot/load"
@@ -501,8 +501,8 @@ func (c *Client) MmdsConfigPut(ctx context.Context, request MmdsConfig) (res Mmd
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/mmds/config"
@@ -593,8 +593,8 @@ func (c *Client) MmdsPatch(ctx context.Context, request OptMmdsPatchReq) (res Mm
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/mmds"
@@ -646,8 +646,8 @@ func (c *Client) MmdsPut(ctx context.Context, request OptMmdsPutReq) (res MmdsPu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/mmds"
@@ -700,8 +700,8 @@ func (c *Client) PatchBalloon(ctx context.Context, request BalloonUpdate) (res P
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/balloon"
@@ -754,8 +754,8 @@ func (c *Client) PatchBalloonStatsInterval(ctx context.Context, request BalloonS
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/balloon/statistics"
@@ -816,8 +816,8 @@ func (c *Client) PatchGuestDriveByID(ctx context.Context, request PartialDrive, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/drives/"
@@ -892,8 +892,8 @@ func (c *Client) PatchGuestNetworkInterfaceByID(ctx context.Context, request Par
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/network-interfaces/"
@@ -976,8 +976,8 @@ func (c *Client) PatchMachineConfiguration(ctx context.Context, request OptMachi
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/machine-config"
@@ -1038,8 +1038,8 @@ func (c *Client) PatchVm(ctx context.Context, request VM) (res PatchVmRes, err e
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/vm"
@@ -1092,8 +1092,8 @@ func (c *Client) PutBalloon(ctx context.Context, request Balloon) (res PutBalloo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/balloon"
@@ -1146,8 +1146,8 @@ func (c *Client) PutGuestBootSource(ctx context.Context, request BootSource) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/boot-source"
@@ -1208,8 +1208,8 @@ func (c *Client) PutGuestDriveByID(ctx context.Context, request Drive, params Pu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/drives/"
@@ -1284,8 +1284,8 @@ func (c *Client) PutGuestNetworkInterfaceByID(ctx context.Context, request Netwo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/network-interfaces/"
@@ -1360,8 +1360,8 @@ func (c *Client) PutGuestVsock(ctx context.Context, request Vsock) (res PutGuest
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/vsock"
@@ -1422,8 +1422,8 @@ func (c *Client) PutLogger(ctx context.Context, request Logger) (res PutLoggerRe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/logger"
@@ -1492,8 +1492,8 @@ func (c *Client) PutMachineConfiguration(ctx context.Context, request OptMachine
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/machine-config"
@@ -1546,8 +1546,8 @@ func (c *Client) PutMetrics(ctx context.Context, request Metrics) (res PutMetric
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/metrics"

--- a/examples/ex_firecracker/oas_req_enc_gen.go
+++ b/examples/ex_firecracker/oas_req_enc_gen.go
@@ -64,286 +64,166 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeCreateSnapshotRequestJSON(req SnapshotCreateParams, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateSnapshotRequestJSON(req SnapshotCreateParams, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreateSyncActionRequestJSON(req InstanceActionInfo, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateSyncActionRequestJSON(req InstanceActionInfo, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeLoadSnapshotRequestJSON(req SnapshotLoadParams, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeLoadSnapshotRequestJSON(req SnapshotLoadParams, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMmdsConfigPutRequestJSON(req MmdsConfig, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMmdsConfigPutRequestJSON(req MmdsConfig, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMmdsPatchRequestJSON(req OptMmdsPatchReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMmdsPatchRequestJSON(req OptMmdsPatchReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMmdsPutRequestJSON(req OptMmdsPutReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMmdsPutRequestJSON(req OptMmdsPutReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchBalloonRequestJSON(req BalloonUpdate, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchBalloonRequestJSON(req BalloonUpdate, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchBalloonStatsIntervalRequestJSON(req BalloonStatsUpdate, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchBalloonStatsIntervalRequestJSON(req BalloonStatsUpdate, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchGuestDriveByIDRequestJSON(req PartialDrive, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchGuestDriveByIDRequestJSON(req PartialDrive, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchGuestNetworkInterfaceByIDRequestJSON(req PartialNetworkInterface, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchGuestNetworkInterfaceByIDRequestJSON(req PartialNetworkInterface, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchMachineConfigurationRequestJSON(req OptMachineConfiguration, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchMachineConfigurationRequestJSON(req OptMachineConfiguration, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePatchVmRequestJSON(req VM, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePatchVmRequestJSON(req VM, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutBalloonRequestJSON(req Balloon, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutBalloonRequestJSON(req Balloon, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutGuestBootSourceRequestJSON(req BootSource, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutGuestBootSourceRequestJSON(req BootSource, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutGuestDriveByIDRequestJSON(req Drive, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutGuestDriveByIDRequestJSON(req Drive, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutGuestNetworkInterfaceByIDRequestJSON(req NetworkInterface, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutGuestNetworkInterfaceByIDRequestJSON(req NetworkInterface, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutGuestVsockRequestJSON(req Vsock, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutGuestVsockRequestJSON(req Vsock, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutLoggerRequestJSON(req Logger, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutLoggerRequestJSON(req Logger, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutMachineConfigurationRequestJSON(req OptMachineConfiguration, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutMachineConfigurationRequestJSON(req OptMachineConfiguration, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePutMetricsRequestJSON(req Metrics, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePutMetricsRequestJSON(req Metrics, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }

--- a/examples/ex_github/oas_client_gen.go
+++ b/examples/ex_github/oas_client_gen.go
@@ -554,8 +554,8 @@ func (c *Client) ActionsCreateOrUpdateEnvironmentSecret(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repositories/"
@@ -660,8 +660,8 @@ func (c *Client) ActionsCreateOrUpdateOrgSecret(ctx context.Context, request Act
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -751,8 +751,8 @@ func (c *Client) ActionsCreateOrUpdateRepoSecret(ctx context.Context, request Ac
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -1107,8 +1107,8 @@ func (c *Client) ActionsCreateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -5817,8 +5817,8 @@ func (c *Client) ActionsReviewPendingDeploymentsForRun(ctx context.Context, requ
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -5916,8 +5916,8 @@ func (c *Client) ActionsSetAllowedActionsOrganization(ctx context.Context, reque
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -5985,8 +5985,8 @@ func (c *Client) ActionsSetAllowedActionsRepository(ctx context.Context, request
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -6077,8 +6077,8 @@ func (c *Client) ActionsSetGithubActionsPermissionsOrganization(ctx context.Cont
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -6154,8 +6154,8 @@ func (c *Client) ActionsSetGithubActionsPermissionsRepository(ctx context.Contex
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -6246,8 +6246,8 @@ func (c *Client) ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Co
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -6338,8 +6338,8 @@ func (c *Client) ActionsSetSelectedReposForOrgSecret(ctx context.Context, reques
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -6430,8 +6430,8 @@ func (c *Client) ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -6507,8 +6507,8 @@ func (c *Client) ActionsSetSelfHostedRunnersInGroupForOrg(ctx context.Context, r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -6599,8 +6599,8 @@ func (c *Client) ActionsUpdateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -8619,8 +8619,8 @@ func (c *Client) ActivityMarkNotificationsAsRead(ctx context.Context, request Op
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/notifications"
@@ -8673,8 +8673,8 @@ func (c *Client) ActivityMarkRepoNotificationsAsRead(ctx context.Context, reques
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -8811,8 +8811,8 @@ func (c *Client) ActivitySetRepoSubscription(ctx context.Context, request OptAct
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -8895,8 +8895,8 @@ func (c *Client) ActivitySetThreadSubscription(ctx context.Context, request OptA
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/notifications/threads/"
@@ -9171,8 +9171,8 @@ func (c *Client) AppsCheckToken(ctx context.Context, request AppsCheckTokenReq, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/applications/"
@@ -9248,8 +9248,8 @@ func (c *Client) AppsCreateContentAttachment(ctx context.Context, request AppsCr
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -9363,8 +9363,8 @@ func (c *Client) AppsCreateInstallationAccessToken(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/app/installations/"
@@ -9432,8 +9432,8 @@ func (c *Client) AppsDeleteAuthorization(ctx context.Context, request AppsDelete
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/applications/"
@@ -9555,8 +9555,8 @@ func (c *Client) AppsDeleteToken(ctx context.Context, request AppsDeleteTokenReq
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/applications/"
@@ -10828,8 +10828,8 @@ func (c *Client) AppsResetToken(ctx context.Context, request AppsResetTokenReq, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/applications/"
@@ -10945,8 +10945,8 @@ func (c *Client) AppsScopeToken(ctx context.Context, request AppsScopeTokenReq, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/applications/"
@@ -11140,8 +11140,8 @@ func (c *Client) AppsUpdateWebhookConfigForApp(ctx context.Context, request OptA
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/app/hook/config"
@@ -11689,8 +11689,8 @@ func (c *Client) ChecksCreateSuite(ctx context.Context, request ChecksCreateSuit
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -12650,8 +12650,8 @@ func (c *Client) ChecksSetSuitesPreferences(ctx context.Context, request ChecksS
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -13601,8 +13601,8 @@ func (c *Client) CodeScanningUpdateAlert(ctx context.Context, request CodeScanni
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -13710,8 +13710,8 @@ func (c *Client) CodeScanningUploadSarif(ctx context.Context, request CodeScanni
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -14214,8 +14214,8 @@ func (c *Client) EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise(ctx con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16043,8 +16043,8 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseGroup(ctx context.Co
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -16120,8 +16120,8 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseUser(ctx context.Con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -16357,8 +16357,8 @@ func (c *Client) EnterpriseAdminSetAllowedActionsEnterprise(ctx context.Context,
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16434,8 +16434,8 @@ func (c *Client) EnterpriseAdminSetGithubActionsPermissionsEnterprise(ctx contex
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16511,8 +16511,8 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseGroup(ctx 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -16602,8 +16602,8 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseUser(ctx c
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -16693,8 +16693,8 @@ func (c *Client) EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise(
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16785,8 +16785,8 @@ func (c *Client) EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnte
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16862,8 +16862,8 @@ func (c *Client) EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise(ctx con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -16954,8 +16954,8 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseGroup(ctx context.Co
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -17045,8 +17045,8 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseUser(ctx context.Con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/scim/v2/enterprises/"
@@ -17144,8 +17144,8 @@ func (c *Client) EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise(ctx con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/enterprises/"
@@ -17290,8 +17290,8 @@ func (c *Client) GistsCreate(ctx context.Context, request GistsCreateReq) (res G
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/gists"
@@ -17352,8 +17352,8 @@ func (c *Client) GistsCreateComment(ctx context.Context, request GistsCreateComm
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/gists/"
@@ -18558,8 +18558,8 @@ func (c *Client) GistsUpdateComment(ctx context.Context, request GistsUpdateComm
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/gists/"
@@ -18641,8 +18641,8 @@ func (c *Client) GitCreateBlob(ctx context.Context, request GitCreateBlobReq, pa
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -18725,8 +18725,8 @@ func (c *Client) GitCreateCommit(ctx context.Context, request GitCreateCommitReq
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -18809,8 +18809,8 @@ func (c *Client) GitCreateRef(ctx context.Context, request GitCreateRefReq, para
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -18901,8 +18901,8 @@ func (c *Client) GitCreateTag(ctx context.Context, request GitCreateTagReq, para
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -18993,8 +18993,8 @@ func (c *Client) GitCreateTree(ctx context.Context, request GitCreateTreeReq, pa
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -19719,8 +19719,8 @@ func (c *Client) GitUpdateRef(ctx context.Context, request GitUpdateRefReq, para
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20084,8 +20084,8 @@ func (c *Client) InteractionsSetRestrictionsForAuthenticatedUser(ctx context.Con
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/interaction-limits"
@@ -20146,8 +20146,8 @@ func (c *Client) InteractionsSetRestrictionsForOrg(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -20223,8 +20223,8 @@ func (c *Client) InteractionsSetRestrictionsForRepo(ctx context.Context, request
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20307,8 +20307,8 @@ func (c *Client) IssuesAddAssignees(ctx context.Context, request OptIssuesAddAss
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20490,8 +20490,8 @@ func (c *Client) IssuesCreate(ctx context.Context, request IssuesCreateReq, para
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20574,8 +20574,8 @@ func (c *Client) IssuesCreateComment(ctx context.Context, request IssuesCreateCo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20673,8 +20673,8 @@ func (c *Client) IssuesCreateLabel(ctx context.Context, request IssuesCreateLabe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -20765,8 +20765,8 @@ func (c *Client) IssuesCreateMilestone(ctx context.Context, request IssuesCreate
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -23375,8 +23375,8 @@ func (c *Client) IssuesLock(ctx context.Context, request OptIssuesLockReq, param
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -23559,8 +23559,8 @@ func (c *Client) IssuesRemoveAssignees(ctx context.Context, request OptIssuesRem
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -23858,8 +23858,8 @@ func (c *Client) IssuesUpdate(ctx context.Context, request OptIssuesUpdateReq, p
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -23956,8 +23956,8 @@ func (c *Client) IssuesUpdateComment(ctx context.Context, request IssuesUpdateCo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -24054,8 +24054,8 @@ func (c *Client) IssuesUpdateLabel(ctx context.Context, request OptIssuesUpdateL
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -24168,8 +24168,8 @@ func (c *Client) IssuesUpdateMilestone(ctx context.Context, request OptIssuesUpd
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -25665,8 +25665,8 @@ func (c *Client) MigrationsMapCommitAuthor(ctx context.Context, request OptMigra
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -25771,8 +25771,8 @@ func (c *Client) MigrationsSetLfsPreference(ctx context.Context, request Migrati
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -25863,8 +25863,8 @@ func (c *Client) MigrationsStartForAuthenticatedUser(ctx context.Context, reques
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/migrations"
@@ -25925,8 +25925,8 @@ func (c *Client) MigrationsStartForOrg(ctx context.Context, request MigrationsSt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -26002,8 +26002,8 @@ func (c *Client) MigrationsStartImport(ctx context.Context, request MigrationsSt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -26241,8 +26241,8 @@ func (c *Client) MigrationsUpdateImport(ctx context.Context, request OptMigratio
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -26341,8 +26341,8 @@ func (c *Client) OAuthAuthorizationsCreateAuthorization(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/authorizations"
@@ -26619,8 +26619,8 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForApp(ctx context.C
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/authorizations/clients/"
@@ -26695,8 +26695,8 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/authorizations/clients/"
@@ -26976,8 +26976,8 @@ func (c *Client) OAuthAuthorizationsUpdateAuthorization(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/authorizations/"
@@ -27474,8 +27474,8 @@ func (c *Client) OrgsCreateInvitation(ctx context.Context, request OptOrgsCreate
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -27551,8 +27551,8 @@ func (c *Client) OrgsCreateWebhook(ctx context.Context, request OrgsCreateWebhoo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -30014,8 +30014,8 @@ func (c *Client) OrgsSetMembershipForUser(ctx context.Context, request OptOrgsSe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -30243,8 +30243,8 @@ func (c *Client) OrgsUpdateMembershipForAuthenticatedUser(ctx context.Context, r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/memberships/orgs/"
@@ -30327,8 +30327,8 @@ func (c *Client) OrgsUpdateWebhook(ctx context.Context, request OptOrgsUpdateWeb
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -30426,8 +30426,8 @@ func (c *Client) OrgsUpdateWebhookConfigForOrg(ctx context.Context, request OptO
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -32734,8 +32734,8 @@ func (c *Client) ProjectsAddCollaborator(ctx context.Context, request OptProject
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/"
@@ -32817,8 +32817,8 @@ func (c *Client) ProjectsCreateColumn(ctx context.Context, request ProjectsCreat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/"
@@ -32886,8 +32886,8 @@ func (c *Client) ProjectsCreateForAuthenticatedUser(ctx context.Context, request
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/projects"
@@ -32940,8 +32940,8 @@ func (c *Client) ProjectsCreateForOrg(ctx context.Context, request ProjectsCreat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -33009,8 +33009,8 @@ func (c *Client) ProjectsCreateForRepo(ctx context.Context, request ProjectsCrea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -34130,8 +34130,8 @@ func (c *Client) ProjectsMoveCard(ctx context.Context, request ProjectsMoveCardR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/columns/cards/"
@@ -34207,8 +34207,8 @@ func (c *Client) ProjectsMoveColumn(ctx context.Context, request ProjectsMoveCol
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/columns/"
@@ -34361,8 +34361,8 @@ func (c *Client) ProjectsUpdate(ctx context.Context, request OptProjectsUpdateRe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/"
@@ -34429,8 +34429,8 @@ func (c *Client) ProjectsUpdateCard(ctx context.Context, request OptProjectsUpda
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/columns/cards/"
@@ -34497,8 +34497,8 @@ func (c *Client) ProjectsUpdateColumn(ctx context.Context, request ProjectsUpdat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/projects/columns/"
@@ -34650,8 +34650,8 @@ func (c *Client) PullsCreate(ctx context.Context, request PullsCreateReq, params
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -34734,8 +34734,8 @@ func (c *Client) PullsCreateReplyForReviewComment(ctx context.Context, request P
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -34864,8 +34864,8 @@ func (c *Client) PullsCreateReview(ctx context.Context, request OptPullsCreateRe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -34971,8 +34971,8 @@ func (c *Client) PullsCreateReviewComment(ctx context.Context, request PullsCrea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -35253,8 +35253,8 @@ func (c *Client) PullsDismissReview(ctx context.Context, request PullsDismissRev
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -36771,8 +36771,8 @@ func (c *Client) PullsMerge(ctx context.Context, request OptPullsMergeReq, param
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -36878,8 +36878,8 @@ func (c *Client) PullsRemoveRequestedReviewers(ctx context.Context, request Pull
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -36985,8 +36985,8 @@ func (c *Client) PullsSubmitReview(ctx context.Context, request PullsSubmitRevie
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37115,8 +37115,8 @@ func (c *Client) PullsUpdate(ctx context.Context, request OptPullsUpdateReq, par
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37213,8 +37213,8 @@ func (c *Client) PullsUpdateBranch(ctx context.Context, request OptPullsUpdateBr
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37312,8 +37312,8 @@ func (c *Client) PullsUpdateReview(ctx context.Context, request PullsUpdateRevie
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37425,8 +37425,8 @@ func (c *Client) PullsUpdateReviewComment(ctx context.Context, request PullsUpda
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37571,8 +37571,8 @@ func (c *Client) ReactionsCreateForCommitComment(ctx context.Context, request Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37678,8 +37678,8 @@ func (c *Client) ReactionsCreateForIssue(ctx context.Context, request ReactionsC
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37785,8 +37785,8 @@ func (c *Client) ReactionsCreateForIssueComment(ctx context.Context, request Rea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37892,8 +37892,8 @@ func (c *Client) ReactionsCreateForPullRequestReviewComment(ctx context.Context,
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -37999,8 +37999,8 @@ func (c *Client) ReactionsCreateForRelease(ctx context.Context, request Reaction
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -38106,8 +38106,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentInOrg(ctx context.Contex
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -38228,8 +38228,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentLegacy(ctx context.Conte
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -38335,8 +38335,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionInOrg(ctx context.Context, requ
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -38442,8 +38442,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionLegacy(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -40347,8 +40347,8 @@ func (c *Client) ReposAddAppAccessRestrictions(ctx context.Context, request OptR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -40462,8 +40462,8 @@ func (c *Client) ReposAddCollaborator(ctx context.Context, request OptReposAddCo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -40576,8 +40576,8 @@ func (c *Client) ReposAddStatusCheckContexts(ctx context.Context, request OptRep
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -40691,8 +40691,8 @@ func (c *Client) ReposAddTeamAccessRestrictions(ctx context.Context, request Opt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -40806,8 +40806,8 @@ func (c *Client) ReposAddUserAccessRestrictions(ctx context.Context, request Opt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41178,8 +41178,8 @@ func (c *Client) ReposCreateAutolink(ctx context.Context, request ReposCreateAut
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41262,8 +41262,8 @@ func (c *Client) ReposCreateCommitComment(ctx context.Context, request ReposCrea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41454,8 +41454,8 @@ func (c *Client) ReposCreateCommitStatus(ctx context.Context, request ReposCreat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41552,8 +41552,8 @@ func (c *Client) ReposCreateDeployKey(ctx context.Context, request ReposCreateDe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41636,8 +41636,8 @@ func (c *Client) ReposCreateDeployment(ctx context.Context, request ReposCreateD
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41728,8 +41728,8 @@ func (c *Client) ReposCreateDeploymentStatus(ctx context.Context, request ReposC
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41835,8 +41835,8 @@ func (c *Client) ReposCreateDispatchEvent(ctx context.Context, request ReposCrea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -41919,8 +41919,8 @@ func (c *Client) ReposCreateForAuthenticatedUser(ctx context.Context, request Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/repos"
@@ -41973,8 +41973,8 @@ func (c *Client) ReposCreateFork(ctx context.Context, request OptReposCreateFork
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -42065,8 +42065,8 @@ func (c *Client) ReposCreateInOrg(ctx context.Context, request ReposCreateInOrgR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -42134,8 +42134,8 @@ func (c *Client) ReposCreateOrUpdateFileContents(ctx context.Context, request Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -42240,8 +42240,8 @@ func (c *Client) ReposCreatePagesSite(ctx context.Context, request ReposCreatePa
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -42324,8 +42324,8 @@ func (c *Client) ReposCreateRelease(ctx context.Context, request ReposCreateRele
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -42408,8 +42408,8 @@ func (c *Client) ReposCreateUsingTemplate(ctx context.Context, request ReposCrea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -42508,8 +42508,8 @@ func (c *Client) ReposCreateWebhook(ctx context.Context, request OptReposCreateW
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -43475,8 +43475,8 @@ func (c *Client) ReposDeleteFile(ctx context.Context, request ReposDeleteFileReq
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -51572,8 +51572,8 @@ func (c *Client) ReposMerge(ctx context.Context, request ReposMergeReq, params R
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -51656,8 +51656,8 @@ func (c *Client) ReposMergeUpstream(ctx context.Context, request ReposMergeUpstr
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -51941,8 +51941,8 @@ func (c *Client) ReposRemoveAppAccessRestrictions(ctx context.Context, request O
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52140,8 +52140,8 @@ func (c *Client) ReposRemoveStatusCheckContexts(ctx context.Context, request Opt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52340,8 +52340,8 @@ func (c *Client) ReposRemoveTeamAccessRestrictions(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52455,8 +52455,8 @@ func (c *Client) ReposRemoveUserAccessRestrictions(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52554,8 +52554,8 @@ func (c *Client) ReposRenameBranch(ctx context.Context, request OptReposRenameBr
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52661,8 +52661,8 @@ func (c *Client) ReposReplaceAllTopics(ctx context.Context, request ReposReplace
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -52916,8 +52916,8 @@ func (c *Client) ReposSetAppAccessRestrictions(ctx context.Context, request OptR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53031,8 +53031,8 @@ func (c *Client) ReposSetStatusCheckContexts(ctx context.Context, request OptRep
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53146,8 +53146,8 @@ func (c *Client) ReposSetTeamAccessRestrictions(ctx context.Context, request Opt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53261,8 +53261,8 @@ func (c *Client) ReposSetUserAccessRestrictions(ctx context.Context, request Opt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53445,8 +53445,8 @@ func (c *Client) ReposTransfer(ctx context.Context, request ReposTransferReq, pa
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53545,8 +53545,8 @@ func (c *Client) ReposUpdate(ctx context.Context, request OptReposUpdateReq, par
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53636,8 +53636,8 @@ func (c *Client) ReposUpdateBranchProtection(ctx context.Context, request ReposU
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53735,8 +53735,8 @@ func (c *Client) ReposUpdateCommitComment(ctx context.Context, request ReposUpda
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53849,8 +53849,8 @@ func (c *Client) ReposUpdateInvitation(ctx context.Context, request OptReposUpda
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -53947,8 +53947,8 @@ func (c *Client) ReposUpdatePullRequestReviewProtection(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -54046,8 +54046,8 @@ func (c *Client) ReposUpdateRelease(ctx context.Context, request OptReposUpdateR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -54144,8 +54144,8 @@ func (c *Client) ReposUpdateReleaseAsset(ctx context.Context, request OptReposUp
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -54242,8 +54242,8 @@ func (c *Client) ReposUpdateStatusCheckProtection(ctx context.Context, request O
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -54357,8 +54357,8 @@ func (c *Client) ReposUpdateWebhook(ctx context.Context, request OptReposUpdateW
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -54471,8 +54471,8 @@ func (c *Client) ReposUpdateWebhookConfigForRepo(ctx context.Context, request Op
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -55814,8 +55814,8 @@ func (c *Client) SecretScanningUpdateAlert(ctx context.Context, request SecretSc
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/repos/"
@@ -56000,8 +56000,8 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserInOrg(ctx context.Context, req
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -56114,8 +56114,8 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserLegacy(ctx context.Context, re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -56213,8 +56213,8 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsInOrg(ctx context.Context, re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -56327,8 +56327,8 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsLegacy(ctx context.Context, r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -56426,8 +56426,8 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsInOrg(ctx context.Context, reque
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -56555,8 +56555,8 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsLegacy(ctx context.Context, requ
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -56997,8 +56997,8 @@ func (c *Client) TeamsCreate(ctx context.Context, request TeamsCreateReq, params
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -57066,8 +57066,8 @@ func (c *Client) TeamsCreateDiscussionCommentInOrg(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -57165,8 +57165,8 @@ func (c *Client) TeamsCreateDiscussionCommentLegacy(ctx context.Context, request
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -57249,8 +57249,8 @@ func (c *Client) TeamsCreateDiscussionInOrg(ctx context.Context, request TeamsCr
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -57333,8 +57333,8 @@ func (c *Client) TeamsCreateDiscussionLegacy(ctx context.Context, request TeamsC
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -57402,8 +57402,8 @@ func (c *Client) TeamsCreateOrUpdateIdpGroupConnectionsInOrg(ctx context.Context
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -57494,8 +57494,8 @@ func (c *Client) TeamsCreateOrUpdateIdpGroupConnectionsLegacy(ctx context.Contex
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -61148,8 +61148,8 @@ func (c *Client) TeamsUpdateDiscussionCommentInOrg(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -61261,8 +61261,8 @@ func (c *Client) TeamsUpdateDiscussionCommentLegacy(ctx context.Context, request
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -61359,8 +61359,8 @@ func (c *Client) TeamsUpdateDiscussionInOrg(ctx context.Context, request OptTeam
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -61457,8 +61457,8 @@ func (c *Client) TeamsUpdateDiscussionLegacy(ctx context.Context, request OptTea
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -61556,8 +61556,8 @@ func (c *Client) TeamsUpdateInOrg(ctx context.Context, request OptTeamsUpdateInO
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orgs/"
@@ -61647,8 +61647,8 @@ func (c *Client) TeamsUpdateLegacy(ctx context.Context, request TeamsUpdateLegac
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/teams/"
@@ -61731,8 +61731,8 @@ func (c *Client) UsersAddEmailForAuthenticated(ctx context.Context, request OptU
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/emails"
@@ -62016,8 +62016,8 @@ func (c *Client) UsersCreateGpgKeyForAuthenticated(ctx context.Context, request 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/gpg_keys"
@@ -62078,8 +62078,8 @@ func (c *Client) UsersCreatePublicSSHKeyForAuthenticated(ctx context.Context, re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/keys"
@@ -62148,8 +62148,8 @@ func (c *Client) UsersDeleteEmailForAuthenticated(ctx context.Context, request O
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/emails"
@@ -63589,8 +63589,8 @@ func (c *Client) UsersSetPrimaryEmailVisibilityForAuthenticated(ctx context.Cont
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user/email/visibility"
@@ -63751,8 +63751,8 @@ func (c *Client) UsersUpdateAuthenticated(ctx context.Context, request OptUsersU
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/user"

--- a/examples/ex_github/oas_req_enc_gen.go
+++ b/examples/ex_github/oas_req_enc_gen.go
@@ -64,2630 +64,1532 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeActionsCreateOrUpdateEnvironmentSecretRequestJSON(req ActionsCreateOrUpdateEnvironmentSecretReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsCreateOrUpdateEnvironmentSecretRequestJSON(req ActionsCreateOrUpdateEnvironmentSecretReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsCreateOrUpdateOrgSecretRequestJSON(req ActionsCreateOrUpdateOrgSecretReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsCreateOrUpdateOrgSecretRequestJSON(req ActionsCreateOrUpdateOrgSecretReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsCreateOrUpdateRepoSecretRequestJSON(req ActionsCreateOrUpdateRepoSecretReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsCreateOrUpdateRepoSecretRequestJSON(req ActionsCreateOrUpdateRepoSecretReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsCreateSelfHostedRunnerGroupForOrgRequestJSON(req ActionsCreateSelfHostedRunnerGroupForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsCreateSelfHostedRunnerGroupForOrgRequestJSON(req ActionsCreateSelfHostedRunnerGroupForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsReviewPendingDeploymentsForRunRequestJSON(req ActionsReviewPendingDeploymentsForRunReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsReviewPendingDeploymentsForRunRequestJSON(req ActionsReviewPendingDeploymentsForRunReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetAllowedActionsOrganizationRequestJSON(req OptSelectedActions, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetAllowedActionsOrganizationRequestJSON(req OptSelectedActions, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetAllowedActionsRepositoryRequestJSON(req OptSelectedActions, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetAllowedActionsRepositoryRequestJSON(req OptSelectedActions, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetGithubActionsPermissionsOrganizationRequestJSON(req ActionsSetGithubActionsPermissionsOrganizationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetGithubActionsPermissionsOrganizationRequestJSON(req ActionsSetGithubActionsPermissionsOrganizationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetGithubActionsPermissionsRepositoryRequestJSON(req ActionsSetGithubActionsPermissionsRepositoryReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetGithubActionsPermissionsRepositoryRequestJSON(req ActionsSetGithubActionsPermissionsRepositoryReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequestJSON(req ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequestJSON(req ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetSelectedReposForOrgSecretRequestJSON(req ActionsSetSelectedReposForOrgSecretReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetSelectedReposForOrgSecretRequestJSON(req ActionsSetSelectedReposForOrgSecretReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationRequestJSON(req ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationRequestJSON(req ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsSetSelfHostedRunnersInGroupForOrgRequestJSON(req ActionsSetSelfHostedRunnersInGroupForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsSetSelfHostedRunnersInGroupForOrgRequestJSON(req ActionsSetSelfHostedRunnersInGroupForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActionsUpdateSelfHostedRunnerGroupForOrgRequestJSON(req ActionsUpdateSelfHostedRunnerGroupForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActionsUpdateSelfHostedRunnerGroupForOrgRequestJSON(req ActionsUpdateSelfHostedRunnerGroupForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActivityMarkNotificationsAsReadRequestJSON(req OptActivityMarkNotificationsAsReadReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActivityMarkNotificationsAsReadRequestJSON(req OptActivityMarkNotificationsAsReadReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActivityMarkRepoNotificationsAsReadRequestJSON(req OptActivityMarkRepoNotificationsAsReadReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActivityMarkRepoNotificationsAsReadRequestJSON(req OptActivityMarkRepoNotificationsAsReadReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActivitySetRepoSubscriptionRequestJSON(req OptActivitySetRepoSubscriptionReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActivitySetRepoSubscriptionRequestJSON(req OptActivitySetRepoSubscriptionReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeActivitySetThreadSubscriptionRequestJSON(req OptActivitySetThreadSubscriptionReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeActivitySetThreadSubscriptionRequestJSON(req OptActivitySetThreadSubscriptionReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsCheckTokenRequestJSON(req AppsCheckTokenReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsCheckTokenRequestJSON(req AppsCheckTokenReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsCreateContentAttachmentRequestJSON(req AppsCreateContentAttachmentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsCreateContentAttachmentRequestJSON(req AppsCreateContentAttachmentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsCreateInstallationAccessTokenRequestJSON(req OptAppsCreateInstallationAccessTokenReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsCreateInstallationAccessTokenRequestJSON(req OptAppsCreateInstallationAccessTokenReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsDeleteAuthorizationRequestJSON(req AppsDeleteAuthorizationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsDeleteAuthorizationRequestJSON(req AppsDeleteAuthorizationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsDeleteTokenRequestJSON(req AppsDeleteTokenReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsDeleteTokenRequestJSON(req AppsDeleteTokenReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsResetTokenRequestJSON(req AppsResetTokenReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsResetTokenRequestJSON(req AppsResetTokenReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsScopeTokenRequestJSON(req AppsScopeTokenReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsScopeTokenRequestJSON(req AppsScopeTokenReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAppsUpdateWebhookConfigForAppRequestJSON(req OptAppsUpdateWebhookConfigForAppReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAppsUpdateWebhookConfigForAppRequestJSON(req OptAppsUpdateWebhookConfigForAppReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeChecksCreateSuiteRequestJSON(req ChecksCreateSuiteReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeChecksCreateSuiteRequestJSON(req ChecksCreateSuiteReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeChecksSetSuitesPreferencesRequestJSON(req ChecksSetSuitesPreferencesReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeChecksSetSuitesPreferencesRequestJSON(req ChecksSetSuitesPreferencesReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCodeScanningUpdateAlertRequestJSON(req CodeScanningUpdateAlertReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCodeScanningUpdateAlertRequestJSON(req CodeScanningUpdateAlertReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCodeScanningUploadSarifRequestJSON(req CodeScanningUploadSarifReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCodeScanningUploadSarifRequestJSON(req CodeScanningUploadSarifReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRequestJSON(req EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRequestJSON(req EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminProvisionAndInviteEnterpriseGroupRequestJSON(req EnterpriseAdminProvisionAndInviteEnterpriseGroupReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminProvisionAndInviteEnterpriseGroupRequestJSON(req EnterpriseAdminProvisionAndInviteEnterpriseGroupReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminProvisionAndInviteEnterpriseUserRequestJSON(req EnterpriseAdminProvisionAndInviteEnterpriseUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminProvisionAndInviteEnterpriseUserRequestJSON(req EnterpriseAdminProvisionAndInviteEnterpriseUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetAllowedActionsEnterpriseRequestJSON(req SelectedActions, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetAllowedActionsEnterpriseRequestJSON(req SelectedActions, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseRequestJSON(req EnterpriseAdminSetGithubActionsPermissionsEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseRequestJSON(req EnterpriseAdminSetGithubActionsPermissionsEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupRequestJSON(req EnterpriseAdminSetInformationForProvisionedEnterpriseGroupReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupRequestJSON(req EnterpriseAdminSetInformationForProvisionedEnterpriseGroupReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserRequestJSON(req EnterpriseAdminSetInformationForProvisionedEnterpriseUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserRequestJSON(req EnterpriseAdminSetInformationForProvisionedEnterpriseUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseRequestJSON(req EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseRequestJSON(req EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseRequestJSON(req EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseRequestJSON(req EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRequestJSON(req EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRequestJSON(req EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminUpdateAttributeForEnterpriseGroupRequestJSON(req EnterpriseAdminUpdateAttributeForEnterpriseGroupReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminUpdateAttributeForEnterpriseGroupRequestJSON(req EnterpriseAdminUpdateAttributeForEnterpriseGroupReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminUpdateAttributeForEnterpriseUserRequestJSON(req EnterpriseAdminUpdateAttributeForEnterpriseUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminUpdateAttributeForEnterpriseUserRequestJSON(req EnterpriseAdminUpdateAttributeForEnterpriseUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRequestJSON(req OptEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRequestJSON(req OptEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGistsCreateRequestJSON(req GistsCreateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGistsCreateRequestJSON(req GistsCreateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGistsCreateCommentRequestJSON(req GistsCreateCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGistsCreateCommentRequestJSON(req GistsCreateCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGistsUpdateCommentRequestJSON(req GistsUpdateCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGistsUpdateCommentRequestJSON(req GistsUpdateCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitCreateBlobRequestJSON(req GitCreateBlobReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitCreateBlobRequestJSON(req GitCreateBlobReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitCreateCommitRequestJSON(req GitCreateCommitReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitCreateCommitRequestJSON(req GitCreateCommitReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitCreateRefRequestJSON(req GitCreateRefReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitCreateRefRequestJSON(req GitCreateRefReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitCreateTagRequestJSON(req GitCreateTagReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitCreateTagRequestJSON(req GitCreateTagReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitCreateTreeRequestJSON(req GitCreateTreeReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitCreateTreeRequestJSON(req GitCreateTreeReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGitUpdateRefRequestJSON(req GitUpdateRefReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGitUpdateRefRequestJSON(req GitUpdateRefReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeInteractionsSetRestrictionsForAuthenticatedUserRequestJSON(req InteractionLimit, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeInteractionsSetRestrictionsForAuthenticatedUserRequestJSON(req InteractionLimit, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeInteractionsSetRestrictionsForOrgRequestJSON(req InteractionLimit, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeInteractionsSetRestrictionsForOrgRequestJSON(req InteractionLimit, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeInteractionsSetRestrictionsForRepoRequestJSON(req InteractionLimit, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeInteractionsSetRestrictionsForRepoRequestJSON(req InteractionLimit, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesAddAssigneesRequestJSON(req OptIssuesAddAssigneesReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesAddAssigneesRequestJSON(req OptIssuesAddAssigneesReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesCreateRequestJSON(req IssuesCreateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesCreateRequestJSON(req IssuesCreateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesCreateCommentRequestJSON(req IssuesCreateCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesCreateCommentRequestJSON(req IssuesCreateCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesCreateLabelRequestJSON(req IssuesCreateLabelReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesCreateLabelRequestJSON(req IssuesCreateLabelReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesCreateMilestoneRequestJSON(req IssuesCreateMilestoneReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesCreateMilestoneRequestJSON(req IssuesCreateMilestoneReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesLockRequestJSON(req OptIssuesLockReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesLockRequestJSON(req OptIssuesLockReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesRemoveAssigneesRequestJSON(req OptIssuesRemoveAssigneesReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesRemoveAssigneesRequestJSON(req OptIssuesRemoveAssigneesReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesUpdateRequestJSON(req OptIssuesUpdateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesUpdateRequestJSON(req OptIssuesUpdateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesUpdateCommentRequestJSON(req IssuesUpdateCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesUpdateCommentRequestJSON(req IssuesUpdateCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesUpdateLabelRequestJSON(req OptIssuesUpdateLabelReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesUpdateLabelRequestJSON(req OptIssuesUpdateLabelReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeIssuesUpdateMilestoneRequestJSON(req OptIssuesUpdateMilestoneReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeIssuesUpdateMilestoneRequestJSON(req OptIssuesUpdateMilestoneReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsMapCommitAuthorRequestJSON(req OptMigrationsMapCommitAuthorReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsMapCommitAuthorRequestJSON(req OptMigrationsMapCommitAuthorReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsSetLfsPreferenceRequestJSON(req MigrationsSetLfsPreferenceReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsSetLfsPreferenceRequestJSON(req MigrationsSetLfsPreferenceReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsStartForAuthenticatedUserRequestJSON(req MigrationsStartForAuthenticatedUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsStartForAuthenticatedUserRequestJSON(req MigrationsStartForAuthenticatedUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsStartForOrgRequestJSON(req MigrationsStartForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsStartForOrgRequestJSON(req MigrationsStartForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsStartImportRequestJSON(req MigrationsStartImportReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsStartImportRequestJSON(req MigrationsStartImportReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeMigrationsUpdateImportRequestJSON(req OptMigrationsUpdateImportReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeMigrationsUpdateImportRequestJSON(req OptMigrationsUpdateImportReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOAuthAuthorizationsCreateAuthorizationRequestJSON(req OptOAuthAuthorizationsCreateAuthorizationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOAuthAuthorizationsCreateAuthorizationRequestJSON(req OptOAuthAuthorizationsCreateAuthorizationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppRequestJSON(req OAuthAuthorizationsGetOrCreateAuthorizationForAppReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppRequestJSON(req OAuthAuthorizationsGetOrCreateAuthorizationForAppReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRequestJSON(req OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRequestJSON(req OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOAuthAuthorizationsUpdateAuthorizationRequestJSON(req OptOAuthAuthorizationsUpdateAuthorizationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOAuthAuthorizationsUpdateAuthorizationRequestJSON(req OptOAuthAuthorizationsUpdateAuthorizationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsCreateInvitationRequestJSON(req OptOrgsCreateInvitationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsCreateInvitationRequestJSON(req OptOrgsCreateInvitationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsCreateWebhookRequestJSON(req OrgsCreateWebhookReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsCreateWebhookRequestJSON(req OrgsCreateWebhookReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsSetMembershipForUserRequestJSON(req OptOrgsSetMembershipForUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsSetMembershipForUserRequestJSON(req OptOrgsSetMembershipForUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsUpdateMembershipForAuthenticatedUserRequestJSON(req OrgsUpdateMembershipForAuthenticatedUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsUpdateMembershipForAuthenticatedUserRequestJSON(req OrgsUpdateMembershipForAuthenticatedUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsUpdateWebhookRequestJSON(req OptOrgsUpdateWebhookReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsUpdateWebhookRequestJSON(req OptOrgsUpdateWebhookReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrgsUpdateWebhookConfigForOrgRequestJSON(req OptOrgsUpdateWebhookConfigForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrgsUpdateWebhookConfigForOrgRequestJSON(req OptOrgsUpdateWebhookConfigForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsAddCollaboratorRequestJSON(req OptProjectsAddCollaboratorReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsAddCollaboratorRequestJSON(req OptProjectsAddCollaboratorReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsCreateColumnRequestJSON(req ProjectsCreateColumnReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsCreateColumnRequestJSON(req ProjectsCreateColumnReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsCreateForAuthenticatedUserRequestJSON(req ProjectsCreateForAuthenticatedUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsCreateForAuthenticatedUserRequestJSON(req ProjectsCreateForAuthenticatedUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsCreateForOrgRequestJSON(req ProjectsCreateForOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsCreateForOrgRequestJSON(req ProjectsCreateForOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsCreateForRepoRequestJSON(req ProjectsCreateForRepoReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsCreateForRepoRequestJSON(req ProjectsCreateForRepoReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsMoveCardRequestJSON(req ProjectsMoveCardReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsMoveCardRequestJSON(req ProjectsMoveCardReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsMoveColumnRequestJSON(req ProjectsMoveColumnReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsMoveColumnRequestJSON(req ProjectsMoveColumnReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsUpdateRequestJSON(req OptProjectsUpdateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsUpdateRequestJSON(req OptProjectsUpdateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsUpdateCardRequestJSON(req OptProjectsUpdateCardReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsUpdateCardRequestJSON(req OptProjectsUpdateCardReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeProjectsUpdateColumnRequestJSON(req ProjectsUpdateColumnReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeProjectsUpdateColumnRequestJSON(req ProjectsUpdateColumnReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsCreateRequestJSON(req PullsCreateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsCreateRequestJSON(req PullsCreateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsCreateReplyForReviewCommentRequestJSON(req PullsCreateReplyForReviewCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsCreateReplyForReviewCommentRequestJSON(req PullsCreateReplyForReviewCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsCreateReviewRequestJSON(req OptPullsCreateReviewReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsCreateReviewRequestJSON(req OptPullsCreateReviewReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsCreateReviewCommentRequestJSON(req PullsCreateReviewCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsCreateReviewCommentRequestJSON(req PullsCreateReviewCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsDismissReviewRequestJSON(req PullsDismissReviewReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsDismissReviewRequestJSON(req PullsDismissReviewReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsMergeRequestJSON(req OptPullsMergeReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsMergeRequestJSON(req OptPullsMergeReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsRemoveRequestedReviewersRequestJSON(req PullsRemoveRequestedReviewersReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsRemoveRequestedReviewersRequestJSON(req PullsRemoveRequestedReviewersReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsSubmitReviewRequestJSON(req PullsSubmitReviewReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsSubmitReviewRequestJSON(req PullsSubmitReviewReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsUpdateRequestJSON(req OptPullsUpdateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsUpdateRequestJSON(req OptPullsUpdateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsUpdateBranchRequestJSON(req OptPullsUpdateBranchReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsUpdateBranchRequestJSON(req OptPullsUpdateBranchReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsUpdateReviewRequestJSON(req PullsUpdateReviewReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsUpdateReviewRequestJSON(req PullsUpdateReviewReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePullsUpdateReviewCommentRequestJSON(req PullsUpdateReviewCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePullsUpdateReviewCommentRequestJSON(req PullsUpdateReviewCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForCommitCommentRequestJSON(req ReactionsCreateForCommitCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForCommitCommentRequestJSON(req ReactionsCreateForCommitCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForIssueRequestJSON(req ReactionsCreateForIssueReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForIssueRequestJSON(req ReactionsCreateForIssueReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForIssueCommentRequestJSON(req ReactionsCreateForIssueCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForIssueCommentRequestJSON(req ReactionsCreateForIssueCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForPullRequestReviewCommentRequestJSON(req ReactionsCreateForPullRequestReviewCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForPullRequestReviewCommentRequestJSON(req ReactionsCreateForPullRequestReviewCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForReleaseRequestJSON(req ReactionsCreateForReleaseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForReleaseRequestJSON(req ReactionsCreateForReleaseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForTeamDiscussionCommentInOrgRequestJSON(req ReactionsCreateForTeamDiscussionCommentInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForTeamDiscussionCommentInOrgRequestJSON(req ReactionsCreateForTeamDiscussionCommentInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForTeamDiscussionCommentLegacyRequestJSON(req ReactionsCreateForTeamDiscussionCommentLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForTeamDiscussionCommentLegacyRequestJSON(req ReactionsCreateForTeamDiscussionCommentLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForTeamDiscussionInOrgRequestJSON(req ReactionsCreateForTeamDiscussionInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForTeamDiscussionInOrgRequestJSON(req ReactionsCreateForTeamDiscussionInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReactionsCreateForTeamDiscussionLegacyRequestJSON(req ReactionsCreateForTeamDiscussionLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReactionsCreateForTeamDiscussionLegacyRequestJSON(req ReactionsCreateForTeamDiscussionLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposAddAppAccessRestrictionsRequestJSON(req OptReposAddAppAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposAddAppAccessRestrictionsRequestJSON(req OptReposAddAppAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposAddCollaboratorRequestJSON(req OptReposAddCollaboratorReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposAddCollaboratorRequestJSON(req OptReposAddCollaboratorReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposAddStatusCheckContextsRequestJSON(req OptReposAddStatusCheckContextsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposAddStatusCheckContextsRequestJSON(req OptReposAddStatusCheckContextsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposAddTeamAccessRestrictionsRequestJSON(req OptReposAddTeamAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposAddTeamAccessRestrictionsRequestJSON(req OptReposAddTeamAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposAddUserAccessRestrictionsRequestJSON(req OptReposAddUserAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposAddUserAccessRestrictionsRequestJSON(req OptReposAddUserAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateAutolinkRequestJSON(req ReposCreateAutolinkReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateAutolinkRequestJSON(req ReposCreateAutolinkReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateCommitCommentRequestJSON(req ReposCreateCommitCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateCommitCommentRequestJSON(req ReposCreateCommitCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateCommitStatusRequestJSON(req ReposCreateCommitStatusReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateCommitStatusRequestJSON(req ReposCreateCommitStatusReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateDeployKeyRequestJSON(req ReposCreateDeployKeyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateDeployKeyRequestJSON(req ReposCreateDeployKeyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateDeploymentRequestJSON(req ReposCreateDeploymentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateDeploymentRequestJSON(req ReposCreateDeploymentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateDeploymentStatusRequestJSON(req ReposCreateDeploymentStatusReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateDeploymentStatusRequestJSON(req ReposCreateDeploymentStatusReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateDispatchEventRequestJSON(req ReposCreateDispatchEventReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateDispatchEventRequestJSON(req ReposCreateDispatchEventReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateForAuthenticatedUserRequestJSON(req ReposCreateForAuthenticatedUserReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateForAuthenticatedUserRequestJSON(req ReposCreateForAuthenticatedUserReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateForkRequestJSON(req OptReposCreateForkReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateForkRequestJSON(req OptReposCreateForkReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateInOrgRequestJSON(req ReposCreateInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateInOrgRequestJSON(req ReposCreateInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateOrUpdateFileContentsRequestJSON(req ReposCreateOrUpdateFileContentsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateOrUpdateFileContentsRequestJSON(req ReposCreateOrUpdateFileContentsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreatePagesSiteRequestJSON(req ReposCreatePagesSiteReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreatePagesSiteRequestJSON(req ReposCreatePagesSiteReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateReleaseRequestJSON(req ReposCreateReleaseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateReleaseRequestJSON(req ReposCreateReleaseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateUsingTemplateRequestJSON(req ReposCreateUsingTemplateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateUsingTemplateRequestJSON(req ReposCreateUsingTemplateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposCreateWebhookRequestJSON(req OptReposCreateWebhookReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposCreateWebhookRequestJSON(req OptReposCreateWebhookReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposDeleteFileRequestJSON(req ReposDeleteFileReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposDeleteFileRequestJSON(req ReposDeleteFileReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposMergeRequestJSON(req ReposMergeReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposMergeRequestJSON(req ReposMergeReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposMergeUpstreamRequestJSON(req ReposMergeUpstreamReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposMergeUpstreamRequestJSON(req ReposMergeUpstreamReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposRemoveAppAccessRestrictionsRequestJSON(req OptReposRemoveAppAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposRemoveAppAccessRestrictionsRequestJSON(req OptReposRemoveAppAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposRemoveStatusCheckContextsRequestJSON(req OptReposRemoveStatusCheckContextsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposRemoveStatusCheckContextsRequestJSON(req OptReposRemoveStatusCheckContextsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposRemoveTeamAccessRestrictionsRequestJSON(req OptReposRemoveTeamAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposRemoveTeamAccessRestrictionsRequestJSON(req OptReposRemoveTeamAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposRemoveUserAccessRestrictionsRequestJSON(req OptReposRemoveUserAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposRemoveUserAccessRestrictionsRequestJSON(req OptReposRemoveUserAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposRenameBranchRequestJSON(req OptReposRenameBranchReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposRenameBranchRequestJSON(req OptReposRenameBranchReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposReplaceAllTopicsRequestJSON(req ReposReplaceAllTopicsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposReplaceAllTopicsRequestJSON(req ReposReplaceAllTopicsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposSetAppAccessRestrictionsRequestJSON(req OptReposSetAppAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposSetAppAccessRestrictionsRequestJSON(req OptReposSetAppAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposSetStatusCheckContextsRequestJSON(req OptReposSetStatusCheckContextsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposSetStatusCheckContextsRequestJSON(req OptReposSetStatusCheckContextsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposSetTeamAccessRestrictionsRequestJSON(req OptReposSetTeamAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposSetTeamAccessRestrictionsRequestJSON(req OptReposSetTeamAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposSetUserAccessRestrictionsRequestJSON(req OptReposSetUserAccessRestrictionsReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposSetUserAccessRestrictionsRequestJSON(req OptReposSetUserAccessRestrictionsReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposTransferRequestJSON(req ReposTransferReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposTransferRequestJSON(req ReposTransferReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateRequestJSON(req OptReposUpdateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateRequestJSON(req OptReposUpdateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateBranchProtectionRequestJSON(req ReposUpdateBranchProtectionReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateBranchProtectionRequestJSON(req ReposUpdateBranchProtectionReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateCommitCommentRequestJSON(req ReposUpdateCommitCommentReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateCommitCommentRequestJSON(req ReposUpdateCommitCommentReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateInvitationRequestJSON(req OptReposUpdateInvitationReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateInvitationRequestJSON(req OptReposUpdateInvitationReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdatePullRequestReviewProtectionRequestJSON(req OptReposUpdatePullRequestReviewProtectionReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdatePullRequestReviewProtectionRequestJSON(req OptReposUpdatePullRequestReviewProtectionReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateReleaseRequestJSON(req OptReposUpdateReleaseReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateReleaseRequestJSON(req OptReposUpdateReleaseReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateReleaseAssetRequestJSON(req OptReposUpdateReleaseAssetReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateReleaseAssetRequestJSON(req OptReposUpdateReleaseAssetReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateStatusCheckProtectionRequestJSON(req OptReposUpdateStatusCheckProtectionReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateStatusCheckProtectionRequestJSON(req OptReposUpdateStatusCheckProtectionReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateWebhookRequestJSON(req OptReposUpdateWebhookReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateWebhookRequestJSON(req OptReposUpdateWebhookReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeReposUpdateWebhookConfigForRepoRequestJSON(req OptReposUpdateWebhookConfigForRepoReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeReposUpdateWebhookConfigForRepoRequestJSON(req OptReposUpdateWebhookConfigForRepoReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSecretScanningUpdateAlertRequestJSON(req SecretScanningUpdateAlertReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSecretScanningUpdateAlertRequestJSON(req SecretScanningUpdateAlertReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateMembershipForUserInOrgRequestJSON(req OptTeamsAddOrUpdateMembershipForUserInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateMembershipForUserInOrgRequestJSON(req OptTeamsAddOrUpdateMembershipForUserInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateMembershipForUserLegacyRequestJSON(req OptTeamsAddOrUpdateMembershipForUserLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateMembershipForUserLegacyRequestJSON(req OptTeamsAddOrUpdateMembershipForUserLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateProjectPermissionsInOrgRequestJSON(req OptTeamsAddOrUpdateProjectPermissionsInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateProjectPermissionsInOrgRequestJSON(req OptTeamsAddOrUpdateProjectPermissionsInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateProjectPermissionsLegacyRequestJSON(req OptTeamsAddOrUpdateProjectPermissionsLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateProjectPermissionsLegacyRequestJSON(req OptTeamsAddOrUpdateProjectPermissionsLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateRepoPermissionsInOrgRequestJSON(req OptTeamsAddOrUpdateRepoPermissionsInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateRepoPermissionsInOrgRequestJSON(req OptTeamsAddOrUpdateRepoPermissionsInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsAddOrUpdateRepoPermissionsLegacyRequestJSON(req OptTeamsAddOrUpdateRepoPermissionsLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsAddOrUpdateRepoPermissionsLegacyRequestJSON(req OptTeamsAddOrUpdateRepoPermissionsLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateRequestJSON(req TeamsCreateReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateRequestJSON(req TeamsCreateReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateDiscussionCommentInOrgRequestJSON(req TeamsCreateDiscussionCommentInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateDiscussionCommentInOrgRequestJSON(req TeamsCreateDiscussionCommentInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateDiscussionCommentLegacyRequestJSON(req TeamsCreateDiscussionCommentLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateDiscussionCommentLegacyRequestJSON(req TeamsCreateDiscussionCommentLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateDiscussionInOrgRequestJSON(req TeamsCreateDiscussionInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateDiscussionInOrgRequestJSON(req TeamsCreateDiscussionInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateDiscussionLegacyRequestJSON(req TeamsCreateDiscussionLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateDiscussionLegacyRequestJSON(req TeamsCreateDiscussionLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequestJSON(req TeamsCreateOrUpdateIdpGroupConnectionsInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequestJSON(req TeamsCreateOrUpdateIdpGroupConnectionsInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequestJSON(req TeamsCreateOrUpdateIdpGroupConnectionsLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequestJSON(req TeamsCreateOrUpdateIdpGroupConnectionsLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateDiscussionCommentInOrgRequestJSON(req TeamsUpdateDiscussionCommentInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateDiscussionCommentInOrgRequestJSON(req TeamsUpdateDiscussionCommentInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateDiscussionCommentLegacyRequestJSON(req TeamsUpdateDiscussionCommentLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateDiscussionCommentLegacyRequestJSON(req TeamsUpdateDiscussionCommentLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateDiscussionInOrgRequestJSON(req OptTeamsUpdateDiscussionInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateDiscussionInOrgRequestJSON(req OptTeamsUpdateDiscussionInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateDiscussionLegacyRequestJSON(req OptTeamsUpdateDiscussionLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateDiscussionLegacyRequestJSON(req OptTeamsUpdateDiscussionLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateInOrgRequestJSON(req OptTeamsUpdateInOrgReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateInOrgRequestJSON(req OptTeamsUpdateInOrgReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeTeamsUpdateLegacyRequestJSON(req TeamsUpdateLegacyReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeTeamsUpdateLegacyRequestJSON(req TeamsUpdateLegacyReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersAddEmailForAuthenticatedRequestJSON(req OptUsersAddEmailForAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersAddEmailForAuthenticatedRequestJSON(req OptUsersAddEmailForAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersCreateGpgKeyForAuthenticatedRequestJSON(req UsersCreateGpgKeyForAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersCreateGpgKeyForAuthenticatedRequestJSON(req UsersCreateGpgKeyForAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersCreatePublicSSHKeyForAuthenticatedRequestJSON(req UsersCreatePublicSSHKeyForAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersCreatePublicSSHKeyForAuthenticatedRequestJSON(req UsersCreatePublicSSHKeyForAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersDeleteEmailForAuthenticatedRequestJSON(req OptUsersDeleteEmailForAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersDeleteEmailForAuthenticatedRequestJSON(req OptUsersDeleteEmailForAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedRequestJSON(req UsersSetPrimaryEmailVisibilityForAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedRequestJSON(req UsersSetPrimaryEmailVisibilityForAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUsersUpdateAuthenticatedRequestJSON(req OptUsersUpdateAuthenticatedReq, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUsersUpdateAuthenticatedRequestJSON(req OptUsersUpdateAuthenticatedReq, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
-	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
 	}
 
-	return buf, nil
+	return e, nil
 }

--- a/examples/ex_gotd/oas_client_gen.go
+++ b/examples/ex_gotd/oas_client_gen.go
@@ -132,8 +132,8 @@ func (c *Client) AddStickerToSet(ctx context.Context, request AddStickerToSet) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/addStickerToSet"
@@ -194,8 +194,8 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request AnswerCallback
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerCallbackQuery"
@@ -256,8 +256,8 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request AnswerInlineQuer
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerInlineQuery"
@@ -310,8 +310,8 @@ func (c *Client) AnswerPreCheckoutQuery(ctx context.Context, request AnswerPreCh
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerPreCheckoutQuery"
@@ -372,8 +372,8 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request AnswerShipping
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerShippingQuery"
@@ -426,8 +426,8 @@ func (c *Client) ApproveChatJoinRequest(ctx context.Context, request ApproveChat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/approveChatJoinRequest"
@@ -480,8 +480,8 @@ func (c *Client) BanChatMember(ctx context.Context, request BanChatMember) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/banChatMember"
@@ -542,8 +542,8 @@ func (c *Client) CopyMessage(ctx context.Context, request CopyMessage) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/copyMessage"
@@ -604,8 +604,8 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request CreateChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/createChatInviteLink"
@@ -666,8 +666,8 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request CreateNewStick
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/createNewStickerSet"
@@ -720,8 +720,8 @@ func (c *Client) DeclineChatJoinRequest(ctx context.Context, request DeclineChat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/declineChatJoinRequest"
@@ -774,8 +774,8 @@ func (c *Client) DeleteChatPhoto(ctx context.Context, request DeleteChatPhoto) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteChatPhoto"
@@ -828,8 +828,8 @@ func (c *Client) DeleteChatStickerSet(ctx context.Context, request DeleteChatSti
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteChatStickerSet"
@@ -882,8 +882,8 @@ func (c *Client) DeleteMessage(ctx context.Context, request DeleteMessage) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteMessage"
@@ -936,8 +936,8 @@ func (c *Client) DeleteMyCommands(ctx context.Context, request DeleteMyCommands)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteMyCommands"
@@ -990,8 +990,8 @@ func (c *Client) DeleteStickerFromSet(ctx context.Context, request DeleteSticker
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteStickerFromSet"
@@ -1044,8 +1044,8 @@ func (c *Client) DeleteWebhook(ctx context.Context, request DeleteWebhook) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteWebhook"
@@ -1106,8 +1106,8 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request EditChatInviteL
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editChatInviteLink"
@@ -1168,8 +1168,8 @@ func (c *Client) EditMessageCaption(ctx context.Context, request EditMessageCapt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageCaption"
@@ -1230,8 +1230,8 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request EditMessag
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageLiveLocation"
@@ -1292,8 +1292,8 @@ func (c *Client) EditMessageMedia(ctx context.Context, request EditMessageMedia)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageMedia"
@@ -1354,8 +1354,8 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request EditMessage
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageReplyMarkup"
@@ -1416,8 +1416,8 @@ func (c *Client) EditMessageText(ctx context.Context, request EditMessageText) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageText"
@@ -1470,8 +1470,8 @@ func (c *Client) ExportChatInviteLink(ctx context.Context, request ExportChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/exportChatInviteLink"
@@ -1524,8 +1524,8 @@ func (c *Client) ForwardMessage(ctx context.Context, request ForwardMessage) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/forwardMessage"
@@ -1578,8 +1578,8 @@ func (c *Client) GetChat(ctx context.Context, request GetChat) (res Result, err 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChat"
@@ -1632,8 +1632,8 @@ func (c *Client) GetChatAdministrators(ctx context.Context, request GetChatAdmin
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatAdministrators"
@@ -1686,8 +1686,8 @@ func (c *Client) GetChatMember(ctx context.Context, request GetChatMember) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatMember"
@@ -1740,8 +1740,8 @@ func (c *Client) GetChatMemberCount(ctx context.Context, request GetChatMemberCo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatMemberCount"
@@ -1794,8 +1794,8 @@ func (c *Client) GetFile(ctx context.Context, request GetFile) (res Result, err 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getFile"
@@ -1848,8 +1848,8 @@ func (c *Client) GetGameHighScores(ctx context.Context, request GetGameHighScore
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getGameHighScores"
@@ -1942,8 +1942,8 @@ func (c *Client) GetMyCommands(ctx context.Context, request GetMyCommands) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getMyCommands"
@@ -1996,8 +1996,8 @@ func (c *Client) GetStickerSet(ctx context.Context, request GetStickerSet) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getStickerSet"
@@ -2058,8 +2058,8 @@ func (c *Client) GetUpdates(ctx context.Context, request GetUpdates) (res Result
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getUpdates"
@@ -2120,8 +2120,8 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request GetUserProfil
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getUserProfilePhotos"
@@ -2174,8 +2174,8 @@ func (c *Client) LeaveChat(ctx context.Context, request LeaveChat) (res Result, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/leaveChat"
@@ -2228,8 +2228,8 @@ func (c *Client) PinChatMessage(ctx context.Context, request PinChatMessage) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pinChatMessage"
@@ -2282,8 +2282,8 @@ func (c *Client) PromoteChatMember(ctx context.Context, request PromoteChatMembe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/promoteChatMember"
@@ -2336,8 +2336,8 @@ func (c *Client) RestrictChatMember(ctx context.Context, request RestrictChatMem
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/restrictChatMember"
@@ -2390,8 +2390,8 @@ func (c *Client) RevokeChatInviteLink(ctx context.Context, request RevokeChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/revokeChatInviteLink"
@@ -2452,8 +2452,8 @@ func (c *Client) SendAnimation(ctx context.Context, request SendAnimation) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendAnimation"
@@ -2514,8 +2514,8 @@ func (c *Client) SendAudio(ctx context.Context, request SendAudio) (res Result, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendAudio"
@@ -2568,8 +2568,8 @@ func (c *Client) SendChatAction(ctx context.Context, request SendChatAction) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendChatAction"
@@ -2630,8 +2630,8 @@ func (c *Client) SendContact(ctx context.Context, request SendContact) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendContact"
@@ -2692,8 +2692,8 @@ func (c *Client) SendDice(ctx context.Context, request SendDice) (res ResultMsg,
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendDice"
@@ -2754,8 +2754,8 @@ func (c *Client) SendDocument(ctx context.Context, request SendDocument) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendDocument"
@@ -2816,8 +2816,8 @@ func (c *Client) SendGame(ctx context.Context, request SendGame) (res ResultMsg,
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendGame"
@@ -2878,8 +2878,8 @@ func (c *Client) SendInvoice(ctx context.Context, request SendInvoice) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendInvoice"
@@ -2940,8 +2940,8 @@ func (c *Client) SendLocation(ctx context.Context, request SendLocation) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendLocation"
@@ -3002,8 +3002,8 @@ func (c *Client) SendMediaGroup(ctx context.Context, request SendMediaGroup) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendMediaGroup"
@@ -3064,8 +3064,8 @@ func (c *Client) SendMessage(ctx context.Context, request SendMessage) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendMessage"
@@ -3126,8 +3126,8 @@ func (c *Client) SendPhoto(ctx context.Context, request SendPhoto) (res ResultMs
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendPhoto"
@@ -3188,8 +3188,8 @@ func (c *Client) SendPoll(ctx context.Context, request SendPoll) (res ResultMsg,
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendPoll"
@@ -3250,8 +3250,8 @@ func (c *Client) SendSticker(ctx context.Context, request SendSticker) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendSticker"
@@ -3312,8 +3312,8 @@ func (c *Client) SendVenue(ctx context.Context, request SendVenue) (res ResultMs
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVenue"
@@ -3374,8 +3374,8 @@ func (c *Client) SendVideo(ctx context.Context, request SendVideo) (res ResultMs
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVideo"
@@ -3436,8 +3436,8 @@ func (c *Client) SendVideoNote(ctx context.Context, request SendVideoNote) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVideoNote"
@@ -3498,8 +3498,8 @@ func (c *Client) SendVoice(ctx context.Context, request SendVoice) (res ResultMs
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVoice"
@@ -3560,8 +3560,8 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request Se
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatAdministratorCustomTitle"
@@ -3622,8 +3622,8 @@ func (c *Client) SetChatDescription(ctx context.Context, request SetChatDescript
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatDescription"
@@ -3676,8 +3676,8 @@ func (c *Client) SetChatPermissions(ctx context.Context, request SetChatPermissi
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatPermissions"
@@ -3730,8 +3730,8 @@ func (c *Client) SetChatPhoto(ctx context.Context, request SetChatPhoto) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatPhoto"
@@ -3784,8 +3784,8 @@ func (c *Client) SetChatStickerSet(ctx context.Context, request SetChatStickerSe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatStickerSet"
@@ -3846,8 +3846,8 @@ func (c *Client) SetChatTitle(ctx context.Context, request SetChatTitle) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatTitle"
@@ -3900,8 +3900,8 @@ func (c *Client) SetGameScore(ctx context.Context, request SetGameScore) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setGameScore"
@@ -3962,8 +3962,8 @@ func (c *Client) SetMyCommands(ctx context.Context, request SetMyCommands) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setMyCommands"
@@ -4024,8 +4024,8 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request SetPassportD
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setPassportDataErrors"
@@ -4078,8 +4078,8 @@ func (c *Client) SetStickerPositionInSet(ctx context.Context, request SetSticker
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setStickerPositionInSet"
@@ -4132,8 +4132,8 @@ func (c *Client) SetStickerSetThumb(ctx context.Context, request SetStickerSetTh
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setStickerSetThumb"
@@ -4186,8 +4186,8 @@ func (c *Client) SetWebhook(ctx context.Context, request SetWebhook) (res Result
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setWebhook"
@@ -4248,8 +4248,8 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request StopMessag
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/stopMessageLiveLocation"
@@ -4310,8 +4310,8 @@ func (c *Client) StopPoll(ctx context.Context, request StopPoll) (res Result, er
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/stopPoll"
@@ -4364,8 +4364,8 @@ func (c *Client) UnbanChatMember(ctx context.Context, request UnbanChatMember) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unbanChatMember"
@@ -4418,8 +4418,8 @@ func (c *Client) UnpinAllChatMessages(ctx context.Context, request UnpinAllChatM
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unpinAllChatMessages"
@@ -4472,8 +4472,8 @@ func (c *Client) UnpinChatMessage(ctx context.Context, request UnpinChatMessage)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unpinChatMessage"
@@ -4526,8 +4526,8 @@ func (c *Client) UploadStickerFile(ctx context.Context, request UploadStickerFil
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/uploadStickerFile"

--- a/examples/ex_gotd/oas_req_enc_gen.go
+++ b/examples/ex_gotd/oas_req_enc_gen.go
@@ -64,1066 +64,610 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeAddStickerToSetRequestJSON(req AddStickerToSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAddStickerToSetRequestJSON(req AddStickerToSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerCallbackQueryRequestJSON(req AnswerCallbackQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerCallbackQueryRequestJSON(req AnswerCallbackQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerInlineQueryRequestJSON(req AnswerInlineQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerInlineQueryRequestJSON(req AnswerInlineQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerPreCheckoutQueryRequestJSON(req AnswerPreCheckoutQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerPreCheckoutQueryRequestJSON(req AnswerPreCheckoutQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerShippingQueryRequestJSON(req AnswerShippingQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerShippingQueryRequestJSON(req AnswerShippingQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeApproveChatJoinRequestRequestJSON(req ApproveChatJoinRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeApproveChatJoinRequestRequestJSON(req ApproveChatJoinRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeBanChatMemberRequestJSON(req BanChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeBanChatMemberRequestJSON(req BanChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCopyMessageRequestJSON(req CopyMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCopyMessageRequestJSON(req CopyMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreateChatInviteLinkRequestJSON(req CreateChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateChatInviteLinkRequestJSON(req CreateChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreateNewStickerSetRequestJSON(req CreateNewStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateNewStickerSetRequestJSON(req CreateNewStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeclineChatJoinRequestRequestJSON(req DeclineChatJoinRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeclineChatJoinRequestRequestJSON(req DeclineChatJoinRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteChatPhotoRequestJSON(req DeleteChatPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteChatPhotoRequestJSON(req DeleteChatPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteChatStickerSetRequestJSON(req DeleteChatStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteChatStickerSetRequestJSON(req DeleteChatStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteMessageRequestJSON(req DeleteMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteMessageRequestJSON(req DeleteMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteMyCommandsRequestJSON(req DeleteMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteMyCommandsRequestJSON(req DeleteMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteStickerFromSetRequestJSON(req DeleteStickerFromSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteStickerFromSetRequestJSON(req DeleteStickerFromSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteWebhookRequestJSON(req DeleteWebhook, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteWebhookRequestJSON(req DeleteWebhook, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditChatInviteLinkRequestJSON(req EditChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditChatInviteLinkRequestJSON(req EditChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageCaptionRequestJSON(req EditMessageCaption, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageCaptionRequestJSON(req EditMessageCaption, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageLiveLocationRequestJSON(req EditMessageLiveLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageLiveLocationRequestJSON(req EditMessageLiveLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageMediaRequestJSON(req EditMessageMedia, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageMediaRequestJSON(req EditMessageMedia, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageReplyMarkupRequestJSON(req EditMessageReplyMarkup, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageReplyMarkupRequestJSON(req EditMessageReplyMarkup, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageTextRequestJSON(req EditMessageText, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageTextRequestJSON(req EditMessageText, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeExportChatInviteLinkRequestJSON(req ExportChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeExportChatInviteLinkRequestJSON(req ExportChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeForwardMessageRequestJSON(req ForwardMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeForwardMessageRequestJSON(req ForwardMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatRequestJSON(req GetChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatRequestJSON(req GetChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatAdministratorsRequestJSON(req GetChatAdministrators, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatAdministratorsRequestJSON(req GetChatAdministrators, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatMemberRequestJSON(req GetChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatMemberRequestJSON(req GetChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatMemberCountRequestJSON(req GetChatMemberCount, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatMemberCountRequestJSON(req GetChatMemberCount, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetFileRequestJSON(req GetFile, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetFileRequestJSON(req GetFile, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetGameHighScoresRequestJSON(req GetGameHighScores, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetGameHighScoresRequestJSON(req GetGameHighScores, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetMyCommandsRequestJSON(req GetMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetMyCommandsRequestJSON(req GetMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetStickerSetRequestJSON(req GetStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetStickerSetRequestJSON(req GetStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetUpdatesRequestJSON(req GetUpdates, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetUpdatesRequestJSON(req GetUpdates, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetUserProfilePhotosRequestJSON(req GetUserProfilePhotos, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetUserProfilePhotosRequestJSON(req GetUserProfilePhotos, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeLeaveChatRequestJSON(req LeaveChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeLeaveChatRequestJSON(req LeaveChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePinChatMessageRequestJSON(req PinChatMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePinChatMessageRequestJSON(req PinChatMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePromoteChatMemberRequestJSON(req PromoteChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePromoteChatMemberRequestJSON(req PromoteChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeRestrictChatMemberRequestJSON(req RestrictChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeRestrictChatMemberRequestJSON(req RestrictChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeRevokeChatInviteLinkRequestJSON(req RevokeChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeRevokeChatInviteLinkRequestJSON(req RevokeChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendAnimationRequestJSON(req SendAnimation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendAnimationRequestJSON(req SendAnimation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendAudioRequestJSON(req SendAudio, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendAudioRequestJSON(req SendAudio, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendChatActionRequestJSON(req SendChatAction, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendChatActionRequestJSON(req SendChatAction, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendContactRequestJSON(req SendContact, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendContactRequestJSON(req SendContact, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendDiceRequestJSON(req SendDice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendDiceRequestJSON(req SendDice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendDocumentRequestJSON(req SendDocument, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendDocumentRequestJSON(req SendDocument, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendGameRequestJSON(req SendGame, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendGameRequestJSON(req SendGame, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendInvoiceRequestJSON(req SendInvoice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendInvoiceRequestJSON(req SendInvoice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendLocationRequestJSON(req SendLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendLocationRequestJSON(req SendLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendMediaGroupRequestJSON(req SendMediaGroup, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendMediaGroupRequestJSON(req SendMediaGroup, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendMessageRequestJSON(req SendMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendMessageRequestJSON(req SendMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendPhotoRequestJSON(req SendPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendPhotoRequestJSON(req SendPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendPollRequestJSON(req SendPoll, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendPollRequestJSON(req SendPoll, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendStickerRequestJSON(req SendSticker, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendStickerRequestJSON(req SendSticker, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVenueRequestJSON(req SendVenue, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVenueRequestJSON(req SendVenue, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVideoRequestJSON(req SendVideo, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVideoRequestJSON(req SendVideo, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVideoNoteRequestJSON(req SendVideoNote, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVideoNoteRequestJSON(req SendVideoNote, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVoiceRequestJSON(req SendVoice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVoiceRequestJSON(req SendVoice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatAdministratorCustomTitleRequestJSON(req SetChatAdministratorCustomTitle, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatAdministratorCustomTitleRequestJSON(req SetChatAdministratorCustomTitle, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatDescriptionRequestJSON(req SetChatDescription, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatDescriptionRequestJSON(req SetChatDescription, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatPermissionsRequestJSON(req SetChatPermissions, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatPermissionsRequestJSON(req SetChatPermissions, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatPhotoRequestJSON(req SetChatPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatPhotoRequestJSON(req SetChatPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatStickerSetRequestJSON(req SetChatStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatStickerSetRequestJSON(req SetChatStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatTitleRequestJSON(req SetChatTitle, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatTitleRequestJSON(req SetChatTitle, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetGameScoreRequestJSON(req SetGameScore, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetGameScoreRequestJSON(req SetGameScore, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetMyCommandsRequestJSON(req SetMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetMyCommandsRequestJSON(req SetMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetPassportDataErrorsRequestJSON(req SetPassportDataErrors, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetPassportDataErrorsRequestJSON(req SetPassportDataErrors, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetStickerPositionInSetRequestJSON(req SetStickerPositionInSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetStickerPositionInSetRequestJSON(req SetStickerPositionInSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetStickerSetThumbRequestJSON(req SetStickerSetThumb, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetStickerSetThumbRequestJSON(req SetStickerSetThumb, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetWebhookRequestJSON(req SetWebhook, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetWebhookRequestJSON(req SetWebhook, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeStopMessageLiveLocationRequestJSON(req StopMessageLiveLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeStopMessageLiveLocationRequestJSON(req StopMessageLiveLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeStopPollRequestJSON(req StopPoll, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeStopPollRequestJSON(req StopPoll, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnbanChatMemberRequestJSON(req UnbanChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnbanChatMemberRequestJSON(req UnbanChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnpinAllChatMessagesRequestJSON(req UnpinAllChatMessages, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnpinAllChatMessagesRequestJSON(req UnpinAllChatMessages, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnpinChatMessageRequestJSON(req UnpinChatMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnpinChatMessageRequestJSON(req UnpinChatMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUploadStickerFileRequestJSON(req UploadStickerFile, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUploadStickerFileRequestJSON(req UploadStickerFile, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }

--- a/examples/ex_telegram/oas_client_gen.go
+++ b/examples/ex_telegram/oas_client_gen.go
@@ -132,8 +132,8 @@ func (c *Client) AddStickerToSet(ctx context.Context, request AddStickerToSet) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/addStickerToSet"
@@ -194,8 +194,8 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request AnswerCallback
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerCallbackQuery"
@@ -256,8 +256,8 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request AnswerInlineQuer
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerInlineQuery"
@@ -310,8 +310,8 @@ func (c *Client) AnswerPreCheckoutQuery(ctx context.Context, request AnswerPreCh
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerPreCheckoutQuery"
@@ -372,8 +372,8 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request AnswerShipping
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/answerShippingQuery"
@@ -426,8 +426,8 @@ func (c *Client) ApproveChatJoinRequest(ctx context.Context, request ApproveChat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/approveChatJoinRequest"
@@ -480,8 +480,8 @@ func (c *Client) BanChatMember(ctx context.Context, request BanChatMember) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/banChatMember"
@@ -534,8 +534,8 @@ func (c *Client) BanChatSenderChat(ctx context.Context, request BanChatSenderCha
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/banChatSenderChat"
@@ -636,8 +636,8 @@ func (c *Client) CopyMessage(ctx context.Context, request CopyMessage) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/copyMessage"
@@ -698,8 +698,8 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request CreateChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/createChatInviteLink"
@@ -760,8 +760,8 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request CreateNewStick
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/createNewStickerSet"
@@ -814,8 +814,8 @@ func (c *Client) DeclineChatJoinRequest(ctx context.Context, request DeclineChat
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/declineChatJoinRequest"
@@ -868,8 +868,8 @@ func (c *Client) DeleteChatPhoto(ctx context.Context, request DeleteChatPhoto) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteChatPhoto"
@@ -922,8 +922,8 @@ func (c *Client) DeleteChatStickerSet(ctx context.Context, request DeleteChatSti
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteChatStickerSet"
@@ -976,8 +976,8 @@ func (c *Client) DeleteMessage(ctx context.Context, request DeleteMessage) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteMessage"
@@ -1030,8 +1030,8 @@ func (c *Client) DeleteMyCommands(ctx context.Context, request OptDeleteMyComman
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteMyCommands"
@@ -1084,8 +1084,8 @@ func (c *Client) DeleteStickerFromSet(ctx context.Context, request DeleteSticker
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteStickerFromSet"
@@ -1138,8 +1138,8 @@ func (c *Client) DeleteWebhook(ctx context.Context, request OptDeleteWebhook) (r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/deleteWebhook"
@@ -1200,8 +1200,8 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request EditChatInviteL
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editChatInviteLink"
@@ -1262,8 +1262,8 @@ func (c *Client) EditMessageCaption(ctx context.Context, request EditMessageCapt
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageCaption"
@@ -1324,8 +1324,8 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request EditMessag
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageLiveLocation"
@@ -1386,8 +1386,8 @@ func (c *Client) EditMessageMedia(ctx context.Context, request EditMessageMedia)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageMedia"
@@ -1448,8 +1448,8 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request EditMessage
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageReplyMarkup"
@@ -1510,8 +1510,8 @@ func (c *Client) EditMessageText(ctx context.Context, request EditMessageText) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/editMessageText"
@@ -1564,8 +1564,8 @@ func (c *Client) ExportChatInviteLink(ctx context.Context, request ExportChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/exportChatInviteLink"
@@ -1618,8 +1618,8 @@ func (c *Client) ForwardMessage(ctx context.Context, request ForwardMessage) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/forwardMessage"
@@ -1672,8 +1672,8 @@ func (c *Client) GetChat(ctx context.Context, request GetChat) (res ResultChat, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChat"
@@ -1726,8 +1726,8 @@ func (c *Client) GetChatAdministrators(ctx context.Context, request GetChatAdmin
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatAdministrators"
@@ -1780,8 +1780,8 @@ func (c *Client) GetChatMember(ctx context.Context, request GetChatMember) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatMember"
@@ -1834,8 +1834,8 @@ func (c *Client) GetChatMemberCount(ctx context.Context, request GetChatMemberCo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getChatMemberCount"
@@ -1888,8 +1888,8 @@ func (c *Client) GetFile(ctx context.Context, request GetFile) (res Result, err 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getFile"
@@ -1942,8 +1942,8 @@ func (c *Client) GetGameHighScores(ctx context.Context, request GetGameHighScore
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getGameHighScores"
@@ -2036,8 +2036,8 @@ func (c *Client) GetMyCommands(ctx context.Context, request OptGetMyCommands) (r
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getMyCommands"
@@ -2090,8 +2090,8 @@ func (c *Client) GetStickerSet(ctx context.Context, request GetStickerSet) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getStickerSet"
@@ -2160,8 +2160,8 @@ func (c *Client) GetUpdates(ctx context.Context, request OptGetUpdates) (res Res
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getUpdates"
@@ -2222,8 +2222,8 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request GetUserProfil
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/getUserProfilePhotos"
@@ -2316,8 +2316,8 @@ func (c *Client) LeaveChat(ctx context.Context, request LeaveChat) (res Result, 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/leaveChat"
@@ -2410,8 +2410,8 @@ func (c *Client) PinChatMessage(ctx context.Context, request PinChatMessage) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pinChatMessage"
@@ -2464,8 +2464,8 @@ func (c *Client) PromoteChatMember(ctx context.Context, request PromoteChatMembe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/promoteChatMember"
@@ -2518,8 +2518,8 @@ func (c *Client) RestrictChatMember(ctx context.Context, request RestrictChatMem
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/restrictChatMember"
@@ -2572,8 +2572,8 @@ func (c *Client) RevokeChatInviteLink(ctx context.Context, request RevokeChatInv
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/revokeChatInviteLink"
@@ -2634,8 +2634,8 @@ func (c *Client) SendAnimation(ctx context.Context, request SendAnimation) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendAnimation"
@@ -2696,8 +2696,8 @@ func (c *Client) SendAudio(ctx context.Context, request SendAudio) (res ResultMe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendAudio"
@@ -2750,8 +2750,8 @@ func (c *Client) SendChatAction(ctx context.Context, request SendChatAction) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendChatAction"
@@ -2812,8 +2812,8 @@ func (c *Client) SendContact(ctx context.Context, request SendContact) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendContact"
@@ -2874,8 +2874,8 @@ func (c *Client) SendDice(ctx context.Context, request SendDice) (res ResultMess
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendDice"
@@ -2936,8 +2936,8 @@ func (c *Client) SendDocument(ctx context.Context, request SendDocument) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendDocument"
@@ -2998,8 +2998,8 @@ func (c *Client) SendGame(ctx context.Context, request SendGame) (res ResultMess
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendGame"
@@ -3060,8 +3060,8 @@ func (c *Client) SendInvoice(ctx context.Context, request SendInvoice) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendInvoice"
@@ -3122,8 +3122,8 @@ func (c *Client) SendLocation(ctx context.Context, request SendLocation) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendLocation"
@@ -3184,8 +3184,8 @@ func (c *Client) SendMediaGroup(ctx context.Context, request SendMediaGroup) (re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendMediaGroup"
@@ -3246,8 +3246,8 @@ func (c *Client) SendMessage(ctx context.Context, request SendMessage) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendMessage"
@@ -3308,8 +3308,8 @@ func (c *Client) SendPhoto(ctx context.Context, request SendPhoto) (res ResultMe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendPhoto"
@@ -3370,8 +3370,8 @@ func (c *Client) SendPoll(ctx context.Context, request SendPoll) (res ResultMess
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendPoll"
@@ -3432,8 +3432,8 @@ func (c *Client) SendSticker(ctx context.Context, request SendSticker) (res Resu
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendSticker"
@@ -3494,8 +3494,8 @@ func (c *Client) SendVenue(ctx context.Context, request SendVenue) (res ResultMe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVenue"
@@ -3556,8 +3556,8 @@ func (c *Client) SendVideo(ctx context.Context, request SendVideo) (res ResultMe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVideo"
@@ -3618,8 +3618,8 @@ func (c *Client) SendVideoNote(ctx context.Context, request SendVideoNote) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVideoNote"
@@ -3680,8 +3680,8 @@ func (c *Client) SendVoice(ctx context.Context, request SendVoice) (res ResultMe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sendVoice"
@@ -3742,8 +3742,8 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request Se
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatAdministratorCustomTitle"
@@ -3804,8 +3804,8 @@ func (c *Client) SetChatDescription(ctx context.Context, request SetChatDescript
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatDescription"
@@ -3858,8 +3858,8 @@ func (c *Client) SetChatPermissions(ctx context.Context, request SetChatPermissi
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatPermissions"
@@ -3912,8 +3912,8 @@ func (c *Client) SetChatPhoto(ctx context.Context, request SetChatPhoto) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatPhoto"
@@ -3966,8 +3966,8 @@ func (c *Client) SetChatStickerSet(ctx context.Context, request SetChatStickerSe
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatStickerSet"
@@ -4028,8 +4028,8 @@ func (c *Client) SetChatTitle(ctx context.Context, request SetChatTitle) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setChatTitle"
@@ -4082,8 +4082,8 @@ func (c *Client) SetGameScore(ctx context.Context, request SetGameScore) (res Re
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setGameScore"
@@ -4144,8 +4144,8 @@ func (c *Client) SetMyCommands(ctx context.Context, request SetMyCommands) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setMyCommands"
@@ -4206,8 +4206,8 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request SetPassportD
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setPassportDataErrors"
@@ -4260,8 +4260,8 @@ func (c *Client) SetStickerPositionInSet(ctx context.Context, request SetSticker
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setStickerPositionInSet"
@@ -4314,8 +4314,8 @@ func (c *Client) SetStickerSetThumb(ctx context.Context, request SetStickerSetTh
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setStickerSetThumb"
@@ -4368,8 +4368,8 @@ func (c *Client) SetWebhook(ctx context.Context, request SetWebhook) (res Result
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/setWebhook"
@@ -4430,8 +4430,8 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request StopMessag
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/stopMessageLiveLocation"
@@ -4492,8 +4492,8 @@ func (c *Client) StopPoll(ctx context.Context, request StopPoll) (res ResultPoll
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/stopPoll"
@@ -4546,8 +4546,8 @@ func (c *Client) UnbanChatMember(ctx context.Context, request UnbanChatMember) (
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unbanChatMember"
@@ -4600,8 +4600,8 @@ func (c *Client) UnbanChatSenderChat(ctx context.Context, request UnbanChatSende
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unbanChatSenderChat"
@@ -4654,8 +4654,8 @@ func (c *Client) UnpinAllChatMessages(ctx context.Context, request UnpinAllChatM
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unpinAllChatMessages"
@@ -4708,8 +4708,8 @@ func (c *Client) UnpinChatMessage(ctx context.Context, request UnpinChatMessage)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/unpinChatMessage"
@@ -4762,8 +4762,8 @@ func (c *Client) UploadStickerFile(ctx context.Context, request UploadStickerFil
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/uploadStickerFile"

--- a/examples/ex_telegram/oas_req_enc_gen.go
+++ b/examples/ex_telegram/oas_req_enc_gen.go
@@ -64,1098 +64,630 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeAddStickerToSetRequestJSON(req AddStickerToSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAddStickerToSetRequestJSON(req AddStickerToSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerCallbackQueryRequestJSON(req AnswerCallbackQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerCallbackQueryRequestJSON(req AnswerCallbackQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerInlineQueryRequestJSON(req AnswerInlineQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerInlineQueryRequestJSON(req AnswerInlineQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerPreCheckoutQueryRequestJSON(req AnswerPreCheckoutQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerPreCheckoutQueryRequestJSON(req AnswerPreCheckoutQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeAnswerShippingQueryRequestJSON(req AnswerShippingQuery, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeAnswerShippingQueryRequestJSON(req AnswerShippingQuery, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeApproveChatJoinRequestRequestJSON(req ApproveChatJoinRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeApproveChatJoinRequestRequestJSON(req ApproveChatJoinRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeBanChatMemberRequestJSON(req BanChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeBanChatMemberRequestJSON(req BanChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeBanChatSenderChatRequestJSON(req BanChatSenderChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeBanChatSenderChatRequestJSON(req BanChatSenderChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCopyMessageRequestJSON(req CopyMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCopyMessageRequestJSON(req CopyMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreateChatInviteLinkRequestJSON(req CreateChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateChatInviteLinkRequestJSON(req CreateChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeCreateNewStickerSetRequestJSON(req CreateNewStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeCreateNewStickerSetRequestJSON(req CreateNewStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeclineChatJoinRequestRequestJSON(req DeclineChatJoinRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeclineChatJoinRequestRequestJSON(req DeclineChatJoinRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteChatPhotoRequestJSON(req DeleteChatPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteChatPhotoRequestJSON(req DeleteChatPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteChatStickerSetRequestJSON(req DeleteChatStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteChatStickerSetRequestJSON(req DeleteChatStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteMessageRequestJSON(req DeleteMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteMessageRequestJSON(req DeleteMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteMyCommandsRequestJSON(req OptDeleteMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteMyCommandsRequestJSON(req OptDeleteMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteStickerFromSetRequestJSON(req DeleteStickerFromSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteStickerFromSetRequestJSON(req DeleteStickerFromSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeDeleteWebhookRequestJSON(req OptDeleteWebhook, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDeleteWebhookRequestJSON(req OptDeleteWebhook, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditChatInviteLinkRequestJSON(req EditChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditChatInviteLinkRequestJSON(req EditChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageCaptionRequestJSON(req EditMessageCaption, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageCaptionRequestJSON(req EditMessageCaption, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageLiveLocationRequestJSON(req EditMessageLiveLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageLiveLocationRequestJSON(req EditMessageLiveLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageMediaRequestJSON(req EditMessageMedia, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageMediaRequestJSON(req EditMessageMedia, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageReplyMarkupRequestJSON(req EditMessageReplyMarkup, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageReplyMarkupRequestJSON(req EditMessageReplyMarkup, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeEditMessageTextRequestJSON(req EditMessageText, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeEditMessageTextRequestJSON(req EditMessageText, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeExportChatInviteLinkRequestJSON(req ExportChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeExportChatInviteLinkRequestJSON(req ExportChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeForwardMessageRequestJSON(req ForwardMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeForwardMessageRequestJSON(req ForwardMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatRequestJSON(req GetChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatRequestJSON(req GetChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatAdministratorsRequestJSON(req GetChatAdministrators, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatAdministratorsRequestJSON(req GetChatAdministrators, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatMemberRequestJSON(req GetChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatMemberRequestJSON(req GetChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetChatMemberCountRequestJSON(req GetChatMemberCount, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetChatMemberCountRequestJSON(req GetChatMemberCount, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetFileRequestJSON(req GetFile, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetFileRequestJSON(req GetFile, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetGameHighScoresRequestJSON(req GetGameHighScores, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetGameHighScoresRequestJSON(req GetGameHighScores, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetMyCommandsRequestJSON(req OptGetMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetMyCommandsRequestJSON(req OptGetMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetStickerSetRequestJSON(req GetStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetStickerSetRequestJSON(req GetStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetUpdatesRequestJSON(req OptGetUpdates, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetUpdatesRequestJSON(req OptGetUpdates, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeGetUserProfilePhotosRequestJSON(req GetUserProfilePhotos, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeGetUserProfilePhotosRequestJSON(req GetUserProfilePhotos, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeLeaveChatRequestJSON(req LeaveChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeLeaveChatRequestJSON(req LeaveChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePinChatMessageRequestJSON(req PinChatMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePinChatMessageRequestJSON(req PinChatMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePromoteChatMemberRequestJSON(req PromoteChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePromoteChatMemberRequestJSON(req PromoteChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeRestrictChatMemberRequestJSON(req RestrictChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeRestrictChatMemberRequestJSON(req RestrictChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeRevokeChatInviteLinkRequestJSON(req RevokeChatInviteLink, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeRevokeChatInviteLinkRequestJSON(req RevokeChatInviteLink, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendAnimationRequestJSON(req SendAnimation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendAnimationRequestJSON(req SendAnimation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendAudioRequestJSON(req SendAudio, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendAudioRequestJSON(req SendAudio, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendChatActionRequestJSON(req SendChatAction, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendChatActionRequestJSON(req SendChatAction, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendContactRequestJSON(req SendContact, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendContactRequestJSON(req SendContact, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendDiceRequestJSON(req SendDice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendDiceRequestJSON(req SendDice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendDocumentRequestJSON(req SendDocument, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendDocumentRequestJSON(req SendDocument, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendGameRequestJSON(req SendGame, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendGameRequestJSON(req SendGame, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendInvoiceRequestJSON(req SendInvoice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendInvoiceRequestJSON(req SendInvoice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendLocationRequestJSON(req SendLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendLocationRequestJSON(req SendLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendMediaGroupRequestJSON(req SendMediaGroup, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendMediaGroupRequestJSON(req SendMediaGroup, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendMessageRequestJSON(req SendMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendMessageRequestJSON(req SendMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendPhotoRequestJSON(req SendPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendPhotoRequestJSON(req SendPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendPollRequestJSON(req SendPoll, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendPollRequestJSON(req SendPoll, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendStickerRequestJSON(req SendSticker, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendStickerRequestJSON(req SendSticker, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVenueRequestJSON(req SendVenue, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVenueRequestJSON(req SendVenue, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVideoRequestJSON(req SendVideo, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVideoRequestJSON(req SendVideo, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVideoNoteRequestJSON(req SendVideoNote, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVideoNoteRequestJSON(req SendVideoNote, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSendVoiceRequestJSON(req SendVoice, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSendVoiceRequestJSON(req SendVoice, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatAdministratorCustomTitleRequestJSON(req SetChatAdministratorCustomTitle, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatAdministratorCustomTitleRequestJSON(req SetChatAdministratorCustomTitle, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatDescriptionRequestJSON(req SetChatDescription, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatDescriptionRequestJSON(req SetChatDescription, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatPermissionsRequestJSON(req SetChatPermissions, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatPermissionsRequestJSON(req SetChatPermissions, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatPhotoRequestJSON(req SetChatPhoto, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatPhotoRequestJSON(req SetChatPhoto, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatStickerSetRequestJSON(req SetChatStickerSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatStickerSetRequestJSON(req SetChatStickerSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetChatTitleRequestJSON(req SetChatTitle, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetChatTitleRequestJSON(req SetChatTitle, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetGameScoreRequestJSON(req SetGameScore, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetGameScoreRequestJSON(req SetGameScore, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetMyCommandsRequestJSON(req SetMyCommands, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetMyCommandsRequestJSON(req SetMyCommands, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetPassportDataErrorsRequestJSON(req SetPassportDataErrors, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetPassportDataErrorsRequestJSON(req SetPassportDataErrors, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetStickerPositionInSetRequestJSON(req SetStickerPositionInSet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetStickerPositionInSetRequestJSON(req SetStickerPositionInSet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetStickerSetThumbRequestJSON(req SetStickerSetThumb, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetStickerSetThumbRequestJSON(req SetStickerSetThumb, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSetWebhookRequestJSON(req SetWebhook, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSetWebhookRequestJSON(req SetWebhook, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeStopMessageLiveLocationRequestJSON(req StopMessageLiveLocation, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeStopMessageLiveLocationRequestJSON(req StopMessageLiveLocation, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeStopPollRequestJSON(req StopPoll, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeStopPollRequestJSON(req StopPoll, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnbanChatMemberRequestJSON(req UnbanChatMember, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnbanChatMemberRequestJSON(req UnbanChatMember, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnbanChatSenderChatRequestJSON(req UnbanChatSenderChat, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnbanChatSenderChatRequestJSON(req UnbanChatSenderChat, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnpinAllChatMessagesRequestJSON(req UnpinAllChatMessages, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnpinAllChatMessagesRequestJSON(req UnpinAllChatMessages, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUnpinChatMessageRequestJSON(req UnpinChatMessage, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUnpinChatMessageRequestJSON(req UnpinChatMessage, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeUploadStickerFileRequestJSON(req UploadStickerFile, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeUploadStickerFileRequestJSON(req UploadStickerFile, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }

--- a/examples/ex_tinkoff/oas_client_gen.go
+++ b/examples/ex_tinkoff/oas_client_gen.go
@@ -788,8 +788,8 @@ func (c *Client) OrdersLimitOrderPost(ctx context.Context, request LimitOrderReq
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orders/limit-order"
@@ -881,8 +881,8 @@ func (c *Client) OrdersMarketOrderPost(ctx context.Context, request MarketOrderR
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/orders/market-order"
@@ -1148,8 +1148,8 @@ func (c *Client) SandboxCurrenciesBalancePost(ctx context.Context, request Sandb
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sandbox/currencies/balance"
@@ -1228,8 +1228,8 @@ func (c *Client) SandboxPositionsBalancePost(ctx context.Context, request Sandbo
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sandbox/positions/balance"
@@ -1316,8 +1316,8 @@ func (c *Client) SandboxRegisterPost(ctx context.Context, request OptSandboxRegi
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/sandbox/register"

--- a/examples/ex_tinkoff/oas_req_enc_gen.go
+++ b/examples/ex_tinkoff/oas_req_enc_gen.go
@@ -64,73 +64,43 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeOrdersLimitOrderPostRequestJSON(req LimitOrderRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrdersLimitOrderPostRequestJSON(req LimitOrderRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeOrdersMarketOrderPostRequestJSON(req MarketOrderRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeOrdersMarketOrderPostRequestJSON(req MarketOrderRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSandboxCurrenciesBalancePostRequestJSON(req SandboxSetCurrencyBalanceRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSandboxCurrenciesBalancePostRequestJSON(req SandboxSetCurrencyBalanceRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSandboxPositionsBalancePostRequestJSON(req SandboxSetPositionBalanceRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSandboxPositionsBalancePostRequestJSON(req SandboxSetPositionBalanceRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 
 	req.Encode(e)
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodeSandboxRegisterPostRequestJSON(req OptSandboxRegisterRequest, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeSandboxRegisterPostRequestJSON(req OptSandboxRegisterRequest, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }

--- a/gen/_template/client.tmpl
+++ b/gen/_template/client.tmpl
@@ -96,15 +96,17 @@ func (c *Client) {{ $op.Name }}(ctx context.Context {{ if $op.Request }}, reques
 	{{- $requestsLength := len $op.Request.Contents }}
 	{{- if eq $requestsLength 1 }}
 	{{- range $contentType, $type := $op.Request.Contents }}
-	contentType = "{{$contentType}}"
-	buf, err := encode{{ $op.Name }}Request{{ $contentType.Name }}(request, span)
-	if err != nil {
-		return res, err
-	}
-	{{- if $contentType.JSON }}
-	defer putBuf(buf)
-	{{- end }}
-	reqBody = buf
+		contentType = "{{$contentType}}"
+		buf, err := encode{{ $op.Name }}Request{{ $contentType.Name }}(request, span)
+		if err != nil {
+			return res, err
+		}
+		{{- if $contentType.JSON }}
+		defer jx.PutWriter(buf)
+		reqBody = bytes.NewReader(buf.Buf)
+		{{- else }}
+		reqBody = buf
+		{{- end }}
 	{{- end }}
 	{{- else }}
 	{{- /* Multiple requests */}}
@@ -117,9 +119,11 @@ func (c *Client) {{ $op.Name }}(ctx context.Context {{ if $op.Request }}, reques
 			return res, err
 		}
 		{{- if $contentType.JSON }}
-		defer putBuf(buf)
-		{{- end }}
+		defer jx.PutWriter(buf)
+		reqBody = bytes.NewReader(buf.Buf)
+		{{- else }}
 		reqBody = buf
+		{{- end }}
 	{{- end }}
 	default:
 		return nil, "", errors.Errorf("unexpected request type: %T", req)

--- a/gen/_template/req_enc.tmpl
+++ b/gen/_template/req_enc.tmpl
@@ -1,12 +1,6 @@
 {{ define "req_json/enc"}}
-buf := getBuf()
 e := jx.GetWriter()
-defer jx.PutWriter(e)
 {{ template "json/enc" req_enc_elem $ }}
-if _, err := e.WriteTo(buf); err != nil {
-	putBuf(buf)
-	return nil, err
-}
 {{ end }}
 
 {{- /*gotype: github.com/ogen-go/ogen/gen.TemplateConfig*/ -}}
@@ -23,7 +17,7 @@ func encode{{ $op.Name }}Request{{ $contentType.Name }}(req {{ $op.Request.Type.
 	return req, nil
 	{{- else if $contentType.JSON }}
 	{{- template "req_json/enc" $type }}
-	return buf, nil
+	return e, nil
 	{{- else }}
 	return nil, errors.New(`{{ $contentType }} encoder not implemented`)
 	{{- end }}

--- a/internal/ir/operation.go
+++ b/internal/ir/operation.go
@@ -63,7 +63,7 @@ func (t ContentType) OctetStream() bool { return t == ContentTypeOctetStream }
 func (t ContentType) EncodedDataTypeGo() string {
 	switch t {
 	case ContentTypeJSON:
-		return "*bytes.Buffer"
+		return "*jx.Writer"
 	case ContentTypeOctetStream:
 		return "io.Reader"
 	default:

--- a/internal/sample_api/oas_client_gen.go
+++ b/internal/sample_api/oas_client_gen.go
@@ -363,8 +363,8 @@ func (c *Client) FoobarPost(ctx context.Context, request OptPet) (res FoobarPost
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/foobar"
@@ -526,8 +526,8 @@ func (c *Client) PetCreate(ctx context.Context, request OptPet) (res Pet, err er
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pet"
@@ -927,8 +927,8 @@ func (c *Client) PetUpdateNameAliasPost(ctx context.Context, request OptPetName)
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pet/updateNameAlias"
@@ -1004,8 +1004,8 @@ func (c *Client) PetUpdateNamePost(ctx context.Context, request OptString) (res 
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/pet/updateName"

--- a/internal/sample_api/oas_req_enc_gen.go
+++ b/internal/sample_api/oas_req_enc_gen.go
@@ -64,64 +64,40 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeFoobarPostRequestJSON(req OptPet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeFoobarPostRequestJSON(req OptPet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePetCreateRequestJSON(req OptPet, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePetCreateRequestJSON(req OptPet, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePetUpdateNameAliasPostRequestJSON(req OptPetName, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePetUpdateNameAliasPostRequestJSON(req OptPetName, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
-func encodePetUpdateNamePostRequestJSON(req OptString, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodePetUpdateNamePostRequestJSON(req OptString, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }
 
 func encodePetUploadAvatarByIDRequestOctetStream(req Stream, span trace.Span) (data io.Reader, err error) {

--- a/internal/sample_err/oas_client_gen.go
+++ b/internal/sample_err/oas_client_gen.go
@@ -124,8 +124,8 @@ func (c *Client) DataCreate(ctx context.Context, request OptData) (res Data, err
 	if err != nil {
 		return res, err
 	}
-	defer putBuf(buf)
-	reqBody = buf
+	defer jx.PutWriter(buf)
+	reqBody = bytes.NewReader(buf.Buf)
 
 	u := uri.Clone(c.serverURL)
 	u.Path += "/data"

--- a/internal/sample_err/oas_req_enc_gen.go
+++ b/internal/sample_err/oas_req_enc_gen.go
@@ -64,17 +64,11 @@ var (
 	_ = sync.Pool{}
 )
 
-func encodeDataCreateRequestJSON(req OptData, span trace.Span) (data *bytes.Buffer, err error) {
-	buf := getBuf()
+func encodeDataCreateRequestJSON(req OptData, span trace.Span) (data *jx.Writer, err error) {
 	e := jx.GetWriter()
-	defer jx.PutWriter(e)
 	if req.Set {
 		req.Encode(e)
 	}
-	if _, err := e.WriteTo(buf); err != nil {
-		putBuf(buf)
-		return nil, err
-	}
 
-	return buf, nil
+	return e, nil
 }


### PR DESCRIPTION
Encoder still allocates bytes.Reader, however allocating a small struct is better
rather than allocating large buffer with encoded JSON

Fixes #123.