### PR TITLE
fix(gen): match parent/{param}/child routes

### DIFF
--- a/_testdata/sample.json
+++ b/_testdata/sample.json
@@ -279,6 +279,37 @@
         }
       }
     },
+    "/pet/{name}/avatar": {
+      "get": {
+        "description": "Returns pet's avatar by name",
+        "operationId": "petGetAvatarByName",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of pet",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A pet avatar",
+            "content": {
+              "application/octet-stream": {}
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/foobar": {
       "get": {
         "description": "Dumb endpoint for testing things",

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -135,6 +135,12 @@ func (s *sampleAPIServer) PetGetByName(ctx context.Context, params api.PetGetByN
 	return s.pet, nil
 }
 
+func (s *sampleAPIServer) PetGetAvatarByName(ctx context.Context, params api.PetGetAvatarByNameParams) (api.PetGetAvatarByNameRes, error) {
+	return &api.PetGetAvatarByNameOK{
+		Data: bytes.NewReader(petAvatar),
+	}, nil
+}
+
 func (s *sampleAPIServer) PetGetAvatarByID(ctx context.Context, params api.PetGetAvatarByIDParams) (api.PetGetAvatarByIDRes, error) {
 	switch params.PetID {
 	case petNotFoundID:

--- a/gen/_template/router.tmpl
+++ b/gen/_template/router.tmpl
@@ -118,11 +118,12 @@ s.handle{{ $.Name }}Request([{{ $.PathParamsCount }}]string{
 			// Match until one of {{ quote $tails }}
 			idx := strings.IndexAny(elem, {{ quote $tails }})
 			{{- end }}
-			if idx > 0 {
-				args[{{ $.ParameterIndex }}] = elem[:idx]
-				elem = elem[idx:]
-				{{ template "route_edge" router_elem $c $.ParameterIndex }}
+			if (idx < 0) {
+				idx = len(elem)
 			}
+			args[{{ $.ParameterIndex }}] = elem[:idx]
+			elem = elem[idx:]
+			{{ template "route_edge" router_elem $c $.ParameterIndex }}
 			{{- else }}
 			// Leaf parameter
 			args[{{ $.ParameterIndex }}] = elem
@@ -182,11 +183,12 @@ s.handle{{ $.Name }}Request([{{ $.PathParamsCount }}]string{
 			// Match until one of {{ quote $tails }}
 			idx := strings.IndexAny(elem, {{ quote $tails }})
 			{{- end }}
-			if idx > 0 {
-				args[{{ $.ParameterIndex }}] = elem[:idx]
-				elem = elem[idx:]
-				{{ template "find_edge" router_elem $c $.ParameterIndex }}
+			if (idx < 0) {
+				idx = len(elem)
 			}
+			args[{{ $.ParameterIndex }}] = elem[:idx]
+			elem = elem[idx:]
+			{{ template "find_edge" router_elem $c $.ParameterIndex }}
 			{{- else }}
 			// Leaf parameter
 			args[{{ $.ParameterIndex }}] = elem

--- a/internal/sample_api/oas_handlers_gen.go
+++ b/internal/sample_api/oas_handlers_gen.go
@@ -370,6 +370,35 @@ func (s *Server) handlePetGetAvatarByIDRequest(args [0]string, w http.ResponseWr
 	}
 }
 
+// HandlePetGetAvatarByNameRequest handles petGetAvatarByName operation.
+//
+// GET /pet/{name}/avatar
+func (s *Server) handlePetGetAvatarByNameRequest(args [1]string, w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "PetGetAvatarByName",
+		trace.WithAttributes(otelogen.OperationID("petGetAvatarByName")),
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
+	defer span.End()
+	params, err := decodePetGetAvatarByNameParams(args, r)
+	if err != nil {
+		span.RecordError(err)
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	response, err := s.h.PetGetAvatarByName(ctx, params)
+	if err != nil {
+		span.RecordError(err)
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := encodePetGetAvatarByNameResponse(response, w, span); err != nil {
+		span.RecordError(err)
+		return
+	}
+}
+
 // HandlePetGetByNameRequest handles petGetByName operation.
 //
 // GET /pet/{name}

--- a/internal/sample_api/oas_interfaces_gen.go
+++ b/internal/sample_api/oas_interfaces_gen.go
@@ -13,6 +13,10 @@ type PetGetAvatarByIDRes interface {
 	petGetAvatarByIDRes()
 }
 
+type PetGetAvatarByNameRes interface {
+	petGetAvatarByNameRes()
+}
+
 type PetGetRes interface {
 	petGetRes()
 }

--- a/internal/sample_api/oas_param_dec_gen.go
+++ b/internal/sample_api/oas_param_dec_gen.go
@@ -562,6 +562,44 @@ func decodePetGetAvatarByIDParams(args [0]string, r *http.Request) (PetGetAvatar
 	return params, nil
 }
 
+func decodePetGetAvatarByNameParams(args [1]string, r *http.Request) (PetGetAvatarByNameParams, error) {
+	var (
+		params PetGetAvatarByNameParams
+	)
+	// Decode path: name.
+	{
+		param := args[0]
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "name",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				s, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(s)
+				if err != nil {
+					return err
+				}
+
+				params.Name = c
+				return nil
+			}(); err != nil {
+				return params, err
+			}
+		} else {
+			return params, errors.New("path: name: not specified")
+		}
+	}
+	return params, nil
+}
+
 func decodePetGetByNameParams(args [1]string, r *http.Request) (PetGetByNameParams, error) {
 	var (
 		params PetGetByNameParams

--- a/internal/sample_api/oas_param_gen.go
+++ b/internal/sample_api/oas_param_gen.go
@@ -104,6 +104,11 @@ type PetGetAvatarByIDParams struct {
 	PetID int64
 }
 
+type PetGetAvatarByNameParams struct {
+	// Name of pet.
+	Name string
+}
+
 type PetGetByNameParams struct {
 	// Name of pet.
 	Name string

--- a/internal/sample_api/oas_res_dec_gen.go
+++ b/internal/sample_api/oas_res_dec_gen.go
@@ -477,6 +477,56 @@ func decodePetGetAvatarByIDResponse(resp *http.Response, span trace.Span) (res P
 	}
 }
 
+func decodePetGetAvatarByNameResponse(resp *http.Response, span trace.Span) (res PetGetAvatarByNameRes, err error) {
+	switch resp.StatusCode {
+	case 200:
+		switch ct := resp.Header.Get("Content-Type"); ct {
+		case "application/octet-stream":
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			return &PetGetAvatarByNameOK{
+				Data: bytes.NewReader(b),
+			}, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		return &NotFound{}, nil
+	default:
+		switch ct := resp.Header.Get("Content-Type"); ct {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &ErrorStatusCode{
+				StatusCode: resp.StatusCode,
+				Response:   response,
+			}, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+}
+
 func decodePetGetByNameResponse(resp *http.Response, span trace.Span) (res Pet, err error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/sample_api/oas_router_gen.go
+++ b/internal/sample_api/oas_router_gen.go
@@ -133,95 +133,99 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// Param: "id"
 				// Match until "/"
 				idx := strings.IndexByte(elem, '/')
-				if idx > 0 {
-					args[0] = elem[:idx]
+				if idx < 0 {
+					idx = len(elem)
+				}
+				args[0] = elem[:idx]
+				elem = elem[idx:]
+
+				if len(elem) == 0 {
+					break
+				}
+				switch elem[0] {
+				case '/': // Prefix: "/"
+					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
+						elem = elem[l:]
+					} else {
+						break
+					}
+
+					// Param: "foo"
+					// Match until "1"
+					idx := strings.IndexByte(elem, '1')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[1] = elem[:idx]
 					elem = elem[idx:]
 
 					if len(elem) == 0 {
 						break
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/"
-						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
+					case '1': // Prefix: "1234"
+						if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
-						// Param: "foo"
-						// Match until "1"
-						idx := strings.IndexByte(elem, '1')
-						if idx > 0 {
-							args[1] = elem[:idx]
+						// Param: "bar"
+						// Match until "-"
+						idx := strings.IndexByte(elem, '-')
+						if idx < 0 {
+							idx = len(elem)
+						}
+						args[2] = elem[:idx]
+						elem = elem[idx:]
+
+						if len(elem) == 0 {
+							break
+						}
+						switch elem[0] {
+						case '-': // Prefix: "-"
+							if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							// Param: "baz"
+							// Match until "!"
+							idx := strings.IndexByte(elem, '!')
+							if idx < 0 {
+								idx = len(elem)
+							}
+							args[3] = elem[:idx]
 							elem = elem[idx:]
 
 							if len(elem) == 0 {
 								break
 							}
 							switch elem[0] {
-							case '1': // Prefix: "1234"
-								if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
+							case '!': // Prefix: "!"
+								if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 									elem = elem[l:]
 								} else {
 									break
 								}
 
-								// Param: "bar"
-								// Match until "-"
-								idx := strings.IndexByte(elem, '-')
-								if idx > 0 {
-									args[2] = elem[:idx]
-									elem = elem[idx:]
+								// Param: "kek"
+								// Leaf parameter
+								args[4] = elem
+								elem = ""
 
-									if len(elem) == 0 {
-										break
-									}
-									switch elem[0] {
-									case '-': // Prefix: "-"
-										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
-											elem = elem[l:]
-										} else {
-											break
-										}
+								if len(elem) == 0 {
+									// Leaf: DataGetFormat
+									s.handleDataGetFormatRequest([5]string{
+										args[0],
+										args[1],
+										args[2],
+										args[3],
+										args[4],
+									}, w, r)
 
-										// Param: "baz"
-										// Match until "!"
-										idx := strings.IndexByte(elem, '!')
-										if idx > 0 {
-											args[3] = elem[:idx]
-											elem = elem[idx:]
-
-											if len(elem) == 0 {
-												break
-											}
-											switch elem[0] {
-											case '!': // Prefix: "!"
-												if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
-													elem = elem[l:]
-												} else {
-													break
-												}
-
-												// Param: "kek"
-												// Leaf parameter
-												args[4] = elem
-												elem = ""
-
-												if len(elem) == 0 {
-													// Leaf: DataGetFormat
-													s.handleDataGetFormatRequest([5]string{
-														args[0],
-														args[1],
-														args[2],
-														args[3],
-														args[4],
-													}, w, r)
-
-													return
-												}
-											}
-										}
-									}
+									return
 								}
 							}
 						}
@@ -308,17 +312,37 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 					// Param: "name"
-					// Leaf parameter
-					args[0] = elem
-					elem = ""
+					// Match until "/"
+					idx := strings.IndexByte(elem, '/')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[0] = elem[:idx]
+					elem = elem[idx:]
 
 					if len(elem) == 0 {
-						// Leaf: PetGetByName
 						s.handlePetGetByNameRequest([1]string{
 							args[0],
 						}, w, r)
 
 						return
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/avatar"
+						if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf: PetGetAvatarByName
+							s.handlePetGetAvatarByNameRequest([1]string{
+								args[0],
+							}, w, r)
+
+							return
+						}
 					}
 				}
 			case 'r': // Prefix: "recursiveMap"
@@ -597,90 +621,94 @@ func (s *Server) FindRoute(method, path string) (r Route, _ bool) {
 				// Param: "id"
 				// Match until "/"
 				idx := strings.IndexByte(elem, '/')
-				if idx > 0 {
-					args[0] = elem[:idx]
+				if idx < 0 {
+					idx = len(elem)
+				}
+				args[0] = elem[:idx]
+				elem = elem[idx:]
+
+				if len(elem) == 0 {
+					break
+				}
+				switch elem[0] {
+				case '/': // Prefix: "/"
+					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
+						elem = elem[l:]
+					} else {
+						break
+					}
+
+					// Param: "foo"
+					// Match until "1"
+					idx := strings.IndexByte(elem, '1')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[1] = elem[:idx]
 					elem = elem[idx:]
 
 					if len(elem) == 0 {
 						break
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/"
-						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
+					case '1': // Prefix: "1234"
+						if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
-						// Param: "foo"
-						// Match until "1"
-						idx := strings.IndexByte(elem, '1')
-						if idx > 0 {
-							args[1] = elem[:idx]
+						// Param: "bar"
+						// Match until "-"
+						idx := strings.IndexByte(elem, '-')
+						if idx < 0 {
+							idx = len(elem)
+						}
+						args[2] = elem[:idx]
+						elem = elem[idx:]
+
+						if len(elem) == 0 {
+							break
+						}
+						switch elem[0] {
+						case '-': // Prefix: "-"
+							if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							// Param: "baz"
+							// Match until "!"
+							idx := strings.IndexByte(elem, '!')
+							if idx < 0 {
+								idx = len(elem)
+							}
+							args[3] = elem[:idx]
 							elem = elem[idx:]
 
 							if len(elem) == 0 {
 								break
 							}
 							switch elem[0] {
-							case '1': // Prefix: "1234"
-								if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
+							case '!': // Prefix: "!"
+								if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 									elem = elem[l:]
 								} else {
 									break
 								}
 
-								// Param: "bar"
-								// Match until "-"
-								idx := strings.IndexByte(elem, '-')
-								if idx > 0 {
-									args[2] = elem[:idx]
-									elem = elem[idx:]
+								// Param: "kek"
+								// Leaf parameter
+								args[4] = elem
+								elem = ""
 
-									if len(elem) == 0 {
-										break
-									}
-									switch elem[0] {
-									case '-': // Prefix: "-"
-										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
-											elem = elem[l:]
-										} else {
-											break
-										}
-
-										// Param: "baz"
-										// Match until "!"
-										idx := strings.IndexByte(elem, '!')
-										if idx > 0 {
-											args[3] = elem[:idx]
-											elem = elem[idx:]
-
-											if len(elem) == 0 {
-												break
-											}
-											switch elem[0] {
-											case '!': // Prefix: "!"
-												if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
-													elem = elem[l:]
-												} else {
-													break
-												}
-
-												// Param: "kek"
-												// Leaf parameter
-												args[4] = elem
-												elem = ""
-
-												if len(elem) == 0 {
-													// Leaf: DataGetFormat
-													r.name = "DataGetFormat"
-													r.args = args
-													r.count = 5
-													return r, true
-												}
-											}
-										}
-									}
+								if len(elem) == 0 {
+									// Leaf: DataGetFormat
+									r.name = "DataGetFormat"
+									r.args = args
+									r.count = 5
+									return r, true
 								}
 							}
 						}
@@ -768,16 +796,35 @@ func (s *Server) FindRoute(method, path string) (r Route, _ bool) {
 						}
 					}
 					// Param: "name"
-					// Leaf parameter
-					args[0] = elem
-					elem = ""
+					// Match until "/"
+					idx := strings.IndexByte(elem, '/')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[0] = elem[:idx]
+					elem = elem[idx:]
 
 					if len(elem) == 0 {
-						// Leaf: PetGetByName
 						r.name = "PetGetByName"
 						r.args = args
 						r.count = 1
 						return r, true
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/avatar"
+						if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf: PetGetAvatarByName
+							r.name = "PetGetAvatarByName"
+							r.args = args
+							r.count = 1
+							return r, true
+						}
 					}
 				}
 			case 'r': // Prefix: "recursiveMap"

--- a/internal/sample_api/oas_schemas_gen.go
+++ b/internal/sample_api/oas_schemas_gen.go
@@ -257,6 +257,7 @@ type ErrorStatusCode struct {
 
 func (*ErrorStatusCode) foobarPostRes()          {}
 func (*ErrorStatusCode) petGetAvatarByIDRes()    {}
+func (*ErrorStatusCode) petGetAvatarByNameRes()  {}
 func (*ErrorStatusCode) petUploadAvatarByIDRes() {}
 
 // FoobarPutDef is default response for FoobarPut operation.
@@ -620,6 +621,7 @@ type NotFound struct{}
 func (*NotFound) foobarGetRes()           {}
 func (*NotFound) foobarPostRes()          {}
 func (*NotFound) petGetAvatarByIDRes()    {}
+func (*NotFound) petGetAvatarByNameRes()  {}
 func (*NotFound) petUploadAvatarByIDRes() {}
 
 // Ref: #/components/schemas/NullableEnums
@@ -2009,6 +2011,16 @@ func (s PetGetAvatarByIDOK) Read(p []byte) (n int, err error) {
 }
 
 func (*PetGetAvatarByIDOK) petGetAvatarByIDRes() {}
+
+type PetGetAvatarByNameOK struct {
+	Data io.Reader
+}
+
+func (s PetGetAvatarByNameOK) Read(p []byte) (n int, err error) {
+	return s.Data.Read(p)
+}
+
+func (*PetGetAvatarByNameOK) petGetAvatarByNameRes() {}
 
 type PetGetDef struct {
 	Message string `json:"message"`

--- a/internal/sample_api/oas_server_gen.go
+++ b/internal/sample_api/oas_server_gen.go
@@ -128,6 +128,12 @@ type Handler interface {
 	//
 	// GET /pet/avatar
 	PetGetAvatarByID(ctx context.Context, params PetGetAvatarByIDParams) (PetGetAvatarByIDRes, error)
+	// PetGetAvatarByName implements petGetAvatarByName operation.
+	//
+	// Returns pet's avatar by name.
+	//
+	// GET /pet/{name}/avatar
+	PetGetAvatarByName(ctx context.Context, params PetGetAvatarByNameParams) (PetGetAvatarByNameRes, error)
 	// PetGetByName implements petGetByName operation.
 	//
 	// Returns pet by name from the system that the user has access to.

--- a/router_test.go
+++ b/router_test.go
@@ -47,6 +47,7 @@ func TestRouter(t *testing.T) {
 		get("/pet/avatar", "PetGetAvatarByID"),
 		post("/pet/avatar", "PetUploadAvatarByID"),
 		get("/pet/aboba", "PetGetByName", "aboba"),
+		get("/pet/aboba/avatar", "PetGetAvatarByName", "aboba"),
 		get("/foobar", "FoobarGet"),
 		post("/foobar", "FoobarPost"),
 		put("/foobar", "FoobarPut"),


### PR DESCRIPTION
For a scheme with defined routes like:
```
/parent/{param}
/parent/{param}/child
```
it is not possible to retrieve the parameter just by finding the index
of tail (/), because its absence is anticipated. If there is no
corresponding tail in the route element, it means a route with a
dangling parameter.