### PR TITLE
Respect response status as otel span's one

### DIFF
--- a/examples/ex_ent/oas_handlers_gen.go
+++ b/examples/ex_ent/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleCreatePetRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -154,7 +153,6 @@ func (s *Server) handleCreatePetCategoriesRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -201,7 +199,6 @@ func (s *Server) handleCreatePetFriendsRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -248,7 +245,6 @@ func (s *Server) handleCreatePetOwnerRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -290,7 +286,6 @@ func (s *Server) handleDeletePetRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -332,7 +327,6 @@ func (s *Server) handleDeletePetOwnerRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -374,7 +368,6 @@ func (s *Server) handleListPetRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -416,7 +409,6 @@ func (s *Server) handleListPetCategoriesRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -458,7 +450,6 @@ func (s *Server) handleListPetFriendsRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -500,7 +491,6 @@ func (s *Server) handleReadPetRequest(args [1]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -542,7 +532,6 @@ func (s *Server) handleReadPetOwnerRequest(args [1]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -589,7 +578,6 @@ func (s *Server) handleUpdatePetRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_ent/oas_res_enc_gen.go
+++ b/examples/ex_ent/oas_res_enc_gen.go
@@ -75,6 +75,7 @@ func encodeCreatePetResponse(response CreatePetRes, w http.ResponseWriter, span 
 	case *PetCreate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeCreatePetResponse(response CreatePetRes, w http.ResponseWriter, span 
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -99,6 +101,7 @@ func encodeCreatePetResponse(response CreatePetRes, w http.ResponseWriter, span 
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -111,6 +114,7 @@ func encodeCreatePetResponse(response CreatePetRes, w http.ResponseWriter, span 
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -130,6 +134,7 @@ func encodeCreatePetCategoriesResponse(response CreatePetCategoriesRes, w http.R
 	case *PetCategoriesCreate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -142,6 +147,7 @@ func encodeCreatePetCategoriesResponse(response CreatePetCategoriesRes, w http.R
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -154,6 +160,7 @@ func encodeCreatePetCategoriesResponse(response CreatePetCategoriesRes, w http.R
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -166,6 +173,7 @@ func encodeCreatePetCategoriesResponse(response CreatePetCategoriesRes, w http.R
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -185,6 +193,7 @@ func encodeCreatePetFriendsResponse(response CreatePetFriendsRes, w http.Respons
 	case *PetFriendsCreate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -197,6 +206,7 @@ func encodeCreatePetFriendsResponse(response CreatePetFriendsRes, w http.Respons
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -209,6 +219,7 @@ func encodeCreatePetFriendsResponse(response CreatePetFriendsRes, w http.Respons
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -221,6 +232,7 @@ func encodeCreatePetFriendsResponse(response CreatePetFriendsRes, w http.Respons
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -240,6 +252,7 @@ func encodeCreatePetOwnerResponse(response CreatePetOwnerRes, w http.ResponseWri
 	case *PetOwnerCreate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -252,6 +265,7 @@ func encodeCreatePetOwnerResponse(response CreatePetOwnerRes, w http.ResponseWri
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -264,6 +278,7 @@ func encodeCreatePetOwnerResponse(response CreatePetOwnerRes, w http.ResponseWri
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -276,6 +291,7 @@ func encodeCreatePetOwnerResponse(response CreatePetOwnerRes, w http.ResponseWri
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -294,10 +310,12 @@ func encodeDeletePetResponse(response DeletePetRes, w http.ResponseWriter, span 
 	switch response := response.(type) {
 	case *DeletePetNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -310,6 +328,7 @@ func encodeDeletePetResponse(response DeletePetRes, w http.ResponseWriter, span 
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -322,6 +341,7 @@ func encodeDeletePetResponse(response DeletePetRes, w http.ResponseWriter, span 
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -340,10 +360,12 @@ func encodeDeletePetOwnerResponse(response DeletePetOwnerRes, w http.ResponseWri
 	switch response := response.(type) {
 	case *DeletePetOwnerNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -356,6 +378,7 @@ func encodeDeletePetOwnerResponse(response DeletePetOwnerRes, w http.ResponseWri
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -368,6 +391,7 @@ func encodeDeletePetOwnerResponse(response DeletePetOwnerRes, w http.ResponseWri
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -387,6 +411,7 @@ func encodeListPetResponse(response ListPetRes, w http.ResponseWriter, span trac
 	case *ListPetOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -399,6 +424,7 @@ func encodeListPetResponse(response ListPetRes, w http.ResponseWriter, span trac
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -411,6 +437,7 @@ func encodeListPetResponse(response ListPetRes, w http.ResponseWriter, span trac
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -423,6 +450,7 @@ func encodeListPetResponse(response ListPetRes, w http.ResponseWriter, span trac
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -442,6 +470,7 @@ func encodeListPetCategoriesResponse(response ListPetCategoriesRes, w http.Respo
 	case *ListPetCategoriesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -454,6 +483,7 @@ func encodeListPetCategoriesResponse(response ListPetCategoriesRes, w http.Respo
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -466,6 +496,7 @@ func encodeListPetCategoriesResponse(response ListPetCategoriesRes, w http.Respo
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -478,6 +509,7 @@ func encodeListPetCategoriesResponse(response ListPetCategoriesRes, w http.Respo
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -497,6 +529,7 @@ func encodeListPetFriendsResponse(response ListPetFriendsRes, w http.ResponseWri
 	case *ListPetFriendsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -509,6 +542,7 @@ func encodeListPetFriendsResponse(response ListPetFriendsRes, w http.ResponseWri
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -521,6 +555,7 @@ func encodeListPetFriendsResponse(response ListPetFriendsRes, w http.ResponseWri
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -533,6 +568,7 @@ func encodeListPetFriendsResponse(response ListPetFriendsRes, w http.ResponseWri
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -552,6 +588,7 @@ func encodeReadPetResponse(response ReadPetRes, w http.ResponseWriter, span trac
 	case *PetRead:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -564,6 +601,7 @@ func encodeReadPetResponse(response ReadPetRes, w http.ResponseWriter, span trac
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -576,6 +614,7 @@ func encodeReadPetResponse(response ReadPetRes, w http.ResponseWriter, span trac
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -588,6 +627,7 @@ func encodeReadPetResponse(response ReadPetRes, w http.ResponseWriter, span trac
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -607,6 +647,7 @@ func encodeReadPetOwnerResponse(response ReadPetOwnerRes, w http.ResponseWriter,
 	case *PetOwnerRead:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -619,6 +660,7 @@ func encodeReadPetOwnerResponse(response ReadPetOwnerRes, w http.ResponseWriter,
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -631,6 +673,7 @@ func encodeReadPetOwnerResponse(response ReadPetOwnerRes, w http.ResponseWriter,
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -643,6 +686,7 @@ func encodeReadPetOwnerResponse(response ReadPetOwnerRes, w http.ResponseWriter,
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -662,6 +706,7 @@ func encodeUpdatePetResponse(response UpdatePetRes, w http.ResponseWriter, span 
 	case *PetUpdate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -674,6 +719,7 @@ func encodeUpdatePetResponse(response UpdatePetRes, w http.ResponseWriter, span 
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -686,6 +732,7 @@ func encodeUpdatePetResponse(response UpdatePetRes, w http.ResponseWriter, span 
 	case *R404:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -698,6 +745,7 @@ func encodeUpdatePetResponse(response UpdatePetRes, w http.ResponseWriter, span 
 	case *R500:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/examples/ex_firecracker/oas_handlers_gen.go
+++ b/examples/ex_firecracker/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleCreateSnapshotRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -149,7 +148,6 @@ func (s *Server) handleCreateSyncActionRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -186,7 +184,6 @@ func (s *Server) handleDescribeBalloonConfigRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -223,7 +220,6 @@ func (s *Server) handleDescribeBalloonStatsRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -260,7 +256,6 @@ func (s *Server) handleDescribeInstanceRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -297,7 +292,6 @@ func (s *Server) handleGetExportVmConfigRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -334,7 +328,6 @@ func (s *Server) handleGetMachineConfigurationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -376,7 +369,6 @@ func (s *Server) handleLoadSnapshotRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -416,7 +408,6 @@ func (s *Server) handleMmdsConfigPutRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -451,7 +442,6 @@ func (s *Server) handleMmdsGetRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -491,7 +481,6 @@ func (s *Server) handleMmdsPatchRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -531,7 +520,6 @@ func (s *Server) handleMmdsPutRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -573,7 +561,6 @@ func (s *Server) handlePatchBalloonRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -615,7 +602,6 @@ func (s *Server) handlePatchBalloonStatsIntervalRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -662,7 +648,6 @@ func (s *Server) handlePatchGuestDriveByIDRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -709,7 +694,6 @@ func (s *Server) handlePatchGuestNetworkInterfaceByIDRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -751,7 +735,6 @@ func (s *Server) handlePatchMachineConfigurationRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -793,7 +776,6 @@ func (s *Server) handlePatchVmRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -835,7 +817,6 @@ func (s *Server) handlePutBalloonRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -877,7 +858,6 @@ func (s *Server) handlePutGuestBootSourceRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -924,7 +904,6 @@ func (s *Server) handlePutGuestDriveByIDRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -971,7 +950,6 @@ func (s *Server) handlePutGuestNetworkInterfaceByIDRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1013,7 +991,6 @@ func (s *Server) handlePutGuestVsockRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1055,7 +1032,6 @@ func (s *Server) handlePutLoggerRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1097,7 +1073,6 @@ func (s *Server) handlePutMachineConfigurationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1139,7 +1114,6 @@ func (s *Server) handlePutMetricsRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_firecracker/oas_res_enc_gen.go
+++ b/examples/ex_firecracker/oas_res_enc_gen.go
@@ -74,10 +74,12 @@ func encodeCreateSnapshotResponse(response CreateSnapshotRes, w http.ResponseWri
 	switch response := response.(type) {
 	case *CreateSnapshotNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -90,6 +92,12 @@ func encodeCreateSnapshotResponse(response CreateSnapshotRes, w http.ResponseWri
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -108,10 +116,12 @@ func encodeCreateSyncActionResponse(response CreateSyncActionRes, w http.Respons
 	switch response := response.(type) {
 	case *CreateSyncActionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -124,6 +134,12 @@ func encodeCreateSyncActionResponse(response CreateSyncActionRes, w http.Respons
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -143,6 +159,7 @@ func encodeDescribeBalloonConfigResponse(response DescribeBalloonConfigRes, w ht
 	case *Balloon:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -155,6 +172,7 @@ func encodeDescribeBalloonConfigResponse(response DescribeBalloonConfigRes, w ht
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -167,6 +185,12 @@ func encodeDescribeBalloonConfigResponse(response DescribeBalloonConfigRes, w ht
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -186,6 +210,7 @@ func encodeDescribeBalloonStatsResponse(response DescribeBalloonStatsRes, w http
 	case *BalloonStats:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -198,6 +223,7 @@ func encodeDescribeBalloonStatsResponse(response DescribeBalloonStatsRes, w http
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -210,6 +236,12 @@ func encodeDescribeBalloonStatsResponse(response DescribeBalloonStatsRes, w http
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -229,6 +261,7 @@ func encodeDescribeInstanceResponse(response DescribeInstanceRes, w http.Respons
 	case *InstanceInfo:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -241,6 +274,12 @@ func encodeDescribeInstanceResponse(response DescribeInstanceRes, w http.Respons
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -260,6 +299,7 @@ func encodeGetExportVmConfigResponse(response GetExportVmConfigRes, w http.Respo
 	case *FullVmConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -272,6 +312,12 @@ func encodeGetExportVmConfigResponse(response GetExportVmConfigRes, w http.Respo
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -291,6 +337,7 @@ func encodeGetMachineConfigurationResponse(response GetMachineConfigurationRes, 
 	case *MachineConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -303,6 +350,12 @@ func encodeGetMachineConfigurationResponse(response GetMachineConfigurationRes, 
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -321,10 +374,12 @@ func encodeLoadSnapshotResponse(response LoadSnapshotRes, w http.ResponseWriter,
 	switch response := response.(type) {
 	case *LoadSnapshotNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -337,6 +392,12 @@ func encodeLoadSnapshotResponse(response LoadSnapshotRes, w http.ResponseWriter,
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -355,10 +416,12 @@ func encodeMmdsConfigPutResponse(response MmdsConfigPutRes, w http.ResponseWrite
 	switch response := response.(type) {
 	case *MmdsConfigPutNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -371,6 +434,12 @@ func encodeMmdsConfigPutResponse(response MmdsConfigPutRes, w http.ResponseWrite
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -390,6 +459,7 @@ func encodeMmdsGetResponse(response MmdsGetRes, w http.ResponseWriter, span trac
 	case *MmdsGetOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -402,6 +472,7 @@ func encodeMmdsGetResponse(response MmdsGetRes, w http.ResponseWriter, span trac
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -414,6 +485,12 @@ func encodeMmdsGetResponse(response MmdsGetRes, w http.ResponseWriter, span trac
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -432,10 +509,12 @@ func encodeMmdsPatchResponse(response MmdsPatchRes, w http.ResponseWriter, span 
 	switch response := response.(type) {
 	case *MmdsPatchNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -448,6 +527,12 @@ func encodeMmdsPatchResponse(response MmdsPatchRes, w http.ResponseWriter, span 
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -466,10 +551,12 @@ func encodeMmdsPutResponse(response MmdsPutRes, w http.ResponseWriter, span trac
 	switch response := response.(type) {
 	case *MmdsPutNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -482,6 +569,12 @@ func encodeMmdsPutResponse(response MmdsPutRes, w http.ResponseWriter, span trac
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -500,10 +593,12 @@ func encodePatchBalloonResponse(response PatchBalloonRes, w http.ResponseWriter,
 	switch response := response.(type) {
 	case *PatchBalloonNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -516,6 +611,12 @@ func encodePatchBalloonResponse(response PatchBalloonRes, w http.ResponseWriter,
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -534,10 +635,12 @@ func encodePatchBalloonStatsIntervalResponse(response PatchBalloonStatsIntervalR
 	switch response := response.(type) {
 	case *PatchBalloonStatsIntervalNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -550,6 +653,12 @@ func encodePatchBalloonStatsIntervalResponse(response PatchBalloonStatsIntervalR
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -568,10 +677,12 @@ func encodePatchGuestDriveByIDResponse(response PatchGuestDriveByIDRes, w http.R
 	switch response := response.(type) {
 	case *PatchGuestDriveByIDNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -584,6 +695,12 @@ func encodePatchGuestDriveByIDResponse(response PatchGuestDriveByIDRes, w http.R
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -602,10 +719,12 @@ func encodePatchGuestNetworkInterfaceByIDResponse(response PatchGuestNetworkInte
 	switch response := response.(type) {
 	case *PatchGuestNetworkInterfaceByIDNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -618,6 +737,12 @@ func encodePatchGuestNetworkInterfaceByIDResponse(response PatchGuestNetworkInte
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -636,10 +761,12 @@ func encodePatchMachineConfigurationResponse(response PatchMachineConfigurationR
 	switch response := response.(type) {
 	case *PatchMachineConfigurationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -652,6 +779,12 @@ func encodePatchMachineConfigurationResponse(response PatchMachineConfigurationR
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -670,10 +803,12 @@ func encodePatchVmResponse(response PatchVmRes, w http.ResponseWriter, span trac
 	switch response := response.(type) {
 	case *PatchVmNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -686,6 +821,12 @@ func encodePatchVmResponse(response PatchVmRes, w http.ResponseWriter, span trac
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -704,10 +845,12 @@ func encodePutBalloonResponse(response PutBalloonRes, w http.ResponseWriter, spa
 	switch response := response.(type) {
 	case *PutBalloonNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -720,6 +863,12 @@ func encodePutBalloonResponse(response PutBalloonRes, w http.ResponseWriter, spa
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -738,10 +887,12 @@ func encodePutGuestBootSourceResponse(response PutGuestBootSourceRes, w http.Res
 	switch response := response.(type) {
 	case *PutGuestBootSourceNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -754,6 +905,12 @@ func encodePutGuestBootSourceResponse(response PutGuestBootSourceRes, w http.Res
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -772,10 +929,12 @@ func encodePutGuestDriveByIDResponse(response PutGuestDriveByIDRes, w http.Respo
 	switch response := response.(type) {
 	case *PutGuestDriveByIDNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -788,6 +947,12 @@ func encodePutGuestDriveByIDResponse(response PutGuestDriveByIDRes, w http.Respo
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -806,10 +971,12 @@ func encodePutGuestNetworkInterfaceByIDResponse(response PutGuestNetworkInterfac
 	switch response := response.(type) {
 	case *PutGuestNetworkInterfaceByIDNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -822,6 +989,12 @@ func encodePutGuestNetworkInterfaceByIDResponse(response PutGuestNetworkInterfac
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -840,10 +1013,12 @@ func encodePutGuestVsockResponse(response PutGuestVsockRes, w http.ResponseWrite
 	switch response := response.(type) {
 	case *PutGuestVsockNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -856,6 +1031,12 @@ func encodePutGuestVsockResponse(response PutGuestVsockRes, w http.ResponseWrite
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -874,10 +1055,12 @@ func encodePutLoggerResponse(response PutLoggerRes, w http.ResponseWriter, span 
 	switch response := response.(type) {
 	case *PutLoggerNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -890,6 +1073,12 @@ func encodePutLoggerResponse(response PutLoggerRes, w http.ResponseWriter, span 
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -908,10 +1097,12 @@ func encodePutMachineConfigurationResponse(response PutMachineConfigurationRes, 
 	switch response := response.(type) {
 	case *PutMachineConfigurationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -924,6 +1115,12 @@ func encodePutMachineConfigurationResponse(response PutMachineConfigurationRes, 
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -942,10 +1139,12 @@ func encodePutMetricsResponse(response PutMetricsRes, w http.ResponseWriter, spa
 	switch response := response.(type) {
 	case *PutMetricsNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -958,6 +1157,12 @@ func encodePutMetricsResponse(response PutMetricsRes, w http.ResponseWriter, spa
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/examples/ex_github/oas_handlers_gen.go
+++ b/examples/ex_github/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleActionsAddRepoAccessToSelfHostedRunnerGroupInOrgRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -149,7 +148,6 @@ func (s *Server) handleActionsAddSelectedRepoToOrgSecretRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -191,7 +189,6 @@ func (s *Server) handleActionsAddSelfHostedRunnerToGroupForOrgRequest(args [3]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -233,7 +230,6 @@ func (s *Server) handleActionsApproveWorkflowRunRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -275,7 +271,6 @@ func (s *Server) handleActionsCancelWorkflowRunRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -322,7 +317,6 @@ func (s *Server) handleActionsCreateOrUpdateEnvironmentSecretRequest(args [3]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -369,7 +363,6 @@ func (s *Server) handleActionsCreateOrUpdateOrgSecretRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -416,7 +409,6 @@ func (s *Server) handleActionsCreateOrUpdateRepoSecretRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -458,7 +450,6 @@ func (s *Server) handleActionsCreateRegistrationTokenForOrgRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -500,7 +491,6 @@ func (s *Server) handleActionsCreateRegistrationTokenForRepoRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -542,7 +532,6 @@ func (s *Server) handleActionsCreateRemoveTokenForOrgRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -584,7 +573,6 @@ func (s *Server) handleActionsCreateRemoveTokenForRepoRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -631,7 +619,6 @@ func (s *Server) handleActionsCreateSelfHostedRunnerGroupForOrgRequest(args [1]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -673,7 +660,6 @@ func (s *Server) handleActionsDeleteArtifactRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -715,7 +701,6 @@ func (s *Server) handleActionsDeleteEnvironmentSecretRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -757,7 +742,6 @@ func (s *Server) handleActionsDeleteOrgSecretRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -799,7 +783,6 @@ func (s *Server) handleActionsDeleteRepoSecretRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -841,7 +824,6 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerFromOrgRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -883,7 +865,6 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerFromRepoRequest(args [3]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -925,7 +906,6 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerGroupFromOrgRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -967,7 +947,6 @@ func (s *Server) handleActionsDeleteWorkflowRunRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1009,7 +988,6 @@ func (s *Server) handleActionsDeleteWorkflowRunLogsRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1051,7 +1029,6 @@ func (s *Server) handleActionsDisableSelectedRepositoryGithubActionsOrganization
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1093,7 +1070,6 @@ func (s *Server) handleActionsDownloadArtifactRequest(args [4]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1135,7 +1111,6 @@ func (s *Server) handleActionsDownloadJobLogsForWorkflowRunRequest(args [3]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1177,7 +1152,6 @@ func (s *Server) handleActionsDownloadWorkflowRunLogsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1219,7 +1193,6 @@ func (s *Server) handleActionsEnableSelectedRepositoryGithubActionsOrganizationR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1261,7 +1234,6 @@ func (s *Server) handleActionsGetAllowedActionsOrganizationRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1303,7 +1275,6 @@ func (s *Server) handleActionsGetAllowedActionsRepositoryRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1345,7 +1316,6 @@ func (s *Server) handleActionsGetArtifactRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1387,7 +1357,6 @@ func (s *Server) handleActionsGetEnvironmentPublicKeyRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1429,7 +1398,6 @@ func (s *Server) handleActionsGetEnvironmentSecretRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1471,7 +1439,6 @@ func (s *Server) handleActionsGetGithubActionsPermissionsOrganizationRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1513,7 +1480,6 @@ func (s *Server) handleActionsGetGithubActionsPermissionsRepositoryRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1555,7 +1521,6 @@ func (s *Server) handleActionsGetJobForWorkflowRunRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1597,7 +1562,6 @@ func (s *Server) handleActionsGetOrgPublicKeyRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1639,7 +1603,6 @@ func (s *Server) handleActionsGetOrgSecretRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1681,7 +1644,6 @@ func (s *Server) handleActionsGetRepoPublicKeyRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1723,7 +1685,6 @@ func (s *Server) handleActionsGetRepoSecretRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1765,7 +1726,6 @@ func (s *Server) handleActionsGetReviewsForRunRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1807,7 +1767,6 @@ func (s *Server) handleActionsGetSelfHostedRunnerForOrgRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1849,7 +1808,6 @@ func (s *Server) handleActionsGetSelfHostedRunnerForRepoRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1891,7 +1849,6 @@ func (s *Server) handleActionsGetSelfHostedRunnerGroupForOrgRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1933,7 +1890,6 @@ func (s *Server) handleActionsGetWorkflowRunRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1975,7 +1931,6 @@ func (s *Server) handleActionsGetWorkflowRunUsageRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2017,7 +1972,6 @@ func (s *Server) handleActionsListArtifactsForRepoRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2059,7 +2013,6 @@ func (s *Server) handleActionsListEnvironmentSecretsRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2101,7 +2054,6 @@ func (s *Server) handleActionsListJobsForWorkflowRunRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2143,7 +2095,6 @@ func (s *Server) handleActionsListOrgSecretsRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2185,7 +2136,6 @@ func (s *Server) handleActionsListRepoAccessToSelfHostedRunnerGroupInOrgRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2227,7 +2177,6 @@ func (s *Server) handleActionsListRepoSecretsRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2269,7 +2218,6 @@ func (s *Server) handleActionsListRepoWorkflowsRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2311,7 +2259,6 @@ func (s *Server) handleActionsListRunnerApplicationsForOrgRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2353,7 +2300,6 @@ func (s *Server) handleActionsListRunnerApplicationsForRepoRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2395,7 +2341,6 @@ func (s *Server) handleActionsListSelectedReposForOrgSecretRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2437,7 +2382,6 @@ func (s *Server) handleActionsListSelectedRepositoriesEnabledGithubActionsOrgani
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2479,7 +2423,6 @@ func (s *Server) handleActionsListSelfHostedRunnerGroupsForOrgRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2521,7 +2464,6 @@ func (s *Server) handleActionsListSelfHostedRunnersForOrgRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2563,7 +2505,6 @@ func (s *Server) handleActionsListSelfHostedRunnersForRepoRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2605,7 +2546,6 @@ func (s *Server) handleActionsListSelfHostedRunnersInGroupForOrgRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2647,7 +2587,6 @@ func (s *Server) handleActionsListWorkflowRunArtifactsRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2689,7 +2628,6 @@ func (s *Server) handleActionsListWorkflowRunsForRepoRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2731,7 +2669,6 @@ func (s *Server) handleActionsReRunWorkflowRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2773,7 +2710,6 @@ func (s *Server) handleActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2815,7 +2751,6 @@ func (s *Server) handleActionsRemoveSelectedRepoFromOrgSecretRequest(args [3]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2857,7 +2792,6 @@ func (s *Server) handleActionsRemoveSelfHostedRunnerFromGroupForOrgRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2899,7 +2833,6 @@ func (s *Server) handleActionsRetryWorkflowRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2946,7 +2879,6 @@ func (s *Server) handleActionsReviewPendingDeploymentsForRunRequest(args [3]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2993,7 +2925,6 @@ func (s *Server) handleActionsSetAllowedActionsOrganizationRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3040,7 +2971,6 @@ func (s *Server) handleActionsSetAllowedActionsRepositoryRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3087,7 +3017,6 @@ func (s *Server) handleActionsSetGithubActionsPermissionsOrganizationRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3134,7 +3063,6 @@ func (s *Server) handleActionsSetGithubActionsPermissionsRepositoryRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3181,7 +3109,6 @@ func (s *Server) handleActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3228,7 +3155,6 @@ func (s *Server) handleActionsSetSelectedReposForOrgSecretRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3275,7 +3201,6 @@ func (s *Server) handleActionsSetSelectedRepositoriesEnabledGithubActionsOrganiz
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3322,7 +3247,6 @@ func (s *Server) handleActionsSetSelfHostedRunnersInGroupForOrgRequest(args [2]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3369,7 +3293,6 @@ func (s *Server) handleActionsUpdateSelfHostedRunnerGroupForOrgRequest(args [2]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3411,7 +3334,6 @@ func (s *Server) handleActivityCheckRepoIsStarredByAuthenticatedUserRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3453,7 +3375,6 @@ func (s *Server) handleActivityDeleteRepoSubscriptionRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3495,7 +3416,6 @@ func (s *Server) handleActivityDeleteThreadSubscriptionRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3532,7 +3452,6 @@ func (s *Server) handleActivityGetFeedsRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3574,7 +3493,6 @@ func (s *Server) handleActivityGetRepoSubscriptionRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3616,7 +3534,6 @@ func (s *Server) handleActivityGetThreadRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3658,7 +3575,6 @@ func (s *Server) handleActivityGetThreadSubscriptionForAuthenticatedUserRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3700,7 +3616,6 @@ func (s *Server) handleActivityListEventsForAuthenticatedUserRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3742,7 +3657,6 @@ func (s *Server) handleActivityListNotificationsForAuthenticatedUserRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3784,7 +3698,6 @@ func (s *Server) handleActivityListOrgEventsForAuthenticatedUserRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3826,7 +3739,6 @@ func (s *Server) handleActivityListPublicEventsRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3868,7 +3780,6 @@ func (s *Server) handleActivityListPublicEventsForRepoNetworkRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3910,7 +3821,6 @@ func (s *Server) handleActivityListPublicEventsForUserRequest(args [1]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3952,7 +3862,6 @@ func (s *Server) handleActivityListPublicOrgEventsRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3994,7 +3903,6 @@ func (s *Server) handleActivityListReceivedEventsForUserRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4036,7 +3944,6 @@ func (s *Server) handleActivityListReceivedPublicEventsForUserRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4078,7 +3985,6 @@ func (s *Server) handleActivityListRepoEventsRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4120,7 +4026,6 @@ func (s *Server) handleActivityListRepoNotificationsForAuthenticatedUserRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4162,7 +4067,6 @@ func (s *Server) handleActivityListReposStarredByAuthenticatedUserRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4204,7 +4108,6 @@ func (s *Server) handleActivityListReposWatchedByUserRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4246,7 +4149,6 @@ func (s *Server) handleActivityListWatchedReposForAuthenticatedUserRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4288,7 +4190,6 @@ func (s *Server) handleActivityListWatchersForRepoRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4330,7 +4231,6 @@ func (s *Server) handleActivityMarkNotificationsAsReadRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4377,7 +4277,6 @@ func (s *Server) handleActivityMarkRepoNotificationsAsReadRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4419,7 +4318,6 @@ func (s *Server) handleActivityMarkThreadAsReadRequest(args [1]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4466,7 +4364,6 @@ func (s *Server) handleActivitySetRepoSubscriptionRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4513,7 +4410,6 @@ func (s *Server) handleActivitySetThreadSubscriptionRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4555,7 +4451,6 @@ func (s *Server) handleActivityStarRepoForAuthenticatedUserRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4597,7 +4492,6 @@ func (s *Server) handleActivityUnstarRepoForAuthenticatedUserRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4639,7 +4533,6 @@ func (s *Server) handleAppsAddRepoToInstallationRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4686,7 +4579,6 @@ func (s *Server) handleAppsCheckTokenRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4733,7 +4625,6 @@ func (s *Server) handleAppsCreateContentAttachmentRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4780,7 +4671,6 @@ func (s *Server) handleAppsCreateInstallationAccessTokenRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4827,7 +4717,6 @@ func (s *Server) handleAppsDeleteAuthorizationRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4869,7 +4758,6 @@ func (s *Server) handleAppsDeleteInstallationRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4916,7 +4804,6 @@ func (s *Server) handleAppsDeleteTokenRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4953,7 +4840,6 @@ func (s *Server) handleAppsGetAuthenticatedRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4995,7 +4881,6 @@ func (s *Server) handleAppsGetBySlugRequest(args [1]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5037,7 +4922,6 @@ func (s *Server) handleAppsGetSubscriptionPlanForAccountRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5079,7 +4963,6 @@ func (s *Server) handleAppsGetSubscriptionPlanForAccountStubbedRequest(args [1]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5116,7 +4999,6 @@ func (s *Server) handleAppsGetWebhookConfigForAppRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5158,7 +5040,6 @@ func (s *Server) handleAppsGetWebhookDeliveryRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5200,7 +5081,6 @@ func (s *Server) handleAppsListAccountsForPlanRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5242,7 +5122,6 @@ func (s *Server) handleAppsListAccountsForPlanStubbedRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5284,7 +5163,6 @@ func (s *Server) handleAppsListInstallationReposForAuthenticatedUserRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5326,7 +5204,6 @@ func (s *Server) handleAppsListPlansRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5368,7 +5245,6 @@ func (s *Server) handleAppsListPlansStubbedRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5410,7 +5286,6 @@ func (s *Server) handleAppsListReposAccessibleToInstallationRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5452,7 +5327,6 @@ func (s *Server) handleAppsListSubscriptionsForAuthenticatedUserRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5494,7 +5368,6 @@ func (s *Server) handleAppsListSubscriptionsForAuthenticatedUserStubbedRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5536,7 +5409,6 @@ func (s *Server) handleAppsListWebhookDeliveriesRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5578,7 +5450,6 @@ func (s *Server) handleAppsRedeliverWebhookDeliveryRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5620,7 +5491,6 @@ func (s *Server) handleAppsRemoveRepoFromInstallationRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5667,7 +5537,6 @@ func (s *Server) handleAppsResetTokenRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5704,7 +5573,6 @@ func (s *Server) handleAppsRevokeInstallationAccessTokenRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5751,7 +5619,6 @@ func (s *Server) handleAppsScopeTokenRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5793,7 +5660,6 @@ func (s *Server) handleAppsSuspendInstallationRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5835,7 +5701,6 @@ func (s *Server) handleAppsUnsuspendInstallationRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5877,7 +5742,6 @@ func (s *Server) handleAppsUpdateWebhookConfigForAppRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5919,7 +5783,6 @@ func (s *Server) handleBillingGetGithubActionsBillingGheRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5961,7 +5824,6 @@ func (s *Server) handleBillingGetGithubActionsBillingOrgRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6003,7 +5865,6 @@ func (s *Server) handleBillingGetGithubActionsBillingUserRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6045,7 +5906,6 @@ func (s *Server) handleBillingGetGithubPackagesBillingGheRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6087,7 +5947,6 @@ func (s *Server) handleBillingGetGithubPackagesBillingOrgRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6129,7 +5988,6 @@ func (s *Server) handleBillingGetGithubPackagesBillingUserRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6171,7 +6029,6 @@ func (s *Server) handleBillingGetSharedStorageBillingGheRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6213,7 +6070,6 @@ func (s *Server) handleBillingGetSharedStorageBillingOrgRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6255,7 +6111,6 @@ func (s *Server) handleBillingGetSharedStorageBillingUserRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6302,7 +6157,6 @@ func (s *Server) handleChecksCreateSuiteRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6344,7 +6198,6 @@ func (s *Server) handleChecksGetRequest(args [3]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6386,7 +6239,6 @@ func (s *Server) handleChecksGetSuiteRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6428,7 +6280,6 @@ func (s *Server) handleChecksListAnnotationsRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6470,7 +6321,6 @@ func (s *Server) handleChecksListForRefRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6512,7 +6362,6 @@ func (s *Server) handleChecksListForSuiteRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6554,7 +6403,6 @@ func (s *Server) handleChecksListSuitesForRefRequest(args [3]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6596,7 +6444,6 @@ func (s *Server) handleChecksRerequestSuiteRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6643,7 +6490,6 @@ func (s *Server) handleChecksSetSuitesPreferencesRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6685,7 +6531,6 @@ func (s *Server) handleCodeScanningDeleteAnalysisRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6727,7 +6572,6 @@ func (s *Server) handleCodeScanningGetAlertRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6769,7 +6613,6 @@ func (s *Server) handleCodeScanningGetAnalysisRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6811,7 +6654,6 @@ func (s *Server) handleCodeScanningGetSarifRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6853,7 +6695,6 @@ func (s *Server) handleCodeScanningListAlertInstancesRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6895,7 +6736,6 @@ func (s *Server) handleCodeScanningListAlertsForRepoRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6937,7 +6777,6 @@ func (s *Server) handleCodeScanningListRecentAnalysesRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6984,7 +6823,6 @@ func (s *Server) handleCodeScanningUpdateAlertRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7031,7 +6869,6 @@ func (s *Server) handleCodeScanningUploadSarifRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7068,7 +6905,6 @@ func (s *Server) handleCodesOfConductGetAllCodesOfConductRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7110,7 +6946,6 @@ func (s *Server) handleCodesOfConductGetConductCodeRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7147,7 +6982,6 @@ func (s *Server) handleEmojisGetRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7189,7 +7023,6 @@ func (s *Server) handleEnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7231,7 +7064,6 @@ func (s *Server) handleEnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseReq
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7273,7 +7105,6 @@ func (s *Server) handleEnterpriseAdminCreateRegistrationTokenForEnterpriseReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7315,7 +7146,6 @@ func (s *Server) handleEnterpriseAdminCreateRemoveTokenForEnterpriseRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7362,7 +7192,6 @@ func (s *Server) handleEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7404,7 +7233,6 @@ func (s *Server) handleEnterpriseAdminDeleteScimGroupFromEnterpriseRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7446,7 +7274,6 @@ func (s *Server) handleEnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7488,7 +7315,6 @@ func (s *Server) handleEnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7530,7 +7356,6 @@ func (s *Server) handleEnterpriseAdminDeleteUserFromEnterpriseRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7572,7 +7397,6 @@ func (s *Server) handleEnterpriseAdminDisableSelectedOrganizationGithubActionsEn
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7614,7 +7438,6 @@ func (s *Server) handleEnterpriseAdminEnableSelectedOrganizationGithubActionsEnt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7656,7 +7479,6 @@ func (s *Server) handleEnterpriseAdminGetAllowedActionsEnterpriseRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7698,7 +7520,6 @@ func (s *Server) handleEnterpriseAdminGetAuditLogRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7740,7 +7561,6 @@ func (s *Server) handleEnterpriseAdminGetGithubActionsPermissionsEnterpriseReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7782,7 +7602,6 @@ func (s *Server) handleEnterpriseAdminGetProvisioningInformationForEnterpriseGro
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7824,7 +7643,6 @@ func (s *Server) handleEnterpriseAdminGetProvisioningInformationForEnterpriseUse
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7866,7 +7684,6 @@ func (s *Server) handleEnterpriseAdminGetSelfHostedRunnerForEnterpriseRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7908,7 +7725,6 @@ func (s *Server) handleEnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7950,7 +7766,6 @@ func (s *Server) handleEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnte
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7992,7 +7807,6 @@ func (s *Server) handleEnterpriseAdminListProvisionedGroupsEnterpriseRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8034,7 +7848,6 @@ func (s *Server) handleEnterpriseAdminListProvisionedIdentitiesEnterpriseRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8076,7 +7889,6 @@ func (s *Server) handleEnterpriseAdminListRunnerApplicationsForEnterpriseRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8118,7 +7930,6 @@ func (s *Server) handleEnterpriseAdminListSelectedOrganizationsEnabledGithubActi
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8160,7 +7971,6 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseReq
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8202,7 +8012,6 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnersForEnterpriseRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8244,7 +8053,6 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8291,7 +8099,6 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseGroupRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8338,7 +8145,6 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseUserRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8380,7 +8186,6 @@ func (s *Server) handleEnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEn
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8422,7 +8227,6 @@ func (s *Server) handleEnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8469,7 +8273,6 @@ func (s *Server) handleEnterpriseAdminSetAllowedActionsEnterpriseRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8516,7 +8319,6 @@ func (s *Server) handleEnterpriseAdminSetGithubActionsPermissionsEnterpriseReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8563,7 +8365,6 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseGrou
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8610,7 +8411,6 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseUser
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8657,7 +8457,6 @@ func (s *Server) handleEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8704,7 +8503,6 @@ func (s *Server) handleEnterpriseAdminSetSelectedOrganizationsEnabledGithubActio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8751,7 +8549,6 @@ func (s *Server) handleEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8798,7 +8595,6 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseGroupRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8845,7 +8641,6 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseUserRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8892,7 +8687,6 @@ func (s *Server) handleEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8934,7 +8728,6 @@ func (s *Server) handleGistsCheckIsStarredRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8976,7 +8769,6 @@ func (s *Server) handleGistsCreateRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9023,7 +8815,6 @@ func (s *Server) handleGistsCreateCommentRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9065,7 +8856,6 @@ func (s *Server) handleGistsDeleteRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9107,7 +8897,6 @@ func (s *Server) handleGistsDeleteCommentRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9149,7 +8938,6 @@ func (s *Server) handleGistsForkRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9191,7 +8979,6 @@ func (s *Server) handleGistsGetRequest(args [1]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9233,7 +9020,6 @@ func (s *Server) handleGistsGetCommentRequest(args [2]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9275,7 +9061,6 @@ func (s *Server) handleGistsGetRevisionRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9317,7 +9102,6 @@ func (s *Server) handleGistsListRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9359,7 +9143,6 @@ func (s *Server) handleGistsListCommentsRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9401,7 +9184,6 @@ func (s *Server) handleGistsListCommitsRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9443,7 +9225,6 @@ func (s *Server) handleGistsListForUserRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9485,7 +9266,6 @@ func (s *Server) handleGistsListForksRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9527,7 +9307,6 @@ func (s *Server) handleGistsListPublicRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9569,7 +9348,6 @@ func (s *Server) handleGistsListStarredRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9611,7 +9389,6 @@ func (s *Server) handleGistsStarRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9653,7 +9430,6 @@ func (s *Server) handleGistsUnstarRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9700,7 +9476,6 @@ func (s *Server) handleGistsUpdateCommentRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9747,7 +9522,6 @@ func (s *Server) handleGitCreateBlobRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9794,7 +9568,6 @@ func (s *Server) handleGitCreateCommitRequest(args [2]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9841,7 +9614,6 @@ func (s *Server) handleGitCreateRefRequest(args [2]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9888,7 +9660,6 @@ func (s *Server) handleGitCreateTagRequest(args [2]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9935,7 +9706,6 @@ func (s *Server) handleGitCreateTreeRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9977,7 +9747,6 @@ func (s *Server) handleGitDeleteRefRequest(args [3]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10019,7 +9788,6 @@ func (s *Server) handleGitGetBlobRequest(args [3]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10061,7 +9829,6 @@ func (s *Server) handleGitGetCommitRequest(args [3]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10103,7 +9870,6 @@ func (s *Server) handleGitGetRefRequest(args [3]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10145,7 +9911,6 @@ func (s *Server) handleGitGetTagRequest(args [3]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10187,7 +9952,6 @@ func (s *Server) handleGitGetTreeRequest(args [3]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10229,7 +9993,6 @@ func (s *Server) handleGitListMatchingRefsRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10276,7 +10039,6 @@ func (s *Server) handleGitUpdateRefRequest(args [3]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10313,7 +10075,6 @@ func (s *Server) handleGitignoreGetAllTemplatesRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10355,7 +10116,6 @@ func (s *Server) handleGitignoreGetTemplateRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10392,7 +10152,6 @@ func (s *Server) handleInteractionsRemoveRestrictionsForAuthenticatedUserRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10434,7 +10193,6 @@ func (s *Server) handleInteractionsRemoveRestrictionsForOrgRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10476,7 +10234,6 @@ func (s *Server) handleInteractionsRemoveRestrictionsForRepoRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10518,7 +10275,6 @@ func (s *Server) handleInteractionsSetRestrictionsForAuthenticatedUserRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10565,7 +10321,6 @@ func (s *Server) handleInteractionsSetRestrictionsForOrgRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10612,7 +10367,6 @@ func (s *Server) handleInteractionsSetRestrictionsForRepoRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10659,7 +10413,6 @@ func (s *Server) handleIssuesAddAssigneesRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10701,7 +10454,6 @@ func (s *Server) handleIssuesCheckUserCanBeAssignedRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10748,7 +10500,6 @@ func (s *Server) handleIssuesCreateRequest(args [2]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10795,7 +10546,6 @@ func (s *Server) handleIssuesCreateCommentRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10842,7 +10592,6 @@ func (s *Server) handleIssuesCreateLabelRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10889,7 +10638,6 @@ func (s *Server) handleIssuesCreateMilestoneRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10931,7 +10679,6 @@ func (s *Server) handleIssuesDeleteCommentRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10973,7 +10720,6 @@ func (s *Server) handleIssuesDeleteLabelRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11015,7 +10761,6 @@ func (s *Server) handleIssuesDeleteMilestoneRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11057,7 +10802,6 @@ func (s *Server) handleIssuesGetRequest(args [3]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11099,7 +10843,6 @@ func (s *Server) handleIssuesGetCommentRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11141,7 +10884,6 @@ func (s *Server) handleIssuesGetEventRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11183,7 +10925,6 @@ func (s *Server) handleIssuesGetLabelRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11225,7 +10966,6 @@ func (s *Server) handleIssuesGetMilestoneRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11267,7 +11007,6 @@ func (s *Server) handleIssuesListRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11309,7 +11048,6 @@ func (s *Server) handleIssuesListAssigneesRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11351,7 +11089,6 @@ func (s *Server) handleIssuesListCommentsRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11393,7 +11130,6 @@ func (s *Server) handleIssuesListCommentsForRepoRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11435,7 +11171,6 @@ func (s *Server) handleIssuesListEventsForRepoRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11477,7 +11212,6 @@ func (s *Server) handleIssuesListForAuthenticatedUserRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11519,7 +11253,6 @@ func (s *Server) handleIssuesListForOrgRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11561,7 +11294,6 @@ func (s *Server) handleIssuesListForRepoRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11603,7 +11335,6 @@ func (s *Server) handleIssuesListLabelsForMilestoneRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11645,7 +11376,6 @@ func (s *Server) handleIssuesListLabelsForRepoRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11687,7 +11417,6 @@ func (s *Server) handleIssuesListLabelsOnIssueRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11729,7 +11458,6 @@ func (s *Server) handleIssuesListMilestonesRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11776,7 +11504,6 @@ func (s *Server) handleIssuesLockRequest(args [3]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11818,7 +11545,6 @@ func (s *Server) handleIssuesRemoveAllLabelsRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11865,7 +11591,6 @@ func (s *Server) handleIssuesRemoveAssigneesRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11907,7 +11632,6 @@ func (s *Server) handleIssuesRemoveLabelRequest(args [4]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11949,7 +11673,6 @@ func (s *Server) handleIssuesUnlockRequest(args [3]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11996,7 +11719,6 @@ func (s *Server) handleIssuesUpdateRequest(args [3]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12043,7 +11765,6 @@ func (s *Server) handleIssuesUpdateCommentRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12090,7 +11811,6 @@ func (s *Server) handleIssuesUpdateLabelRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12137,7 +11857,6 @@ func (s *Server) handleIssuesUpdateMilestoneRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12179,7 +11898,6 @@ func (s *Server) handleLicensesGetRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12221,7 +11939,6 @@ func (s *Server) handleLicensesGetAllCommonlyUsedRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12263,7 +11980,6 @@ func (s *Server) handleLicensesGetForRepoRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12300,7 +12016,6 @@ func (s *Server) handleMetaGetRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12337,7 +12052,6 @@ func (s *Server) handleMetaRootRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12379,7 +12093,6 @@ func (s *Server) handleMigrationsCancelImportRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12421,7 +12134,6 @@ func (s *Server) handleMigrationsDeleteArchiveForAuthenticatedUserRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12463,7 +12175,6 @@ func (s *Server) handleMigrationsDeleteArchiveForOrgRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12505,7 +12216,6 @@ func (s *Server) handleMigrationsDownloadArchiveForOrgRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12547,7 +12257,6 @@ func (s *Server) handleMigrationsGetArchiveForAuthenticatedUserRequest(args [1]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12589,7 +12298,6 @@ func (s *Server) handleMigrationsGetCommitAuthorsRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12631,7 +12339,6 @@ func (s *Server) handleMigrationsGetImportStatusRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12673,7 +12380,6 @@ func (s *Server) handleMigrationsGetLargeFilesRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12715,7 +12421,6 @@ func (s *Server) handleMigrationsGetStatusForAuthenticatedUserRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12757,7 +12462,6 @@ func (s *Server) handleMigrationsGetStatusForOrgRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12799,7 +12503,6 @@ func (s *Server) handleMigrationsListForAuthenticatedUserRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12841,7 +12544,6 @@ func (s *Server) handleMigrationsListForOrgRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12883,7 +12585,6 @@ func (s *Server) handleMigrationsListReposForOrgRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12925,7 +12626,6 @@ func (s *Server) handleMigrationsListReposForUserRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12972,7 +12672,6 @@ func (s *Server) handleMigrationsMapCommitAuthorRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13019,7 +12718,6 @@ func (s *Server) handleMigrationsSetLfsPreferenceRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13061,7 +12759,6 @@ func (s *Server) handleMigrationsStartForAuthenticatedUserRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13108,7 +12805,6 @@ func (s *Server) handleMigrationsStartForOrgRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13155,7 +12851,6 @@ func (s *Server) handleMigrationsStartImportRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13197,7 +12892,6 @@ func (s *Server) handleMigrationsUnlockRepoForAuthenticatedUserRequest(args [2]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13239,7 +12933,6 @@ func (s *Server) handleMigrationsUnlockRepoForOrgRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13286,7 +12979,6 @@ func (s *Server) handleMigrationsUpdateImportRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13328,7 +13020,6 @@ func (s *Server) handleOAuthAuthorizationsCreateAuthorizationRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13370,7 +13061,6 @@ func (s *Server) handleOAuthAuthorizationsDeleteAuthorizationRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13412,7 +13102,6 @@ func (s *Server) handleOAuthAuthorizationsDeleteGrantRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13454,7 +13143,6 @@ func (s *Server) handleOAuthAuthorizationsGetAuthorizationRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13496,7 +13184,6 @@ func (s *Server) handleOAuthAuthorizationsGetGrantRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13543,7 +13230,6 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13590,7 +13276,6 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFinge
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13632,7 +13317,6 @@ func (s *Server) handleOAuthAuthorizationsListAuthorizationsRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13674,7 +13358,6 @@ func (s *Server) handleOAuthAuthorizationsListGrantsRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13721,7 +13404,6 @@ func (s *Server) handleOAuthAuthorizationsUpdateAuthorizationRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13763,7 +13445,6 @@ func (s *Server) handleOrgsBlockUserRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13805,7 +13486,6 @@ func (s *Server) handleOrgsCancelInvitationRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13847,7 +13527,6 @@ func (s *Server) handleOrgsCheckBlockedUserRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13889,7 +13568,6 @@ func (s *Server) handleOrgsCheckMembershipForUserRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13931,7 +13609,6 @@ func (s *Server) handleOrgsCheckPublicMembershipForUserRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13973,7 +13650,6 @@ func (s *Server) handleOrgsConvertMemberToOutsideCollaboratorRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14020,7 +13696,6 @@ func (s *Server) handleOrgsCreateInvitationRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14067,7 +13742,6 @@ func (s *Server) handleOrgsCreateWebhookRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14109,7 +13783,6 @@ func (s *Server) handleOrgsDeleteWebhookRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14151,7 +13824,6 @@ func (s *Server) handleOrgsGetRequest(args [1]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14193,7 +13865,6 @@ func (s *Server) handleOrgsGetAuditLogRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14235,7 +13906,6 @@ func (s *Server) handleOrgsGetMembershipForAuthenticatedUserRequest(args [1]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14277,7 +13947,6 @@ func (s *Server) handleOrgsGetMembershipForUserRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14319,7 +13988,6 @@ func (s *Server) handleOrgsGetWebhookRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14361,7 +14029,6 @@ func (s *Server) handleOrgsGetWebhookConfigForOrgRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14403,7 +14070,6 @@ func (s *Server) handleOrgsGetWebhookDeliveryRequest(args [3]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14445,7 +14111,6 @@ func (s *Server) handleOrgsListRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14487,7 +14152,6 @@ func (s *Server) handleOrgsListBlockedUsersRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14529,7 +14193,6 @@ func (s *Server) handleOrgsListFailedInvitationsRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14571,7 +14234,6 @@ func (s *Server) handleOrgsListForAuthenticatedUserRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14613,7 +14275,6 @@ func (s *Server) handleOrgsListForUserRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14655,7 +14316,6 @@ func (s *Server) handleOrgsListInvitationTeamsRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14697,7 +14357,6 @@ func (s *Server) handleOrgsListMembersRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14739,7 +14398,6 @@ func (s *Server) handleOrgsListMembershipsForAuthenticatedUserRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14781,7 +14439,6 @@ func (s *Server) handleOrgsListOutsideCollaboratorsRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14823,7 +14480,6 @@ func (s *Server) handleOrgsListPendingInvitationsRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14865,7 +14521,6 @@ func (s *Server) handleOrgsListPublicMembersRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14907,7 +14562,6 @@ func (s *Server) handleOrgsListSamlSSOAuthorizationsRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14949,7 +14603,6 @@ func (s *Server) handleOrgsListWebhookDeliveriesRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14991,7 +14644,6 @@ func (s *Server) handleOrgsListWebhooksRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15033,7 +14685,6 @@ func (s *Server) handleOrgsPingWebhookRequest(args [2]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15075,7 +14726,6 @@ func (s *Server) handleOrgsRedeliverWebhookDeliveryRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15117,7 +14767,6 @@ func (s *Server) handleOrgsRemoveMemberRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15159,7 +14808,6 @@ func (s *Server) handleOrgsRemoveMembershipForUserRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15201,7 +14849,6 @@ func (s *Server) handleOrgsRemoveOutsideCollaboratorRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15243,7 +14890,6 @@ func (s *Server) handleOrgsRemovePublicMembershipForAuthenticatedUserRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15285,7 +14931,6 @@ func (s *Server) handleOrgsRemoveSamlSSOAuthorizationRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15332,7 +14977,6 @@ func (s *Server) handleOrgsSetMembershipForUserRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15374,7 +15018,6 @@ func (s *Server) handleOrgsSetPublicMembershipForAuthenticatedUserRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15416,7 +15059,6 @@ func (s *Server) handleOrgsUnblockUserRequest(args [2]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15463,7 +15105,6 @@ func (s *Server) handleOrgsUpdateMembershipForAuthenticatedUserRequest(args [1]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15510,7 +15151,6 @@ func (s *Server) handleOrgsUpdateWebhookRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15557,7 +15197,6 @@ func (s *Server) handleOrgsUpdateWebhookConfigForOrgRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15599,7 +15238,6 @@ func (s *Server) handlePackagesDeletePackageForAuthenticatedUserRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15641,7 +15279,6 @@ func (s *Server) handlePackagesDeletePackageForOrgRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15683,7 +15320,6 @@ func (s *Server) handlePackagesDeletePackageForUserRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15725,7 +15361,6 @@ func (s *Server) handlePackagesDeletePackageVersionForAuthenticatedUserRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15767,7 +15402,6 @@ func (s *Server) handlePackagesDeletePackageVersionForOrgRequest(args [4]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15809,7 +15443,6 @@ func (s *Server) handlePackagesDeletePackageVersionForUserRequest(args [4]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15851,7 +15484,6 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByAuthenticat
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15893,7 +15525,6 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByOrgRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15935,7 +15566,6 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByUserRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15977,7 +15607,6 @@ func (s *Server) handlePackagesGetPackageForAuthenticatedUserRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16019,7 +15648,6 @@ func (s *Server) handlePackagesGetPackageForOrganizationRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16061,7 +15689,6 @@ func (s *Server) handlePackagesGetPackageForUserRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16103,7 +15730,6 @@ func (s *Server) handlePackagesGetPackageVersionForAuthenticatedUserRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16145,7 +15771,6 @@ func (s *Server) handlePackagesGetPackageVersionForOrganizationRequest(args [4]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16187,7 +15812,6 @@ func (s *Server) handlePackagesGetPackageVersionForUserRequest(args [4]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16229,7 +15853,6 @@ func (s *Server) handlePackagesListPackagesForAuthenticatedUserRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16271,7 +15894,6 @@ func (s *Server) handlePackagesListPackagesForOrganizationRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16313,7 +15935,6 @@ func (s *Server) handlePackagesListPackagesForUserRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16355,7 +15976,6 @@ func (s *Server) handlePackagesRestorePackageForAuthenticatedUserRequest(args [2
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16397,7 +16017,6 @@ func (s *Server) handlePackagesRestorePackageForOrgRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16439,7 +16058,6 @@ func (s *Server) handlePackagesRestorePackageForUserRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16481,7 +16099,6 @@ func (s *Server) handlePackagesRestorePackageVersionForAuthenticatedUserRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16523,7 +16140,6 @@ func (s *Server) handlePackagesRestorePackageVersionForOrgRequest(args [4]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16565,7 +16181,6 @@ func (s *Server) handlePackagesRestorePackageVersionForUserRequest(args [4]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16612,7 +16227,6 @@ func (s *Server) handleProjectsAddCollaboratorRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16659,7 +16273,6 @@ func (s *Server) handleProjectsCreateColumnRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16701,7 +16314,6 @@ func (s *Server) handleProjectsCreateForAuthenticatedUserRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16748,7 +16360,6 @@ func (s *Server) handleProjectsCreateForOrgRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16795,7 +16406,6 @@ func (s *Server) handleProjectsCreateForRepoRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16837,7 +16447,6 @@ func (s *Server) handleProjectsDeleteRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16879,7 +16488,6 @@ func (s *Server) handleProjectsDeleteCardRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16921,7 +16529,6 @@ func (s *Server) handleProjectsDeleteColumnRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16963,7 +16570,6 @@ func (s *Server) handleProjectsGetRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17005,7 +16611,6 @@ func (s *Server) handleProjectsGetCardRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17047,7 +16652,6 @@ func (s *Server) handleProjectsGetColumnRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17089,7 +16693,6 @@ func (s *Server) handleProjectsGetPermissionForUserRequest(args [2]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17131,7 +16734,6 @@ func (s *Server) handleProjectsListCardsRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17173,7 +16775,6 @@ func (s *Server) handleProjectsListCollaboratorsRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17215,7 +16816,6 @@ func (s *Server) handleProjectsListColumnsRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17257,7 +16857,6 @@ func (s *Server) handleProjectsListForOrgRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17299,7 +16898,6 @@ func (s *Server) handleProjectsListForRepoRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17341,7 +16939,6 @@ func (s *Server) handleProjectsListForUserRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17388,7 +16985,6 @@ func (s *Server) handleProjectsMoveCardRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17435,7 +17031,6 @@ func (s *Server) handleProjectsMoveColumnRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17477,7 +17072,6 @@ func (s *Server) handleProjectsRemoveCollaboratorRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17524,7 +17118,6 @@ func (s *Server) handleProjectsUpdateRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17571,7 +17164,6 @@ func (s *Server) handleProjectsUpdateCardRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17618,7 +17210,6 @@ func (s *Server) handleProjectsUpdateColumnRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17660,7 +17251,6 @@ func (s *Server) handlePullsCheckIfMergedRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17707,7 +17297,6 @@ func (s *Server) handlePullsCreateRequest(args [2]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17754,7 +17343,6 @@ func (s *Server) handlePullsCreateReplyForReviewCommentRequest(args [4]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17801,7 +17389,6 @@ func (s *Server) handlePullsCreateReviewRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17848,7 +17435,6 @@ func (s *Server) handlePullsCreateReviewCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17890,7 +17476,6 @@ func (s *Server) handlePullsDeletePendingReviewRequest(args [4]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17932,7 +17517,6 @@ func (s *Server) handlePullsDeleteReviewCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17979,7 +17563,6 @@ func (s *Server) handlePullsDismissReviewRequest(args [4]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18021,7 +17604,6 @@ func (s *Server) handlePullsGetRequest(args [3]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18063,7 +17645,6 @@ func (s *Server) handlePullsGetReviewRequest(args [4]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18105,7 +17686,6 @@ func (s *Server) handlePullsGetReviewCommentRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18147,7 +17727,6 @@ func (s *Server) handlePullsListRequest(args [2]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18189,7 +17768,6 @@ func (s *Server) handlePullsListCommentsForReviewRequest(args [4]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18231,7 +17809,6 @@ func (s *Server) handlePullsListCommitsRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18273,7 +17850,6 @@ func (s *Server) handlePullsListFilesRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18315,7 +17891,6 @@ func (s *Server) handlePullsListRequestedReviewersRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18357,7 +17932,6 @@ func (s *Server) handlePullsListReviewCommentsRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18399,7 +17973,6 @@ func (s *Server) handlePullsListReviewCommentsForRepoRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18441,7 +18014,6 @@ func (s *Server) handlePullsListReviewsRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18488,7 +18060,6 @@ func (s *Server) handlePullsMergeRequest(args [3]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18535,7 +18106,6 @@ func (s *Server) handlePullsRemoveRequestedReviewersRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18582,7 +18152,6 @@ func (s *Server) handlePullsSubmitReviewRequest(args [4]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18629,7 +18198,6 @@ func (s *Server) handlePullsUpdateRequest(args [3]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18676,7 +18244,6 @@ func (s *Server) handlePullsUpdateBranchRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18723,7 +18290,6 @@ func (s *Server) handlePullsUpdateReviewRequest(args [4]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18770,7 +18336,6 @@ func (s *Server) handlePullsUpdateReviewCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18807,7 +18372,6 @@ func (s *Server) handleRateLimitGetRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18854,7 +18418,6 @@ func (s *Server) handleReactionsCreateForCommitCommentRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18901,7 +18464,6 @@ func (s *Server) handleReactionsCreateForIssueRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18948,7 +18510,6 @@ func (s *Server) handleReactionsCreateForIssueCommentRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18995,7 +18556,6 @@ func (s *Server) handleReactionsCreateForPullRequestReviewCommentRequest(args [3
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19042,7 +18602,6 @@ func (s *Server) handleReactionsCreateForReleaseRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19089,7 +18648,6 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentInOrgRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19136,7 +18694,6 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentLegacyRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19183,7 +18740,6 @@ func (s *Server) handleReactionsCreateForTeamDiscussionInOrgRequest(args [3]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19230,7 +18786,6 @@ func (s *Server) handleReactionsCreateForTeamDiscussionLegacyRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19272,7 +18827,6 @@ func (s *Server) handleReactionsDeleteForCommitCommentRequest(args [4]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19314,7 +18868,6 @@ func (s *Server) handleReactionsDeleteForIssueRequest(args [4]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19356,7 +18909,6 @@ func (s *Server) handleReactionsDeleteForIssueCommentRequest(args [4]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19398,7 +18950,6 @@ func (s *Server) handleReactionsDeleteForPullRequestCommentRequest(args [4]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19440,7 +18991,6 @@ func (s *Server) handleReactionsDeleteForTeamDiscussionRequest(args [4]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19482,7 +19032,6 @@ func (s *Server) handleReactionsDeleteForTeamDiscussionCommentRequest(args [5]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19524,7 +19073,6 @@ func (s *Server) handleReactionsDeleteLegacyRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19566,7 +19114,6 @@ func (s *Server) handleReactionsListForCommitCommentRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19608,7 +19155,6 @@ func (s *Server) handleReactionsListForIssueRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19650,7 +19196,6 @@ func (s *Server) handleReactionsListForIssueCommentRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19692,7 +19237,6 @@ func (s *Server) handleReactionsListForPullRequestReviewCommentRequest(args [3]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19734,7 +19278,6 @@ func (s *Server) handleReactionsListForTeamDiscussionCommentInOrgRequest(args [4
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19776,7 +19319,6 @@ func (s *Server) handleReactionsListForTeamDiscussionCommentLegacyRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19818,7 +19360,6 @@ func (s *Server) handleReactionsListForTeamDiscussionInOrgRequest(args [3]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19860,7 +19401,6 @@ func (s *Server) handleReactionsListForTeamDiscussionLegacyRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19902,7 +19442,6 @@ func (s *Server) handleReposAcceptInvitationRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19949,7 +19488,6 @@ func (s *Server) handleReposAddAppAccessRestrictionsRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19996,7 +19534,6 @@ func (s *Server) handleReposAddCollaboratorRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20043,7 +19580,6 @@ func (s *Server) handleReposAddStatusCheckContextsRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20090,7 +19626,6 @@ func (s *Server) handleReposAddTeamAccessRestrictionsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20137,7 +19672,6 @@ func (s *Server) handleReposAddUserAccessRestrictionsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20179,7 +19713,6 @@ func (s *Server) handleReposCheckCollaboratorRequest(args [3]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20221,7 +19754,6 @@ func (s *Server) handleReposCheckVulnerabilityAlertsRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20263,7 +19795,6 @@ func (s *Server) handleReposCompareCommitsRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20310,7 +19841,6 @@ func (s *Server) handleReposCreateAutolinkRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20357,7 +19887,6 @@ func (s *Server) handleReposCreateCommitCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20399,7 +19928,6 @@ func (s *Server) handleReposCreateCommitSignatureProtectionRequest(args [3]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20446,7 +19974,6 @@ func (s *Server) handleReposCreateCommitStatusRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20493,7 +20020,6 @@ func (s *Server) handleReposCreateDeployKeyRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20540,7 +20066,6 @@ func (s *Server) handleReposCreateDeploymentRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20587,7 +20112,6 @@ func (s *Server) handleReposCreateDeploymentStatusRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20634,7 +20158,6 @@ func (s *Server) handleReposCreateDispatchEventRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20676,7 +20199,6 @@ func (s *Server) handleReposCreateForAuthenticatedUserRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20723,7 +20245,6 @@ func (s *Server) handleReposCreateForkRequest(args [2]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20770,7 +20291,6 @@ func (s *Server) handleReposCreateInOrgRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20817,7 +20337,6 @@ func (s *Server) handleReposCreateOrUpdateFileContentsRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20864,7 +20383,6 @@ func (s *Server) handleReposCreatePagesSiteRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20911,7 +20429,6 @@ func (s *Server) handleReposCreateReleaseRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -20958,7 +20475,6 @@ func (s *Server) handleReposCreateUsingTemplateRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21005,7 +20521,6 @@ func (s *Server) handleReposCreateWebhookRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21047,7 +20562,6 @@ func (s *Server) handleReposDeclineInvitationRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21089,7 +20603,6 @@ func (s *Server) handleReposDeleteRequest(args [2]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21131,7 +20644,6 @@ func (s *Server) handleReposDeleteAccessRestrictionsRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21173,7 +20685,6 @@ func (s *Server) handleReposDeleteAdminBranchProtectionRequest(args [3]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21215,7 +20726,6 @@ func (s *Server) handleReposDeleteAnEnvironmentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21257,7 +20767,6 @@ func (s *Server) handleReposDeleteAutolinkRequest(args [3]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21299,7 +20808,6 @@ func (s *Server) handleReposDeleteBranchProtectionRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21341,7 +20849,6 @@ func (s *Server) handleReposDeleteCommitCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21383,7 +20890,6 @@ func (s *Server) handleReposDeleteCommitSignatureProtectionRequest(args [3]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21425,7 +20931,6 @@ func (s *Server) handleReposDeleteDeployKeyRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21467,7 +20972,6 @@ func (s *Server) handleReposDeleteDeploymentRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21514,7 +21018,6 @@ func (s *Server) handleReposDeleteFileRequest(args [3]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21556,7 +21059,6 @@ func (s *Server) handleReposDeleteInvitationRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21598,7 +21100,6 @@ func (s *Server) handleReposDeletePagesSiteRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21640,7 +21141,6 @@ func (s *Server) handleReposDeletePullRequestReviewProtectionRequest(args [3]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21682,7 +21182,6 @@ func (s *Server) handleReposDeleteReleaseRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21724,7 +21223,6 @@ func (s *Server) handleReposDeleteReleaseAssetRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21766,7 +21264,6 @@ func (s *Server) handleReposDeleteWebhookRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21808,7 +21305,6 @@ func (s *Server) handleReposDisableAutomatedSecurityFixesRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21850,7 +21346,6 @@ func (s *Server) handleReposDisableLfsForRepoRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21892,7 +21387,6 @@ func (s *Server) handleReposDisableVulnerabilityAlertsRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21934,7 +21428,6 @@ func (s *Server) handleReposDownloadTarballArchiveRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -21976,7 +21469,6 @@ func (s *Server) handleReposDownloadZipballArchiveRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22018,7 +21510,6 @@ func (s *Server) handleReposEnableAutomatedSecurityFixesRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22060,7 +21551,6 @@ func (s *Server) handleReposEnableLfsForRepoRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22102,7 +21592,6 @@ func (s *Server) handleReposEnableVulnerabilityAlertsRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22144,7 +21633,6 @@ func (s *Server) handleReposGetRequest(args [2]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22186,7 +21674,6 @@ func (s *Server) handleReposGetAccessRestrictionsRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22228,7 +21715,6 @@ func (s *Server) handleReposGetAdminBranchProtectionRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22270,7 +21756,6 @@ func (s *Server) handleReposGetAllStatusCheckContextsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22312,7 +21797,6 @@ func (s *Server) handleReposGetAllTopicsRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22354,7 +21838,6 @@ func (s *Server) handleReposGetAppsWithAccessToProtectedBranchRequest(args [3]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22396,7 +21879,6 @@ func (s *Server) handleReposGetAutolinkRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22438,7 +21920,6 @@ func (s *Server) handleReposGetBranchRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22480,7 +21961,6 @@ func (s *Server) handleReposGetBranchProtectionRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22522,7 +22002,6 @@ func (s *Server) handleReposGetClonesRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22564,7 +22043,6 @@ func (s *Server) handleReposGetCodeFrequencyStatsRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22606,7 +22084,6 @@ func (s *Server) handleReposGetCollaboratorPermissionLevelRequest(args [3]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22648,7 +22125,6 @@ func (s *Server) handleReposGetCombinedStatusForRefRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22690,7 +22166,6 @@ func (s *Server) handleReposGetCommitRequest(args [3]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22732,7 +22207,6 @@ func (s *Server) handleReposGetCommitActivityStatsRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22774,7 +22248,6 @@ func (s *Server) handleReposGetCommitCommentRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22816,7 +22289,6 @@ func (s *Server) handleReposGetCommitSignatureProtectionRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22858,7 +22330,6 @@ func (s *Server) handleReposGetCommunityProfileMetricsRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22900,7 +22371,6 @@ func (s *Server) handleReposGetContributorsStatsRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22942,7 +22412,6 @@ func (s *Server) handleReposGetDeployKeyRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -22984,7 +22453,6 @@ func (s *Server) handleReposGetDeploymentRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23026,7 +22494,6 @@ func (s *Server) handleReposGetDeploymentStatusRequest(args [4]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23068,7 +22535,6 @@ func (s *Server) handleReposGetLatestPagesBuildRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23110,7 +22576,6 @@ func (s *Server) handleReposGetLatestReleaseRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23152,7 +22617,6 @@ func (s *Server) handleReposGetPagesRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23194,7 +22658,6 @@ func (s *Server) handleReposGetPagesBuildRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23236,7 +22699,6 @@ func (s *Server) handleReposGetPagesHealthCheckRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23278,7 +22740,6 @@ func (s *Server) handleReposGetParticipationStatsRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23320,7 +22781,6 @@ func (s *Server) handleReposGetPullRequestReviewProtectionRequest(args [3]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23362,7 +22822,6 @@ func (s *Server) handleReposGetPunchCardStatsRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23404,7 +22863,6 @@ func (s *Server) handleReposGetReadmeRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23446,7 +22904,6 @@ func (s *Server) handleReposGetReadmeInDirectoryRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23488,7 +22945,6 @@ func (s *Server) handleReposGetReleaseRequest(args [3]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23530,7 +22986,6 @@ func (s *Server) handleReposGetReleaseAssetRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23572,7 +23027,6 @@ func (s *Server) handleReposGetReleaseByTagRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23614,7 +23068,6 @@ func (s *Server) handleReposGetStatusChecksProtectionRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23656,7 +23109,6 @@ func (s *Server) handleReposGetTeamsWithAccessToProtectedBranchRequest(args [3]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23698,7 +23150,6 @@ func (s *Server) handleReposGetTopPathsRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23740,7 +23191,6 @@ func (s *Server) handleReposGetTopReferrersRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23782,7 +23232,6 @@ func (s *Server) handleReposGetUsersWithAccessToProtectedBranchRequest(args [3]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23824,7 +23273,6 @@ func (s *Server) handleReposGetViewsRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23866,7 +23314,6 @@ func (s *Server) handleReposGetWebhookRequest(args [3]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23908,7 +23355,6 @@ func (s *Server) handleReposGetWebhookConfigForRepoRequest(args [3]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23950,7 +23396,6 @@ func (s *Server) handleReposGetWebhookDeliveryRequest(args [4]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -23992,7 +23437,6 @@ func (s *Server) handleReposListAutolinksRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24034,7 +23478,6 @@ func (s *Server) handleReposListBranchesRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24076,7 +23519,6 @@ func (s *Server) handleReposListBranchesForHeadCommitRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24118,7 +23560,6 @@ func (s *Server) handleReposListCollaboratorsRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24160,7 +23601,6 @@ func (s *Server) handleReposListCommentsForCommitRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24202,7 +23642,6 @@ func (s *Server) handleReposListCommitCommentsForRepoRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24244,7 +23683,6 @@ func (s *Server) handleReposListCommitStatusesForRefRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24286,7 +23724,6 @@ func (s *Server) handleReposListCommitsRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24328,7 +23765,6 @@ func (s *Server) handleReposListContributorsRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24370,7 +23806,6 @@ func (s *Server) handleReposListDeployKeysRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24412,7 +23847,6 @@ func (s *Server) handleReposListDeploymentStatusesRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24454,7 +23888,6 @@ func (s *Server) handleReposListDeploymentsRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24496,7 +23929,6 @@ func (s *Server) handleReposListForAuthenticatedUserRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24538,7 +23970,6 @@ func (s *Server) handleReposListForOrgRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24580,7 +24011,6 @@ func (s *Server) handleReposListForUserRequest(args [1]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24622,7 +24052,6 @@ func (s *Server) handleReposListForksRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24664,7 +24093,6 @@ func (s *Server) handleReposListInvitationsRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24706,7 +24134,6 @@ func (s *Server) handleReposListInvitationsForAuthenticatedUserRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24748,7 +24175,6 @@ func (s *Server) handleReposListLanguagesRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24790,7 +24216,6 @@ func (s *Server) handleReposListPagesBuildsRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24832,7 +24257,6 @@ func (s *Server) handleReposListPublicRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24874,7 +24298,6 @@ func (s *Server) handleReposListPullRequestsAssociatedWithCommitRequest(args [3]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24916,7 +24339,6 @@ func (s *Server) handleReposListReleaseAssetsRequest(args [3]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -24958,7 +24380,6 @@ func (s *Server) handleReposListReleasesRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25000,7 +24421,6 @@ func (s *Server) handleReposListTagsRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25042,7 +24462,6 @@ func (s *Server) handleReposListTeamsRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25084,7 +24503,6 @@ func (s *Server) handleReposListWebhookDeliveriesRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25126,7 +24544,6 @@ func (s *Server) handleReposListWebhooksRequest(args [2]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25173,7 +24590,6 @@ func (s *Server) handleReposMergeRequest(args [2]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25220,7 +24636,6 @@ func (s *Server) handleReposMergeUpstreamRequest(args [2]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25262,7 +24677,6 @@ func (s *Server) handleReposPingWebhookRequest(args [3]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25304,7 +24718,6 @@ func (s *Server) handleReposRedeliverWebhookDeliveryRequest(args [4]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25351,7 +24764,6 @@ func (s *Server) handleReposRemoveAppAccessRestrictionsRequest(args [3]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25393,7 +24805,6 @@ func (s *Server) handleReposRemoveCollaboratorRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25440,7 +24851,6 @@ func (s *Server) handleReposRemoveStatusCheckContextsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25482,7 +24892,6 @@ func (s *Server) handleReposRemoveStatusCheckProtectionRequest(args [3]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25529,7 +24938,6 @@ func (s *Server) handleReposRemoveTeamAccessRestrictionsRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25576,7 +24984,6 @@ func (s *Server) handleReposRemoveUserAccessRestrictionsRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25623,7 +25030,6 @@ func (s *Server) handleReposRenameBranchRequest(args [3]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25670,7 +25076,6 @@ func (s *Server) handleReposReplaceAllTopicsRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25712,7 +25117,6 @@ func (s *Server) handleReposRequestPagesBuildRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25754,7 +25158,6 @@ func (s *Server) handleReposSetAdminBranchProtectionRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25801,7 +25204,6 @@ func (s *Server) handleReposSetAppAccessRestrictionsRequest(args [3]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25848,7 +25250,6 @@ func (s *Server) handleReposSetStatusCheckContextsRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25895,7 +25296,6 @@ func (s *Server) handleReposSetTeamAccessRestrictionsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25942,7 +25342,6 @@ func (s *Server) handleReposSetUserAccessRestrictionsRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -25984,7 +25383,6 @@ func (s *Server) handleReposTestPushWebhookRequest(args [3]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26031,7 +25429,6 @@ func (s *Server) handleReposTransferRequest(args [2]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26078,7 +25475,6 @@ func (s *Server) handleReposUpdateRequest(args [2]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26125,7 +25521,6 @@ func (s *Server) handleReposUpdateBranchProtectionRequest(args [3]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26172,7 +25567,6 @@ func (s *Server) handleReposUpdateCommitCommentRequest(args [3]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26219,7 +25613,6 @@ func (s *Server) handleReposUpdateInvitationRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26266,7 +25659,6 @@ func (s *Server) handleReposUpdatePullRequestReviewProtectionRequest(args [3]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26313,7 +25705,6 @@ func (s *Server) handleReposUpdateReleaseRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26360,7 +25751,6 @@ func (s *Server) handleReposUpdateReleaseAssetRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26407,7 +25797,6 @@ func (s *Server) handleReposUpdateStatusCheckProtectionRequest(args [3]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26454,7 +25843,6 @@ func (s *Server) handleReposUpdateWebhookRequest(args [3]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26501,7 +25889,6 @@ func (s *Server) handleReposUpdateWebhookConfigForRepoRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26543,7 +25930,6 @@ func (s *Server) handleScimDeleteUserFromOrgRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26585,7 +25971,6 @@ func (s *Server) handleSearchCodeRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26627,7 +26012,6 @@ func (s *Server) handleSearchCommitsRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26669,7 +26053,6 @@ func (s *Server) handleSearchIssuesAndPullRequestsRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26711,7 +26094,6 @@ func (s *Server) handleSearchLabelsRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26753,7 +26135,6 @@ func (s *Server) handleSearchReposRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26795,7 +26176,6 @@ func (s *Server) handleSearchTopicsRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26837,7 +26217,6 @@ func (s *Server) handleSearchUsersRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26879,7 +26258,6 @@ func (s *Server) handleSecretScanningGetAlertRequest(args [3]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26921,7 +26299,6 @@ func (s *Server) handleSecretScanningListAlertsForOrgRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -26963,7 +26340,6 @@ func (s *Server) handleSecretScanningListAlertsForRepoRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27010,7 +26386,6 @@ func (s *Server) handleSecretScanningUpdateAlertRequest(args [3]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27052,7 +26427,6 @@ func (s *Server) handleTeamsAddMemberLegacyRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27099,7 +26473,6 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserInOrgRequest(args [3]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27146,7 +26519,6 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserLegacyRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27193,7 +26565,6 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsInOrgRequest(args [3]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27240,7 +26611,6 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsLegacyRequest(args [2]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27287,7 +26657,6 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsInOrgRequest(args [4]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27334,7 +26703,6 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsLegacyRequest(args [3]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27376,7 +26744,6 @@ func (s *Server) handleTeamsCheckPermissionsForProjectInOrgRequest(args [3]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27418,7 +26785,6 @@ func (s *Server) handleTeamsCheckPermissionsForProjectLegacyRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27460,7 +26826,6 @@ func (s *Server) handleTeamsCheckPermissionsForRepoInOrgRequest(args [4]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27502,7 +26867,6 @@ func (s *Server) handleTeamsCheckPermissionsForRepoLegacyRequest(args [3]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27549,7 +26913,6 @@ func (s *Server) handleTeamsCreateRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27596,7 +26959,6 @@ func (s *Server) handleTeamsCreateDiscussionCommentInOrgRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27643,7 +27005,6 @@ func (s *Server) handleTeamsCreateDiscussionCommentLegacyRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27690,7 +27051,6 @@ func (s *Server) handleTeamsCreateDiscussionInOrgRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27737,7 +27097,6 @@ func (s *Server) handleTeamsCreateDiscussionLegacyRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27784,7 +27143,6 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27831,7 +27189,6 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27873,7 +27230,6 @@ func (s *Server) handleTeamsDeleteDiscussionCommentInOrgRequest(args [4]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27915,7 +27271,6 @@ func (s *Server) handleTeamsDeleteDiscussionCommentLegacyRequest(args [3]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27957,7 +27312,6 @@ func (s *Server) handleTeamsDeleteDiscussionInOrgRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -27999,7 +27353,6 @@ func (s *Server) handleTeamsDeleteDiscussionLegacyRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28041,7 +27394,6 @@ func (s *Server) handleTeamsDeleteInOrgRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28083,7 +27435,6 @@ func (s *Server) handleTeamsDeleteLegacyRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28125,7 +27476,6 @@ func (s *Server) handleTeamsGetByNameRequest(args [2]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28167,7 +27517,6 @@ func (s *Server) handleTeamsGetDiscussionCommentInOrgRequest(args [4]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28209,7 +27558,6 @@ func (s *Server) handleTeamsGetDiscussionCommentLegacyRequest(args [3]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28251,7 +27599,6 @@ func (s *Server) handleTeamsGetDiscussionInOrgRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28293,7 +27640,6 @@ func (s *Server) handleTeamsGetDiscussionLegacyRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28335,7 +27681,6 @@ func (s *Server) handleTeamsGetLegacyRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28377,7 +27722,6 @@ func (s *Server) handleTeamsGetMemberLegacyRequest(args [2]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28419,7 +27763,6 @@ func (s *Server) handleTeamsGetMembershipForUserInOrgRequest(args [3]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28461,7 +27804,6 @@ func (s *Server) handleTeamsGetMembershipForUserLegacyRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28503,7 +27845,6 @@ func (s *Server) handleTeamsListRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28545,7 +27886,6 @@ func (s *Server) handleTeamsListChildInOrgRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28587,7 +27927,6 @@ func (s *Server) handleTeamsListChildLegacyRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28629,7 +27968,6 @@ func (s *Server) handleTeamsListDiscussionCommentsInOrgRequest(args [3]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28671,7 +28009,6 @@ func (s *Server) handleTeamsListDiscussionCommentsLegacyRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28713,7 +28050,6 @@ func (s *Server) handleTeamsListDiscussionsInOrgRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28755,7 +28091,6 @@ func (s *Server) handleTeamsListDiscussionsLegacyRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28797,7 +28132,6 @@ func (s *Server) handleTeamsListForAuthenticatedUserRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28839,7 +28173,6 @@ func (s *Server) handleTeamsListIdpGroupsForLegacyRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28881,7 +28214,6 @@ func (s *Server) handleTeamsListIdpGroupsForOrgRequest(args [1]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28923,7 +28255,6 @@ func (s *Server) handleTeamsListIdpGroupsInOrgRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -28965,7 +28296,6 @@ func (s *Server) handleTeamsListMembersInOrgRequest(args [2]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29007,7 +28337,6 @@ func (s *Server) handleTeamsListMembersLegacyRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29049,7 +28378,6 @@ func (s *Server) handleTeamsListPendingInvitationsInOrgRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29091,7 +28419,6 @@ func (s *Server) handleTeamsListPendingInvitationsLegacyRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29133,7 +28460,6 @@ func (s *Server) handleTeamsListProjectsInOrgRequest(args [2]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29175,7 +28501,6 @@ func (s *Server) handleTeamsListProjectsLegacyRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29217,7 +28542,6 @@ func (s *Server) handleTeamsListReposInOrgRequest(args [2]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29259,7 +28583,6 @@ func (s *Server) handleTeamsListReposLegacyRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29301,7 +28624,6 @@ func (s *Server) handleTeamsRemoveMemberLegacyRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29343,7 +28665,6 @@ func (s *Server) handleTeamsRemoveMembershipForUserInOrgRequest(args [3]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29385,7 +28706,6 @@ func (s *Server) handleTeamsRemoveMembershipForUserLegacyRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29427,7 +28747,6 @@ func (s *Server) handleTeamsRemoveProjectInOrgRequest(args [3]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29469,7 +28788,6 @@ func (s *Server) handleTeamsRemoveProjectLegacyRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29511,7 +28829,6 @@ func (s *Server) handleTeamsRemoveRepoInOrgRequest(args [4]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29553,7 +28870,6 @@ func (s *Server) handleTeamsRemoveRepoLegacyRequest(args [3]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29600,7 +28916,6 @@ func (s *Server) handleTeamsUpdateDiscussionCommentInOrgRequest(args [4]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29647,7 +28962,6 @@ func (s *Server) handleTeamsUpdateDiscussionCommentLegacyRequest(args [3]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29694,7 +29008,6 @@ func (s *Server) handleTeamsUpdateDiscussionInOrgRequest(args [3]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29741,7 +29054,6 @@ func (s *Server) handleTeamsUpdateDiscussionLegacyRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29788,7 +29100,6 @@ func (s *Server) handleTeamsUpdateInOrgRequest(args [2]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29835,7 +29146,6 @@ func (s *Server) handleTeamsUpdateLegacyRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29877,7 +29187,6 @@ func (s *Server) handleUsersAddEmailForAuthenticatedRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29919,7 +29228,6 @@ func (s *Server) handleUsersBlockRequest(args [1]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -29961,7 +29269,6 @@ func (s *Server) handleUsersCheckBlockedRequest(args [1]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30003,7 +29310,6 @@ func (s *Server) handleUsersCheckFollowingForUserRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30045,7 +29351,6 @@ func (s *Server) handleUsersCheckPersonIsFollowedByAuthenticatedRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30087,7 +29392,6 @@ func (s *Server) handleUsersCreateGpgKeyForAuthenticatedRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30129,7 +29433,6 @@ func (s *Server) handleUsersCreatePublicSSHKeyForAuthenticatedRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30171,7 +29474,6 @@ func (s *Server) handleUsersDeleteEmailForAuthenticatedRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30213,7 +29515,6 @@ func (s *Server) handleUsersDeleteGpgKeyForAuthenticatedRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30255,7 +29556,6 @@ func (s *Server) handleUsersDeletePublicSSHKeyForAuthenticatedRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30297,7 +29597,6 @@ func (s *Server) handleUsersFollowRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30334,7 +29633,6 @@ func (s *Server) handleUsersGetAuthenticatedRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30376,7 +29674,6 @@ func (s *Server) handleUsersGetByUsernameRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30418,7 +29715,6 @@ func (s *Server) handleUsersGetContextForUserRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30460,7 +29756,6 @@ func (s *Server) handleUsersGetGpgKeyForAuthenticatedRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30502,7 +29797,6 @@ func (s *Server) handleUsersGetPublicSSHKeyForAuthenticatedRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30544,7 +29838,6 @@ func (s *Server) handleUsersListRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30581,7 +29874,6 @@ func (s *Server) handleUsersListBlockedByAuthenticatedRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30623,7 +29915,6 @@ func (s *Server) handleUsersListEmailsForAuthenticatedRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30665,7 +29956,6 @@ func (s *Server) handleUsersListFollowedByAuthenticatedRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30707,7 +29997,6 @@ func (s *Server) handleUsersListFollowersForAuthenticatedUserRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30749,7 +30038,6 @@ func (s *Server) handleUsersListFollowersForUserRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30791,7 +30079,6 @@ func (s *Server) handleUsersListFollowingForUserRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30833,7 +30120,6 @@ func (s *Server) handleUsersListGpgKeysForAuthenticatedRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30875,7 +30161,6 @@ func (s *Server) handleUsersListGpgKeysForUserRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30917,7 +30202,6 @@ func (s *Server) handleUsersListPublicEmailsForAuthenticatedRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -30959,7 +30243,6 @@ func (s *Server) handleUsersListPublicKeysForUserRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -31001,7 +30284,6 @@ func (s *Server) handleUsersListPublicSSHKeysForAuthenticatedRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -31043,7 +30325,6 @@ func (s *Server) handleUsersSetPrimaryEmailVisibilityForAuthenticatedRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -31085,7 +30366,6 @@ func (s *Server) handleUsersUnblockRequest(args [1]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -31127,7 +30407,6 @@ func (s *Server) handleUsersUnfollowRequest(args [1]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -31169,7 +30448,6 @@ func (s *Server) handleUsersUpdateAuthenticatedRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_github/oas_res_enc_gen.go
+++ b/examples/ex_github/oas_res_enc_gen.go
@@ -72,6 +72,7 @@ var (
 
 func encodeActionsAddRepoAccessToSelfHostedRunnerGroupInOrgResponse(response ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -79,9 +80,11 @@ func encodeActionsAddSelectedRepoToOrgSecretResponse(response ActionsAddSelected
 	switch response := response.(type) {
 	case *ActionsAddSelectedRepoToOrgSecretNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ActionsAddSelectedRepoToOrgSecretConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"+`: unexpected response type: %T`, response)
@@ -90,6 +93,7 @@ func encodeActionsAddSelectedRepoToOrgSecretResponse(response ActionsAddSelected
 
 func encodeActionsAddSelfHostedRunnerToGroupForOrgResponse(response ActionsAddSelfHostedRunnerToGroupForOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -98,6 +102,7 @@ func encodeActionsApproveWorkflowRunResponse(response ActionsApproveWorkflowRunR
 	case *EmptyObject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -110,6 +115,7 @@ func encodeActionsApproveWorkflowRunResponse(response ActionsApproveWorkflowRunR
 	case *ActionsApproveWorkflowRunApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -122,6 +128,7 @@ func encodeActionsApproveWorkflowRunResponse(response ActionsApproveWorkflowRunR
 	case *ActionsApproveWorkflowRunApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -139,6 +146,7 @@ func encodeActionsApproveWorkflowRunResponse(response ActionsApproveWorkflowRunR
 func encodeActionsCancelWorkflowRunResponse(response ActionsCancelWorkflowRunAccepted, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(202)
+	span.SetStatus(codes.Ok, http.StatusText(202))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -155,6 +163,7 @@ func encodeActionsCreateOrUpdateEnvironmentSecretResponse(response ActionsCreate
 	case *EmptyObject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -166,6 +175,7 @@ func encodeActionsCreateOrUpdateEnvironmentSecretResponse(response ActionsCreate
 		return nil
 	case *ActionsCreateOrUpdateEnvironmentSecretNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}"+`: unexpected response type: %T`, response)
@@ -177,6 +187,7 @@ func encodeActionsCreateOrUpdateOrgSecretResponse(response ActionsCreateOrUpdate
 	case *EmptyObject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -188,6 +199,7 @@ func encodeActionsCreateOrUpdateOrgSecretResponse(response ActionsCreateOrUpdate
 		return nil
 	case *ActionsCreateOrUpdateOrgSecretNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/actions/secrets/{secret_name}"+`: unexpected response type: %T`, response)
@@ -199,6 +211,7 @@ func encodeActionsCreateOrUpdateRepoSecretResponse(response ActionsCreateOrUpdat
 	case *ActionsCreateOrUpdateRepoSecretCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -210,6 +223,7 @@ func encodeActionsCreateOrUpdateRepoSecretResponse(response ActionsCreateOrUpdat
 		return nil
 	case *ActionsCreateOrUpdateRepoSecretNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/actions/secrets/{secret_name}"+`: unexpected response type: %T`, response)
@@ -219,6 +233,7 @@ func encodeActionsCreateOrUpdateRepoSecretResponse(response ActionsCreateOrUpdat
 func encodeActionsCreateRegistrationTokenForOrgResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -233,6 +248,7 @@ func encodeActionsCreateRegistrationTokenForOrgResponse(response AuthenticationT
 func encodeActionsCreateRegistrationTokenForRepoResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -247,6 +263,7 @@ func encodeActionsCreateRegistrationTokenForRepoResponse(response Authentication
 func encodeActionsCreateRemoveTokenForOrgResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -261,6 +278,7 @@ func encodeActionsCreateRemoveTokenForOrgResponse(response AuthenticationToken, 
 func encodeActionsCreateRemoveTokenForRepoResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -275,6 +293,7 @@ func encodeActionsCreateRemoveTokenForRepoResponse(response AuthenticationToken,
 func encodeActionsCreateSelfHostedRunnerGroupForOrgResponse(response RunnerGroupsOrg, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -288,77 +307,92 @@ func encodeActionsCreateSelfHostedRunnerGroupForOrgResponse(response RunnerGroup
 
 func encodeActionsDeleteArtifactResponse(response ActionsDeleteArtifactNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteEnvironmentSecretResponse(response ActionsDeleteEnvironmentSecretNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteOrgSecretResponse(response ActionsDeleteOrgSecretNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteRepoSecretResponse(response ActionsDeleteRepoSecretNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteSelfHostedRunnerFromOrgResponse(response ActionsDeleteSelfHostedRunnerFromOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteSelfHostedRunnerFromRepoResponse(response ActionsDeleteSelfHostedRunnerFromRepoNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteSelfHostedRunnerGroupFromOrgResponse(response ActionsDeleteSelfHostedRunnerGroupFromOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteWorkflowRunResponse(response ActionsDeleteWorkflowRunNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDeleteWorkflowRunLogsResponse(response ActionsDeleteWorkflowRunLogsNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDisableSelectedRepositoryGithubActionsOrganizationResponse(response ActionsDisableSelectedRepositoryGithubActionsOrganizationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsDownloadArtifactResponse(response ActionsDownloadArtifactFound, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(302)
+	span.SetStatus(codes.Ok, http.StatusText(302))
 	return nil
 }
 
 func encodeActionsDownloadJobLogsForWorkflowRunResponse(response ActionsDownloadJobLogsForWorkflowRunFound, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(302)
+	span.SetStatus(codes.Ok, http.StatusText(302))
 	return nil
 }
 
 func encodeActionsDownloadWorkflowRunLogsResponse(response ActionsDownloadWorkflowRunLogsFound, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(302)
+	span.SetStatus(codes.Ok, http.StatusText(302))
 	return nil
 }
 
 func encodeActionsEnableSelectedRepositoryGithubActionsOrganizationResponse(response ActionsEnableSelectedRepositoryGithubActionsOrganizationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsGetAllowedActionsOrganizationResponse(response SelectedActions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -373,6 +407,7 @@ func encodeActionsGetAllowedActionsOrganizationResponse(response SelectedActions
 func encodeActionsGetAllowedActionsRepositoryResponse(response SelectedActions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -387,6 +422,7 @@ func encodeActionsGetAllowedActionsRepositoryResponse(response SelectedActions, 
 func encodeActionsGetArtifactResponse(response Artifact, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -401,6 +437,7 @@ func encodeActionsGetArtifactResponse(response Artifact, w http.ResponseWriter, 
 func encodeActionsGetEnvironmentPublicKeyResponse(response ActionsPublicKey, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -415,6 +452,7 @@ func encodeActionsGetEnvironmentPublicKeyResponse(response ActionsPublicKey, w h
 func encodeActionsGetEnvironmentSecretResponse(response ActionsSecret, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -429,6 +467,7 @@ func encodeActionsGetEnvironmentSecretResponse(response ActionsSecret, w http.Re
 func encodeActionsGetGithubActionsPermissionsOrganizationResponse(response ActionsOrganizationPermissions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -443,6 +482,7 @@ func encodeActionsGetGithubActionsPermissionsOrganizationResponse(response Actio
 func encodeActionsGetGithubActionsPermissionsRepositoryResponse(response ActionsRepositoryPermissions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -457,6 +497,7 @@ func encodeActionsGetGithubActionsPermissionsRepositoryResponse(response Actions
 func encodeActionsGetJobForWorkflowRunResponse(response Job, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -471,6 +512,7 @@ func encodeActionsGetJobForWorkflowRunResponse(response Job, w http.ResponseWrit
 func encodeActionsGetOrgPublicKeyResponse(response ActionsPublicKey, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -485,6 +527,7 @@ func encodeActionsGetOrgPublicKeyResponse(response ActionsPublicKey, w http.Resp
 func encodeActionsGetOrgSecretResponse(response OrganizationActionsSecret, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -499,6 +542,7 @@ func encodeActionsGetOrgSecretResponse(response OrganizationActionsSecret, w htt
 func encodeActionsGetRepoPublicKeyResponse(response ActionsPublicKey, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -513,6 +557,7 @@ func encodeActionsGetRepoPublicKeyResponse(response ActionsPublicKey, w http.Res
 func encodeActionsGetRepoSecretResponse(response ActionsSecret, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -527,6 +572,7 @@ func encodeActionsGetRepoSecretResponse(response ActionsSecret, w http.ResponseW
 func encodeActionsGetReviewsForRunResponse(response []EnvironmentApprovals, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -545,6 +591,7 @@ func encodeActionsGetReviewsForRunResponse(response []EnvironmentApprovals, w ht
 func encodeActionsGetSelfHostedRunnerForOrgResponse(response Runner, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -559,6 +606,7 @@ func encodeActionsGetSelfHostedRunnerForOrgResponse(response Runner, w http.Resp
 func encodeActionsGetSelfHostedRunnerForRepoResponse(response Runner, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -573,6 +621,7 @@ func encodeActionsGetSelfHostedRunnerForRepoResponse(response Runner, w http.Res
 func encodeActionsGetSelfHostedRunnerGroupForOrgResponse(response RunnerGroupsOrg, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -587,6 +636,7 @@ func encodeActionsGetSelfHostedRunnerGroupForOrgResponse(response RunnerGroupsOr
 func encodeActionsGetWorkflowRunResponse(response WorkflowRun, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -601,6 +651,7 @@ func encodeActionsGetWorkflowRunResponse(response WorkflowRun, w http.ResponseWr
 func encodeActionsGetWorkflowRunUsageResponse(response WorkflowRunUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -615,6 +666,7 @@ func encodeActionsGetWorkflowRunUsageResponse(response WorkflowRunUsage, w http.
 func encodeActionsListArtifactsForRepoResponse(response ActionsListArtifactsForRepoOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -629,6 +681,7 @@ func encodeActionsListArtifactsForRepoResponse(response ActionsListArtifactsForR
 func encodeActionsListEnvironmentSecretsResponse(response ActionsListEnvironmentSecretsOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -643,6 +696,7 @@ func encodeActionsListEnvironmentSecretsResponse(response ActionsListEnvironment
 func encodeActionsListJobsForWorkflowRunResponse(response ActionsListJobsForWorkflowRunOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -657,6 +711,7 @@ func encodeActionsListJobsForWorkflowRunResponse(response ActionsListJobsForWork
 func encodeActionsListOrgSecretsResponse(response ActionsListOrgSecretsOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -671,6 +726,7 @@ func encodeActionsListOrgSecretsResponse(response ActionsListOrgSecretsOK, w htt
 func encodeActionsListRepoAccessToSelfHostedRunnerGroupInOrgResponse(response ActionsListRepoAccessToSelfHostedRunnerGroupInOrgOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -685,6 +741,7 @@ func encodeActionsListRepoAccessToSelfHostedRunnerGroupInOrgResponse(response Ac
 func encodeActionsListRepoSecretsResponse(response ActionsListRepoSecretsOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -699,6 +756,7 @@ func encodeActionsListRepoSecretsResponse(response ActionsListRepoSecretsOK, w h
 func encodeActionsListRepoWorkflowsResponse(response ActionsListRepoWorkflowsOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -713,6 +771,7 @@ func encodeActionsListRepoWorkflowsResponse(response ActionsListRepoWorkflowsOK,
 func encodeActionsListRunnerApplicationsForOrgResponse(response []RunnerApplication, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -731,6 +790,7 @@ func encodeActionsListRunnerApplicationsForOrgResponse(response []RunnerApplicat
 func encodeActionsListRunnerApplicationsForRepoResponse(response []RunnerApplication, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -749,6 +809,7 @@ func encodeActionsListRunnerApplicationsForRepoResponse(response []RunnerApplica
 func encodeActionsListSelectedReposForOrgSecretResponse(response ActionsListSelectedReposForOrgSecretOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -763,6 +824,7 @@ func encodeActionsListSelectedReposForOrgSecretResponse(response ActionsListSele
 func encodeActionsListSelectedRepositoriesEnabledGithubActionsOrganizationResponse(response ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -777,6 +839,7 @@ func encodeActionsListSelectedRepositoriesEnabledGithubActionsOrganizationRespon
 func encodeActionsListSelfHostedRunnerGroupsForOrgResponse(response ActionsListSelfHostedRunnerGroupsForOrgOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -791,6 +854,7 @@ func encodeActionsListSelfHostedRunnerGroupsForOrgResponse(response ActionsListS
 func encodeActionsListSelfHostedRunnersForOrgResponse(response ActionsListSelfHostedRunnersForOrgOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -805,6 +869,7 @@ func encodeActionsListSelfHostedRunnersForOrgResponse(response ActionsListSelfHo
 func encodeActionsListSelfHostedRunnersForRepoResponse(response ActionsListSelfHostedRunnersForRepoOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -819,6 +884,7 @@ func encodeActionsListSelfHostedRunnersForRepoResponse(response ActionsListSelfH
 func encodeActionsListSelfHostedRunnersInGroupForOrgResponse(response ActionsListSelfHostedRunnersInGroupForOrgOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -833,6 +899,7 @@ func encodeActionsListSelfHostedRunnersInGroupForOrgResponse(response ActionsLis
 func encodeActionsListWorkflowRunArtifactsResponse(response ActionsListWorkflowRunArtifactsOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -847,6 +914,7 @@ func encodeActionsListWorkflowRunArtifactsResponse(response ActionsListWorkflowR
 func encodeActionsListWorkflowRunsForRepoResponse(response ActionsListWorkflowRunsForRepoOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -861,6 +929,7 @@ func encodeActionsListWorkflowRunsForRepoResponse(response ActionsListWorkflowRu
 func encodeActionsReRunWorkflowResponse(response ActionsReRunWorkflowCreated, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -874,6 +943,7 @@ func encodeActionsReRunWorkflowResponse(response ActionsReRunWorkflowCreated, w 
 
 func encodeActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgResponse(response ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -881,9 +951,11 @@ func encodeActionsRemoveSelectedRepoFromOrgSecretResponse(response ActionsRemove
 	switch response := response.(type) {
 	case *ActionsRemoveSelectedRepoFromOrgSecretNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ActionsRemoveSelectedRepoFromOrgSecretConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"+`: unexpected response type: %T`, response)
@@ -892,12 +964,14 @@ func encodeActionsRemoveSelectedRepoFromOrgSecretResponse(response ActionsRemove
 
 func encodeActionsRemoveSelfHostedRunnerFromGroupForOrgResponse(response ActionsRemoveSelfHostedRunnerFromGroupForOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsRetryWorkflowResponse(response ActionsRetryWorkflowCreated, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -912,6 +986,7 @@ func encodeActionsRetryWorkflowResponse(response ActionsRetryWorkflowCreated, w 
 func encodeActionsReviewPendingDeploymentsForRunResponse(response []Deployment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -929,47 +1004,56 @@ func encodeActionsReviewPendingDeploymentsForRunResponse(response []Deployment, 
 
 func encodeActionsSetAllowedActionsOrganizationResponse(response ActionsSetAllowedActionsOrganizationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetAllowedActionsRepositoryResponse(response ActionsSetAllowedActionsRepositoryNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetGithubActionsPermissionsOrganizationResponse(response ActionsSetGithubActionsPermissionsOrganizationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetGithubActionsPermissionsRepositoryResponse(response ActionsSetGithubActionsPermissionsRepositoryNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgResponse(response ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetSelectedReposForOrgSecretResponse(response ActionsSetSelectedReposForOrgSecretNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationResponse(response ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsSetSelfHostedRunnersInGroupForOrgResponse(response ActionsSetSelfHostedRunnersInGroupForOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeActionsUpdateSelfHostedRunnerGroupForOrgResponse(response RunnerGroupsOrg, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -985,13 +1069,16 @@ func encodeActivityCheckRepoIsStarredByAuthenticatedUserResponse(response Activi
 	switch response := response.(type) {
 	case *ActivityCheckRepoIsStarredByAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityCheckRepoIsStarredByAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1004,6 +1091,7 @@ func encodeActivityCheckRepoIsStarredByAuthenticatedUserResponse(response Activi
 	case *ActivityCheckRepoIsStarredByAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1016,6 +1104,7 @@ func encodeActivityCheckRepoIsStarredByAuthenticatedUserResponse(response Activi
 	case *ActivityCheckRepoIsStarredByAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1032,6 +1121,7 @@ func encodeActivityCheckRepoIsStarredByAuthenticatedUserResponse(response Activi
 
 func encodeActivityDeleteRepoSubscriptionResponse(response ActivityDeleteRepoSubscriptionNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -1039,13 +1129,16 @@ func encodeActivityDeleteThreadSubscriptionResponse(response ActivityDeleteThrea
 	switch response := response.(type) {
 	case *ActivityDeleteThreadSubscriptionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityDeleteThreadSubscriptionApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1058,6 +1151,7 @@ func encodeActivityDeleteThreadSubscriptionResponse(response ActivityDeleteThrea
 	case *ActivityDeleteThreadSubscriptionApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1075,6 +1169,7 @@ func encodeActivityDeleteThreadSubscriptionResponse(response ActivityDeleteThrea
 func encodeActivityGetFeedsResponse(response Feed, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1091,6 +1186,7 @@ func encodeActivityGetRepoSubscriptionResponse(response ActivityGetRepoSubscript
 	case *RepositorySubscription:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1103,6 +1199,7 @@ func encodeActivityGetRepoSubscriptionResponse(response ActivityGetRepoSubscript
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1114,6 +1211,7 @@ func encodeActivityGetRepoSubscriptionResponse(response ActivityGetRepoSubscript
 		return nil
 	case *ActivityGetRepoSubscriptionNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/subscription"+`: unexpected response type: %T`, response)
@@ -1125,6 +1223,7 @@ func encodeActivityGetThreadResponse(response ActivityGetThreadRes, w http.Respo
 	case *Thread:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1136,10 +1235,12 @@ func encodeActivityGetThreadResponse(response ActivityGetThreadRes, w http.Respo
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityGetThreadApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1152,6 +1253,7 @@ func encodeActivityGetThreadResponse(response ActivityGetThreadRes, w http.Respo
 	case *ActivityGetThreadApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1171,6 +1273,7 @@ func encodeActivityGetThreadSubscriptionForAuthenticatedUserResponse(response Ac
 	case *ThreadSubscription:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1182,10 +1285,12 @@ func encodeActivityGetThreadSubscriptionForAuthenticatedUserResponse(response Ac
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityGetThreadSubscriptionForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1198,6 +1303,7 @@ func encodeActivityGetThreadSubscriptionForAuthenticatedUserResponse(response Ac
 	case *ActivityGetThreadSubscriptionForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1215,6 +1321,7 @@ func encodeActivityGetThreadSubscriptionForAuthenticatedUserResponse(response Ac
 func encodeActivityListEventsForAuthenticatedUserResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1235,6 +1342,7 @@ func encodeActivityListNotificationsForAuthenticatedUserResponse(response Activi
 	case *ActivityListNotificationsForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1246,10 +1354,12 @@ func encodeActivityListNotificationsForAuthenticatedUserResponse(response Activi
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityListNotificationsForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1262,6 +1372,7 @@ func encodeActivityListNotificationsForAuthenticatedUserResponse(response Activi
 	case *ActivityListNotificationsForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1274,6 +1385,7 @@ func encodeActivityListNotificationsForAuthenticatedUserResponse(response Activi
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1291,6 +1403,7 @@ func encodeActivityListNotificationsForAuthenticatedUserResponse(response Activi
 func encodeActivityListOrgEventsForAuthenticatedUserResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1311,6 +1424,7 @@ func encodeActivityListPublicEventsResponse(response ActivityListPublicEventsRes
 	case *ActivityListPublicEventsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1322,10 +1436,12 @@ func encodeActivityListPublicEventsResponse(response ActivityListPublicEventsRes
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1338,6 +1454,7 @@ func encodeActivityListPublicEventsResponse(response ActivityListPublicEventsRes
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1357,6 +1474,7 @@ func encodeActivityListPublicEventsForRepoNetworkResponse(response ActivityListP
 	case *ActivityListPublicEventsForRepoNetworkOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1369,6 +1487,7 @@ func encodeActivityListPublicEventsForRepoNetworkResponse(response ActivityListP
 	case *ActivityListPublicEventsForRepoNetworkApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1380,10 +1499,12 @@ func encodeActivityListPublicEventsForRepoNetworkResponse(response ActivityListP
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityListPublicEventsForRepoNetworkApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1396,6 +1517,7 @@ func encodeActivityListPublicEventsForRepoNetworkResponse(response ActivityListP
 	case *ActivityListPublicEventsForRepoNetworkApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1413,6 +1535,7 @@ func encodeActivityListPublicEventsForRepoNetworkResponse(response ActivityListP
 func encodeActivityListPublicEventsForUserResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1431,6 +1554,7 @@ func encodeActivityListPublicEventsForUserResponse(response []Event, w http.Resp
 func encodeActivityListPublicOrgEventsResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1449,6 +1573,7 @@ func encodeActivityListPublicOrgEventsResponse(response []Event, w http.Response
 func encodeActivityListReceivedEventsForUserResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1467,6 +1592,7 @@ func encodeActivityListReceivedEventsForUserResponse(response []Event, w http.Re
 func encodeActivityListReceivedPublicEventsForUserResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1485,6 +1611,7 @@ func encodeActivityListReceivedPublicEventsForUserResponse(response []Event, w h
 func encodeActivityListRepoEventsResponse(response []Event, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1503,6 +1630,7 @@ func encodeActivityListRepoEventsResponse(response []Event, w http.ResponseWrite
 func encodeActivityListRepoNotificationsForAuthenticatedUserResponse(response []Thread, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1523,6 +1651,7 @@ func encodeActivityListReposStarredByAuthenticatedUserResponse(response Activity
 	case *ActivityListReposStarredByAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1534,10 +1663,12 @@ func encodeActivityListReposStarredByAuthenticatedUserResponse(response Activity
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityListReposStarredByAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1550,6 +1681,7 @@ func encodeActivityListReposStarredByAuthenticatedUserResponse(response Activity
 	case *ActivityListReposStarredByAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1567,6 +1699,7 @@ func encodeActivityListReposStarredByAuthenticatedUserResponse(response Activity
 func encodeActivityListReposWatchedByUserResponse(response []MinimalRepository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1587,6 +1720,7 @@ func encodeActivityListWatchedReposForAuthenticatedUserResponse(response Activit
 	case *ActivityListWatchedReposForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1598,10 +1732,12 @@ func encodeActivityListWatchedReposForAuthenticatedUserResponse(response Activit
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityListWatchedReposForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1614,6 +1750,7 @@ func encodeActivityListWatchedReposForAuthenticatedUserResponse(response Activit
 	case *ActivityListWatchedReposForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1631,6 +1768,7 @@ func encodeActivityListWatchedReposForAuthenticatedUserResponse(response Activit
 func encodeActivityListWatchersForRepoResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1651,6 +1789,7 @@ func encodeActivityMarkNotificationsAsReadResponse(response ActivityMarkNotifica
 	case *ActivityMarkNotificationsAsReadAccepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1662,13 +1801,16 @@ func encodeActivityMarkNotificationsAsReadResponse(response ActivityMarkNotifica
 		return nil
 	case *ActivityMarkNotificationsAsReadResetContent:
 		w.WriteHeader(205)
+		span.SetStatus(codes.Ok, http.StatusText(205))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityMarkNotificationsAsReadApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1681,6 +1823,7 @@ func encodeActivityMarkNotificationsAsReadResponse(response ActivityMarkNotifica
 	case *ActivityMarkNotificationsAsReadApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1700,6 +1843,7 @@ func encodeActivityMarkRepoNotificationsAsReadResponse(response ActivityMarkRepo
 	case *ActivityMarkRepoNotificationsAsReadAccepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1711,6 +1855,7 @@ func encodeActivityMarkRepoNotificationsAsReadResponse(response ActivityMarkRepo
 		return nil
 	case *ActivityMarkRepoNotificationsAsReadResetContent:
 		w.WriteHeader(205)
+		span.SetStatus(codes.Ok, http.StatusText(205))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/notifications"+`: unexpected response type: %T`, response)
@@ -1721,13 +1866,16 @@ func encodeActivityMarkThreadAsReadResponse(response ActivityMarkThreadAsReadRes
 	switch response := response.(type) {
 	case *ActivityMarkThreadAsReadResetContent:
 		w.WriteHeader(205)
+		span.SetStatus(codes.Ok, http.StatusText(205))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1745,6 +1893,7 @@ func encodeActivityMarkThreadAsReadResponse(response ActivityMarkThreadAsReadRes
 func encodeActivitySetRepoSubscriptionResponse(response RepositorySubscription, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1761,6 +1910,7 @@ func encodeActivitySetThreadSubscriptionResponse(response ActivitySetThreadSubsc
 	case *ThreadSubscription:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1772,10 +1922,12 @@ func encodeActivitySetThreadSubscriptionResponse(response ActivitySetThreadSubsc
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivitySetThreadSubscriptionApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1788,6 +1940,7 @@ func encodeActivitySetThreadSubscriptionResponse(response ActivitySetThreadSubsc
 	case *ActivitySetThreadSubscriptionApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1806,13 +1959,16 @@ func encodeActivityStarRepoForAuthenticatedUserResponse(response ActivityStarRep
 	switch response := response.(type) {
 	case *ActivityStarRepoForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityStarRepoForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1825,6 +1981,7 @@ func encodeActivityStarRepoForAuthenticatedUserResponse(response ActivityStarRep
 	case *ActivityStarRepoForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1837,6 +1994,7 @@ func encodeActivityStarRepoForAuthenticatedUserResponse(response ActivityStarRep
 	case *ActivityStarRepoForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1855,13 +2013,16 @@ func encodeActivityUnstarRepoForAuthenticatedUserResponse(response ActivityUnsta
 	switch response := response.(type) {
 	case *ActivityUnstarRepoForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ActivityUnstarRepoForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1874,6 +2035,7 @@ func encodeActivityUnstarRepoForAuthenticatedUserResponse(response ActivityUnsta
 	case *ActivityUnstarRepoForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1886,6 +2048,7 @@ func encodeActivityUnstarRepoForAuthenticatedUserResponse(response ActivityUnsta
 	case *ActivityUnstarRepoForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1904,13 +2067,16 @@ func encodeAppsAddRepoToInstallationResponse(response AppsAddRepoToInstallationR
 	switch response := response.(type) {
 	case *AppsAddRepoToInstallationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsAddRepoToInstallationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1923,6 +2089,7 @@ func encodeAppsAddRepoToInstallationResponse(response AppsAddRepoToInstallationR
 	case *AppsAddRepoToInstallationApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1942,6 +2109,7 @@ func encodeAppsCheckTokenResponse(response AppsCheckTokenRes, w http.ResponseWri
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1954,6 +2122,7 @@ func encodeAppsCheckTokenResponse(response AppsCheckTokenRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1966,6 +2135,7 @@ func encodeAppsCheckTokenResponse(response AppsCheckTokenRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1985,6 +2155,7 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 	case *ContentReferenceAttachment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1996,10 +2167,12 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsCreateContentAttachmentApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2012,6 +2185,7 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 	case *AppsCreateContentAttachmentApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2024,6 +2198,7 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 	case *AppsCreateContentAttachmentApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2036,6 +2211,7 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2048,6 +2224,7 @@ func encodeAppsCreateContentAttachmentResponse(response AppsCreateContentAttachm
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2067,6 +2244,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *InstallationToken:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2079,6 +2257,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *AppsCreateInstallationAccessTokenApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2091,6 +2270,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *AppsCreateInstallationAccessTokenApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2103,6 +2283,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *AppsCreateInstallationAccessTokenApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2115,6 +2296,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2127,6 +2309,7 @@ func encodeAppsCreateInstallationAccessTokenResponse(response AppsCreateInstalla
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2145,10 +2328,12 @@ func encodeAppsDeleteAuthorizationResponse(response AppsDeleteAuthorizationRes, 
 	switch response := response.(type) {
 	case *AppsDeleteAuthorizationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2167,10 +2352,12 @@ func encodeAppsDeleteInstallationResponse(response AppsDeleteInstallationRes, w 
 	switch response := response.(type) {
 	case *AppsDeleteInstallationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2189,10 +2376,12 @@ func encodeAppsDeleteTokenResponse(response AppsDeleteTokenRes, w http.ResponseW
 	switch response := response.(type) {
 	case *AppsDeleteTokenNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2210,6 +2399,7 @@ func encodeAppsDeleteTokenResponse(response AppsDeleteTokenRes, w http.ResponseW
 func encodeAppsGetAuthenticatedResponse(response Integration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2226,6 +2416,7 @@ func encodeAppsGetBySlugResponse(response AppsGetBySlugRes, w http.ResponseWrite
 	case *Integration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2238,6 +2429,7 @@ func encodeAppsGetBySlugResponse(response AppsGetBySlugRes, w http.ResponseWrite
 	case *AppsGetBySlugApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2250,6 +2442,7 @@ func encodeAppsGetBySlugResponse(response AppsGetBySlugRes, w http.ResponseWrite
 	case *AppsGetBySlugApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2262,6 +2455,7 @@ func encodeAppsGetBySlugResponse(response AppsGetBySlugRes, w http.ResponseWrite
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2281,6 +2475,7 @@ func encodeAppsGetSubscriptionPlanForAccountResponse(response AppsGetSubscriptio
 	case *MarketplacePurchase:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2293,6 +2488,7 @@ func encodeAppsGetSubscriptionPlanForAccountResponse(response AppsGetSubscriptio
 	case *AppsGetSubscriptionPlanForAccountApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2305,6 +2501,7 @@ func encodeAppsGetSubscriptionPlanForAccountResponse(response AppsGetSubscriptio
 	case *AppsGetSubscriptionPlanForAccountApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2324,6 +2521,7 @@ func encodeAppsGetSubscriptionPlanForAccountStubbedResponse(response AppsGetSubs
 	case *MarketplacePurchase:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2336,6 +2534,7 @@ func encodeAppsGetSubscriptionPlanForAccountStubbedResponse(response AppsGetSubs
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2347,6 +2546,7 @@ func encodeAppsGetSubscriptionPlanForAccountStubbedResponse(response AppsGetSubs
 		return nil
 	case *AppsGetSubscriptionPlanForAccountStubbedNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/marketplace_listing/stubbed/accounts/{account_id}"+`: unexpected response type: %T`, response)
@@ -2356,6 +2556,7 @@ func encodeAppsGetSubscriptionPlanForAccountStubbedResponse(response AppsGetSubs
 func encodeAppsGetWebhookConfigForAppResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2372,6 +2573,7 @@ func encodeAppsGetWebhookDeliveryResponse(response AppsGetWebhookDeliveryRes, w 
 	case *HookDelivery:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2384,6 +2586,7 @@ func encodeAppsGetWebhookDeliveryResponse(response AppsGetWebhookDeliveryRes, w 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2396,6 +2599,7 @@ func encodeAppsGetWebhookDeliveryResponse(response AppsGetWebhookDeliveryRes, w 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2415,6 +2619,7 @@ func encodeAppsListAccountsForPlanResponse(response AppsListAccountsForPlanRes, 
 	case *AppsListAccountsForPlanOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2427,6 +2632,7 @@ func encodeAppsListAccountsForPlanResponse(response AppsListAccountsForPlanRes, 
 	case *AppsListAccountsForPlanApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2439,6 +2645,7 @@ func encodeAppsListAccountsForPlanResponse(response AppsListAccountsForPlanRes, 
 	case *AppsListAccountsForPlanApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2451,6 +2658,7 @@ func encodeAppsListAccountsForPlanResponse(response AppsListAccountsForPlanRes, 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2470,6 +2678,7 @@ func encodeAppsListAccountsForPlanStubbedResponse(response AppsListAccountsForPl
 	case *AppsListAccountsForPlanStubbedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2482,6 +2691,7 @@ func encodeAppsListAccountsForPlanStubbedResponse(response AppsListAccountsForPl
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2501,6 +2711,7 @@ func encodeAppsListInstallationReposForAuthenticatedUserResponse(response AppsLi
 	case *AppsListInstallationReposForAuthenticatedUserOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2512,10 +2723,12 @@ func encodeAppsListInstallationReposForAuthenticatedUserResponse(response AppsLi
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsListInstallationReposForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2528,6 +2741,7 @@ func encodeAppsListInstallationReposForAuthenticatedUserResponse(response AppsLi
 	case *AppsListInstallationReposForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2547,6 +2761,7 @@ func encodeAppsListPlansResponse(response AppsListPlansRes, w http.ResponseWrite
 	case *AppsListPlansOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2559,6 +2774,7 @@ func encodeAppsListPlansResponse(response AppsListPlansRes, w http.ResponseWrite
 	case *AppsListPlansApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2571,6 +2787,7 @@ func encodeAppsListPlansResponse(response AppsListPlansRes, w http.ResponseWrite
 	case *AppsListPlansApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2590,6 +2807,7 @@ func encodeAppsListPlansStubbedResponse(response AppsListPlansStubbedRes, w http
 	case *AppsListPlansStubbedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2602,6 +2820,7 @@ func encodeAppsListPlansStubbedResponse(response AppsListPlansStubbedRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2621,6 +2840,7 @@ func encodeAppsListReposAccessibleToInstallationResponse(response AppsListReposA
 	case *AppsListReposAccessibleToInstallationOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2632,10 +2852,12 @@ func encodeAppsListReposAccessibleToInstallationResponse(response AppsListReposA
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsListReposAccessibleToInstallationApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2648,6 +2870,7 @@ func encodeAppsListReposAccessibleToInstallationResponse(response AppsListReposA
 	case *AppsListReposAccessibleToInstallationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2667,6 +2890,7 @@ func encodeAppsListSubscriptionsForAuthenticatedUserResponse(response AppsListSu
 	case *AppsListSubscriptionsForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2678,10 +2902,12 @@ func encodeAppsListSubscriptionsForAuthenticatedUserResponse(response AppsListSu
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsListSubscriptionsForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2694,6 +2920,7 @@ func encodeAppsListSubscriptionsForAuthenticatedUserResponse(response AppsListSu
 	case *AppsListSubscriptionsForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2713,6 +2940,7 @@ func encodeAppsListSubscriptionsForAuthenticatedUserStubbedResponse(response App
 	case *AppsListSubscriptionsForAuthenticatedUserStubbedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2724,10 +2952,12 @@ func encodeAppsListSubscriptionsForAuthenticatedUserStubbedResponse(response App
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2747,6 +2977,7 @@ func encodeAppsListWebhookDeliveriesResponse(response AppsListWebhookDeliveriesR
 	case *AppsListWebhookDeliveriesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2759,6 +2990,7 @@ func encodeAppsListWebhookDeliveriesResponse(response AppsListWebhookDeliveriesR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2771,6 +3003,7 @@ func encodeAppsListWebhookDeliveriesResponse(response AppsListWebhookDeliveriesR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2790,6 +3023,7 @@ func encodeAppsRedeliverWebhookDeliveryResponse(response AppsRedeliverWebhookDel
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2802,6 +3036,7 @@ func encodeAppsRedeliverWebhookDeliveryResponse(response AppsRedeliverWebhookDel
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2814,6 +3049,7 @@ func encodeAppsRedeliverWebhookDeliveryResponse(response AppsRedeliverWebhookDel
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2832,13 +3068,16 @@ func encodeAppsRemoveRepoFromInstallationResponse(response AppsRemoveRepoFromIns
 	switch response := response.(type) {
 	case *AppsRemoveRepoFromInstallationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *AppsRemoveRepoFromInstallationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2851,6 +3090,7 @@ func encodeAppsRemoveRepoFromInstallationResponse(response AppsRemoveRepoFromIns
 	case *AppsRemoveRepoFromInstallationApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2870,6 +3110,7 @@ func encodeAppsResetTokenResponse(response AppsResetTokenRes, w http.ResponseWri
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2882,6 +3123,7 @@ func encodeAppsResetTokenResponse(response AppsResetTokenRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2898,6 +3140,7 @@ func encodeAppsResetTokenResponse(response AppsResetTokenRes, w http.ResponseWri
 
 func encodeAppsRevokeInstallationAccessTokenResponse(response AppsRevokeInstallationAccessTokenNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -2906,6 +3149,7 @@ func encodeAppsScopeTokenResponse(response AppsScopeTokenRes, w http.ResponseWri
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2918,6 +3162,7 @@ func encodeAppsScopeTokenResponse(response AppsScopeTokenRes, w http.ResponseWri
 	case *AppsScopeTokenApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2930,6 +3175,7 @@ func encodeAppsScopeTokenResponse(response AppsScopeTokenRes, w http.ResponseWri
 	case *AppsScopeTokenApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2942,6 +3188,7 @@ func encodeAppsScopeTokenResponse(response AppsScopeTokenRes, w http.ResponseWri
 	case *AppsScopeTokenApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2954,6 +3201,7 @@ func encodeAppsScopeTokenResponse(response AppsScopeTokenRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2972,10 +3220,12 @@ func encodeAppsSuspendInstallationResponse(response AppsSuspendInstallationRes, 
 	switch response := response.(type) {
 	case *AppsSuspendInstallationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2994,10 +3244,12 @@ func encodeAppsUnsuspendInstallationResponse(response AppsUnsuspendInstallationR
 	switch response := response.(type) {
 	case *AppsUnsuspendInstallationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3015,6 +3267,7 @@ func encodeAppsUnsuspendInstallationResponse(response AppsUnsuspendInstallationR
 func encodeAppsUpdateWebhookConfigForAppResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3029,6 +3282,7 @@ func encodeAppsUpdateWebhookConfigForAppResponse(response WebhookConfig, w http.
 func encodeBillingGetGithubActionsBillingGheResponse(response ActionsBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3043,6 +3297,7 @@ func encodeBillingGetGithubActionsBillingGheResponse(response ActionsBillingUsag
 func encodeBillingGetGithubActionsBillingOrgResponse(response ActionsBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3057,6 +3312,7 @@ func encodeBillingGetGithubActionsBillingOrgResponse(response ActionsBillingUsag
 func encodeBillingGetGithubActionsBillingUserResponse(response ActionsBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3071,6 +3327,7 @@ func encodeBillingGetGithubActionsBillingUserResponse(response ActionsBillingUsa
 func encodeBillingGetGithubPackagesBillingGheResponse(response PackagesBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3085,6 +3342,7 @@ func encodeBillingGetGithubPackagesBillingGheResponse(response PackagesBillingUs
 func encodeBillingGetGithubPackagesBillingOrgResponse(response PackagesBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3099,6 +3357,7 @@ func encodeBillingGetGithubPackagesBillingOrgResponse(response PackagesBillingUs
 func encodeBillingGetGithubPackagesBillingUserResponse(response PackagesBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3113,6 +3372,7 @@ func encodeBillingGetGithubPackagesBillingUserResponse(response PackagesBillingU
 func encodeBillingGetSharedStorageBillingGheResponse(response CombinedBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3127,6 +3387,7 @@ func encodeBillingGetSharedStorageBillingGheResponse(response CombinedBillingUsa
 func encodeBillingGetSharedStorageBillingOrgResponse(response CombinedBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3141,6 +3402,7 @@ func encodeBillingGetSharedStorageBillingOrgResponse(response CombinedBillingUsa
 func encodeBillingGetSharedStorageBillingUserResponse(response CombinedBillingUsage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3157,6 +3419,7 @@ func encodeChecksCreateSuiteResponse(response ChecksCreateSuiteRes, w http.Respo
 	case *ChecksCreateSuiteApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3169,6 +3432,7 @@ func encodeChecksCreateSuiteResponse(response ChecksCreateSuiteRes, w http.Respo
 	case *ChecksCreateSuiteApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3186,6 +3450,7 @@ func encodeChecksCreateSuiteResponse(response ChecksCreateSuiteRes, w http.Respo
 func encodeChecksGetResponse(response CheckRun, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3200,6 +3465,7 @@ func encodeChecksGetResponse(response CheckRun, w http.ResponseWriter, span trac
 func encodeChecksGetSuiteResponse(response CheckSuite, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3214,6 +3480,7 @@ func encodeChecksGetSuiteResponse(response CheckSuite, w http.ResponseWriter, sp
 func encodeChecksListAnnotationsResponse(response []CheckAnnotation, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3232,6 +3499,7 @@ func encodeChecksListAnnotationsResponse(response []CheckAnnotation, w http.Resp
 func encodeChecksListForRefResponse(response ChecksListForRefOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3246,6 +3514,7 @@ func encodeChecksListForRefResponse(response ChecksListForRefOK, w http.Response
 func encodeChecksListForSuiteResponse(response ChecksListForSuiteOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3260,6 +3529,7 @@ func encodeChecksListForSuiteResponse(response ChecksListForSuiteOK, w http.Resp
 func encodeChecksListSuitesForRefResponse(response ChecksListSuitesForRefOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3274,6 +3544,7 @@ func encodeChecksListSuitesForRefResponse(response ChecksListSuitesForRefOK, w h
 func encodeChecksRerequestSuiteResponse(response ChecksRerequestSuiteCreated, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3288,6 +3559,7 @@ func encodeChecksRerequestSuiteResponse(response ChecksRerequestSuiteCreated, w 
 func encodeChecksSetSuitesPreferencesResponse(response CheckSuitePreference, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3304,6 +3576,7 @@ func encodeCodeScanningDeleteAnalysisResponse(response CodeScanningDeleteAnalysi
 	case *CodeScanningAnalysisDeletion:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3316,6 +3589,7 @@ func encodeCodeScanningDeleteAnalysisResponse(response CodeScanningDeleteAnalysi
 	case *CodeScanningDeleteAnalysisApplicationJSONBadRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3328,6 +3602,7 @@ func encodeCodeScanningDeleteAnalysisResponse(response CodeScanningDeleteAnalysi
 	case *CodeScanningDeleteAnalysisApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3340,6 +3615,7 @@ func encodeCodeScanningDeleteAnalysisResponse(response CodeScanningDeleteAnalysi
 	case *CodeScanningDeleteAnalysisApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3352,6 +3628,7 @@ func encodeCodeScanningDeleteAnalysisResponse(response CodeScanningDeleteAnalysi
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3371,6 +3648,7 @@ func encodeCodeScanningGetAlertResponse(response CodeScanningGetAlertRes, w http
 	case *CodeScanningAlert:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3383,6 +3661,7 @@ func encodeCodeScanningGetAlertResponse(response CodeScanningGetAlertRes, w http
 	case *CodeScanningGetAlertApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3395,6 +3674,7 @@ func encodeCodeScanningGetAlertResponse(response CodeScanningGetAlertRes, w http
 	case *CodeScanningGetAlertApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3407,6 +3687,7 @@ func encodeCodeScanningGetAlertResponse(response CodeScanningGetAlertRes, w http
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3426,6 +3707,7 @@ func encodeCodeScanningGetAnalysisResponse(response CodeScanningGetAnalysisRes, 
 	case *CodeScanningAnalysis:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3438,6 +3720,7 @@ func encodeCodeScanningGetAnalysisResponse(response CodeScanningGetAnalysisRes, 
 	case *CodeScanningGetAnalysisApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3450,6 +3733,7 @@ func encodeCodeScanningGetAnalysisResponse(response CodeScanningGetAnalysisRes, 
 	case *CodeScanningGetAnalysisApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3462,6 +3746,7 @@ func encodeCodeScanningGetAnalysisResponse(response CodeScanningGetAnalysisRes, 
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3481,6 +3766,7 @@ func encodeCodeScanningGetSarifResponse(response CodeScanningGetSarifRes, w http
 	case *CodeScanningSarifsStatus:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3493,6 +3779,7 @@ func encodeCodeScanningGetSarifResponse(response CodeScanningGetSarifRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3504,10 +3791,12 @@ func encodeCodeScanningGetSarifResponse(response CodeScanningGetSarifRes, w http
 		return nil
 	case *CodeScanningGetSarifNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3527,6 +3816,7 @@ func encodeCodeScanningListAlertInstancesResponse(response CodeScanningListAlert
 	case *CodeScanningListAlertInstancesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3539,6 +3829,7 @@ func encodeCodeScanningListAlertInstancesResponse(response CodeScanningListAlert
 	case *CodeScanningListAlertInstancesApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3551,6 +3842,7 @@ func encodeCodeScanningListAlertInstancesResponse(response CodeScanningListAlert
 	case *CodeScanningListAlertInstancesApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3563,6 +3855,7 @@ func encodeCodeScanningListAlertInstancesResponse(response CodeScanningListAlert
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3582,6 +3875,7 @@ func encodeCodeScanningListAlertsForRepoResponse(response CodeScanningListAlerts
 	case *CodeScanningListAlertsForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3594,6 +3888,7 @@ func encodeCodeScanningListAlertsForRepoResponse(response CodeScanningListAlerts
 	case *CodeScanningListAlertsForRepoApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3606,6 +3901,7 @@ func encodeCodeScanningListAlertsForRepoResponse(response CodeScanningListAlerts
 	case *CodeScanningListAlertsForRepoApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3618,6 +3914,7 @@ func encodeCodeScanningListAlertsForRepoResponse(response CodeScanningListAlerts
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3637,6 +3934,7 @@ func encodeCodeScanningListRecentAnalysesResponse(response CodeScanningListRecen
 	case *CodeScanningListRecentAnalysesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3649,6 +3947,7 @@ func encodeCodeScanningListRecentAnalysesResponse(response CodeScanningListRecen
 	case *CodeScanningListRecentAnalysesApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3661,6 +3960,7 @@ func encodeCodeScanningListRecentAnalysesResponse(response CodeScanningListRecen
 	case *CodeScanningListRecentAnalysesApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3673,6 +3973,7 @@ func encodeCodeScanningListRecentAnalysesResponse(response CodeScanningListRecen
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3692,6 +3993,7 @@ func encodeCodeScanningUpdateAlertResponse(response CodeScanningUpdateAlertRes, 
 	case *CodeScanningAlert:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3704,6 +4006,7 @@ func encodeCodeScanningUpdateAlertResponse(response CodeScanningUpdateAlertRes, 
 	case *CodeScanningUpdateAlertApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3716,6 +4019,7 @@ func encodeCodeScanningUpdateAlertResponse(response CodeScanningUpdateAlertRes, 
 	case *CodeScanningUpdateAlertApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3728,6 +4032,7 @@ func encodeCodeScanningUpdateAlertResponse(response CodeScanningUpdateAlertRes, 
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3747,6 +4052,7 @@ func encodeCodeScanningUploadSarifResponse(response CodeScanningUploadSarifRes, 
 	case *CodeScanningSarifsReceipt:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3758,10 +4064,12 @@ func encodeCodeScanningUploadSarifResponse(response CodeScanningUploadSarifRes, 
 		return nil
 	case *CodeScanningUploadSarifBadRequest:
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		return nil
 	case *CodeScanningUploadSarifApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3774,6 +4082,7 @@ func encodeCodeScanningUploadSarifResponse(response CodeScanningUploadSarifRes, 
 	case *CodeScanningUploadSarifApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3785,10 +4094,12 @@ func encodeCodeScanningUploadSarifResponse(response CodeScanningUploadSarifRes, 
 		return nil
 	case *CodeScanningUploadSarifRequestEntityTooLarge:
 		w.WriteHeader(413)
+		span.SetStatus(codes.Error, http.StatusText(413))
 		return nil
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3808,6 +4119,7 @@ func encodeCodesOfConductGetAllCodesOfConductResponse(response CodesOfConductGet
 	case *CodesOfConductGetAllCodesOfConductOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3819,6 +4131,7 @@ func encodeCodesOfConductGetAllCodesOfConductResponse(response CodesOfConductGet
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/codes_of_conduct"+`: unexpected response type: %T`, response)
@@ -3830,6 +4143,7 @@ func encodeCodesOfConductGetConductCodeResponse(response CodesOfConductGetConduc
 	case *CodeOfConduct:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3841,10 +4155,12 @@ func encodeCodesOfConductGetConductCodeResponse(response CodesOfConductGetConduc
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3864,6 +4180,7 @@ func encodeEmojisGetResponse(response EmojisGetRes, w http.ResponseWriter, span 
 	case *EmojisGetOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3875,6 +4192,7 @@ func encodeEmojisGetResponse(response EmojisGetRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/emojis"+`: unexpected response type: %T`, response)
@@ -3883,17 +4201,20 @@ func encodeEmojisGetResponse(response EmojisGetRes, w http.ResponseWriter, span 
 
 func encodeEnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseResponse(response EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseResponse(response EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminCreateRegistrationTokenForEnterpriseResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3908,6 +4229,7 @@ func encodeEnterpriseAdminCreateRegistrationTokenForEnterpriseResponse(response 
 func encodeEnterpriseAdminCreateRemoveTokenForEnterpriseResponse(response AuthenticationToken, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3922,6 +4244,7 @@ func encodeEnterpriseAdminCreateRemoveTokenForEnterpriseResponse(response Authen
 func encodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseResponse(response RunnerGroupsEnterprise, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3935,37 +4258,44 @@ func encodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseResponse(respo
 
 func encodeEnterpriseAdminDeleteScimGroupFromEnterpriseResponse(response EnterpriseAdminDeleteScimGroupFromEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseResponse(response EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseResponse(response EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminDeleteUserFromEnterpriseResponse(response EnterpriseAdminDeleteUserFromEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseResponse(response EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseResponse(response EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminGetAllowedActionsEnterpriseResponse(response SelectedActions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3980,6 +4310,7 @@ func encodeEnterpriseAdminGetAllowedActionsEnterpriseResponse(response SelectedA
 func encodeEnterpriseAdminGetAuditLogResponse(response []AuditLogEvent, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3998,6 +4329,7 @@ func encodeEnterpriseAdminGetAuditLogResponse(response []AuditLogEvent, w http.R
 func encodeEnterpriseAdminGetGithubActionsPermissionsEnterpriseResponse(response ActionsEnterprisePermissions, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4012,6 +4344,7 @@ func encodeEnterpriseAdminGetGithubActionsPermissionsEnterpriseResponse(response
 func encodeEnterpriseAdminGetProvisioningInformationForEnterpriseGroupResponse(response ScimEnterpriseGroup, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4026,6 +4359,7 @@ func encodeEnterpriseAdminGetProvisioningInformationForEnterpriseGroupResponse(r
 func encodeEnterpriseAdminGetProvisioningInformationForEnterpriseUserResponse(response ScimEnterpriseUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4040,6 +4374,7 @@ func encodeEnterpriseAdminGetProvisioningInformationForEnterpriseUserResponse(re
 func encodeEnterpriseAdminGetSelfHostedRunnerForEnterpriseResponse(response Runner, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4054,6 +4389,7 @@ func encodeEnterpriseAdminGetSelfHostedRunnerForEnterpriseResponse(response Runn
 func encodeEnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseResponse(response RunnerGroupsEnterprise, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4068,6 +4404,7 @@ func encodeEnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseResponse(response
 func encodeEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseResponse(response EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4082,6 +4419,7 @@ func encodeEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseRespon
 func encodeEnterpriseAdminListProvisionedGroupsEnterpriseResponse(response ScimGroupListEnterprise, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4096,6 +4434,7 @@ func encodeEnterpriseAdminListProvisionedGroupsEnterpriseResponse(response ScimG
 func encodeEnterpriseAdminListProvisionedIdentitiesEnterpriseResponse(response ScimUserListEnterprise, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4110,6 +4449,7 @@ func encodeEnterpriseAdminListProvisionedIdentitiesEnterpriseResponse(response S
 func encodeEnterpriseAdminListRunnerApplicationsForEnterpriseResponse(response []RunnerApplication, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4128,6 +4468,7 @@ func encodeEnterpriseAdminListRunnerApplicationsForEnterpriseResponse(response [
 func encodeEnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseResponse(response EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4142,6 +4483,7 @@ func encodeEnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpris
 func encodeEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseResponse(response EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4156,6 +4498,7 @@ func encodeEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseResponse(respon
 func encodeEnterpriseAdminListSelfHostedRunnersForEnterpriseResponse(response EnterpriseAdminListSelfHostedRunnersForEnterpriseOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4170,6 +4513,7 @@ func encodeEnterpriseAdminListSelfHostedRunnersForEnterpriseResponse(response En
 func encodeEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseResponse(response EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4184,6 +4528,7 @@ func encodeEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseResponse(resp
 func encodeEnterpriseAdminProvisionAndInviteEnterpriseGroupResponse(response ScimEnterpriseGroup, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4198,6 +4543,7 @@ func encodeEnterpriseAdminProvisionAndInviteEnterpriseGroupResponse(response Sci
 func encodeEnterpriseAdminProvisionAndInviteEnterpriseUserResponse(response ScimEnterpriseUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4211,27 +4557,32 @@ func encodeEnterpriseAdminProvisionAndInviteEnterpriseUserResponse(response Scim
 
 func encodeEnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseResponse(response EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseResponse(response EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminSetAllowedActionsEnterpriseResponse(response EnterpriseAdminSetAllowedActionsEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseResponse(response EnterpriseAdminSetGithubActionsPermissionsEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupResponse(response ScimEnterpriseGroup, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4246,6 +4597,7 @@ func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupResponse(re
 func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserResponse(response ScimEnterpriseUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4259,22 +4611,26 @@ func encodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserResponse(res
 
 func encodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseResponse(response EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseResponse(response EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseResponse(response EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeEnterpriseAdminUpdateAttributeForEnterpriseGroupResponse(response ScimEnterpriseGroup, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4289,6 +4645,7 @@ func encodeEnterpriseAdminUpdateAttributeForEnterpriseGroupResponse(response Sci
 func encodeEnterpriseAdminUpdateAttributeForEnterpriseUserResponse(response ScimEnterpriseUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4303,6 +4660,7 @@ func encodeEnterpriseAdminUpdateAttributeForEnterpriseUserResponse(response Scim
 func encodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseResponse(response RunnerGroupsEnterprise, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4318,13 +4676,16 @@ func encodeGistsCheckIsStarredResponse(response GistsCheckIsStarredRes, w http.R
 	switch response := response.(type) {
 	case *GistsCheckIsStarredNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4337,6 +4698,7 @@ func encodeGistsCheckIsStarredResponse(response GistsCheckIsStarredRes, w http.R
 	case *GistsCheckIsStarredNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4356,6 +4718,7 @@ func encodeGistsCreateResponse(response GistsCreateRes, w http.ResponseWriter, s
 	case *GistSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4367,10 +4730,12 @@ func encodeGistsCreateResponse(response GistsCreateRes, w http.ResponseWriter, s
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsCreateApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4383,6 +4748,7 @@ func encodeGistsCreateResponse(response GistsCreateRes, w http.ResponseWriter, s
 	case *GistsCreateApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4395,6 +4761,7 @@ func encodeGistsCreateResponse(response GistsCreateRes, w http.ResponseWriter, s
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4414,6 +4781,7 @@ func encodeGistsCreateCommentResponse(response GistsCreateCommentRes, w http.Res
 	case *GistComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4425,10 +4793,12 @@ func encodeGistsCreateCommentResponse(response GistsCreateCommentRes, w http.Res
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsCreateCommentApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4441,6 +4811,7 @@ func encodeGistsCreateCommentResponse(response GistsCreateCommentRes, w http.Res
 	case *GistsCreateCommentApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4459,13 +4830,16 @@ func encodeGistsDeleteResponse(response GistsDeleteRes, w http.ResponseWriter, s
 	switch response := response.(type) {
 	case *GistsDeleteNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsDeleteApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4478,6 +4852,7 @@ func encodeGistsDeleteResponse(response GistsDeleteRes, w http.ResponseWriter, s
 	case *GistsDeleteApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4496,13 +4871,16 @@ func encodeGistsDeleteCommentResponse(response GistsDeleteCommentRes, w http.Res
 	switch response := response.(type) {
 	case *GistsDeleteCommentNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsDeleteCommentApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4515,6 +4893,7 @@ func encodeGistsDeleteCommentResponse(response GistsDeleteCommentRes, w http.Res
 	case *GistsDeleteCommentApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4534,6 +4913,7 @@ func encodeGistsForkResponse(response GistsForkRes, w http.ResponseWriter, span 
 	case *BaseGist:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4545,10 +4925,12 @@ func encodeGistsForkResponse(response GistsForkRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsForkApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4561,6 +4943,7 @@ func encodeGistsForkResponse(response GistsForkRes, w http.ResponseWriter, span 
 	case *GistsForkApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4573,6 +4956,7 @@ func encodeGistsForkResponse(response GistsForkRes, w http.ResponseWriter, span 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4592,6 +4976,7 @@ func encodeGistsGetResponse(response GistsGetRes, w http.ResponseWriter, span tr
 	case *GistSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4603,10 +4988,12 @@ func encodeGistsGetResponse(response GistsGetRes, w http.ResponseWriter, span tr
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ForbiddenGist:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4619,6 +5006,7 @@ func encodeGistsGetResponse(response GistsGetRes, w http.ResponseWriter, span tr
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4638,6 +5026,7 @@ func encodeGistsGetCommentResponse(response GistsGetCommentRes, w http.ResponseW
 	case *GistComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4649,10 +5038,12 @@ func encodeGistsGetCommentResponse(response GistsGetCommentRes, w http.ResponseW
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ForbiddenGist:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4665,6 +5056,7 @@ func encodeGistsGetCommentResponse(response GistsGetCommentRes, w http.ResponseW
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4684,6 +5076,7 @@ func encodeGistsGetRevisionResponse(response GistsGetRevisionRes, w http.Respons
 	case *GistSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4696,6 +5089,7 @@ func encodeGistsGetRevisionResponse(response GistsGetRevisionRes, w http.Respons
 	case *GistsGetRevisionApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4708,6 +5102,7 @@ func encodeGistsGetRevisionResponse(response GistsGetRevisionRes, w http.Respons
 	case *GistsGetRevisionApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4720,6 +5115,7 @@ func encodeGistsGetRevisionResponse(response GistsGetRevisionRes, w http.Respons
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4739,6 +5135,7 @@ func encodeGistsListResponse(response GistsListRes, w http.ResponseWriter, span 
 	case *GistsListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4750,10 +5147,12 @@ func encodeGistsListResponse(response GistsListRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4773,6 +5172,7 @@ func encodeGistsListCommentsResponse(response GistsListCommentsRes, w http.Respo
 	case *GistsListCommentsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4784,10 +5184,12 @@ func encodeGistsListCommentsResponse(response GistsListCommentsRes, w http.Respo
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsListCommentsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4800,6 +5202,7 @@ func encodeGistsListCommentsResponse(response GistsListCommentsRes, w http.Respo
 	case *GistsListCommentsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4819,6 +5222,7 @@ func encodeGistsListCommitsResponse(response GistsListCommitsRes, w http.Respons
 	case *GistsListCommitsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4830,10 +5234,12 @@ func encodeGistsListCommitsResponse(response GistsListCommitsRes, w http.Respons
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsListCommitsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4846,6 +5252,7 @@ func encodeGistsListCommitsResponse(response GistsListCommitsRes, w http.Respons
 	case *GistsListCommitsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4865,6 +5272,7 @@ func encodeGistsListForUserResponse(response GistsListForUserRes, w http.Respons
 	case *GistsListForUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4877,6 +5285,7 @@ func encodeGistsListForUserResponse(response GistsListForUserRes, w http.Respons
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4896,6 +5305,7 @@ func encodeGistsListForksResponse(response GistsListForksRes, w http.ResponseWri
 	case *GistsListForksOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4907,10 +5317,12 @@ func encodeGistsListForksResponse(response GistsListForksRes, w http.ResponseWri
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsListForksApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4923,6 +5335,7 @@ func encodeGistsListForksResponse(response GistsListForksRes, w http.ResponseWri
 	case *GistsListForksApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4942,6 +5355,7 @@ func encodeGistsListPublicResponse(response GistsListPublicRes, w http.ResponseW
 	case *GistsListPublicOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4953,10 +5367,12 @@ func encodeGistsListPublicResponse(response GistsListPublicRes, w http.ResponseW
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4969,6 +5385,7 @@ func encodeGistsListPublicResponse(response GistsListPublicRes, w http.ResponseW
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4988,6 +5405,7 @@ func encodeGistsListStarredResponse(response GistsListStarredRes, w http.Respons
 	case *GistsListStarredOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4999,10 +5417,12 @@ func encodeGistsListStarredResponse(response GistsListStarredRes, w http.Respons
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsListStarredApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5015,6 +5435,7 @@ func encodeGistsListStarredResponse(response GistsListStarredRes, w http.Respons
 	case *GistsListStarredApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5033,13 +5454,16 @@ func encodeGistsStarResponse(response GistsStarRes, w http.ResponseWriter, span 
 	switch response := response.(type) {
 	case *GistsStarNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsStarApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5052,6 +5476,7 @@ func encodeGistsStarResponse(response GistsStarRes, w http.ResponseWriter, span 
 	case *GistsStarApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5070,13 +5495,16 @@ func encodeGistsUnstarResponse(response GistsUnstarRes, w http.ResponseWriter, s
 	switch response := response.(type) {
 	case *GistsUnstarNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *GistsUnstarApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5089,6 +5517,7 @@ func encodeGistsUnstarResponse(response GistsUnstarRes, w http.ResponseWriter, s
 	case *GistsUnstarApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5108,6 +5537,7 @@ func encodeGistsUpdateCommentResponse(response GistsUpdateCommentRes, w http.Res
 	case *GistComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5120,6 +5550,7 @@ func encodeGistsUpdateCommentResponse(response GistsUpdateCommentRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5139,6 +5570,7 @@ func encodeGitCreateBlobResponse(response GitCreateBlobRes, w http.ResponseWrite
 	case *ShortBlob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5151,6 +5583,7 @@ func encodeGitCreateBlobResponse(response GitCreateBlobRes, w http.ResponseWrite
 	case *GitCreateBlobApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5163,6 +5596,7 @@ func encodeGitCreateBlobResponse(response GitCreateBlobRes, w http.ResponseWrite
 	case *GitCreateBlobApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5175,6 +5609,7 @@ func encodeGitCreateBlobResponse(response GitCreateBlobRes, w http.ResponseWrite
 	case *GitCreateBlobApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5187,6 +5622,7 @@ func encodeGitCreateBlobResponse(response GitCreateBlobRes, w http.ResponseWrite
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5206,6 +5642,7 @@ func encodeGitCreateCommitResponse(response GitCreateCommitRes, w http.ResponseW
 	case *GitCommit:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5218,6 +5655,7 @@ func encodeGitCreateCommitResponse(response GitCreateCommitRes, w http.ResponseW
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5230,6 +5668,7 @@ func encodeGitCreateCommitResponse(response GitCreateCommitRes, w http.ResponseW
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5249,6 +5688,7 @@ func encodeGitCreateRefResponse(response GitCreateRefRes, w http.ResponseWriter,
 	case *GitRef:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5261,6 +5701,7 @@ func encodeGitCreateRefResponse(response GitCreateRefRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5280,6 +5721,7 @@ func encodeGitCreateTagResponse(response GitCreateTagRes, w http.ResponseWriter,
 	case *GitTag:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5292,6 +5734,7 @@ func encodeGitCreateTagResponse(response GitCreateTagRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5311,6 +5754,7 @@ func encodeGitCreateTreeResponse(response GitCreateTreeRes, w http.ResponseWrite
 	case *GitTree:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5323,6 +5767,7 @@ func encodeGitCreateTreeResponse(response GitCreateTreeRes, w http.ResponseWrite
 	case *GitCreateTreeApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5335,6 +5780,7 @@ func encodeGitCreateTreeResponse(response GitCreateTreeRes, w http.ResponseWrite
 	case *GitCreateTreeApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5347,6 +5793,7 @@ func encodeGitCreateTreeResponse(response GitCreateTreeRes, w http.ResponseWrite
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5365,10 +5812,12 @@ func encodeGitDeleteRefResponse(response GitDeleteRefRes, w http.ResponseWriter,
 	switch response := response.(type) {
 	case *GitDeleteRefNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5388,6 +5837,7 @@ func encodeGitGetBlobResponse(response GitGetBlobRes, w http.ResponseWriter, spa
 	case *Blob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5400,6 +5850,7 @@ func encodeGitGetBlobResponse(response GitGetBlobRes, w http.ResponseWriter, spa
 	case *GitGetBlobApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5412,6 +5863,7 @@ func encodeGitGetBlobResponse(response GitGetBlobRes, w http.ResponseWriter, spa
 	case *GitGetBlobApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5424,6 +5876,7 @@ func encodeGitGetBlobResponse(response GitGetBlobRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5443,6 +5896,7 @@ func encodeGitGetCommitResponse(response GitGetCommitRes, w http.ResponseWriter,
 	case *GitCommit:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5455,6 +5909,7 @@ func encodeGitGetCommitResponse(response GitGetCommitRes, w http.ResponseWriter,
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5474,6 +5929,7 @@ func encodeGitGetRefResponse(response GitGetRefRes, w http.ResponseWriter, span 
 	case *GitRef:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5486,6 +5942,7 @@ func encodeGitGetRefResponse(response GitGetRefRes, w http.ResponseWriter, span 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5505,6 +5962,7 @@ func encodeGitGetTagResponse(response GitGetTagRes, w http.ResponseWriter, span 
 	case *GitTag:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5517,6 +5975,7 @@ func encodeGitGetTagResponse(response GitGetTagRes, w http.ResponseWriter, span 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5536,6 +5995,7 @@ func encodeGitGetTreeResponse(response GitGetTreeRes, w http.ResponseWriter, spa
 	case *GitTree:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5548,6 +6008,7 @@ func encodeGitGetTreeResponse(response GitGetTreeRes, w http.ResponseWriter, spa
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5560,6 +6021,7 @@ func encodeGitGetTreeResponse(response GitGetTreeRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5577,6 +6039,7 @@ func encodeGitGetTreeResponse(response GitGetTreeRes, w http.ResponseWriter, spa
 func encodeGitListMatchingRefsResponse(response []GitRef, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5597,6 +6060,7 @@ func encodeGitUpdateRefResponse(response GitUpdateRefRes, w http.ResponseWriter,
 	case *GitRef:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5609,6 +6073,7 @@ func encodeGitUpdateRefResponse(response GitUpdateRefRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5628,6 +6093,7 @@ func encodeGitignoreGetAllTemplatesResponse(response GitignoreGetAllTemplatesRes
 	case *GitignoreGetAllTemplatesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5639,6 +6105,7 @@ func encodeGitignoreGetAllTemplatesResponse(response GitignoreGetAllTemplatesRes
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/gitignore/templates"+`: unexpected response type: %T`, response)
@@ -5650,6 +6117,7 @@ func encodeGitignoreGetTemplateResponse(response GitignoreGetTemplateRes, w http
 	case *GitignoreTemplate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5661,6 +6129,7 @@ func encodeGitignoreGetTemplateResponse(response GitignoreGetTemplateRes, w http
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/gitignore/templates/{name}"+`: unexpected response type: %T`, response)
@@ -5669,11 +6138,13 @@ func encodeGitignoreGetTemplateResponse(response GitignoreGetTemplateRes, w http
 
 func encodeInteractionsRemoveRestrictionsForAuthenticatedUserResponse(response InteractionsRemoveRestrictionsForAuthenticatedUserNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeInteractionsRemoveRestrictionsForOrgResponse(response InteractionsRemoveRestrictionsForOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -5681,9 +6152,11 @@ func encodeInteractionsRemoveRestrictionsForRepoResponse(response InteractionsRe
 	switch response := response.(type) {
 	case *InteractionsRemoveRestrictionsForRepoNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *InteractionsRemoveRestrictionsForRepoConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/interaction-limits"+`: unexpected response type: %T`, response)
@@ -5695,6 +6168,7 @@ func encodeInteractionsSetRestrictionsForAuthenticatedUserResponse(response Inte
 	case *InteractionLimitResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5707,6 +6181,7 @@ func encodeInteractionsSetRestrictionsForAuthenticatedUserResponse(response Inte
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5726,6 +6201,7 @@ func encodeInteractionsSetRestrictionsForOrgResponse(response InteractionsSetRes
 	case *InteractionLimitResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5738,6 +6214,7 @@ func encodeInteractionsSetRestrictionsForOrgResponse(response InteractionsSetRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5757,6 +6234,7 @@ func encodeInteractionsSetRestrictionsForRepoResponse(response InteractionsSetRe
 	case *InteractionLimitResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5768,6 +6246,7 @@ func encodeInteractionsSetRestrictionsForRepoResponse(response InteractionsSetRe
 		return nil
 	case *InteractionsSetRestrictionsForRepoConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/interaction-limits"+`: unexpected response type: %T`, response)
@@ -5777,6 +6256,7 @@ func encodeInteractionsSetRestrictionsForRepoResponse(response InteractionsSetRe
 func encodeIssuesAddAssigneesResponse(response IssueSimple, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5792,10 +6272,12 @@ func encodeIssuesCheckUserCanBeAssignedResponse(response IssuesCheckUserCanBeAss
 	switch response := response.(type) {
 	case *IssuesCheckUserCanBeAssignedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5815,6 +6297,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *Issue:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5827,6 +6310,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *IssuesCreateApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5839,6 +6323,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *IssuesCreateApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5851,6 +6336,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *IssuesCreateApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5863,6 +6349,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5875,6 +6362,7 @@ func encodeIssuesCreateResponse(response IssuesCreateRes, w http.ResponseWriter,
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5894,6 +6382,7 @@ func encodeIssuesCreateCommentResponse(response IssuesCreateCommentRes, w http.R
 	case *IssueComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5906,6 +6395,7 @@ func encodeIssuesCreateCommentResponse(response IssuesCreateCommentRes, w http.R
 	case *IssuesCreateCommentApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5918,6 +6408,7 @@ func encodeIssuesCreateCommentResponse(response IssuesCreateCommentRes, w http.R
 	case *IssuesCreateCommentApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5930,6 +6421,7 @@ func encodeIssuesCreateCommentResponse(response IssuesCreateCommentRes, w http.R
 	case *IssuesCreateCommentApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5942,6 +6434,7 @@ func encodeIssuesCreateCommentResponse(response IssuesCreateCommentRes, w http.R
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5961,6 +6454,7 @@ func encodeIssuesCreateLabelResponse(response IssuesCreateLabelRes, w http.Respo
 	case *Label:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5973,6 +6467,7 @@ func encodeIssuesCreateLabelResponse(response IssuesCreateLabelRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5985,6 +6480,7 @@ func encodeIssuesCreateLabelResponse(response IssuesCreateLabelRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6004,6 +6500,7 @@ func encodeIssuesCreateMilestoneResponse(response IssuesCreateMilestoneRes, w ht
 	case *Milestone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6016,6 +6513,7 @@ func encodeIssuesCreateMilestoneResponse(response IssuesCreateMilestoneRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6028,6 +6526,7 @@ func encodeIssuesCreateMilestoneResponse(response IssuesCreateMilestoneRes, w ht
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6044,11 +6543,13 @@ func encodeIssuesCreateMilestoneResponse(response IssuesCreateMilestoneRes, w ht
 
 func encodeIssuesDeleteCommentResponse(response IssuesDeleteCommentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeIssuesDeleteLabelResponse(response IssuesDeleteLabelNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -6056,10 +6557,12 @@ func encodeIssuesDeleteMilestoneResponse(response IssuesDeleteMilestoneRes, w ht
 	switch response := response.(type) {
 	case *IssuesDeleteMilestoneNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6079,6 +6582,7 @@ func encodeIssuesGetResponse(response IssuesGetRes, w http.ResponseWriter, span 
 	case *Issue:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6091,6 +6595,7 @@ func encodeIssuesGetResponse(response IssuesGetRes, w http.ResponseWriter, span 
 	case *IssuesGetApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6102,10 +6607,12 @@ func encodeIssuesGetResponse(response IssuesGetRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *IssuesGetApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6118,6 +6625,7 @@ func encodeIssuesGetResponse(response IssuesGetRes, w http.ResponseWriter, span 
 	case *IssuesGetApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6137,6 +6645,7 @@ func encodeIssuesGetCommentResponse(response IssuesGetCommentRes, w http.Respons
 	case *IssueComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6149,6 +6658,7 @@ func encodeIssuesGetCommentResponse(response IssuesGetCommentRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6168,6 +6678,7 @@ func encodeIssuesGetEventResponse(response IssuesGetEventRes, w http.ResponseWri
 	case *IssueEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6180,6 +6691,7 @@ func encodeIssuesGetEventResponse(response IssuesGetEventRes, w http.ResponseWri
 	case *IssuesGetEventApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6192,6 +6704,7 @@ func encodeIssuesGetEventResponse(response IssuesGetEventRes, w http.ResponseWri
 	case *IssuesGetEventApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6204,6 +6717,7 @@ func encodeIssuesGetEventResponse(response IssuesGetEventRes, w http.ResponseWri
 	case *IssuesGetEventApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6223,6 +6737,7 @@ func encodeIssuesGetLabelResponse(response IssuesGetLabelRes, w http.ResponseWri
 	case *Label:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6235,6 +6750,7 @@ func encodeIssuesGetLabelResponse(response IssuesGetLabelRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6254,6 +6770,7 @@ func encodeIssuesGetMilestoneResponse(response IssuesGetMilestoneRes, w http.Res
 	case *Milestone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6266,6 +6783,7 @@ func encodeIssuesGetMilestoneResponse(response IssuesGetMilestoneRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6285,6 +6803,7 @@ func encodeIssuesListResponse(response IssuesListRes, w http.ResponseWriter, spa
 	case *IssuesListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6296,10 +6815,12 @@ func encodeIssuesListResponse(response IssuesListRes, w http.ResponseWriter, spa
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6312,6 +6833,7 @@ func encodeIssuesListResponse(response IssuesListRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6331,6 +6853,7 @@ func encodeIssuesListAssigneesResponse(response IssuesListAssigneesRes, w http.R
 	case *IssuesListAssigneesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6343,6 +6866,7 @@ func encodeIssuesListAssigneesResponse(response IssuesListAssigneesRes, w http.R
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6362,6 +6886,7 @@ func encodeIssuesListCommentsResponse(response IssuesListCommentsRes, w http.Res
 	case *IssuesListCommentsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6374,6 +6899,7 @@ func encodeIssuesListCommentsResponse(response IssuesListCommentsRes, w http.Res
 	case *IssuesListCommentsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6386,6 +6912,7 @@ func encodeIssuesListCommentsResponse(response IssuesListCommentsRes, w http.Res
 	case *IssuesListCommentsApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6405,6 +6932,7 @@ func encodeIssuesListCommentsForRepoResponse(response IssuesListCommentsForRepoR
 	case *IssuesListCommentsForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6417,6 +6945,7 @@ func encodeIssuesListCommentsForRepoResponse(response IssuesListCommentsForRepoR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6429,6 +6958,7 @@ func encodeIssuesListCommentsForRepoResponse(response IssuesListCommentsForRepoR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6448,6 +6978,7 @@ func encodeIssuesListEventsForRepoResponse(response IssuesListEventsForRepoRes, 
 	case *IssuesListEventsForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6460,6 +6991,7 @@ func encodeIssuesListEventsForRepoResponse(response IssuesListEventsForRepoRes, 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6479,6 +7011,7 @@ func encodeIssuesListForAuthenticatedUserResponse(response IssuesListForAuthenti
 	case *IssuesListForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6490,10 +7023,12 @@ func encodeIssuesListForAuthenticatedUserResponse(response IssuesListForAuthenti
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6513,6 +7048,7 @@ func encodeIssuesListForOrgResponse(response IssuesListForOrgRes, w http.Respons
 	case *IssuesListForOrgOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6525,6 +7061,7 @@ func encodeIssuesListForOrgResponse(response IssuesListForOrgRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6544,6 +7081,7 @@ func encodeIssuesListForRepoResponse(response IssuesListForRepoRes, w http.Respo
 	case *IssuesListForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6556,6 +7094,7 @@ func encodeIssuesListForRepoResponse(response IssuesListForRepoRes, w http.Respo
 	case *IssuesListForRepoApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6568,6 +7107,7 @@ func encodeIssuesListForRepoResponse(response IssuesListForRepoRes, w http.Respo
 	case *IssuesListForRepoApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6580,6 +7120,7 @@ func encodeIssuesListForRepoResponse(response IssuesListForRepoRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6597,6 +7138,7 @@ func encodeIssuesListForRepoResponse(response IssuesListForRepoRes, w http.Respo
 func encodeIssuesListLabelsForMilestoneResponse(response []Label, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6617,6 +7159,7 @@ func encodeIssuesListLabelsForRepoResponse(response IssuesListLabelsForRepoRes, 
 	case *IssuesListLabelsForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6629,6 +7172,7 @@ func encodeIssuesListLabelsForRepoResponse(response IssuesListLabelsForRepoRes, 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6648,6 +7192,7 @@ func encodeIssuesListLabelsOnIssueResponse(response IssuesListLabelsOnIssueRes, 
 	case *IssuesListLabelsOnIssueOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6660,6 +7205,7 @@ func encodeIssuesListLabelsOnIssueResponse(response IssuesListLabelsOnIssueRes, 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6679,6 +7225,7 @@ func encodeIssuesListMilestonesResponse(response IssuesListMilestonesRes, w http
 	case *IssuesListMilestonesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6691,6 +7238,7 @@ func encodeIssuesListMilestonesResponse(response IssuesListMilestonesRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6709,10 +7257,12 @@ func encodeIssuesLockResponse(response IssuesLockRes, w http.ResponseWriter, spa
 	switch response := response.(type) {
 	case *IssuesLockNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *IssuesLockApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6725,6 +7275,7 @@ func encodeIssuesLockResponse(response IssuesLockRes, w http.ResponseWriter, spa
 	case *IssuesLockApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6737,6 +7288,7 @@ func encodeIssuesLockResponse(response IssuesLockRes, w http.ResponseWriter, spa
 	case *IssuesLockApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6749,6 +7301,7 @@ func encodeIssuesLockResponse(response IssuesLockRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6767,10 +7320,12 @@ func encodeIssuesRemoveAllLabelsResponse(response IssuesRemoveAllLabelsRes, w ht
 	switch response := response.(type) {
 	case *IssuesRemoveAllLabelsNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6788,6 +7343,7 @@ func encodeIssuesRemoveAllLabelsResponse(response IssuesRemoveAllLabelsRes, w ht
 func encodeIssuesRemoveAssigneesResponse(response IssueSimple, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6804,6 +7360,7 @@ func encodeIssuesRemoveLabelResponse(response IssuesRemoveLabelRes, w http.Respo
 	case *IssuesRemoveLabelOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6816,6 +7373,7 @@ func encodeIssuesRemoveLabelResponse(response IssuesRemoveLabelRes, w http.Respo
 	case *IssuesRemoveLabelApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6828,6 +7386,7 @@ func encodeIssuesRemoveLabelResponse(response IssuesRemoveLabelRes, w http.Respo
 	case *IssuesRemoveLabelApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6846,10 +7405,12 @@ func encodeIssuesUnlockResponse(response IssuesUnlockRes, w http.ResponseWriter,
 	switch response := response.(type) {
 	case *IssuesUnlockNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *IssuesUnlockApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6862,6 +7423,7 @@ func encodeIssuesUnlockResponse(response IssuesUnlockRes, w http.ResponseWriter,
 	case *IssuesUnlockApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6881,6 +7443,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *Issue:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6893,6 +7456,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *IssuesUpdateApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6905,6 +7469,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *IssuesUpdateApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6917,6 +7482,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *IssuesUpdateApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6929,6 +7495,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *IssuesUpdateApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6941,6 +7508,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6953,6 +7521,7 @@ func encodeIssuesUpdateResponse(response IssuesUpdateRes, w http.ResponseWriter,
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6972,6 +7541,7 @@ func encodeIssuesUpdateCommentResponse(response IssuesUpdateCommentRes, w http.R
 	case *IssueComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6984,6 +7554,7 @@ func encodeIssuesUpdateCommentResponse(response IssuesUpdateCommentRes, w http.R
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7001,6 +7572,7 @@ func encodeIssuesUpdateCommentResponse(response IssuesUpdateCommentRes, w http.R
 func encodeIssuesUpdateLabelResponse(response Label, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7015,6 +7587,7 @@ func encodeIssuesUpdateLabelResponse(response Label, w http.ResponseWriter, span
 func encodeIssuesUpdateMilestoneResponse(response Milestone, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7031,6 +7604,7 @@ func encodeLicensesGetResponse(response LicensesGetRes, w http.ResponseWriter, s
 	case *License:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7042,10 +7616,12 @@ func encodeLicensesGetResponse(response LicensesGetRes, w http.ResponseWriter, s
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *LicensesGetApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7058,6 +7634,7 @@ func encodeLicensesGetResponse(response LicensesGetRes, w http.ResponseWriter, s
 	case *LicensesGetApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7077,6 +7654,7 @@ func encodeLicensesGetAllCommonlyUsedResponse(response LicensesGetAllCommonlyUse
 	case *LicensesGetAllCommonlyUsedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7088,6 +7666,7 @@ func encodeLicensesGetAllCommonlyUsedResponse(response LicensesGetAllCommonlyUse
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/licenses"+`: unexpected response type: %T`, response)
@@ -7097,6 +7676,7 @@ func encodeLicensesGetAllCommonlyUsedResponse(response LicensesGetAllCommonlyUse
 func encodeLicensesGetForRepoResponse(response LicenseContent, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7113,6 +7693,7 @@ func encodeMetaGetResponse(response MetaGetRes, w http.ResponseWriter, span trac
 	case *APIOverview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7124,6 +7705,7 @@ func encodeMetaGetResponse(response MetaGetRes, w http.ResponseWriter, span trac
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/meta"+`: unexpected response type: %T`, response)
@@ -7133,6 +7715,7 @@ func encodeMetaGetResponse(response MetaGetRes, w http.ResponseWriter, span trac
 func encodeMetaRootResponse(response MetaRootOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7146,6 +7729,7 @@ func encodeMetaRootResponse(response MetaRootOK, w http.ResponseWriter, span tra
 
 func encodeMigrationsCancelImportResponse(response MigrationsCancelImportNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -7153,13 +7737,16 @@ func encodeMigrationsDeleteArchiveForAuthenticatedUserResponse(response Migratio
 	switch response := response.(type) {
 	case *MigrationsDeleteArchiveForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsDeleteArchiveForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7172,6 +7759,7 @@ func encodeMigrationsDeleteArchiveForAuthenticatedUserResponse(response Migratio
 	case *MigrationsDeleteArchiveForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7184,6 +7772,7 @@ func encodeMigrationsDeleteArchiveForAuthenticatedUserResponse(response Migratio
 	case *MigrationsDeleteArchiveForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7202,10 +7791,12 @@ func encodeMigrationsDeleteArchiveForOrgResponse(response MigrationsDeleteArchiv
 	switch response := response.(type) {
 	case *MigrationsDeleteArchiveForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7224,10 +7815,12 @@ func encodeMigrationsDownloadArchiveForOrgResponse(response MigrationsDownloadAr
 	switch response := response.(type) {
 	case *MigrationsDownloadArchiveForOrgFound:
 		w.WriteHeader(302)
+		span.SetStatus(codes.Ok, http.StatusText(302))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7246,13 +7839,16 @@ func encodeMigrationsGetArchiveForAuthenticatedUserResponse(response MigrationsG
 	switch response := response.(type) {
 	case *MigrationsGetArchiveForAuthenticatedUserFound:
 		w.WriteHeader(302)
+		span.SetStatus(codes.Ok, http.StatusText(302))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsGetArchiveForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7265,6 +7861,7 @@ func encodeMigrationsGetArchiveForAuthenticatedUserResponse(response MigrationsG
 	case *MigrationsGetArchiveForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7284,6 +7881,7 @@ func encodeMigrationsGetCommitAuthorsResponse(response MigrationsGetCommitAuthor
 	case *MigrationsGetCommitAuthorsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7296,6 +7894,7 @@ func encodeMigrationsGetCommitAuthorsResponse(response MigrationsGetCommitAuthor
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7315,6 +7914,7 @@ func encodeMigrationsGetImportStatusResponse(response MigrationsGetImportStatusR
 	case *Import:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7327,6 +7927,7 @@ func encodeMigrationsGetImportStatusResponse(response MigrationsGetImportStatusR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7344,6 +7945,7 @@ func encodeMigrationsGetImportStatusResponse(response MigrationsGetImportStatusR
 func encodeMigrationsGetLargeFilesResponse(response []PorterLargeFile, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7364,6 +7966,7 @@ func encodeMigrationsGetStatusForAuthenticatedUserResponse(response MigrationsGe
 	case *Migration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7375,10 +7978,12 @@ func encodeMigrationsGetStatusForAuthenticatedUserResponse(response MigrationsGe
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsGetStatusForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7391,6 +7996,7 @@ func encodeMigrationsGetStatusForAuthenticatedUserResponse(response MigrationsGe
 	case *MigrationsGetStatusForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7403,6 +8009,7 @@ func encodeMigrationsGetStatusForAuthenticatedUserResponse(response MigrationsGe
 	case *MigrationsGetStatusForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7422,6 +8029,7 @@ func encodeMigrationsGetStatusForOrgResponse(response MigrationsGetStatusForOrgR
 	case *Migration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7434,6 +8042,7 @@ func encodeMigrationsGetStatusForOrgResponse(response MigrationsGetStatusForOrgR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7453,6 +8062,7 @@ func encodeMigrationsListForAuthenticatedUserResponse(response MigrationsListFor
 	case *MigrationsListForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7464,10 +8074,12 @@ func encodeMigrationsListForAuthenticatedUserResponse(response MigrationsListFor
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsListForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7480,6 +8092,7 @@ func encodeMigrationsListForAuthenticatedUserResponse(response MigrationsListFor
 	case *MigrationsListForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7497,6 +8110,7 @@ func encodeMigrationsListForAuthenticatedUserResponse(response MigrationsListFor
 func encodeMigrationsListForOrgResponse(response []Migration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7517,6 +8131,7 @@ func encodeMigrationsListReposForOrgResponse(response MigrationsListReposForOrgR
 	case *MigrationsListReposForOrgOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7529,6 +8144,7 @@ func encodeMigrationsListReposForOrgResponse(response MigrationsListReposForOrgR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7548,6 +8164,7 @@ func encodeMigrationsListReposForUserResponse(response MigrationsListReposForUse
 	case *MigrationsListReposForUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7560,6 +8177,7 @@ func encodeMigrationsListReposForUserResponse(response MigrationsListReposForUse
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7579,6 +8197,7 @@ func encodeMigrationsMapCommitAuthorResponse(response MigrationsMapCommitAuthorR
 	case *PorterAuthor:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7591,6 +8210,7 @@ func encodeMigrationsMapCommitAuthorResponse(response MigrationsMapCommitAuthorR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7603,6 +8223,7 @@ func encodeMigrationsMapCommitAuthorResponse(response MigrationsMapCommitAuthorR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7622,6 +8243,7 @@ func encodeMigrationsSetLfsPreferenceResponse(response MigrationsSetLfsPreferenc
 	case *Import:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7634,6 +8256,7 @@ func encodeMigrationsSetLfsPreferenceResponse(response MigrationsSetLfsPreferenc
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7653,6 +8276,7 @@ func encodeMigrationsStartForAuthenticatedUserResponse(response MigrationsStartF
 	case *Migration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7664,10 +8288,12 @@ func encodeMigrationsStartForAuthenticatedUserResponse(response MigrationsStartF
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsStartForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7680,6 +8306,7 @@ func encodeMigrationsStartForAuthenticatedUserResponse(response MigrationsStartF
 	case *MigrationsStartForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7692,6 +8319,7 @@ func encodeMigrationsStartForAuthenticatedUserResponse(response MigrationsStartF
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7711,6 +8339,7 @@ func encodeMigrationsStartForOrgResponse(response MigrationsStartForOrgRes, w ht
 	case *Migration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7723,6 +8352,7 @@ func encodeMigrationsStartForOrgResponse(response MigrationsStartForOrgRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7735,6 +8365,7 @@ func encodeMigrationsStartForOrgResponse(response MigrationsStartForOrgRes, w ht
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7754,6 +8385,7 @@ func encodeMigrationsStartImportResponse(response MigrationsStartImportRes, w ht
 	case *Import:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7766,6 +8398,7 @@ func encodeMigrationsStartImportResponse(response MigrationsStartImportRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7778,6 +8411,7 @@ func encodeMigrationsStartImportResponse(response MigrationsStartImportRes, w ht
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7796,13 +8430,16 @@ func encodeMigrationsUnlockRepoForAuthenticatedUserResponse(response MigrationsU
 	switch response := response.(type) {
 	case *MigrationsUnlockRepoForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *MigrationsUnlockRepoForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7815,6 +8452,7 @@ func encodeMigrationsUnlockRepoForAuthenticatedUserResponse(response MigrationsU
 	case *MigrationsUnlockRepoForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7827,6 +8465,7 @@ func encodeMigrationsUnlockRepoForAuthenticatedUserResponse(response MigrationsU
 	case *MigrationsUnlockRepoForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7845,10 +8484,12 @@ func encodeMigrationsUnlockRepoForOrgResponse(response MigrationsUnlockRepoForOr
 	switch response := response.(type) {
 	case *MigrationsUnlockRepoForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7866,6 +8507,7 @@ func encodeMigrationsUnlockRepoForOrgResponse(response MigrationsUnlockRepoForOr
 func encodeMigrationsUpdateImportResponse(response Import, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -7882,6 +8524,7 @@ func encodeOAuthAuthorizationsCreateAuthorizationResponse(response OAuthAuthoriz
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7893,10 +8536,12 @@ func encodeOAuthAuthorizationsCreateAuthorizationResponse(response OAuthAuthoriz
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsCreateAuthorizationApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7909,6 +8554,7 @@ func encodeOAuthAuthorizationsCreateAuthorizationResponse(response OAuthAuthoriz
 	case *OAuthAuthorizationsCreateAuthorizationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7921,6 +8567,7 @@ func encodeOAuthAuthorizationsCreateAuthorizationResponse(response OAuthAuthoriz
 	case *OAuthAuthorizationsCreateAuthorizationApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7933,6 +8580,7 @@ func encodeOAuthAuthorizationsCreateAuthorizationResponse(response OAuthAuthoriz
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7951,13 +8599,16 @@ func encodeOAuthAuthorizationsDeleteAuthorizationResponse(response OAuthAuthoriz
 	switch response := response.(type) {
 	case *OAuthAuthorizationsDeleteAuthorizationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsDeleteAuthorizationApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7970,6 +8621,7 @@ func encodeOAuthAuthorizationsDeleteAuthorizationResponse(response OAuthAuthoriz
 	case *OAuthAuthorizationsDeleteAuthorizationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7988,13 +8640,16 @@ func encodeOAuthAuthorizationsDeleteGrantResponse(response OAuthAuthorizationsDe
 	switch response := response.(type) {
 	case *OAuthAuthorizationsDeleteGrantNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsDeleteGrantApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8007,6 +8662,7 @@ func encodeOAuthAuthorizationsDeleteGrantResponse(response OAuthAuthorizationsDe
 	case *OAuthAuthorizationsDeleteGrantApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8026,6 +8682,7 @@ func encodeOAuthAuthorizationsGetAuthorizationResponse(response OAuthAuthorizati
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8037,10 +8694,12 @@ func encodeOAuthAuthorizationsGetAuthorizationResponse(response OAuthAuthorizati
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsGetAuthorizationApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8053,6 +8712,7 @@ func encodeOAuthAuthorizationsGetAuthorizationResponse(response OAuthAuthorizati
 	case *OAuthAuthorizationsGetAuthorizationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8072,6 +8732,7 @@ func encodeOAuthAuthorizationsGetGrantResponse(response OAuthAuthorizationsGetGr
 	case *ApplicationGrant:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8083,10 +8744,12 @@ func encodeOAuthAuthorizationsGetGrantResponse(response OAuthAuthorizationsGetGr
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsGetGrantApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8099,6 +8762,7 @@ func encodeOAuthAuthorizationsGetGrantResponse(response OAuthAuthorizationsGetGr
 	case *OAuthAuthorizationsGetGrantApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8118,6 +8782,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppResponse(response OA
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8130,6 +8795,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppResponse(response OA
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8141,10 +8807,12 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppResponse(response OA
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8157,6 +8825,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppResponse(response OA
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8169,6 +8838,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppResponse(response OA
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8188,6 +8858,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRespon
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8200,6 +8871,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRespon
 	case *OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8212,6 +8884,7 @@ func encodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRespon
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8231,6 +8904,7 @@ func encodeOAuthAuthorizationsListAuthorizationsResponse(response OAuthAuthoriza
 	case *OAuthAuthorizationsListAuthorizationsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8242,10 +8916,12 @@ func encodeOAuthAuthorizationsListAuthorizationsResponse(response OAuthAuthoriza
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsListAuthorizationsApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8258,6 +8934,7 @@ func encodeOAuthAuthorizationsListAuthorizationsResponse(response OAuthAuthoriza
 	case *OAuthAuthorizationsListAuthorizationsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8270,6 +8947,7 @@ func encodeOAuthAuthorizationsListAuthorizationsResponse(response OAuthAuthoriza
 	case *OAuthAuthorizationsListAuthorizationsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8289,6 +8967,7 @@ func encodeOAuthAuthorizationsListGrantsResponse(response OAuthAuthorizationsLis
 	case *OAuthAuthorizationsListGrantsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8300,10 +8979,12 @@ func encodeOAuthAuthorizationsListGrantsResponse(response OAuthAuthorizationsLis
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OAuthAuthorizationsListGrantsApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8316,6 +8997,7 @@ func encodeOAuthAuthorizationsListGrantsResponse(response OAuthAuthorizationsLis
 	case *OAuthAuthorizationsListGrantsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8328,6 +9010,7 @@ func encodeOAuthAuthorizationsListGrantsResponse(response OAuthAuthorizationsLis
 	case *OAuthAuthorizationsListGrantsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8347,6 +9030,7 @@ func encodeOAuthAuthorizationsUpdateAuthorizationResponse(response OAuthAuthoriz
 	case *Authorization:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8359,6 +9043,7 @@ func encodeOAuthAuthorizationsUpdateAuthorizationResponse(response OAuthAuthoriz
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8377,10 +9062,12 @@ func encodeOrgsBlockUserResponse(response OrgsBlockUserRes, w http.ResponseWrite
 	switch response := response.(type) {
 	case *OrgsBlockUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8399,10 +9086,12 @@ func encodeOrgsCancelInvitationResponse(response OrgsCancelInvitationRes, w http
 	switch response := response.(type) {
 	case *OrgsCancelInvitationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8415,6 +9104,7 @@ func encodeOrgsCancelInvitationResponse(response OrgsCancelInvitationRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8433,10 +9123,12 @@ func encodeOrgsCheckBlockedUserResponse(response OrgsCheckBlockedUserRes, w http
 	switch response := response.(type) {
 	case *OrgsCheckBlockedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8455,12 +9147,15 @@ func encodeOrgsCheckMembershipForUserResponse(response OrgsCheckMembershipForUse
 	switch response := response.(type) {
 	case *OrgsCheckMembershipForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *OrgsCheckMembershipForUserFound:
 		w.WriteHeader(302)
+		span.SetStatus(codes.Ok, http.StatusText(302))
 		return nil
 	case *OrgsCheckMembershipForUserNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/members/{username}"+`: unexpected response type: %T`, response)
@@ -8471,9 +9166,11 @@ func encodeOrgsCheckPublicMembershipForUserResponse(response OrgsCheckPublicMemb
 	switch response := response.(type) {
 	case *OrgsCheckPublicMembershipForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *OrgsCheckPublicMembershipForUserNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/public_members/{username}"+`: unexpected response type: %T`, response)
@@ -8485,6 +9182,7 @@ func encodeOrgsConvertMemberToOutsideCollaboratorResponse(response OrgsConvertMe
 	case *OrgsConvertMemberToOutsideCollaboratorAccepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8496,13 +9194,16 @@ func encodeOrgsConvertMemberToOutsideCollaboratorResponse(response OrgsConvertMe
 		return nil
 	case *OrgsConvertMemberToOutsideCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *OrgsConvertMemberToOutsideCollaboratorForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8522,6 +9223,7 @@ func encodeOrgsCreateInvitationResponse(response OrgsCreateInvitationRes, w http
 	case *OrganizationInvitation:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8534,6 +9236,7 @@ func encodeOrgsCreateInvitationResponse(response OrgsCreateInvitationRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8546,6 +9249,7 @@ func encodeOrgsCreateInvitationResponse(response OrgsCreateInvitationRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8565,6 +9269,7 @@ func encodeOrgsCreateWebhookResponse(response OrgsCreateWebhookRes, w http.Respo
 	case *OrgHook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8577,6 +9282,7 @@ func encodeOrgsCreateWebhookResponse(response OrgsCreateWebhookRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8589,6 +9295,7 @@ func encodeOrgsCreateWebhookResponse(response OrgsCreateWebhookRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8607,10 +9314,12 @@ func encodeOrgsDeleteWebhookResponse(response OrgsDeleteWebhookRes, w http.Respo
 	switch response := response.(type) {
 	case *OrgsDeleteWebhookNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8630,6 +9339,7 @@ func encodeOrgsGetResponse(response OrgsGetRes, w http.ResponseWriter, span trac
 	case *OrganizationFull:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8642,6 +9352,7 @@ func encodeOrgsGetResponse(response OrgsGetRes, w http.ResponseWriter, span trac
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8659,6 +9370,7 @@ func encodeOrgsGetResponse(response OrgsGetRes, w http.ResponseWriter, span trac
 func encodeOrgsGetAuditLogResponse(response []AuditLogEvent, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -8679,6 +9391,7 @@ func encodeOrgsGetMembershipForAuthenticatedUserResponse(response OrgsGetMembers
 	case *OrgMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8691,6 +9404,7 @@ func encodeOrgsGetMembershipForAuthenticatedUserResponse(response OrgsGetMembers
 	case *OrgsGetMembershipForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8703,6 +9417,7 @@ func encodeOrgsGetMembershipForAuthenticatedUserResponse(response OrgsGetMembers
 	case *OrgsGetMembershipForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8722,6 +9437,7 @@ func encodeOrgsGetMembershipForUserResponse(response OrgsGetMembershipForUserRes
 	case *OrgMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8734,6 +9450,7 @@ func encodeOrgsGetMembershipForUserResponse(response OrgsGetMembershipForUserRes
 	case *OrgsGetMembershipForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8746,6 +9463,7 @@ func encodeOrgsGetMembershipForUserResponse(response OrgsGetMembershipForUserRes
 	case *OrgsGetMembershipForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8765,6 +9483,7 @@ func encodeOrgsGetWebhookResponse(response OrgsGetWebhookRes, w http.ResponseWri
 	case *OrgHook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8777,6 +9496,7 @@ func encodeOrgsGetWebhookResponse(response OrgsGetWebhookRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8794,6 +9514,7 @@ func encodeOrgsGetWebhookResponse(response OrgsGetWebhookRes, w http.ResponseWri
 func encodeOrgsGetWebhookConfigForOrgResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -8810,6 +9531,7 @@ func encodeOrgsGetWebhookDeliveryResponse(response OrgsGetWebhookDeliveryRes, w 
 	case *HookDelivery:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8822,6 +9544,7 @@ func encodeOrgsGetWebhookDeliveryResponse(response OrgsGetWebhookDeliveryRes, w 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8834,6 +9557,7 @@ func encodeOrgsGetWebhookDeliveryResponse(response OrgsGetWebhookDeliveryRes, w 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8853,6 +9577,7 @@ func encodeOrgsListResponse(response OrgsListRes, w http.ResponseWriter, span tr
 	case *OrgsListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8864,6 +9589,7 @@ func encodeOrgsListResponse(response OrgsListRes, w http.ResponseWriter, span tr
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/organizations"+`: unexpected response type: %T`, response)
@@ -8875,6 +9601,7 @@ func encodeOrgsListBlockedUsersResponse(response OrgsListBlockedUsersRes, w http
 	case *OrgsListBlockedUsersOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8887,6 +9614,7 @@ func encodeOrgsListBlockedUsersResponse(response OrgsListBlockedUsersRes, w http
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8906,6 +9634,7 @@ func encodeOrgsListFailedInvitationsResponse(response OrgsListFailedInvitationsR
 	case *OrgsListFailedInvitationsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8918,6 +9647,7 @@ func encodeOrgsListFailedInvitationsResponse(response OrgsListFailedInvitationsR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8937,6 +9667,7 @@ func encodeOrgsListForAuthenticatedUserResponse(response OrgsListForAuthenticate
 	case *OrgsListForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8948,10 +9679,12 @@ func encodeOrgsListForAuthenticatedUserResponse(response OrgsListForAuthenticate
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OrgsListForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8964,6 +9697,7 @@ func encodeOrgsListForAuthenticatedUserResponse(response OrgsListForAuthenticate
 	case *OrgsListForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8981,6 +9715,7 @@ func encodeOrgsListForAuthenticatedUserResponse(response OrgsListForAuthenticate
 func encodeOrgsListForUserResponse(response []OrganizationSimple, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -9001,6 +9736,7 @@ func encodeOrgsListInvitationTeamsResponse(response OrgsListInvitationTeamsRes, 
 	case *OrgsListInvitationTeamsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9013,6 +9749,7 @@ func encodeOrgsListInvitationTeamsResponse(response OrgsListInvitationTeamsRes, 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9032,6 +9769,7 @@ func encodeOrgsListMembersResponse(response OrgsListMembersRes, w http.ResponseW
 	case *OrgsListMembersOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9043,10 +9781,12 @@ func encodeOrgsListMembersResponse(response OrgsListMembersRes, w http.ResponseW
 		return nil
 	case *OrgsListMembersFound:
 		w.WriteHeader(302)
+		span.SetStatus(codes.Ok, http.StatusText(302))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9066,6 +9806,7 @@ func encodeOrgsListMembershipsForAuthenticatedUserResponse(response OrgsListMemb
 	case *OrgsListMembershipsForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9077,10 +9818,12 @@ func encodeOrgsListMembershipsForAuthenticatedUserResponse(response OrgsListMemb
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *OrgsListMembershipsForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9093,6 +9836,7 @@ func encodeOrgsListMembershipsForAuthenticatedUserResponse(response OrgsListMemb
 	case *OrgsListMembershipsForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9105,6 +9849,7 @@ func encodeOrgsListMembershipsForAuthenticatedUserResponse(response OrgsListMemb
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9122,6 +9867,7 @@ func encodeOrgsListMembershipsForAuthenticatedUserResponse(response OrgsListMemb
 func encodeOrgsListOutsideCollaboratorsResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -9142,6 +9888,7 @@ func encodeOrgsListPendingInvitationsResponse(response OrgsListPendingInvitation
 	case *OrgsListPendingInvitationsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9154,6 +9901,7 @@ func encodeOrgsListPendingInvitationsResponse(response OrgsListPendingInvitation
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9171,6 +9919,7 @@ func encodeOrgsListPendingInvitationsResponse(response OrgsListPendingInvitation
 func encodeOrgsListPublicMembersResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -9189,6 +9938,7 @@ func encodeOrgsListPublicMembersResponse(response []SimpleUser, w http.ResponseW
 func encodeOrgsListSamlSSOAuthorizationsResponse(response []CredentialAuthorization, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -9209,6 +9959,7 @@ func encodeOrgsListWebhookDeliveriesResponse(response OrgsListWebhookDeliveriesR
 	case *OrgsListWebhookDeliveriesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9221,6 +9972,7 @@ func encodeOrgsListWebhookDeliveriesResponse(response OrgsListWebhookDeliveriesR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9233,6 +9985,7 @@ func encodeOrgsListWebhookDeliveriesResponse(response OrgsListWebhookDeliveriesR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9252,6 +10005,7 @@ func encodeOrgsListWebhooksResponse(response OrgsListWebhooksRes, w http.Respons
 	case *OrgsListWebhooksOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9264,6 +10018,7 @@ func encodeOrgsListWebhooksResponse(response OrgsListWebhooksRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9282,10 +10037,12 @@ func encodeOrgsPingWebhookResponse(response OrgsPingWebhookRes, w http.ResponseW
 	switch response := response.(type) {
 	case *OrgsPingWebhookNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9305,6 +10062,7 @@ func encodeOrgsRedeliverWebhookDeliveryResponse(response OrgsRedeliverWebhookDel
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9317,6 +10075,7 @@ func encodeOrgsRedeliverWebhookDeliveryResponse(response OrgsRedeliverWebhookDel
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9329,6 +10088,7 @@ func encodeOrgsRedeliverWebhookDeliveryResponse(response OrgsRedeliverWebhookDel
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9347,10 +10107,12 @@ func encodeOrgsRemoveMemberResponse(response OrgsRemoveMemberRes, w http.Respons
 	switch response := response.(type) {
 	case *OrgsRemoveMemberNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9369,10 +10131,12 @@ func encodeOrgsRemoveMembershipForUserResponse(response OrgsRemoveMembershipForU
 	switch response := response.(type) {
 	case *OrgsRemoveMembershipForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *OrgsRemoveMembershipForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9385,6 +10149,7 @@ func encodeOrgsRemoveMembershipForUserResponse(response OrgsRemoveMembershipForU
 	case *OrgsRemoveMembershipForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9403,10 +10168,12 @@ func encodeOrgsRemoveOutsideCollaboratorResponse(response OrgsRemoveOutsideColla
 	switch response := response.(type) {
 	case *OrgsRemoveOutsideCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *OrgsRemoveOutsideCollaboratorUnprocessableEntity:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9423,6 +10190,7 @@ func encodeOrgsRemoveOutsideCollaboratorResponse(response OrgsRemoveOutsideColla
 
 func encodeOrgsRemovePublicMembershipForAuthenticatedUserResponse(response OrgsRemovePublicMembershipForAuthenticatedUserNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -9430,10 +10198,12 @@ func encodeOrgsRemoveSamlSSOAuthorizationResponse(response OrgsRemoveSamlSSOAuth
 	switch response := response.(type) {
 	case *OrgsRemoveSamlSSOAuthorizationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9453,6 +10223,7 @@ func encodeOrgsSetMembershipForUserResponse(response OrgsSetMembershipForUserRes
 	case *OrgMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9465,6 +10236,7 @@ func encodeOrgsSetMembershipForUserResponse(response OrgsSetMembershipForUserRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9477,6 +10249,7 @@ func encodeOrgsSetMembershipForUserResponse(response OrgsSetMembershipForUserRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9495,10 +10268,12 @@ func encodeOrgsSetPublicMembershipForAuthenticatedUserResponse(response OrgsSetP
 	switch response := response.(type) {
 	case *OrgsSetPublicMembershipForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9515,6 +10290,7 @@ func encodeOrgsSetPublicMembershipForAuthenticatedUserResponse(response OrgsSetP
 
 func encodeOrgsUnblockUserResponse(response OrgsUnblockUserNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -9523,6 +10299,7 @@ func encodeOrgsUpdateMembershipForAuthenticatedUserResponse(response OrgsUpdateM
 	case *OrgMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9535,6 +10312,7 @@ func encodeOrgsUpdateMembershipForAuthenticatedUserResponse(response OrgsUpdateM
 	case *OrgsUpdateMembershipForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9547,6 +10325,7 @@ func encodeOrgsUpdateMembershipForAuthenticatedUserResponse(response OrgsUpdateM
 	case *OrgsUpdateMembershipForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9559,6 +10338,7 @@ func encodeOrgsUpdateMembershipForAuthenticatedUserResponse(response OrgsUpdateM
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9578,6 +10358,7 @@ func encodeOrgsUpdateWebhookResponse(response OrgsUpdateWebhookRes, w http.Respo
 	case *OrgHook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9590,6 +10371,7 @@ func encodeOrgsUpdateWebhookResponse(response OrgsUpdateWebhookRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9602,6 +10384,7 @@ func encodeOrgsUpdateWebhookResponse(response OrgsUpdateWebhookRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9619,6 +10402,7 @@ func encodeOrgsUpdateWebhookResponse(response OrgsUpdateWebhookRes, w http.Respo
 func encodeOrgsUpdateWebhookConfigForOrgResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -9634,10 +10418,12 @@ func encodePackagesDeletePackageForAuthenticatedUserResponse(response PackagesDe
 	switch response := response.(type) {
 	case *PackagesDeletePackageForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9650,6 +10436,7 @@ func encodePackagesDeletePackageForAuthenticatedUserResponse(response PackagesDe
 	case *PackagesDeletePackageForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9662,6 +10449,7 @@ func encodePackagesDeletePackageForAuthenticatedUserResponse(response PackagesDe
 	case *PackagesDeletePackageForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9680,10 +10468,12 @@ func encodePackagesDeletePackageForOrgResponse(response PackagesDeletePackageFor
 	switch response := response.(type) {
 	case *PackagesDeletePackageForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageForOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9696,6 +10486,7 @@ func encodePackagesDeletePackageForOrgResponse(response PackagesDeletePackageFor
 	case *PackagesDeletePackageForOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9708,6 +10499,7 @@ func encodePackagesDeletePackageForOrgResponse(response PackagesDeletePackageFor
 	case *PackagesDeletePackageForOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9726,10 +10518,12 @@ func encodePackagesDeletePackageForUserResponse(response PackagesDeletePackageFo
 	switch response := response.(type) {
 	case *PackagesDeletePackageForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9742,6 +10536,7 @@ func encodePackagesDeletePackageForUserResponse(response PackagesDeletePackageFo
 	case *PackagesDeletePackageForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9754,6 +10549,7 @@ func encodePackagesDeletePackageForUserResponse(response PackagesDeletePackageFo
 	case *PackagesDeletePackageForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9772,10 +10568,12 @@ func encodePackagesDeletePackageVersionForAuthenticatedUserResponse(response Pac
 	switch response := response.(type) {
 	case *PackagesDeletePackageVersionForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageVersionForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9788,6 +10586,7 @@ func encodePackagesDeletePackageVersionForAuthenticatedUserResponse(response Pac
 	case *PackagesDeletePackageVersionForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9800,6 +10599,7 @@ func encodePackagesDeletePackageVersionForAuthenticatedUserResponse(response Pac
 	case *PackagesDeletePackageVersionForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9818,10 +10618,12 @@ func encodePackagesDeletePackageVersionForOrgResponse(response PackagesDeletePac
 	switch response := response.(type) {
 	case *PackagesDeletePackageVersionForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageVersionForOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9834,6 +10636,7 @@ func encodePackagesDeletePackageVersionForOrgResponse(response PackagesDeletePac
 	case *PackagesDeletePackageVersionForOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9846,6 +10649,7 @@ func encodePackagesDeletePackageVersionForOrgResponse(response PackagesDeletePac
 	case *PackagesDeletePackageVersionForOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9864,10 +10668,12 @@ func encodePackagesDeletePackageVersionForUserResponse(response PackagesDeletePa
 	switch response := response.(type) {
 	case *PackagesDeletePackageVersionForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesDeletePackageVersionForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9880,6 +10686,7 @@ func encodePackagesDeletePackageVersionForUserResponse(response PackagesDeletePa
 	case *PackagesDeletePackageVersionForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9892,6 +10699,7 @@ func encodePackagesDeletePackageVersionForUserResponse(response PackagesDeletePa
 	case *PackagesDeletePackageVersionForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9911,6 +10719,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserRespon
 	case *PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9923,6 +10732,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserRespon
 	case *PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9935,6 +10745,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserRespon
 	case *PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9947,6 +10758,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserRespon
 	case *PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9966,6 +10778,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByOrgResponse(response Pa
 	case *PackagesGetAllPackageVersionsForPackageOwnedByOrgOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9978,6 +10791,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByOrgResponse(response Pa
 	case *PackagesGetAllPackageVersionsForPackageOwnedByOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9990,6 +10804,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByOrgResponse(response Pa
 	case *PackagesGetAllPackageVersionsForPackageOwnedByOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10002,6 +10817,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByOrgResponse(response Pa
 	case *PackagesGetAllPackageVersionsForPackageOwnedByOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10021,6 +10837,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByUserResponse(response P
 	case *PackagesGetAllPackageVersionsForPackageOwnedByUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10033,6 +10850,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByUserResponse(response P
 	case *PackagesGetAllPackageVersionsForPackageOwnedByUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10045,6 +10863,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByUserResponse(response P
 	case *PackagesGetAllPackageVersionsForPackageOwnedByUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10057,6 +10876,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByUserResponse(response P
 	case *PackagesGetAllPackageVersionsForPackageOwnedByUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10074,6 +10894,7 @@ func encodePackagesGetAllPackageVersionsForPackageOwnedByUserResponse(response P
 func encodePackagesGetPackageForAuthenticatedUserResponse(response Package, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10088,6 +10909,7 @@ func encodePackagesGetPackageForAuthenticatedUserResponse(response Package, w ht
 func encodePackagesGetPackageForOrganizationResponse(response Package, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10102,6 +10924,7 @@ func encodePackagesGetPackageForOrganizationResponse(response Package, w http.Re
 func encodePackagesGetPackageForUserResponse(response Package, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10116,6 +10939,7 @@ func encodePackagesGetPackageForUserResponse(response Package, w http.ResponseWr
 func encodePackagesGetPackageVersionForAuthenticatedUserResponse(response PackageVersion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10130,6 +10954,7 @@ func encodePackagesGetPackageVersionForAuthenticatedUserResponse(response Packag
 func encodePackagesGetPackageVersionForOrganizationResponse(response PackageVersion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10144,6 +10969,7 @@ func encodePackagesGetPackageVersionForOrganizationResponse(response PackageVers
 func encodePackagesGetPackageVersionForUserResponse(response PackageVersion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10158,6 +10984,7 @@ func encodePackagesGetPackageVersionForUserResponse(response PackageVersion, w h
 func encodePackagesListPackagesForAuthenticatedUserResponse(response []Package, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -10178,6 +11005,7 @@ func encodePackagesListPackagesForOrganizationResponse(response PackagesListPack
 	case *PackagesListPackagesForOrganizationOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10190,6 +11018,7 @@ func encodePackagesListPackagesForOrganizationResponse(response PackagesListPack
 	case *PackagesListPackagesForOrganizationApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10202,6 +11031,7 @@ func encodePackagesListPackagesForOrganizationResponse(response PackagesListPack
 	case *PackagesListPackagesForOrganizationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10221,6 +11051,7 @@ func encodePackagesListPackagesForUserResponse(response PackagesListPackagesForU
 	case *PackagesListPackagesForUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10233,6 +11064,7 @@ func encodePackagesListPackagesForUserResponse(response PackagesListPackagesForU
 	case *PackagesListPackagesForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10245,6 +11077,7 @@ func encodePackagesListPackagesForUserResponse(response PackagesListPackagesForU
 	case *PackagesListPackagesForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10263,10 +11096,12 @@ func encodePackagesRestorePackageForAuthenticatedUserResponse(response PackagesR
 	switch response := response.(type) {
 	case *PackagesRestorePackageForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10279,6 +11114,7 @@ func encodePackagesRestorePackageForAuthenticatedUserResponse(response PackagesR
 	case *PackagesRestorePackageForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10291,6 +11127,7 @@ func encodePackagesRestorePackageForAuthenticatedUserResponse(response PackagesR
 	case *PackagesRestorePackageForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10309,10 +11146,12 @@ func encodePackagesRestorePackageForOrgResponse(response PackagesRestorePackageF
 	switch response := response.(type) {
 	case *PackagesRestorePackageForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageForOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10325,6 +11164,7 @@ func encodePackagesRestorePackageForOrgResponse(response PackagesRestorePackageF
 	case *PackagesRestorePackageForOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10337,6 +11177,7 @@ func encodePackagesRestorePackageForOrgResponse(response PackagesRestorePackageF
 	case *PackagesRestorePackageForOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10355,10 +11196,12 @@ func encodePackagesRestorePackageForUserResponse(response PackagesRestorePackage
 	switch response := response.(type) {
 	case *PackagesRestorePackageForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10371,6 +11214,7 @@ func encodePackagesRestorePackageForUserResponse(response PackagesRestorePackage
 	case *PackagesRestorePackageForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10383,6 +11227,7 @@ func encodePackagesRestorePackageForUserResponse(response PackagesRestorePackage
 	case *PackagesRestorePackageForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10401,10 +11246,12 @@ func encodePackagesRestorePackageVersionForAuthenticatedUserResponse(response Pa
 	switch response := response.(type) {
 	case *PackagesRestorePackageVersionForAuthenticatedUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageVersionForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10417,6 +11264,7 @@ func encodePackagesRestorePackageVersionForAuthenticatedUserResponse(response Pa
 	case *PackagesRestorePackageVersionForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10429,6 +11277,7 @@ func encodePackagesRestorePackageVersionForAuthenticatedUserResponse(response Pa
 	case *PackagesRestorePackageVersionForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10447,10 +11296,12 @@ func encodePackagesRestorePackageVersionForOrgResponse(response PackagesRestoreP
 	switch response := response.(type) {
 	case *PackagesRestorePackageVersionForOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageVersionForOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10463,6 +11314,7 @@ func encodePackagesRestorePackageVersionForOrgResponse(response PackagesRestoreP
 	case *PackagesRestorePackageVersionForOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10475,6 +11327,7 @@ func encodePackagesRestorePackageVersionForOrgResponse(response PackagesRestoreP
 	case *PackagesRestorePackageVersionForOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10493,10 +11346,12 @@ func encodePackagesRestorePackageVersionForUserResponse(response PackagesRestore
 	switch response := response.(type) {
 	case *PackagesRestorePackageVersionForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PackagesRestorePackageVersionForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10509,6 +11364,7 @@ func encodePackagesRestorePackageVersionForUserResponse(response PackagesRestore
 	case *PackagesRestorePackageVersionForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10521,6 +11377,7 @@ func encodePackagesRestorePackageVersionForUserResponse(response PackagesRestore
 	case *PackagesRestorePackageVersionForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10539,13 +11396,16 @@ func encodeProjectsAddCollaboratorResponse(response ProjectsAddCollaboratorRes, 
 	switch response := response.(type) {
 	case *ProjectsAddCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsAddCollaboratorApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10558,6 +11418,7 @@ func encodeProjectsAddCollaboratorResponse(response ProjectsAddCollaboratorRes, 
 	case *ProjectsAddCollaboratorApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10570,6 +11431,7 @@ func encodeProjectsAddCollaboratorResponse(response ProjectsAddCollaboratorRes, 
 	case *ProjectsAddCollaboratorApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10582,6 +11444,7 @@ func encodeProjectsAddCollaboratorResponse(response ProjectsAddCollaboratorRes, 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10601,6 +11464,7 @@ func encodeProjectsCreateColumnResponse(response ProjectsCreateColumnRes, w http
 	case *ProjectColumn:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10612,10 +11476,12 @@ func encodeProjectsCreateColumnResponse(response ProjectsCreateColumnRes, w http
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsCreateColumnApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10628,6 +11494,7 @@ func encodeProjectsCreateColumnResponse(response ProjectsCreateColumnRes, w http
 	case *ProjectsCreateColumnApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10640,6 +11507,7 @@ func encodeProjectsCreateColumnResponse(response ProjectsCreateColumnRes, w http
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10659,6 +11527,7 @@ func encodeProjectsCreateForAuthenticatedUserResponse(response ProjectsCreateFor
 	case *Project:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10670,10 +11539,12 @@ func encodeProjectsCreateForAuthenticatedUserResponse(response ProjectsCreateFor
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsCreateForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10686,6 +11557,7 @@ func encodeProjectsCreateForAuthenticatedUserResponse(response ProjectsCreateFor
 	case *ProjectsCreateForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10698,6 +11570,7 @@ func encodeProjectsCreateForAuthenticatedUserResponse(response ProjectsCreateFor
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10710,6 +11583,7 @@ func encodeProjectsCreateForAuthenticatedUserResponse(response ProjectsCreateFor
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10729,6 +11603,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *Project:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10741,6 +11616,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *ProjectsCreateForOrgApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10753,6 +11629,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *ProjectsCreateForOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10765,6 +11642,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *ProjectsCreateForOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10777,6 +11655,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *ProjectsCreateForOrgApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10789,6 +11668,7 @@ func encodeProjectsCreateForOrgResponse(response ProjectsCreateForOrgRes, w http
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10808,6 +11688,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *Project:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10820,6 +11701,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *ProjectsCreateForRepoApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10832,6 +11714,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *ProjectsCreateForRepoApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10844,6 +11727,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *ProjectsCreateForRepoApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10856,6 +11740,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *ProjectsCreateForRepoApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10868,6 +11753,7 @@ func encodeProjectsCreateForRepoResponse(response ProjectsCreateForRepoRes, w ht
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10886,13 +11772,16 @@ func encodeProjectsDeleteResponse(response ProjectsDeleteRes, w http.ResponseWri
 	switch response := response.(type) {
 	case *ProjectsDeleteNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsDeleteApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10905,6 +11794,7 @@ func encodeProjectsDeleteResponse(response ProjectsDeleteRes, w http.ResponseWri
 	case *ProjectsDeleteForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10917,6 +11807,7 @@ func encodeProjectsDeleteResponse(response ProjectsDeleteRes, w http.ResponseWri
 	case *ProjectsDeleteApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10929,6 +11820,7 @@ func encodeProjectsDeleteResponse(response ProjectsDeleteRes, w http.ResponseWri
 	case *ProjectsDeleteApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10947,13 +11839,16 @@ func encodeProjectsDeleteCardResponse(response ProjectsDeleteCardRes, w http.Res
 	switch response := response.(type) {
 	case *ProjectsDeleteCardNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsDeleteCardApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10966,6 +11861,7 @@ func encodeProjectsDeleteCardResponse(response ProjectsDeleteCardRes, w http.Res
 	case *ProjectsDeleteCardForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10978,6 +11874,7 @@ func encodeProjectsDeleteCardResponse(response ProjectsDeleteCardRes, w http.Res
 	case *ProjectsDeleteCardApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -10996,13 +11893,16 @@ func encodeProjectsDeleteColumnResponse(response ProjectsDeleteColumnRes, w http
 	switch response := response.(type) {
 	case *ProjectsDeleteColumnNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsDeleteColumnApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11015,6 +11915,7 @@ func encodeProjectsDeleteColumnResponse(response ProjectsDeleteColumnRes, w http
 	case *ProjectsDeleteColumnApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11034,6 +11935,7 @@ func encodeProjectsGetResponse(response ProjectsGetRes, w http.ResponseWriter, s
 	case *Project:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11045,10 +11947,12 @@ func encodeProjectsGetResponse(response ProjectsGetRes, w http.ResponseWriter, s
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsGetApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11061,6 +11965,7 @@ func encodeProjectsGetResponse(response ProjectsGetRes, w http.ResponseWriter, s
 	case *ProjectsGetApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11080,6 +11985,7 @@ func encodeProjectsGetCardResponse(response ProjectsGetCardRes, w http.ResponseW
 	case *ProjectCard:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11091,10 +11997,12 @@ func encodeProjectsGetCardResponse(response ProjectsGetCardRes, w http.ResponseW
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsGetCardApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11107,6 +12015,7 @@ func encodeProjectsGetCardResponse(response ProjectsGetCardRes, w http.ResponseW
 	case *ProjectsGetCardApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11119,6 +12028,7 @@ func encodeProjectsGetCardResponse(response ProjectsGetCardRes, w http.ResponseW
 	case *ProjectsGetCardApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11138,6 +12048,7 @@ func encodeProjectsGetColumnResponse(response ProjectsGetColumnRes, w http.Respo
 	case *ProjectColumn:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11149,10 +12060,12 @@ func encodeProjectsGetColumnResponse(response ProjectsGetColumnRes, w http.Respo
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsGetColumnApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11165,6 +12078,7 @@ func encodeProjectsGetColumnResponse(response ProjectsGetColumnRes, w http.Respo
 	case *ProjectsGetColumnApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11177,6 +12091,7 @@ func encodeProjectsGetColumnResponse(response ProjectsGetColumnRes, w http.Respo
 	case *ProjectsGetColumnApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11196,6 +12111,7 @@ func encodeProjectsGetPermissionForUserResponse(response ProjectsGetPermissionFo
 	case *RepositoryCollaboratorPermission:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11207,10 +12123,12 @@ func encodeProjectsGetPermissionForUserResponse(response ProjectsGetPermissionFo
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsGetPermissionForUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11223,6 +12141,7 @@ func encodeProjectsGetPermissionForUserResponse(response ProjectsGetPermissionFo
 	case *ProjectsGetPermissionForUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11235,6 +12154,7 @@ func encodeProjectsGetPermissionForUserResponse(response ProjectsGetPermissionFo
 	case *ProjectsGetPermissionForUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11247,6 +12167,7 @@ func encodeProjectsGetPermissionForUserResponse(response ProjectsGetPermissionFo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11266,6 +12187,7 @@ func encodeProjectsListCardsResponse(response ProjectsListCardsRes, w http.Respo
 	case *ProjectsListCardsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11277,10 +12199,12 @@ func encodeProjectsListCardsResponse(response ProjectsListCardsRes, w http.Respo
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsListCardsApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11293,6 +12217,7 @@ func encodeProjectsListCardsResponse(response ProjectsListCardsRes, w http.Respo
 	case *ProjectsListCardsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11312,6 +12237,7 @@ func encodeProjectsListCollaboratorsResponse(response ProjectsListCollaboratorsR
 	case *ProjectsListCollaboratorsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11323,10 +12249,12 @@ func encodeProjectsListCollaboratorsResponse(response ProjectsListCollaboratorsR
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsListCollaboratorsApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11339,6 +12267,7 @@ func encodeProjectsListCollaboratorsResponse(response ProjectsListCollaboratorsR
 	case *ProjectsListCollaboratorsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11351,6 +12280,7 @@ func encodeProjectsListCollaboratorsResponse(response ProjectsListCollaboratorsR
 	case *ProjectsListCollaboratorsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11363,6 +12293,7 @@ func encodeProjectsListCollaboratorsResponse(response ProjectsListCollaboratorsR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11382,6 +12313,7 @@ func encodeProjectsListColumnsResponse(response ProjectsListColumnsRes, w http.R
 	case *ProjectsListColumnsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11393,10 +12325,12 @@ func encodeProjectsListColumnsResponse(response ProjectsListColumnsRes, w http.R
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsListColumnsApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11409,6 +12343,7 @@ func encodeProjectsListColumnsResponse(response ProjectsListColumnsRes, w http.R
 	case *ProjectsListColumnsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11428,6 +12363,7 @@ func encodeProjectsListForOrgResponse(response ProjectsListForOrgRes, w http.Res
 	case *ProjectsListForOrgOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11440,6 +12376,7 @@ func encodeProjectsListForOrgResponse(response ProjectsListForOrgRes, w http.Res
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11459,6 +12396,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ProjectsListForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11471,6 +12409,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ProjectsListForRepoApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11483,6 +12422,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ProjectsListForRepoApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11495,6 +12435,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ProjectsListForRepoApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11507,6 +12448,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ProjectsListForRepoApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11519,6 +12461,7 @@ func encodeProjectsListForRepoResponse(response ProjectsListForRepoRes, w http.R
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11538,6 +12481,7 @@ func encodeProjectsListForUserResponse(response ProjectsListForUserRes, w http.R
 	case *ProjectsListForUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11550,6 +12494,7 @@ func encodeProjectsListForUserResponse(response ProjectsListForUserRes, w http.R
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11569,6 +12514,7 @@ func encodeProjectsMoveCardResponse(response ProjectsMoveCardRes, w http.Respons
 	case *ProjectsMoveCardCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11580,10 +12526,12 @@ func encodeProjectsMoveCardResponse(response ProjectsMoveCardRes, w http.Respons
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11596,6 +12544,7 @@ func encodeProjectsMoveCardResponse(response ProjectsMoveCardRes, w http.Respons
 	case *ProjectsMoveCardForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11608,6 +12557,7 @@ func encodeProjectsMoveCardResponse(response ProjectsMoveCardRes, w http.Respons
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11620,6 +12570,7 @@ func encodeProjectsMoveCardResponse(response ProjectsMoveCardRes, w http.Respons
 	case *ProjectsMoveCardServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11639,6 +12590,7 @@ func encodeProjectsMoveColumnResponse(response ProjectsMoveColumnRes, w http.Res
 	case *ProjectsMoveColumnCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11650,10 +12602,12 @@ func encodeProjectsMoveColumnResponse(response ProjectsMoveColumnRes, w http.Res
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsMoveColumnApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11666,6 +12620,7 @@ func encodeProjectsMoveColumnResponse(response ProjectsMoveColumnRes, w http.Res
 	case *ProjectsMoveColumnApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11678,6 +12633,7 @@ func encodeProjectsMoveColumnResponse(response ProjectsMoveColumnRes, w http.Res
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11696,13 +12652,16 @@ func encodeProjectsRemoveCollaboratorResponse(response ProjectsRemoveCollaborato
 	switch response := response.(type) {
 	case *ProjectsRemoveCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsRemoveCollaboratorApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11715,6 +12674,7 @@ func encodeProjectsRemoveCollaboratorResponse(response ProjectsRemoveCollaborato
 	case *ProjectsRemoveCollaboratorApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11727,6 +12687,7 @@ func encodeProjectsRemoveCollaboratorResponse(response ProjectsRemoveCollaborato
 	case *ProjectsRemoveCollaboratorApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11739,6 +12700,7 @@ func encodeProjectsRemoveCollaboratorResponse(response ProjectsRemoveCollaborato
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11758,6 +12720,7 @@ func encodeProjectsUpdateResponse(response ProjectsUpdateRes, w http.ResponseWri
 	case *Project:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11769,10 +12732,12 @@ func encodeProjectsUpdateResponse(response ProjectsUpdateRes, w http.ResponseWri
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsUpdateApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11785,6 +12750,7 @@ func encodeProjectsUpdateResponse(response ProjectsUpdateRes, w http.ResponseWri
 	case *ProjectsUpdateForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11796,10 +12762,12 @@ func encodeProjectsUpdateResponse(response ProjectsUpdateRes, w http.ResponseWri
 		return nil
 	case *ProjectsUpdateNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ProjectsUpdateApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11812,6 +12780,7 @@ func encodeProjectsUpdateResponse(response ProjectsUpdateRes, w http.ResponseWri
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11831,6 +12800,7 @@ func encodeProjectsUpdateCardResponse(response ProjectsUpdateCardRes, w http.Res
 	case *ProjectCard:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11842,10 +12812,12 @@ func encodeProjectsUpdateCardResponse(response ProjectsUpdateCardRes, w http.Res
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsUpdateCardApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11858,6 +12830,7 @@ func encodeProjectsUpdateCardResponse(response ProjectsUpdateCardRes, w http.Res
 	case *ProjectsUpdateCardApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11870,6 +12843,7 @@ func encodeProjectsUpdateCardResponse(response ProjectsUpdateCardRes, w http.Res
 	case *ProjectsUpdateCardApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11882,6 +12856,7 @@ func encodeProjectsUpdateCardResponse(response ProjectsUpdateCardRes, w http.Res
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11901,6 +12876,7 @@ func encodeProjectsUpdateColumnResponse(response ProjectsUpdateColumnRes, w http
 	case *ProjectColumn:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11912,10 +12888,12 @@ func encodeProjectsUpdateColumnResponse(response ProjectsUpdateColumnRes, w http
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ProjectsUpdateColumnApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11928,6 +12906,7 @@ func encodeProjectsUpdateColumnResponse(response ProjectsUpdateColumnRes, w http
 	case *ProjectsUpdateColumnApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11946,9 +12925,11 @@ func encodePullsCheckIfMergedResponse(response PullsCheckIfMergedRes, w http.Res
 	switch response := response.(type) {
 	case *PullsCheckIfMergedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *PullsCheckIfMergedNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/pulls/{pull_number}/merge"+`: unexpected response type: %T`, response)
@@ -11960,6 +12941,7 @@ func encodePullsCreateResponse(response PullsCreateRes, w http.ResponseWriter, s
 	case *PullRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11972,6 +12954,7 @@ func encodePullsCreateResponse(response PullsCreateRes, w http.ResponseWriter, s
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -11984,6 +12967,7 @@ func encodePullsCreateResponse(response PullsCreateRes, w http.ResponseWriter, s
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12003,6 +12987,7 @@ func encodePullsCreateReplyForReviewCommentResponse(response PullsCreateReplyFor
 	case *PullRequestReviewComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12015,6 +13000,7 @@ func encodePullsCreateReplyForReviewCommentResponse(response PullsCreateReplyFor
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12034,6 +13020,7 @@ func encodePullsCreateReviewResponse(response PullsCreateReviewRes, w http.Respo
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12046,6 +13033,7 @@ func encodePullsCreateReviewResponse(response PullsCreateReviewRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12058,6 +13046,7 @@ func encodePullsCreateReviewResponse(response PullsCreateReviewRes, w http.Respo
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12077,6 +13066,7 @@ func encodePullsCreateReviewCommentResponse(response PullsCreateReviewCommentRes
 	case *PullRequestReviewComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12089,6 +13079,7 @@ func encodePullsCreateReviewCommentResponse(response PullsCreateReviewCommentRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12101,6 +13092,7 @@ func encodePullsCreateReviewCommentResponse(response PullsCreateReviewCommentRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12120,6 +13112,7 @@ func encodePullsDeletePendingReviewResponse(response PullsDeletePendingReviewRes
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12132,6 +13125,7 @@ func encodePullsDeletePendingReviewResponse(response PullsDeletePendingReviewRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12144,6 +13138,7 @@ func encodePullsDeletePendingReviewResponse(response PullsDeletePendingReviewRes
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12162,10 +13157,12 @@ func encodePullsDeleteReviewCommentResponse(response PullsDeleteReviewCommentRes
 	switch response := response.(type) {
 	case *PullsDeleteReviewCommentNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12185,6 +13182,7 @@ func encodePullsDismissReviewResponse(response PullsDismissReviewRes, w http.Res
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12197,6 +13195,7 @@ func encodePullsDismissReviewResponse(response PullsDismissReviewRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12209,6 +13208,7 @@ func encodePullsDismissReviewResponse(response PullsDismissReviewRes, w http.Res
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12228,6 +13228,7 @@ func encodePullsGetResponse(response PullsGetRes, w http.ResponseWriter, span tr
 	case *PullRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12239,10 +13240,12 @@ func encodePullsGetResponse(response PullsGetRes, w http.ResponseWriter, span tr
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *PullsGetApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12255,6 +13258,7 @@ func encodePullsGetResponse(response PullsGetRes, w http.ResponseWriter, span tr
 	case *PullsGetApplicationJSONInternalServerError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12274,6 +13278,7 @@ func encodePullsGetReviewResponse(response PullsGetReviewRes, w http.ResponseWri
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12286,6 +13291,7 @@ func encodePullsGetReviewResponse(response PullsGetReviewRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12305,6 +13311,7 @@ func encodePullsGetReviewCommentResponse(response PullsGetReviewCommentRes, w ht
 	case *PullRequestReviewComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12317,6 +13324,7 @@ func encodePullsGetReviewCommentResponse(response PullsGetReviewCommentRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12336,6 +13344,7 @@ func encodePullsListResponse(response PullsListRes, w http.ResponseWriter, span 
 	case *PullsListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12347,10 +13356,12 @@ func encodePullsListResponse(response PullsListRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12370,6 +13381,7 @@ func encodePullsListCommentsForReviewResponse(response PullsListCommentsForRevie
 	case *PullsListCommentsForReviewOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12382,6 +13394,7 @@ func encodePullsListCommentsForReviewResponse(response PullsListCommentsForRevie
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12399,6 +13412,7 @@ func encodePullsListCommentsForReviewResponse(response PullsListCommentsForRevie
 func encodePullsListCommitsResponse(response []Commit, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12419,6 +13433,7 @@ func encodePullsListFilesResponse(response PullsListFilesRes, w http.ResponseWri
 	case *PullsListFilesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12431,6 +13446,7 @@ func encodePullsListFilesResponse(response PullsListFilesRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12443,6 +13459,7 @@ func encodePullsListFilesResponse(response PullsListFilesRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12460,6 +13477,7 @@ func encodePullsListFilesResponse(response PullsListFilesRes, w http.ResponseWri
 func encodePullsListRequestedReviewersResponse(response PullRequestReviewRequest, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12474,6 +13492,7 @@ func encodePullsListRequestedReviewersResponse(response PullRequestReviewRequest
 func encodePullsListReviewCommentsResponse(response []PullRequestReviewComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12492,6 +13511,7 @@ func encodePullsListReviewCommentsResponse(response []PullRequestReviewComment, 
 func encodePullsListReviewCommentsForRepoResponse(response []PullRequestReviewComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12510,6 +13530,7 @@ func encodePullsListReviewCommentsForRepoResponse(response []PullRequestReviewCo
 func encodePullsListReviewsResponse(response []PullRequestReview, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12530,6 +13551,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *PullRequestMergeResult:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12542,6 +13564,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *PullsMergeApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12554,6 +13577,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *PullsMergeApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12566,6 +13590,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *PullsMergeMethodNotAllowed:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(405)
+		span.SetStatus(codes.Error, http.StatusText(405))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12578,6 +13603,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *PullsMergeConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12590,6 +13616,7 @@ func encodePullsMergeResponse(response PullsMergeRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12609,6 +13636,7 @@ func encodePullsRemoveRequestedReviewersResponse(response PullsRemoveRequestedRe
 	case *PullRequestSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12621,6 +13649,7 @@ func encodePullsRemoveRequestedReviewersResponse(response PullsRemoveRequestedRe
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12640,6 +13669,7 @@ func encodePullsSubmitReviewResponse(response PullsSubmitReviewRes, w http.Respo
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12652,6 +13682,7 @@ func encodePullsSubmitReviewResponse(response PullsSubmitReviewRes, w http.Respo
 	case *PullsSubmitReviewApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12664,6 +13695,7 @@ func encodePullsSubmitReviewResponse(response PullsSubmitReviewRes, w http.Respo
 	case *PullsSubmitReviewApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12676,6 +13708,7 @@ func encodePullsSubmitReviewResponse(response PullsSubmitReviewRes, w http.Respo
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12695,6 +13728,7 @@ func encodePullsUpdateResponse(response PullsUpdateRes, w http.ResponseWriter, s
 	case *PullRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12707,6 +13741,7 @@ func encodePullsUpdateResponse(response PullsUpdateRes, w http.ResponseWriter, s
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12719,6 +13754,7 @@ func encodePullsUpdateResponse(response PullsUpdateRes, w http.ResponseWriter, s
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12738,6 +13774,7 @@ func encodePullsUpdateBranchResponse(response PullsUpdateBranchRes, w http.Respo
 	case *PullsUpdateBranchAccepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12750,6 +13787,7 @@ func encodePullsUpdateBranchResponse(response PullsUpdateBranchRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12762,6 +13800,7 @@ func encodePullsUpdateBranchResponse(response PullsUpdateBranchRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12781,6 +13820,7 @@ func encodePullsUpdateReviewResponse(response PullsUpdateReviewRes, w http.Respo
 	case *PullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12793,6 +13833,7 @@ func encodePullsUpdateReviewResponse(response PullsUpdateReviewRes, w http.Respo
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12810,6 +13851,7 @@ func encodePullsUpdateReviewResponse(response PullsUpdateReviewRes, w http.Respo
 func encodePullsUpdateReviewCommentResponse(response PullRequestReviewComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -12826,6 +13868,7 @@ func encodeRateLimitGetResponse(response RateLimitGetRes, w http.ResponseWriter,
 	case *RateLimitOverview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12837,10 +13880,12 @@ func encodeRateLimitGetResponse(response RateLimitGetRes, w http.ResponseWriter,
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12860,6 +13905,7 @@ func encodeReactionsCreateForCommitCommentResponse(response ReactionsCreateForCo
 	case *ReactionsCreateForCommitCommentApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12872,6 +13918,7 @@ func encodeReactionsCreateForCommitCommentResponse(response ReactionsCreateForCo
 	case *ReactionsCreateForCommitCommentApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12884,6 +13931,7 @@ func encodeReactionsCreateForCommitCommentResponse(response ReactionsCreateForCo
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12896,6 +13944,7 @@ func encodeReactionsCreateForCommitCommentResponse(response ReactionsCreateForCo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12915,6 +13964,7 @@ func encodeReactionsCreateForIssueResponse(response ReactionsCreateForIssueRes, 
 	case *ReactionsCreateForIssueApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12927,6 +13977,7 @@ func encodeReactionsCreateForIssueResponse(response ReactionsCreateForIssueRes, 
 	case *ReactionsCreateForIssueApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12939,6 +13990,7 @@ func encodeReactionsCreateForIssueResponse(response ReactionsCreateForIssueRes, 
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12951,6 +14003,7 @@ func encodeReactionsCreateForIssueResponse(response ReactionsCreateForIssueRes, 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12970,6 +14023,7 @@ func encodeReactionsCreateForIssueCommentResponse(response ReactionsCreateForIss
 	case *ReactionsCreateForIssueCommentApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12982,6 +14036,7 @@ func encodeReactionsCreateForIssueCommentResponse(response ReactionsCreateForIss
 	case *ReactionsCreateForIssueCommentApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -12994,6 +14049,7 @@ func encodeReactionsCreateForIssueCommentResponse(response ReactionsCreateForIss
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13006,6 +14062,7 @@ func encodeReactionsCreateForIssueCommentResponse(response ReactionsCreateForIss
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13025,6 +14082,7 @@ func encodeReactionsCreateForPullRequestReviewCommentResponse(response Reactions
 	case *ReactionsCreateForPullRequestReviewCommentApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13037,6 +14095,7 @@ func encodeReactionsCreateForPullRequestReviewCommentResponse(response Reactions
 	case *ReactionsCreateForPullRequestReviewCommentApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13049,6 +14108,7 @@ func encodeReactionsCreateForPullRequestReviewCommentResponse(response Reactions
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13061,6 +14121,7 @@ func encodeReactionsCreateForPullRequestReviewCommentResponse(response Reactions
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13080,6 +14141,7 @@ func encodeReactionsCreateForReleaseResponse(response ReactionsCreateForReleaseR
 	case *ReactionsCreateForReleaseApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13092,6 +14154,7 @@ func encodeReactionsCreateForReleaseResponse(response ReactionsCreateForReleaseR
 	case *ReactionsCreateForReleaseApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13104,6 +14167,7 @@ func encodeReactionsCreateForReleaseResponse(response ReactionsCreateForReleaseR
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13116,6 +14180,7 @@ func encodeReactionsCreateForReleaseResponse(response ReactionsCreateForReleaseR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13135,6 +14200,7 @@ func encodeReactionsCreateForTeamDiscussionCommentInOrgResponse(response Reactio
 	case *ReactionsCreateForTeamDiscussionCommentInOrgApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13147,6 +14213,7 @@ func encodeReactionsCreateForTeamDiscussionCommentInOrgResponse(response Reactio
 	case *ReactionsCreateForTeamDiscussionCommentInOrgApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13164,6 +14231,7 @@ func encodeReactionsCreateForTeamDiscussionCommentInOrgResponse(response Reactio
 func encodeReactionsCreateForTeamDiscussionCommentLegacyResponse(response Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13180,6 +14248,7 @@ func encodeReactionsCreateForTeamDiscussionInOrgResponse(response ReactionsCreat
 	case *ReactionsCreateForTeamDiscussionInOrgApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13192,6 +14261,7 @@ func encodeReactionsCreateForTeamDiscussionInOrgResponse(response ReactionsCreat
 	case *ReactionsCreateForTeamDiscussionInOrgApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13209,6 +14279,7 @@ func encodeReactionsCreateForTeamDiscussionInOrgResponse(response ReactionsCreat
 func encodeReactionsCreateForTeamDiscussionLegacyResponse(response Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13222,31 +14293,37 @@ func encodeReactionsCreateForTeamDiscussionLegacyResponse(response Reaction, w h
 
 func encodeReactionsDeleteForCommitCommentResponse(response ReactionsDeleteForCommitCommentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReactionsDeleteForIssueResponse(response ReactionsDeleteForIssueNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReactionsDeleteForIssueCommentResponse(response ReactionsDeleteForIssueCommentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReactionsDeleteForPullRequestCommentResponse(response ReactionsDeleteForPullRequestCommentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReactionsDeleteForTeamDiscussionResponse(response ReactionsDeleteForTeamDiscussionNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReactionsDeleteForTeamDiscussionCommentResponse(response ReactionsDeleteForTeamDiscussionCommentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -13254,13 +14331,16 @@ func encodeReactionsDeleteLegacyResponse(response ReactionsDeleteLegacyRes, w ht
 	switch response := response.(type) {
 	case *ReactionsDeleteLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReactionsDeleteLegacyApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13273,6 +14353,7 @@ func encodeReactionsDeleteLegacyResponse(response ReactionsDeleteLegacyRes, w ht
 	case *ReactionsDeleteLegacyApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13285,6 +14366,7 @@ func encodeReactionsDeleteLegacyResponse(response ReactionsDeleteLegacyRes, w ht
 	case *ReactionsDeleteLegacyApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13297,6 +14379,7 @@ func encodeReactionsDeleteLegacyResponse(response ReactionsDeleteLegacyRes, w ht
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13316,6 +14399,7 @@ func encodeReactionsListForCommitCommentResponse(response ReactionsListForCommit
 	case *ReactionsListForCommitCommentOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13328,6 +14412,7 @@ func encodeReactionsListForCommitCommentResponse(response ReactionsListForCommit
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13340,6 +14425,7 @@ func encodeReactionsListForCommitCommentResponse(response ReactionsListForCommit
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13359,6 +14445,7 @@ func encodeReactionsListForIssueResponse(response ReactionsListForIssueRes, w ht
 	case *ReactionsListForIssueOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13371,6 +14458,7 @@ func encodeReactionsListForIssueResponse(response ReactionsListForIssueRes, w ht
 	case *ReactionsListForIssueApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13383,6 +14471,7 @@ func encodeReactionsListForIssueResponse(response ReactionsListForIssueRes, w ht
 	case *ReactionsListForIssueApplicationJSONGone:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(410)
+		span.SetStatus(codes.Error, http.StatusText(410))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13395,6 +14484,7 @@ func encodeReactionsListForIssueResponse(response ReactionsListForIssueRes, w ht
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13414,6 +14504,7 @@ func encodeReactionsListForIssueCommentResponse(response ReactionsListForIssueCo
 	case *ReactionsListForIssueCommentOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13426,6 +14517,7 @@ func encodeReactionsListForIssueCommentResponse(response ReactionsListForIssueCo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13438,6 +14530,7 @@ func encodeReactionsListForIssueCommentResponse(response ReactionsListForIssueCo
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13457,6 +14550,7 @@ func encodeReactionsListForPullRequestReviewCommentResponse(response ReactionsLi
 	case *ReactionsListForPullRequestReviewCommentOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13469,6 +14563,7 @@ func encodeReactionsListForPullRequestReviewCommentResponse(response ReactionsLi
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13481,6 +14576,7 @@ func encodeReactionsListForPullRequestReviewCommentResponse(response ReactionsLi
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13498,6 +14594,7 @@ func encodeReactionsListForPullRequestReviewCommentResponse(response ReactionsLi
 func encodeReactionsListForTeamDiscussionCommentInOrgResponse(response []Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13516,6 +14613,7 @@ func encodeReactionsListForTeamDiscussionCommentInOrgResponse(response []Reactio
 func encodeReactionsListForTeamDiscussionCommentLegacyResponse(response []Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13534,6 +14632,7 @@ func encodeReactionsListForTeamDiscussionCommentLegacyResponse(response []Reacti
 func encodeReactionsListForTeamDiscussionInOrgResponse(response []Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13552,6 +14651,7 @@ func encodeReactionsListForTeamDiscussionInOrgResponse(response []Reaction, w ht
 func encodeReactionsListForTeamDiscussionLegacyResponse(response []Reaction, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -13571,13 +14671,16 @@ func encodeReposAcceptInvitationResponse(response ReposAcceptInvitationRes, w ht
 	switch response := response.(type) {
 	case *ReposAcceptInvitationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReposAcceptInvitationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13590,6 +14693,7 @@ func encodeReposAcceptInvitationResponse(response ReposAcceptInvitationRes, w ht
 	case *ReposAcceptInvitationApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13602,6 +14706,7 @@ func encodeReposAcceptInvitationResponse(response ReposAcceptInvitationRes, w ht
 	case *ReposAcceptInvitationApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13621,6 +14726,7 @@ func encodeReposAddAppAccessRestrictionsResponse(response ReposAddAppAccessRestr
 	case *ReposAddAppAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13633,6 +14739,7 @@ func encodeReposAddAppAccessRestrictionsResponse(response ReposAddAppAccessRestr
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13652,6 +14759,7 @@ func encodeReposAddCollaboratorResponse(response ReposAddCollaboratorRes, w http
 	case *RepositoryInvitation:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13663,10 +14771,12 @@ func encodeReposAddCollaboratorResponse(response ReposAddCollaboratorRes, w http
 		return nil
 	case *ReposAddCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13679,6 +14789,7 @@ func encodeReposAddCollaboratorResponse(response ReposAddCollaboratorRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13698,6 +14809,7 @@ func encodeReposAddStatusCheckContextsResponse(response ReposAddStatusCheckConte
 	case *ReposAddStatusCheckContextsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13710,6 +14822,7 @@ func encodeReposAddStatusCheckContextsResponse(response ReposAddStatusCheckConte
 	case *ReposAddStatusCheckContextsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13722,6 +14835,7 @@ func encodeReposAddStatusCheckContextsResponse(response ReposAddStatusCheckConte
 	case *ReposAddStatusCheckContextsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13734,6 +14848,7 @@ func encodeReposAddStatusCheckContextsResponse(response ReposAddStatusCheckConte
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13753,6 +14868,7 @@ func encodeReposAddTeamAccessRestrictionsResponse(response ReposAddTeamAccessRes
 	case *ReposAddTeamAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13765,6 +14881,7 @@ func encodeReposAddTeamAccessRestrictionsResponse(response ReposAddTeamAccessRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13784,6 +14901,7 @@ func encodeReposAddUserAccessRestrictionsResponse(response ReposAddUserAccessRes
 	case *ReposAddUserAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13796,6 +14914,7 @@ func encodeReposAddUserAccessRestrictionsResponse(response ReposAddUserAccessRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13814,9 +14933,11 @@ func encodeReposCheckCollaboratorResponse(response ReposCheckCollaboratorRes, w 
 	switch response := response.(type) {
 	case *ReposCheckCollaboratorNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ReposCheckCollaboratorNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/collaborators/{username}"+`: unexpected response type: %T`, response)
@@ -13827,9 +14948,11 @@ func encodeReposCheckVulnerabilityAlertsResponse(response ReposCheckVulnerabilit
 	switch response := response.(type) {
 	case *ReposCheckVulnerabilityAlertsNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ReposCheckVulnerabilityAlertsNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/vulnerability-alerts"+`: unexpected response type: %T`, response)
@@ -13841,6 +14964,7 @@ func encodeReposCompareCommitsResponse(response ReposCompareCommitsRes, w http.R
 	case *CommitComparison:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13853,6 +14977,7 @@ func encodeReposCompareCommitsResponse(response ReposCompareCommitsRes, w http.R
 	case *ReposCompareCommitsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13865,6 +14990,7 @@ func encodeReposCompareCommitsResponse(response ReposCompareCommitsRes, w http.R
 	case *ReposCompareCommitsApplicationJSONInternalServerError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13884,6 +15010,7 @@ func encodeReposCreateAutolinkResponse(response ReposCreateAutolinkRes, w http.R
 	case *Autolink:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13896,6 +15023,7 @@ func encodeReposCreateAutolinkResponse(response ReposCreateAutolinkRes, w http.R
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13915,6 +15043,7 @@ func encodeReposCreateCommitCommentResponse(response ReposCreateCommitCommentRes
 	case *CommitComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13927,6 +15056,7 @@ func encodeReposCreateCommitCommentResponse(response ReposCreateCommitCommentRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13939,6 +15069,7 @@ func encodeReposCreateCommitCommentResponse(response ReposCreateCommitCommentRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13958,6 +15089,7 @@ func encodeReposCreateCommitSignatureProtectionResponse(response ReposCreateComm
 	case *ProtectedBranchAdminEnforced:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13970,6 +15102,7 @@ func encodeReposCreateCommitSignatureProtectionResponse(response ReposCreateComm
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -13987,6 +15120,7 @@ func encodeReposCreateCommitSignatureProtectionResponse(response ReposCreateComm
 func encodeReposCreateCommitStatusResponse(response Status, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -14003,6 +15137,7 @@ func encodeReposCreateDeployKeyResponse(response ReposCreateDeployKeyRes, w http
 	case *DeployKey:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14015,6 +15150,7 @@ func encodeReposCreateDeployKeyResponse(response ReposCreateDeployKeyRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14034,6 +15170,7 @@ func encodeReposCreateDeploymentResponse(response ReposCreateDeploymentRes, w ht
 	case *Deployment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14046,6 +15183,7 @@ func encodeReposCreateDeploymentResponse(response ReposCreateDeploymentRes, w ht
 	case *ReposCreateDeploymentAccepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14057,10 +15195,12 @@ func encodeReposCreateDeploymentResponse(response ReposCreateDeploymentRes, w ht
 		return nil
 	case *ReposCreateDeploymentConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14080,6 +15220,7 @@ func encodeReposCreateDeploymentStatusResponse(response ReposCreateDeploymentSta
 	case *DeploymentStatus:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14092,6 +15233,7 @@ func encodeReposCreateDeploymentStatusResponse(response ReposCreateDeploymentSta
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14110,10 +15252,12 @@ func encodeReposCreateDispatchEventResponse(response ReposCreateDispatchEventRes
 	switch response := response.(type) {
 	case *ReposCreateDispatchEventNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14133,6 +15277,7 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 	case *Repository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14144,10 +15289,12 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReposCreateForAuthenticatedUserApplicationJSONBadRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14160,6 +15307,7 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 	case *ReposCreateForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14172,6 +15320,7 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 	case *ReposCreateForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14184,6 +15333,7 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 	case *ReposCreateForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14196,6 +15346,7 @@ func encodeReposCreateForAuthenticatedUserResponse(response ReposCreateForAuthen
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14215,6 +15366,7 @@ func encodeReposCreateForkResponse(response ReposCreateForkRes, w http.ResponseW
 	case *FullRepository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14227,6 +15379,7 @@ func encodeReposCreateForkResponse(response ReposCreateForkRes, w http.ResponseW
 	case *ReposCreateForkApplicationJSONBadRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14239,6 +15392,7 @@ func encodeReposCreateForkResponse(response ReposCreateForkRes, w http.ResponseW
 	case *ReposCreateForkApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14251,6 +15405,7 @@ func encodeReposCreateForkResponse(response ReposCreateForkRes, w http.ResponseW
 	case *ReposCreateForkApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14263,6 +15418,7 @@ func encodeReposCreateForkResponse(response ReposCreateForkRes, w http.ResponseW
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14282,6 +15438,7 @@ func encodeReposCreateInOrgResponse(response ReposCreateInOrgRes, w http.Respons
 	case *Repository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14294,6 +15451,7 @@ func encodeReposCreateInOrgResponse(response ReposCreateInOrgRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14306,6 +15464,7 @@ func encodeReposCreateInOrgResponse(response ReposCreateInOrgRes, w http.Respons
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14325,6 +15484,7 @@ func encodeReposCreateOrUpdateFileContentsResponse(response ReposCreateOrUpdateF
 	case *ReposCreateOrUpdateFileContentsApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14337,6 +15497,7 @@ func encodeReposCreateOrUpdateFileContentsResponse(response ReposCreateOrUpdateF
 	case *ReposCreateOrUpdateFileContentsApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14349,6 +15510,7 @@ func encodeReposCreateOrUpdateFileContentsResponse(response ReposCreateOrUpdateF
 	case *ReposCreateOrUpdateFileContentsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14361,6 +15523,7 @@ func encodeReposCreateOrUpdateFileContentsResponse(response ReposCreateOrUpdateF
 	case *ReposCreateOrUpdateFileContentsApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14373,6 +15536,7 @@ func encodeReposCreateOrUpdateFileContentsResponse(response ReposCreateOrUpdateF
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14392,6 +15556,7 @@ func encodeReposCreatePagesSiteResponse(response ReposCreatePagesSiteRes, w http
 	case *Page:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14404,6 +15569,7 @@ func encodeReposCreatePagesSiteResponse(response ReposCreatePagesSiteRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14416,6 +15582,7 @@ func encodeReposCreatePagesSiteResponse(response ReposCreatePagesSiteRes, w http
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14428,6 +15595,7 @@ func encodeReposCreatePagesSiteResponse(response ReposCreatePagesSiteRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14447,6 +15615,7 @@ func encodeReposCreateReleaseResponse(response ReposCreateReleaseRes, w http.Res
 	case *Release:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14459,6 +15628,7 @@ func encodeReposCreateReleaseResponse(response ReposCreateReleaseRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14471,6 +15641,7 @@ func encodeReposCreateReleaseResponse(response ReposCreateReleaseRes, w http.Res
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14488,6 +15659,7 @@ func encodeReposCreateReleaseResponse(response ReposCreateReleaseRes, w http.Res
 func encodeReposCreateUsingTemplateResponse(response Repository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -14504,6 +15676,7 @@ func encodeReposCreateWebhookResponse(response ReposCreateWebhookRes, w http.Res
 	case *Hook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14516,6 +15689,7 @@ func encodeReposCreateWebhookResponse(response ReposCreateWebhookRes, w http.Res
 	case *ReposCreateWebhookApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14528,6 +15702,7 @@ func encodeReposCreateWebhookResponse(response ReposCreateWebhookRes, w http.Res
 	case *ReposCreateWebhookApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14540,6 +15715,7 @@ func encodeReposCreateWebhookResponse(response ReposCreateWebhookRes, w http.Res
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14558,13 +15734,16 @@ func encodeReposDeclineInvitationResponse(response ReposDeclineInvitationRes, w 
 	switch response := response.(type) {
 	case *ReposDeclineInvitationNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReposDeclineInvitationApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14577,6 +15756,7 @@ func encodeReposDeclineInvitationResponse(response ReposDeclineInvitationRes, w 
 	case *ReposDeclineInvitationApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14589,6 +15769,7 @@ func encodeReposDeclineInvitationResponse(response ReposDeclineInvitationRes, w 
 	case *ReposDeclineInvitationApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14607,10 +15788,12 @@ func encodeReposDeleteResponse(response ReposDeleteRes, w http.ResponseWriter, s
 	switch response := response.(type) {
 	case *ReposDeleteNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ReposDeleteApplicationJSONTemporaryRedirect:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(307)
+		span.SetStatus(codes.Ok, http.StatusText(307))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14623,6 +15806,7 @@ func encodeReposDeleteResponse(response ReposDeleteRes, w http.ResponseWriter, s
 	case *ReposDeleteForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14635,6 +15819,7 @@ func encodeReposDeleteResponse(response ReposDeleteRes, w http.ResponseWriter, s
 	case *ReposDeleteApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14651,6 +15836,7 @@ func encodeReposDeleteResponse(response ReposDeleteRes, w http.ResponseWriter, s
 
 func encodeReposDeleteAccessRestrictionsResponse(response ReposDeleteAccessRestrictionsNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -14658,10 +15844,12 @@ func encodeReposDeleteAdminBranchProtectionResponse(response ReposDeleteAdminBra
 	switch response := response.(type) {
 	case *ReposDeleteAdminBranchProtectionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14678,6 +15866,7 @@ func encodeReposDeleteAdminBranchProtectionResponse(response ReposDeleteAdminBra
 
 func encodeReposDeleteAnEnvironmentResponse(response ReposDeleteAnEnvironmentNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -14685,10 +15874,12 @@ func encodeReposDeleteAutolinkResponse(response ReposDeleteAutolinkRes, w http.R
 	switch response := response.(type) {
 	case *ReposDeleteAutolinkNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14707,10 +15898,12 @@ func encodeReposDeleteBranchProtectionResponse(response ReposDeleteBranchProtect
 	switch response := response.(type) {
 	case *ReposDeleteBranchProtectionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14729,10 +15922,12 @@ func encodeReposDeleteCommitCommentResponse(response ReposDeleteCommitCommentRes
 	switch response := response.(type) {
 	case *ReposDeleteCommitCommentNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14751,10 +15946,12 @@ func encodeReposDeleteCommitSignatureProtectionResponse(response ReposDeleteComm
 	switch response := response.(type) {
 	case *ReposDeleteCommitSignatureProtectionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14771,6 +15968,7 @@ func encodeReposDeleteCommitSignatureProtectionResponse(response ReposDeleteComm
 
 func encodeReposDeleteDeployKeyResponse(response ReposDeleteDeployKeyNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -14778,10 +15976,12 @@ func encodeReposDeleteDeploymentResponse(response ReposDeleteDeploymentRes, w ht
 	switch response := response.(type) {
 	case *ReposDeleteDeploymentNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14794,6 +15994,7 @@ func encodeReposDeleteDeploymentResponse(response ReposDeleteDeploymentRes, w ht
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14813,6 +16014,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 	case *FileCommit:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14825,6 +16027,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 	case *ReposDeleteFileApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14837,6 +16040,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 	case *ReposDeleteFileApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14849,6 +16053,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14861,6 +16066,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14877,6 +16083,7 @@ func encodeReposDeleteFileResponse(response ReposDeleteFileRes, w http.ResponseW
 
 func encodeReposDeleteInvitationResponse(response ReposDeleteInvitationNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -14884,10 +16091,12 @@ func encodeReposDeletePagesSiteResponse(response ReposDeletePagesSiteRes, w http
 	switch response := response.(type) {
 	case *ReposDeletePagesSiteNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14900,6 +16109,7 @@ func encodeReposDeletePagesSiteResponse(response ReposDeletePagesSiteRes, w http
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14912,6 +16122,7 @@ func encodeReposDeletePagesSiteResponse(response ReposDeletePagesSiteRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14930,10 +16141,12 @@ func encodeReposDeletePullRequestReviewProtectionResponse(response ReposDeletePu
 	switch response := response.(type) {
 	case *ReposDeletePullRequestReviewProtectionNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14950,11 +16163,13 @@ func encodeReposDeletePullRequestReviewProtectionResponse(response ReposDeletePu
 
 func encodeReposDeleteReleaseResponse(response ReposDeleteReleaseNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReposDeleteReleaseAssetResponse(response ReposDeleteReleaseAssetNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -14962,10 +16177,12 @@ func encodeReposDeleteWebhookResponse(response ReposDeleteWebhookRes, w http.Res
 	switch response := response.(type) {
 	case *ReposDeleteWebhookNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -14982,31 +16199,37 @@ func encodeReposDeleteWebhookResponse(response ReposDeleteWebhookRes, w http.Res
 
 func encodeReposDisableAutomatedSecurityFixesResponse(response ReposDisableAutomatedSecurityFixesNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReposDisableLfsForRepoResponse(response ReposDisableLfsForRepoNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReposDisableVulnerabilityAlertsResponse(response ReposDisableVulnerabilityAlertsNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeReposDownloadTarballArchiveResponse(response ReposDownloadTarballArchiveFound, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(302)
+	span.SetStatus(codes.Ok, http.StatusText(302))
 	return nil
 }
 
 func encodeReposDownloadZipballArchiveResponse(response ReposDownloadZipballArchiveFound, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(302)
+	span.SetStatus(codes.Ok, http.StatusText(302))
 	return nil
 }
 
 func encodeReposEnableAutomatedSecurityFixesResponse(response ReposEnableAutomatedSecurityFixesNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -15015,6 +16238,7 @@ func encodeReposEnableLfsForRepoResponse(response ReposEnableLfsForRepoRes, w ht
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15026,6 +16250,7 @@ func encodeReposEnableLfsForRepoResponse(response ReposEnableLfsForRepoRes, w ht
 		return nil
 	case *ReposEnableLfsForRepoForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/lfs"+`: unexpected response type: %T`, response)
@@ -15034,6 +16259,7 @@ func encodeReposEnableLfsForRepoResponse(response ReposEnableLfsForRepoRes, w ht
 
 func encodeReposEnableVulnerabilityAlertsResponse(response ReposEnableVulnerabilityAlertsNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -15042,6 +16268,7 @@ func encodeReposGetResponse(response ReposGetRes, w http.ResponseWriter, span tr
 	case *FullRepository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15054,6 +16281,7 @@ func encodeReposGetResponse(response ReposGetRes, w http.ResponseWriter, span tr
 	case *ReposGetApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15066,6 +16294,7 @@ func encodeReposGetResponse(response ReposGetRes, w http.ResponseWriter, span tr
 	case *ReposGetApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15078,6 +16307,7 @@ func encodeReposGetResponse(response ReposGetRes, w http.ResponseWriter, span tr
 	case *ReposGetApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15097,6 +16327,7 @@ func encodeReposGetAccessRestrictionsResponse(response ReposGetAccessRestriction
 	case *BranchRestrictionPolicy:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15109,6 +16340,7 @@ func encodeReposGetAccessRestrictionsResponse(response ReposGetAccessRestriction
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15126,6 +16358,7 @@ func encodeReposGetAccessRestrictionsResponse(response ReposGetAccessRestriction
 func encodeReposGetAdminBranchProtectionResponse(response ProtectedBranchAdminEnforced, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15142,6 +16375,7 @@ func encodeReposGetAllStatusCheckContextsResponse(response ReposGetAllStatusChec
 	case *ReposGetAllStatusCheckContextsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15154,6 +16388,7 @@ func encodeReposGetAllStatusCheckContextsResponse(response ReposGetAllStatusChec
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15173,6 +16408,7 @@ func encodeReposGetAllTopicsResponse(response ReposGetAllTopicsRes, w http.Respo
 	case *Topic:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15185,6 +16421,7 @@ func encodeReposGetAllTopicsResponse(response ReposGetAllTopicsRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15197,6 +16434,7 @@ func encodeReposGetAllTopicsResponse(response ReposGetAllTopicsRes, w http.Respo
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15216,6 +16454,7 @@ func encodeReposGetAppsWithAccessToProtectedBranchResponse(response ReposGetApps
 	case *ReposGetAppsWithAccessToProtectedBranchOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15228,6 +16467,7 @@ func encodeReposGetAppsWithAccessToProtectedBranchResponse(response ReposGetApps
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15247,6 +16487,7 @@ func encodeReposGetAutolinkResponse(response ReposGetAutolinkRes, w http.Respons
 	case *Autolink:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15259,6 +16500,7 @@ func encodeReposGetAutolinkResponse(response ReposGetAutolinkRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15278,6 +16520,7 @@ func encodeReposGetBranchResponse(response ReposGetBranchRes, w http.ResponseWri
 	case *BranchWithProtection:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15290,6 +16533,7 @@ func encodeReposGetBranchResponse(response ReposGetBranchRes, w http.ResponseWri
 	case *ReposGetBranchApplicationJSONMovedPermanently:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15302,6 +16546,7 @@ func encodeReposGetBranchResponse(response ReposGetBranchRes, w http.ResponseWri
 	case *ReposGetBranchApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15314,6 +16559,7 @@ func encodeReposGetBranchResponse(response ReposGetBranchRes, w http.ResponseWri
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15333,6 +16579,7 @@ func encodeReposGetBranchProtectionResponse(response ReposGetBranchProtectionRes
 	case *BranchProtection:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15345,6 +16592,7 @@ func encodeReposGetBranchProtectionResponse(response ReposGetBranchProtectionRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15364,6 +16612,7 @@ func encodeReposGetClonesResponse(response ReposGetClonesRes, w http.ResponseWri
 	case *CloneTraffic:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15376,6 +16625,7 @@ func encodeReposGetClonesResponse(response ReposGetClonesRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15395,6 +16645,7 @@ func encodeReposGetCodeFrequencyStatsResponse(response ReposGetCodeFrequencyStat
 	case *ReposGetCodeFrequencyStatsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15407,6 +16658,7 @@ func encodeReposGetCodeFrequencyStatsResponse(response ReposGetCodeFrequencyStat
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15418,6 +16670,7 @@ func encodeReposGetCodeFrequencyStatsResponse(response ReposGetCodeFrequencyStat
 		return nil
 	case *NoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/stats/code_frequency"+`: unexpected response type: %T`, response)
@@ -15429,6 +16682,7 @@ func encodeReposGetCollaboratorPermissionLevelResponse(response ReposGetCollabor
 	case *RepositoryCollaboratorPermission:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15441,6 +16695,7 @@ func encodeReposGetCollaboratorPermissionLevelResponse(response ReposGetCollabor
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15460,6 +16715,7 @@ func encodeReposGetCombinedStatusForRefResponse(response ReposGetCombinedStatusF
 	case *CombinedCommitStatus:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15472,6 +16728,7 @@ func encodeReposGetCombinedStatusForRefResponse(response ReposGetCombinedStatusF
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15491,6 +16748,7 @@ func encodeReposGetCommitResponse(response ReposGetCommitRes, w http.ResponseWri
 	case *Commit:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15503,6 +16761,7 @@ func encodeReposGetCommitResponse(response ReposGetCommitRes, w http.ResponseWri
 	case *ReposGetCommitApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15515,6 +16774,7 @@ func encodeReposGetCommitResponse(response ReposGetCommitRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15527,6 +16787,7 @@ func encodeReposGetCommitResponse(response ReposGetCommitRes, w http.ResponseWri
 	case *ReposGetCommitApplicationJSONInternalServerError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15546,6 +16807,7 @@ func encodeReposGetCommitActivityStatsResponse(response ReposGetCommitActivitySt
 	case *ReposGetCommitActivityStatsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15558,6 +16820,7 @@ func encodeReposGetCommitActivityStatsResponse(response ReposGetCommitActivitySt
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15569,6 +16832,7 @@ func encodeReposGetCommitActivityStatsResponse(response ReposGetCommitActivitySt
 		return nil
 	case *NoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/stats/commit_activity"+`: unexpected response type: %T`, response)
@@ -15580,6 +16844,7 @@ func encodeReposGetCommitCommentResponse(response ReposGetCommitCommentRes, w ht
 	case *CommitComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15592,6 +16857,7 @@ func encodeReposGetCommitCommentResponse(response ReposGetCommitCommentRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15611,6 +16877,7 @@ func encodeReposGetCommitSignatureProtectionResponse(response ReposGetCommitSign
 	case *ProtectedBranchAdminEnforced:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15623,6 +16890,7 @@ func encodeReposGetCommitSignatureProtectionResponse(response ReposGetCommitSign
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15640,6 +16908,7 @@ func encodeReposGetCommitSignatureProtectionResponse(response ReposGetCommitSign
 func encodeReposGetCommunityProfileMetricsResponse(response CommunityProfile, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15656,6 +16925,7 @@ func encodeReposGetContributorsStatsResponse(response ReposGetContributorsStatsR
 	case *ReposGetContributorsStatsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15668,6 +16938,7 @@ func encodeReposGetContributorsStatsResponse(response ReposGetContributorsStatsR
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15679,6 +16950,7 @@ func encodeReposGetContributorsStatsResponse(response ReposGetContributorsStatsR
 		return nil
 	case *NoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/stats/contributors"+`: unexpected response type: %T`, response)
@@ -15690,6 +16962,7 @@ func encodeReposGetDeployKeyResponse(response ReposGetDeployKeyRes, w http.Respo
 	case *DeployKey:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15702,6 +16975,7 @@ func encodeReposGetDeployKeyResponse(response ReposGetDeployKeyRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15721,6 +16995,7 @@ func encodeReposGetDeploymentResponse(response ReposGetDeploymentRes, w http.Res
 	case *Deployment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15733,6 +17008,7 @@ func encodeReposGetDeploymentResponse(response ReposGetDeploymentRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15752,6 +17028,7 @@ func encodeReposGetDeploymentStatusResponse(response ReposGetDeploymentStatusRes
 	case *DeploymentStatus:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15764,6 +17041,7 @@ func encodeReposGetDeploymentStatusResponse(response ReposGetDeploymentStatusRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15776,6 +17054,7 @@ func encodeReposGetDeploymentStatusResponse(response ReposGetDeploymentStatusRes
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15793,6 +17072,7 @@ func encodeReposGetDeploymentStatusResponse(response ReposGetDeploymentStatusRes
 func encodeReposGetLatestPagesBuildResponse(response PageBuild, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15807,6 +17087,7 @@ func encodeReposGetLatestPagesBuildResponse(response PageBuild, w http.ResponseW
 func encodeReposGetLatestReleaseResponse(response Release, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15823,6 +17104,7 @@ func encodeReposGetPagesResponse(response ReposGetPagesRes, w http.ResponseWrite
 	case *Page:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15835,6 +17117,7 @@ func encodeReposGetPagesResponse(response ReposGetPagesRes, w http.ResponseWrite
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15852,6 +17135,7 @@ func encodeReposGetPagesResponse(response ReposGetPagesRes, w http.ResponseWrite
 func encodeReposGetPagesBuildResponse(response PageBuild, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15868,6 +17152,7 @@ func encodeReposGetPagesHealthCheckResponse(response ReposGetPagesHealthCheckRes
 	case *PagesHealthCheck:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15880,6 +17165,7 @@ func encodeReposGetPagesHealthCheckResponse(response ReposGetPagesHealthCheckRes
 	case *EmptyObject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15891,10 +17177,12 @@ func encodeReposGetPagesHealthCheckResponse(response ReposGetPagesHealthCheckRes
 		return nil
 	case *ReposGetPagesHealthCheckBadRequest:
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15906,6 +17194,7 @@ func encodeReposGetPagesHealthCheckResponse(response ReposGetPagesHealthCheckRes
 		return nil
 	case *ReposGetPagesHealthCheckUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/pages/health"+`: unexpected response type: %T`, response)
@@ -15917,6 +17206,7 @@ func encodeReposGetParticipationStatsResponse(response ReposGetParticipationStat
 	case *ParticipationStats:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15929,6 +17219,7 @@ func encodeReposGetParticipationStatsResponse(response ReposGetParticipationStat
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15946,6 +17237,7 @@ func encodeReposGetParticipationStatsResponse(response ReposGetParticipationStat
 func encodeReposGetPullRequestReviewProtectionResponse(response ProtectedBranchPullRequestReview, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -15962,6 +17254,7 @@ func encodeReposGetPunchCardStatsResponse(response ReposGetPunchCardStatsRes, w 
 	case *ReposGetPunchCardStatsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15973,6 +17266,7 @@ func encodeReposGetPunchCardStatsResponse(response ReposGetPunchCardStatsRes, w 
 		return nil
 	case *NoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/stats/punch_card"+`: unexpected response type: %T`, response)
@@ -15984,6 +17278,7 @@ func encodeReposGetReadmeResponse(response ReposGetReadmeRes, w http.ResponseWri
 	case *ContentFile:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -15996,6 +17291,7 @@ func encodeReposGetReadmeResponse(response ReposGetReadmeRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16008,6 +17304,7 @@ func encodeReposGetReadmeResponse(response ReposGetReadmeRes, w http.ResponseWri
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16027,6 +17324,7 @@ func encodeReposGetReadmeInDirectoryResponse(response ReposGetReadmeInDirectoryR
 	case *ContentFile:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16039,6 +17337,7 @@ func encodeReposGetReadmeInDirectoryResponse(response ReposGetReadmeInDirectoryR
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16051,6 +17350,7 @@ func encodeReposGetReadmeInDirectoryResponse(response ReposGetReadmeInDirectoryR
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16070,6 +17370,7 @@ func encodeReposGetReleaseResponse(response ReposGetReleaseRes, w http.ResponseW
 	case *Release:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16082,6 +17383,7 @@ func encodeReposGetReleaseResponse(response ReposGetReleaseRes, w http.ResponseW
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16101,6 +17403,7 @@ func encodeReposGetReleaseAssetResponse(response ReposGetReleaseAssetRes, w http
 	case *ReleaseAsset:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16112,10 +17415,12 @@ func encodeReposGetReleaseAssetResponse(response ReposGetReleaseAssetRes, w http
 		return nil
 	case *Found:
 		w.WriteHeader(302)
+		span.SetStatus(codes.Ok, http.StatusText(302))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16128,6 +17433,7 @@ func encodeReposGetReleaseAssetResponse(response ReposGetReleaseAssetRes, w http
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16147,6 +17453,7 @@ func encodeReposGetReleaseByTagResponse(response ReposGetReleaseByTagRes, w http
 	case *Release:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16159,6 +17466,7 @@ func encodeReposGetReleaseByTagResponse(response ReposGetReleaseByTagRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16178,6 +17486,7 @@ func encodeReposGetStatusChecksProtectionResponse(response ReposGetStatusChecksP
 	case *StatusCheckPolicy:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16190,6 +17499,7 @@ func encodeReposGetStatusChecksProtectionResponse(response ReposGetStatusChecksP
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16209,6 +17519,7 @@ func encodeReposGetTeamsWithAccessToProtectedBranchResponse(response ReposGetTea
 	case *ReposGetTeamsWithAccessToProtectedBranchOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16221,6 +17532,7 @@ func encodeReposGetTeamsWithAccessToProtectedBranchResponse(response ReposGetTea
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16240,6 +17552,7 @@ func encodeReposGetTopPathsResponse(response ReposGetTopPathsRes, w http.Respons
 	case *ReposGetTopPathsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16252,6 +17565,7 @@ func encodeReposGetTopPathsResponse(response ReposGetTopPathsRes, w http.Respons
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16271,6 +17585,7 @@ func encodeReposGetTopReferrersResponse(response ReposGetTopReferrersRes, w http
 	case *ReposGetTopReferrersOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16283,6 +17598,7 @@ func encodeReposGetTopReferrersResponse(response ReposGetTopReferrersRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16302,6 +17618,7 @@ func encodeReposGetUsersWithAccessToProtectedBranchResponse(response ReposGetUse
 	case *ReposGetUsersWithAccessToProtectedBranchOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16314,6 +17631,7 @@ func encodeReposGetUsersWithAccessToProtectedBranchResponse(response ReposGetUse
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16333,6 +17651,7 @@ func encodeReposGetViewsResponse(response ReposGetViewsRes, w http.ResponseWrite
 	case *ViewTraffic:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16345,6 +17664,7 @@ func encodeReposGetViewsResponse(response ReposGetViewsRes, w http.ResponseWrite
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16364,6 +17684,7 @@ func encodeReposGetWebhookResponse(response ReposGetWebhookRes, w http.ResponseW
 	case *Hook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16376,6 +17697,7 @@ func encodeReposGetWebhookResponse(response ReposGetWebhookRes, w http.ResponseW
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16393,6 +17715,7 @@ func encodeReposGetWebhookResponse(response ReposGetWebhookRes, w http.ResponseW
 func encodeReposGetWebhookConfigForRepoResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16409,6 +17732,7 @@ func encodeReposGetWebhookDeliveryResponse(response ReposGetWebhookDeliveryRes, 
 	case *HookDelivery:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16421,6 +17745,7 @@ func encodeReposGetWebhookDeliveryResponse(response ReposGetWebhookDeliveryRes, 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16433,6 +17758,7 @@ func encodeReposGetWebhookDeliveryResponse(response ReposGetWebhookDeliveryRes, 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16450,6 +17776,7 @@ func encodeReposGetWebhookDeliveryResponse(response ReposGetWebhookDeliveryRes, 
 func encodeReposListAutolinksResponse(response []Autolink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16470,6 +17797,7 @@ func encodeReposListBranchesResponse(response ReposListBranchesRes, w http.Respo
 	case *ReposListBranchesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16482,6 +17810,7 @@ func encodeReposListBranchesResponse(response ReposListBranchesRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16501,6 +17830,7 @@ func encodeReposListBranchesForHeadCommitResponse(response ReposListBranchesForH
 	case *ReposListBranchesForHeadCommitOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16513,6 +17843,7 @@ func encodeReposListBranchesForHeadCommitResponse(response ReposListBranchesForH
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16532,6 +17863,7 @@ func encodeReposListCollaboratorsResponse(response ReposListCollaboratorsRes, w 
 	case *ReposListCollaboratorsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16544,6 +17876,7 @@ func encodeReposListCollaboratorsResponse(response ReposListCollaboratorsRes, w 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16561,6 +17894,7 @@ func encodeReposListCollaboratorsResponse(response ReposListCollaboratorsRes, w 
 func encodeReposListCommentsForCommitResponse(response []CommitComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16579,6 +17913,7 @@ func encodeReposListCommentsForCommitResponse(response []CommitComment, w http.R
 func encodeReposListCommitCommentsForRepoResponse(response []CommitComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16599,6 +17934,7 @@ func encodeReposListCommitStatusesForRefResponse(response ReposListCommitStatuse
 	case *ReposListCommitStatusesForRefOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16611,6 +17947,7 @@ func encodeReposListCommitStatusesForRefResponse(response ReposListCommitStatuse
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(301)
+		span.SetStatus(codes.Ok, http.StatusText(301))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16630,6 +17967,7 @@ func encodeReposListCommitsResponse(response ReposListCommitsRes, w http.Respons
 	case *ReposListCommitsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16642,6 +17980,7 @@ func encodeReposListCommitsResponse(response ReposListCommitsRes, w http.Respons
 	case *ReposListCommitsApplicationJSONBadRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16654,6 +17993,7 @@ func encodeReposListCommitsResponse(response ReposListCommitsRes, w http.Respons
 	case *ReposListCommitsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16666,6 +18006,7 @@ func encodeReposListCommitsResponse(response ReposListCommitsRes, w http.Respons
 	case *ReposListCommitsApplicationJSONConflict:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16678,6 +18019,7 @@ func encodeReposListCommitsResponse(response ReposListCommitsRes, w http.Respons
 	case *ReposListCommitsApplicationJSONInternalServerError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16697,6 +18039,7 @@ func encodeReposListContributorsResponse(response ReposListContributorsRes, w ht
 	case *ReposListContributorsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16708,10 +18051,12 @@ func encodeReposListContributorsResponse(response ReposListContributorsRes, w ht
 		return nil
 	case *ReposListContributorsNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ReposListContributorsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16724,6 +18069,7 @@ func encodeReposListContributorsResponse(response ReposListContributorsRes, w ht
 	case *ReposListContributorsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16741,6 +18087,7 @@ func encodeReposListContributorsResponse(response ReposListContributorsRes, w ht
 func encodeReposListDeployKeysResponse(response []DeployKey, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16761,6 +18108,7 @@ func encodeReposListDeploymentStatusesResponse(response ReposListDeploymentStatu
 	case *ReposListDeploymentStatusesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16773,6 +18121,7 @@ func encodeReposListDeploymentStatusesResponse(response ReposListDeploymentStatu
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16790,6 +18139,7 @@ func encodeReposListDeploymentStatusesResponse(response ReposListDeploymentStatu
 func encodeReposListDeploymentsResponse(response []Deployment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16810,6 +18160,7 @@ func encodeReposListForAuthenticatedUserResponse(response ReposListForAuthentica
 	case *ReposListForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16821,10 +18172,12 @@ func encodeReposListForAuthenticatedUserResponse(response ReposListForAuthentica
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReposListForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16837,6 +18190,7 @@ func encodeReposListForAuthenticatedUserResponse(response ReposListForAuthentica
 	case *ReposListForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16849,6 +18203,7 @@ func encodeReposListForAuthenticatedUserResponse(response ReposListForAuthentica
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16866,6 +18221,7 @@ func encodeReposListForAuthenticatedUserResponse(response ReposListForAuthentica
 func encodeReposListForOrgResponse(response []MinimalRepository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16884,6 +18240,7 @@ func encodeReposListForOrgResponse(response []MinimalRepository, w http.Response
 func encodeReposListForUserResponse(response []MinimalRepository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16904,6 +18261,7 @@ func encodeReposListForksResponse(response ReposListForksRes, w http.ResponseWri
 	case *ReposListForksOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16916,6 +18274,7 @@ func encodeReposListForksResponse(response ReposListForksRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16933,6 +18292,7 @@ func encodeReposListForksResponse(response ReposListForksRes, w http.ResponseWri
 func encodeReposListInvitationsResponse(response []RepositoryInvitation, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -16953,6 +18313,7 @@ func encodeReposListInvitationsForAuthenticatedUserResponse(response ReposListIn
 	case *ReposListInvitationsForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16964,10 +18325,12 @@ func encodeReposListInvitationsForAuthenticatedUserResponse(response ReposListIn
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ReposListInvitationsForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16980,6 +18343,7 @@ func encodeReposListInvitationsForAuthenticatedUserResponse(response ReposListIn
 	case *ReposListInvitationsForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -16992,6 +18356,7 @@ func encodeReposListInvitationsForAuthenticatedUserResponse(response ReposListIn
 	case *ReposListInvitationsForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17009,6 +18374,7 @@ func encodeReposListInvitationsForAuthenticatedUserResponse(response ReposListIn
 func encodeReposListLanguagesResponse(response Language, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17023,6 +18389,7 @@ func encodeReposListLanguagesResponse(response Language, w http.ResponseWriter, 
 func encodeReposListPagesBuildsResponse(response []PageBuild, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17043,6 +18410,7 @@ func encodeReposListPublicResponse(response ReposListPublicRes, w http.ResponseW
 	case *ReposListPublicOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17054,10 +18422,12 @@ func encodeReposListPublicResponse(response ReposListPublicRes, w http.ResponseW
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17075,6 +18445,7 @@ func encodeReposListPublicResponse(response ReposListPublicRes, w http.ResponseW
 func encodeReposListPullRequestsAssociatedWithCommitResponse(response []PullRequestSimple, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17093,6 +18464,7 @@ func encodeReposListPullRequestsAssociatedWithCommitResponse(response []PullRequ
 func encodeReposListReleaseAssetsResponse(response []ReleaseAsset, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17113,6 +18485,7 @@ func encodeReposListReleasesResponse(response ReposListReleasesRes, w http.Respo
 	case *ReposListReleasesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17125,6 +18498,7 @@ func encodeReposListReleasesResponse(response ReposListReleasesRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17142,6 +18516,7 @@ func encodeReposListReleasesResponse(response ReposListReleasesRes, w http.Respo
 func encodeReposListTagsResponse(response []Tag, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17160,6 +18535,7 @@ func encodeReposListTagsResponse(response []Tag, w http.ResponseWriter, span tra
 func encodeReposListTeamsResponse(response []Team, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17180,6 +18556,7 @@ func encodeReposListWebhookDeliveriesResponse(response ReposListWebhookDeliverie
 	case *ReposListWebhookDeliveriesOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17192,6 +18569,7 @@ func encodeReposListWebhookDeliveriesResponse(response ReposListWebhookDeliverie
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17204,6 +18582,7 @@ func encodeReposListWebhookDeliveriesResponse(response ReposListWebhookDeliverie
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17223,6 +18602,7 @@ func encodeReposListWebhooksResponse(response ReposListWebhooksRes, w http.Respo
 	case *ReposListWebhooksOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17235,6 +18615,7 @@ func encodeReposListWebhooksResponse(response ReposListWebhooksRes, w http.Respo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17254,6 +18635,7 @@ func encodeReposMergeResponse(response ReposMergeRes, w http.ResponseWriter, spa
 	case *Commit:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17265,10 +18647,12 @@ func encodeReposMergeResponse(response ReposMergeRes, w http.ResponseWriter, spa
 		return nil
 	case *ReposMergeNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17280,13 +18664,16 @@ func encodeReposMergeResponse(response ReposMergeRes, w http.ResponseWriter, spa
 		return nil
 	case *ReposMergeNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ReposMergeConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17306,6 +18693,7 @@ func encodeReposMergeUpstreamResponse(response ReposMergeUpstreamRes, w http.Res
 	case *MergedUpstream:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17317,9 +18705,11 @@ func encodeReposMergeUpstreamResponse(response ReposMergeUpstreamRes, w http.Res
 		return nil
 	case *ReposMergeUpstreamConflict:
 		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 		return nil
 	case *ReposMergeUpstreamUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	default:
 		return errors.Errorf("/repos/{owner}/{repo}/merge-upstream"+`: unexpected response type: %T`, response)
@@ -17330,10 +18720,12 @@ func encodeReposPingWebhookResponse(response ReposPingWebhookRes, w http.Respons
 	switch response := response.(type) {
 	case *ReposPingWebhookNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17353,6 +18745,7 @@ func encodeReposRedeliverWebhookDeliveryResponse(response ReposRedeliverWebhookD
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17365,6 +18758,7 @@ func encodeReposRedeliverWebhookDeliveryResponse(response ReposRedeliverWebhookD
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17377,6 +18771,7 @@ func encodeReposRedeliverWebhookDeliveryResponse(response ReposRedeliverWebhookD
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17396,6 +18791,7 @@ func encodeReposRemoveAppAccessRestrictionsResponse(response ReposRemoveAppAcces
 	case *ReposRemoveAppAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17408,6 +18804,7 @@ func encodeReposRemoveAppAccessRestrictionsResponse(response ReposRemoveAppAcces
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17424,6 +18821,7 @@ func encodeReposRemoveAppAccessRestrictionsResponse(response ReposRemoveAppAcces
 
 func encodeReposRemoveCollaboratorResponse(response ReposRemoveCollaboratorNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -17432,6 +18830,7 @@ func encodeReposRemoveStatusCheckContextsResponse(response ReposRemoveStatusChec
 	case *ReposRemoveStatusCheckContextsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17444,6 +18843,7 @@ func encodeReposRemoveStatusCheckContextsResponse(response ReposRemoveStatusChec
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17456,6 +18856,7 @@ func encodeReposRemoveStatusCheckContextsResponse(response ReposRemoveStatusChec
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17472,6 +18873,7 @@ func encodeReposRemoveStatusCheckContextsResponse(response ReposRemoveStatusChec
 
 func encodeReposRemoveStatusCheckProtectionResponse(response ReposRemoveStatusCheckProtectionNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -17480,6 +18882,7 @@ func encodeReposRemoveTeamAccessRestrictionsResponse(response ReposRemoveTeamAcc
 	case *ReposRemoveTeamAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17492,6 +18895,7 @@ func encodeReposRemoveTeamAccessRestrictionsResponse(response ReposRemoveTeamAcc
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17511,6 +18915,7 @@ func encodeReposRemoveUserAccessRestrictionsResponse(response ReposRemoveUserAcc
 	case *ReposRemoveUserAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17523,6 +18928,7 @@ func encodeReposRemoveUserAccessRestrictionsResponse(response ReposRemoveUserAcc
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17542,6 +18948,7 @@ func encodeReposRenameBranchResponse(response ReposRenameBranchRes, w http.Respo
 	case *BranchWithProtection:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17554,6 +18961,7 @@ func encodeReposRenameBranchResponse(response ReposRenameBranchRes, w http.Respo
 	case *ReposRenameBranchApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17566,6 +18974,7 @@ func encodeReposRenameBranchResponse(response ReposRenameBranchRes, w http.Respo
 	case *ReposRenameBranchApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17578,6 +18987,7 @@ func encodeReposRenameBranchResponse(response ReposRenameBranchRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17597,6 +19007,7 @@ func encodeReposReplaceAllTopicsResponse(response ReposReplaceAllTopicsRes, w ht
 	case *Topic:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17609,6 +19020,7 @@ func encodeReposReplaceAllTopicsResponse(response ReposReplaceAllTopicsRes, w ht
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17621,6 +19033,7 @@ func encodeReposReplaceAllTopicsResponse(response ReposReplaceAllTopicsRes, w ht
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17633,6 +19046,7 @@ func encodeReposReplaceAllTopicsResponse(response ReposReplaceAllTopicsRes, w ht
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17650,6 +19064,7 @@ func encodeReposReplaceAllTopicsResponse(response ReposReplaceAllTopicsRes, w ht
 func encodeReposRequestPagesBuildResponse(response PageBuildStatus, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17664,6 +19079,7 @@ func encodeReposRequestPagesBuildResponse(response PageBuildStatus, w http.Respo
 func encodeReposSetAdminBranchProtectionResponse(response ProtectedBranchAdminEnforced, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17680,6 +19096,7 @@ func encodeReposSetAppAccessRestrictionsResponse(response ReposSetAppAccessRestr
 	case *ReposSetAppAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17692,6 +19109,7 @@ func encodeReposSetAppAccessRestrictionsResponse(response ReposSetAppAccessRestr
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17711,6 +19129,7 @@ func encodeReposSetStatusCheckContextsResponse(response ReposSetStatusCheckConte
 	case *ReposSetStatusCheckContextsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17723,6 +19142,7 @@ func encodeReposSetStatusCheckContextsResponse(response ReposSetStatusCheckConte
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17735,6 +19155,7 @@ func encodeReposSetStatusCheckContextsResponse(response ReposSetStatusCheckConte
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17754,6 +19175,7 @@ func encodeReposSetTeamAccessRestrictionsResponse(response ReposSetTeamAccessRes
 	case *ReposSetTeamAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17766,6 +19188,7 @@ func encodeReposSetTeamAccessRestrictionsResponse(response ReposSetTeamAccessRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17785,6 +19208,7 @@ func encodeReposSetUserAccessRestrictionsResponse(response ReposSetUserAccessRes
 	case *ReposSetUserAccessRestrictionsOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17797,6 +19221,7 @@ func encodeReposSetUserAccessRestrictionsResponse(response ReposSetUserAccessRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17815,10 +19240,12 @@ func encodeReposTestPushWebhookResponse(response ReposTestPushWebhookRes, w http
 	switch response := response.(type) {
 	case *ReposTestPushWebhookNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17836,6 +19263,7 @@ func encodeReposTestPushWebhookResponse(response ReposTestPushWebhookRes, w http
 func encodeReposTransferResponse(response MinimalRepository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(202)
+	span.SetStatus(codes.Ok, http.StatusText(202))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -17852,6 +19280,7 @@ func encodeReposUpdateResponse(response ReposUpdateRes, w http.ResponseWriter, s
 	case *FullRepository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17864,6 +19293,7 @@ func encodeReposUpdateResponse(response ReposUpdateRes, w http.ResponseWriter, s
 	case *ReposUpdateApplicationJSONTemporaryRedirect:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(307)
+		span.SetStatus(codes.Ok, http.StatusText(307))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17876,6 +19306,7 @@ func encodeReposUpdateResponse(response ReposUpdateRes, w http.ResponseWriter, s
 	case *ReposUpdateApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17888,6 +19319,7 @@ func encodeReposUpdateResponse(response ReposUpdateRes, w http.ResponseWriter, s
 	case *ReposUpdateApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17900,6 +19332,7 @@ func encodeReposUpdateResponse(response ReposUpdateRes, w http.ResponseWriter, s
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17919,6 +19352,7 @@ func encodeReposUpdateBranchProtectionResponse(response ReposUpdateBranchProtect
 	case *ProtectedBranch:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17931,6 +19365,7 @@ func encodeReposUpdateBranchProtectionResponse(response ReposUpdateBranchProtect
 	case *ReposUpdateBranchProtectionApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17943,6 +19378,7 @@ func encodeReposUpdateBranchProtectionResponse(response ReposUpdateBranchProtect
 	case *ReposUpdateBranchProtectionApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17955,6 +19391,7 @@ func encodeReposUpdateBranchProtectionResponse(response ReposUpdateBranchProtect
 	case *ValidationErrorSimple:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17974,6 +19411,7 @@ func encodeReposUpdateCommitCommentResponse(response ReposUpdateCommitCommentRes
 	case *CommitComment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -17986,6 +19424,7 @@ func encodeReposUpdateCommitCommentResponse(response ReposUpdateCommitCommentRes
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18003,6 +19442,7 @@ func encodeReposUpdateCommitCommentResponse(response ReposUpdateCommitCommentRes
 func encodeReposUpdateInvitationResponse(response RepositoryInvitation, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -18019,6 +19459,7 @@ func encodeReposUpdatePullRequestReviewProtectionResponse(response ReposUpdatePu
 	case *ProtectedBranchPullRequestReview:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18031,6 +19472,7 @@ func encodeReposUpdatePullRequestReviewProtectionResponse(response ReposUpdatePu
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18050,6 +19492,7 @@ func encodeReposUpdateReleaseResponse(response ReposUpdateReleaseRes, w http.Res
 	case *Release:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18062,6 +19505,7 @@ func encodeReposUpdateReleaseResponse(response ReposUpdateReleaseRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18079,6 +19523,7 @@ func encodeReposUpdateReleaseResponse(response ReposUpdateReleaseRes, w http.Res
 func encodeReposUpdateReleaseAssetResponse(response ReleaseAsset, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -18095,6 +19540,7 @@ func encodeReposUpdateStatusCheckProtectionResponse(response ReposUpdateStatusCh
 	case *StatusCheckPolicy:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18107,6 +19553,7 @@ func encodeReposUpdateStatusCheckProtectionResponse(response ReposUpdateStatusCh
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18119,6 +19566,7 @@ func encodeReposUpdateStatusCheckProtectionResponse(response ReposUpdateStatusCh
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18138,6 +19586,7 @@ func encodeReposUpdateWebhookResponse(response ReposUpdateWebhookRes, w http.Res
 	case *Hook:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18150,6 +19599,7 @@ func encodeReposUpdateWebhookResponse(response ReposUpdateWebhookRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18162,6 +19612,7 @@ func encodeReposUpdateWebhookResponse(response ReposUpdateWebhookRes, w http.Res
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18179,6 +19630,7 @@ func encodeReposUpdateWebhookResponse(response ReposUpdateWebhookRes, w http.Res
 func encodeReposUpdateWebhookConfigForRepoResponse(response WebhookConfig, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -18194,13 +19646,16 @@ func encodeScimDeleteUserFromOrgResponse(response ScimDeleteUserFromOrgRes, w ht
 	switch response := response.(type) {
 	case *ScimDeleteUserFromOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ScimDeleteUserFromOrgApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18213,6 +19668,7 @@ func encodeScimDeleteUserFromOrgResponse(response ScimDeleteUserFromOrgRes, w ht
 	case *ScimDeleteUserFromOrgApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18232,6 +19688,7 @@ func encodeSearchCodeResponse(response SearchCodeRes, w http.ResponseWriter, spa
 	case *SearchCodeOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18243,10 +19700,12 @@ func encodeSearchCodeResponse(response SearchCodeRes, w http.ResponseWriter, spa
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18259,6 +19718,7 @@ func encodeSearchCodeResponse(response SearchCodeRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18271,6 +19731,7 @@ func encodeSearchCodeResponse(response SearchCodeRes, w http.ResponseWriter, spa
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18290,6 +19751,7 @@ func encodeSearchCommitsResponse(response SearchCommitsRes, w http.ResponseWrite
 	case *SearchCommitsOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18301,10 +19763,12 @@ func encodeSearchCommitsResponse(response SearchCommitsRes, w http.ResponseWrite
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18324,6 +19788,7 @@ func encodeSearchIssuesAndPullRequestsResponse(response SearchIssuesAndPullReque
 	case *SearchIssuesAndPullRequestsOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18335,10 +19800,12 @@ func encodeSearchIssuesAndPullRequestsResponse(response SearchIssuesAndPullReque
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18351,6 +19818,7 @@ func encodeSearchIssuesAndPullRequestsResponse(response SearchIssuesAndPullReque
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18363,6 +19831,7 @@ func encodeSearchIssuesAndPullRequestsResponse(response SearchIssuesAndPullReque
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18382,6 +19851,7 @@ func encodeSearchLabelsResponse(response SearchLabelsRes, w http.ResponseWriter,
 	case *SearchLabelsOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18393,10 +19863,12 @@ func encodeSearchLabelsResponse(response SearchLabelsRes, w http.ResponseWriter,
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *SearchLabelsApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18409,6 +19881,7 @@ func encodeSearchLabelsResponse(response SearchLabelsRes, w http.ResponseWriter,
 	case *SearchLabelsApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18421,6 +19894,7 @@ func encodeSearchLabelsResponse(response SearchLabelsRes, w http.ResponseWriter,
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18440,6 +19914,7 @@ func encodeSearchReposResponse(response SearchReposRes, w http.ResponseWriter, s
 	case *SearchReposOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18451,10 +19926,12 @@ func encodeSearchReposResponse(response SearchReposRes, w http.ResponseWriter, s
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18467,6 +19944,7 @@ func encodeSearchReposResponse(response SearchReposRes, w http.ResponseWriter, s
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18486,6 +19964,7 @@ func encodeSearchTopicsResponse(response SearchTopicsRes, w http.ResponseWriter,
 	case *SearchTopicsOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18497,10 +19976,12 @@ func encodeSearchTopicsResponse(response SearchTopicsRes, w http.ResponseWriter,
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18520,6 +20001,7 @@ func encodeSearchUsersResponse(response SearchUsersRes, w http.ResponseWriter, s
 	case *SearchUsersOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18531,10 +20013,12 @@ func encodeSearchUsersResponse(response SearchUsersRes, w http.ResponseWriter, s
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18547,6 +20031,7 @@ func encodeSearchUsersResponse(response SearchUsersRes, w http.ResponseWriter, s
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18566,6 +20051,7 @@ func encodeSecretScanningGetAlertResponse(response SecretScanningGetAlertRes, w 
 	case *SecretScanningAlert:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18577,10 +20063,12 @@ func encodeSecretScanningGetAlertResponse(response SecretScanningGetAlertRes, w 
 		return nil
 	case *SecretScanningGetAlertNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18600,6 +20088,7 @@ func encodeSecretScanningListAlertsForOrgResponse(response SecretScanningListAle
 	case *SecretScanningListAlertsForOrgOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18612,6 +20101,7 @@ func encodeSecretScanningListAlertsForOrgResponse(response SecretScanningListAle
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18624,6 +20114,7 @@ func encodeSecretScanningListAlertsForOrgResponse(response SecretScanningListAle
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18643,6 +20134,7 @@ func encodeSecretScanningListAlertsForRepoResponse(response SecretScanningListAl
 	case *SecretScanningListAlertsForRepoOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18654,10 +20146,12 @@ func encodeSecretScanningListAlertsForRepoResponse(response SecretScanningListAl
 		return nil
 	case *SecretScanningListAlertsForRepoNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18677,6 +20171,7 @@ func encodeSecretScanningUpdateAlertResponse(response SecretScanningUpdateAlertR
 	case *SecretScanningAlert:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18688,13 +20183,16 @@ func encodeSecretScanningUpdateAlertResponse(response SecretScanningUpdateAlertR
 		return nil
 	case *SecretScanningUpdateAlertNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *SecretScanningUpdateAlertUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	case *ServiceUnavailable:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18713,10 +20211,12 @@ func encodeTeamsAddMemberLegacyResponse(response TeamsAddMemberLegacyRes, w http
 	switch response := response.(type) {
 	case *TeamsAddMemberLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18728,9 +20228,11 @@ func encodeTeamsAddMemberLegacyResponse(response TeamsAddMemberLegacyRes, w http
 		return nil
 	case *TeamsAddMemberLegacyNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *TeamsAddMemberLegacyUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/members/{username}"+`: unexpected response type: %T`, response)
@@ -18742,6 +20244,7 @@ func encodeTeamsAddOrUpdateMembershipForUserInOrgResponse(response TeamsAddOrUpd
 	case *TeamMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18753,9 +20256,11 @@ func encodeTeamsAddOrUpdateMembershipForUserInOrgResponse(response TeamsAddOrUpd
 		return nil
 	case *TeamsAddOrUpdateMembershipForUserInOrgForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	case *TeamsAddOrUpdateMembershipForUserInOrgUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/teams/{team_slug}/memberships/{username}"+`: unexpected response type: %T`, response)
@@ -18767,6 +20272,7 @@ func encodeTeamsAddOrUpdateMembershipForUserLegacyResponse(response TeamsAddOrUp
 	case *TeamMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18778,10 +20284,12 @@ func encodeTeamsAddOrUpdateMembershipForUserLegacyResponse(response TeamsAddOrUp
 		return nil
 	case *TeamsAddOrUpdateMembershipForUserLegacyForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18793,6 +20301,7 @@ func encodeTeamsAddOrUpdateMembershipForUserLegacyResponse(response TeamsAddOrUp
 		return nil
 	case *TeamsAddOrUpdateMembershipForUserLegacyUnprocessableEntity:
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/memberships/{username}"+`: unexpected response type: %T`, response)
@@ -18803,10 +20312,12 @@ func encodeTeamsAddOrUpdateProjectPermissionsInOrgResponse(response TeamsAddOrUp
 	switch response := response.(type) {
 	case *TeamsAddOrUpdateProjectPermissionsInOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsAddOrUpdateProjectPermissionsInOrgForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18825,10 +20336,12 @@ func encodeTeamsAddOrUpdateProjectPermissionsLegacyResponse(response TeamsAddOrU
 	switch response := response.(type) {
 	case *TeamsAddOrUpdateProjectPermissionsLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsAddOrUpdateProjectPermissionsLegacyForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18841,6 +20354,7 @@ func encodeTeamsAddOrUpdateProjectPermissionsLegacyResponse(response TeamsAddOrU
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18853,6 +20367,7 @@ func encodeTeamsAddOrUpdateProjectPermissionsLegacyResponse(response TeamsAddOrU
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18869,6 +20384,7 @@ func encodeTeamsAddOrUpdateProjectPermissionsLegacyResponse(response TeamsAddOrU
 
 func encodeTeamsAddOrUpdateRepoPermissionsInOrgResponse(response TeamsAddOrUpdateRepoPermissionsInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -18876,10 +20392,12 @@ func encodeTeamsAddOrUpdateRepoPermissionsLegacyResponse(response TeamsAddOrUpda
 	switch response := response.(type) {
 	case *TeamsAddOrUpdateRepoPermissionsLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18892,6 +20410,7 @@ func encodeTeamsAddOrUpdateRepoPermissionsLegacyResponse(response TeamsAddOrUpda
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18911,6 +20430,7 @@ func encodeTeamsCheckPermissionsForProjectInOrgResponse(response TeamsCheckPermi
 	case *TeamProject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18922,6 +20442,7 @@ func encodeTeamsCheckPermissionsForProjectInOrgResponse(response TeamsCheckPermi
 		return nil
 	case *TeamsCheckPermissionsForProjectInOrgNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/teams/{team_slug}/projects/{project_id}"+`: unexpected response type: %T`, response)
@@ -18933,6 +20454,7 @@ func encodeTeamsCheckPermissionsForProjectLegacyResponse(response TeamsCheckPerm
 	case *TeamProject:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18944,6 +20466,7 @@ func encodeTeamsCheckPermissionsForProjectLegacyResponse(response TeamsCheckPerm
 		return nil
 	case *TeamsCheckPermissionsForProjectLegacyNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/projects/{project_id}"+`: unexpected response type: %T`, response)
@@ -18955,6 +20478,7 @@ func encodeTeamsCheckPermissionsForRepoInOrgResponse(response TeamsCheckPermissi
 	case *TeamRepository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18966,9 +20490,11 @@ func encodeTeamsCheckPermissionsForRepoInOrgResponse(response TeamsCheckPermissi
 		return nil
 	case *TeamsCheckPermissionsForRepoInOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsCheckPermissionsForRepoInOrgNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"+`: unexpected response type: %T`, response)
@@ -18980,6 +20506,7 @@ func encodeTeamsCheckPermissionsForRepoLegacyResponse(response TeamsCheckPermiss
 	case *TeamRepository:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -18991,9 +20518,11 @@ func encodeTeamsCheckPermissionsForRepoLegacyResponse(response TeamsCheckPermiss
 		return nil
 	case *TeamsCheckPermissionsForRepoLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsCheckPermissionsForRepoLegacyNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/repos/{owner}/{repo}"+`: unexpected response type: %T`, response)
@@ -19005,6 +20534,7 @@ func encodeTeamsCreateResponse(response TeamsCreateRes, w http.ResponseWriter, s
 	case *TeamFull:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19017,6 +20547,7 @@ func encodeTeamsCreateResponse(response TeamsCreateRes, w http.ResponseWriter, s
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19029,6 +20560,7 @@ func encodeTeamsCreateResponse(response TeamsCreateRes, w http.ResponseWriter, s
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19046,6 +20578,7 @@ func encodeTeamsCreateResponse(response TeamsCreateRes, w http.ResponseWriter, s
 func encodeTeamsCreateDiscussionCommentInOrgResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19060,6 +20593,7 @@ func encodeTeamsCreateDiscussionCommentInOrgResponse(response TeamDiscussionComm
 func encodeTeamsCreateDiscussionCommentLegacyResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19074,6 +20608,7 @@ func encodeTeamsCreateDiscussionCommentLegacyResponse(response TeamDiscussionCom
 func encodeTeamsCreateDiscussionInOrgResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19088,6 +20623,7 @@ func encodeTeamsCreateDiscussionInOrgResponse(response TeamDiscussion, w http.Re
 func encodeTeamsCreateDiscussionLegacyResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19102,6 +20638,7 @@ func encodeTeamsCreateDiscussionLegacyResponse(response TeamDiscussion, w http.R
 func encodeTeamsCreateOrUpdateIdpGroupConnectionsInOrgResponse(response GroupMapping, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19118,6 +20655,7 @@ func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse(response TeamsCr
 	case *GroupMapping:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19130,6 +20668,7 @@ func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse(response TeamsCr
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19142,6 +20681,7 @@ func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse(response TeamsCr
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19158,26 +20698,31 @@ func encodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyResponse(response TeamsCr
 
 func encodeTeamsDeleteDiscussionCommentInOrgResponse(response TeamsDeleteDiscussionCommentInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsDeleteDiscussionCommentLegacyResponse(response TeamsDeleteDiscussionCommentLegacyNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsDeleteDiscussionInOrgResponse(response TeamsDeleteDiscussionInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsDeleteDiscussionLegacyResponse(response TeamsDeleteDiscussionLegacyNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsDeleteInOrgResponse(response TeamsDeleteInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -19185,10 +20730,12 @@ func encodeTeamsDeleteLegacyResponse(response TeamsDeleteLegacyRes, w http.Respo
 	switch response := response.(type) {
 	case *TeamsDeleteLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19201,6 +20748,7 @@ func encodeTeamsDeleteLegacyResponse(response TeamsDeleteLegacyRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19220,6 +20768,7 @@ func encodeTeamsGetByNameResponse(response TeamsGetByNameRes, w http.ResponseWri
 	case *TeamFull:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19232,6 +20781,7 @@ func encodeTeamsGetByNameResponse(response TeamsGetByNameRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19249,6 +20799,7 @@ func encodeTeamsGetByNameResponse(response TeamsGetByNameRes, w http.ResponseWri
 func encodeTeamsGetDiscussionCommentInOrgResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19263,6 +20814,7 @@ func encodeTeamsGetDiscussionCommentInOrgResponse(response TeamDiscussionComment
 func encodeTeamsGetDiscussionCommentLegacyResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19277,6 +20829,7 @@ func encodeTeamsGetDiscussionCommentLegacyResponse(response TeamDiscussionCommen
 func encodeTeamsGetDiscussionInOrgResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19291,6 +20844,7 @@ func encodeTeamsGetDiscussionInOrgResponse(response TeamDiscussion, w http.Respo
 func encodeTeamsGetDiscussionLegacyResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19307,6 +20861,7 @@ func encodeTeamsGetLegacyResponse(response TeamsGetLegacyRes, w http.ResponseWri
 	case *TeamFull:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19319,6 +20874,7 @@ func encodeTeamsGetLegacyResponse(response TeamsGetLegacyRes, w http.ResponseWri
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19337,9 +20893,11 @@ func encodeTeamsGetMemberLegacyResponse(response TeamsGetMemberLegacyRes, w http
 	switch response := response.(type) {
 	case *TeamsGetMemberLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsGetMemberLegacyNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/members/{username}"+`: unexpected response type: %T`, response)
@@ -19351,6 +20909,7 @@ func encodeTeamsGetMembershipForUserInOrgResponse(response TeamsGetMembershipFor
 	case *TeamMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19362,6 +20921,7 @@ func encodeTeamsGetMembershipForUserInOrgResponse(response TeamsGetMembershipFor
 		return nil
 	case *TeamsGetMembershipForUserInOrgNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/teams/{team_slug}/memberships/{username}"+`: unexpected response type: %T`, response)
@@ -19373,6 +20933,7 @@ func encodeTeamsGetMembershipForUserLegacyResponse(response TeamsGetMembershipFo
 	case *TeamMembership:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19385,6 +20946,7 @@ func encodeTeamsGetMembershipForUserLegacyResponse(response TeamsGetMembershipFo
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19404,6 +20966,7 @@ func encodeTeamsListResponse(response TeamsListRes, w http.ResponseWriter, span 
 	case *TeamsListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19416,6 +20979,7 @@ func encodeTeamsListResponse(response TeamsListRes, w http.ResponseWriter, span 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19433,6 +20997,7 @@ func encodeTeamsListResponse(response TeamsListRes, w http.ResponseWriter, span 
 func encodeTeamsListChildInOrgResponse(response []Team, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19453,6 +21018,7 @@ func encodeTeamsListChildLegacyResponse(response TeamsListChildLegacyRes, w http
 	case *TeamsListChildLegacyOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19465,6 +21031,7 @@ func encodeTeamsListChildLegacyResponse(response TeamsListChildLegacyRes, w http
 	case *TeamsListChildLegacyApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19477,6 +21044,7 @@ func encodeTeamsListChildLegacyResponse(response TeamsListChildLegacyRes, w http
 	case *TeamsListChildLegacyApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19489,6 +21057,7 @@ func encodeTeamsListChildLegacyResponse(response TeamsListChildLegacyRes, w http
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19506,6 +21075,7 @@ func encodeTeamsListChildLegacyResponse(response TeamsListChildLegacyRes, w http
 func encodeTeamsListDiscussionCommentsInOrgResponse(response []TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19524,6 +21094,7 @@ func encodeTeamsListDiscussionCommentsInOrgResponse(response []TeamDiscussionCom
 func encodeTeamsListDiscussionCommentsLegacyResponse(response []TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19542,6 +21113,7 @@ func encodeTeamsListDiscussionCommentsLegacyResponse(response []TeamDiscussionCo
 func encodeTeamsListDiscussionsInOrgResponse(response []TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19560,6 +21132,7 @@ func encodeTeamsListDiscussionsInOrgResponse(response []TeamDiscussion, w http.R
 func encodeTeamsListDiscussionsLegacyResponse(response []TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19580,6 +21153,7 @@ func encodeTeamsListForAuthenticatedUserResponse(response TeamsListForAuthentica
 	case *TeamsListForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19591,10 +21165,12 @@ func encodeTeamsListForAuthenticatedUserResponse(response TeamsListForAuthentica
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *TeamsListForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19607,6 +21183,7 @@ func encodeTeamsListForAuthenticatedUserResponse(response TeamsListForAuthentica
 	case *TeamsListForAuthenticatedUserApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19626,6 +21203,7 @@ func encodeTeamsListIdpGroupsForLegacyResponse(response TeamsListIdpGroupsForLeg
 	case *GroupMapping:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19638,6 +21216,7 @@ func encodeTeamsListIdpGroupsForLegacyResponse(response TeamsListIdpGroupsForLeg
 	case *TeamsListIdpGroupsForLegacyApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19650,6 +21229,7 @@ func encodeTeamsListIdpGroupsForLegacyResponse(response TeamsListIdpGroupsForLeg
 	case *TeamsListIdpGroupsForLegacyApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19667,6 +21247,7 @@ func encodeTeamsListIdpGroupsForLegacyResponse(response TeamsListIdpGroupsForLeg
 func encodeTeamsListIdpGroupsForOrgResponse(response GroupMapping, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19681,6 +21262,7 @@ func encodeTeamsListIdpGroupsForOrgResponse(response GroupMapping, w http.Respon
 func encodeTeamsListIdpGroupsInOrgResponse(response GroupMapping, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19695,6 +21277,7 @@ func encodeTeamsListIdpGroupsInOrgResponse(response GroupMapping, w http.Respons
 func encodeTeamsListMembersInOrgResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19715,6 +21298,7 @@ func encodeTeamsListMembersLegacyResponse(response TeamsListMembersLegacyRes, w 
 	case *TeamsListMembersLegacyOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19727,6 +21311,7 @@ func encodeTeamsListMembersLegacyResponse(response TeamsListMembersLegacyRes, w 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19744,6 +21329,7 @@ func encodeTeamsListMembersLegacyResponse(response TeamsListMembersLegacyRes, w 
 func encodeTeamsListPendingInvitationsInOrgResponse(response []OrganizationInvitation, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19762,6 +21348,7 @@ func encodeTeamsListPendingInvitationsInOrgResponse(response []OrganizationInvit
 func encodeTeamsListPendingInvitationsLegacyResponse(response []OrganizationInvitation, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19780,6 +21367,7 @@ func encodeTeamsListPendingInvitationsLegacyResponse(response []OrganizationInvi
 func encodeTeamsListProjectsInOrgResponse(response []TeamProject, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19800,6 +21388,7 @@ func encodeTeamsListProjectsLegacyResponse(response TeamsListProjectsLegacyRes, 
 	case *TeamsListProjectsLegacyOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19812,6 +21401,7 @@ func encodeTeamsListProjectsLegacyResponse(response TeamsListProjectsLegacyRes, 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19829,6 +21419,7 @@ func encodeTeamsListProjectsLegacyResponse(response TeamsListProjectsLegacyRes, 
 func encodeTeamsListReposInOrgResponse(response []MinimalRepository, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19849,6 +21440,7 @@ func encodeTeamsListReposLegacyResponse(response TeamsListReposLegacyRes, w http
 	case *TeamsListReposLegacyOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19861,6 +21453,7 @@ func encodeTeamsListReposLegacyResponse(response TeamsListReposLegacyRes, w http
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19879,9 +21472,11 @@ func encodeTeamsRemoveMemberLegacyResponse(response TeamsRemoveMemberLegacyRes, 
 	switch response := response.(type) {
 	case *TeamsRemoveMemberLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsRemoveMemberLegacyNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/members/{username}"+`: unexpected response type: %T`, response)
@@ -19892,9 +21487,11 @@ func encodeTeamsRemoveMembershipForUserInOrgResponse(response TeamsRemoveMembers
 	switch response := response.(type) {
 	case *TeamsRemoveMembershipForUserInOrgNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsRemoveMembershipForUserInOrgForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/orgs/{org}/teams/{team_slug}/memberships/{username}"+`: unexpected response type: %T`, response)
@@ -19905,9 +21502,11 @@ func encodeTeamsRemoveMembershipForUserLegacyResponse(response TeamsRemoveMember
 	switch response := response.(type) {
 	case *TeamsRemoveMembershipForUserLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *TeamsRemoveMembershipForUserLegacyForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/teams/{team_id}/memberships/{username}"+`: unexpected response type: %T`, response)
@@ -19916,6 +21515,7 @@ func encodeTeamsRemoveMembershipForUserLegacyResponse(response TeamsRemoveMember
 
 func encodeTeamsRemoveProjectInOrgResponse(response TeamsRemoveProjectInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
@@ -19923,10 +21523,12 @@ func encodeTeamsRemoveProjectLegacyResponse(response TeamsRemoveProjectLegacyRes
 	switch response := response.(type) {
 	case *TeamsRemoveProjectLegacyNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19939,6 +21541,7 @@ func encodeTeamsRemoveProjectLegacyResponse(response TeamsRemoveProjectLegacyRes
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19951,6 +21554,7 @@ func encodeTeamsRemoveProjectLegacyResponse(response TeamsRemoveProjectLegacyRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -19967,17 +21571,20 @@ func encodeTeamsRemoveProjectLegacyResponse(response TeamsRemoveProjectLegacyRes
 
 func encodeTeamsRemoveRepoInOrgResponse(response TeamsRemoveRepoInOrgNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsRemoveRepoLegacyResponse(response TeamsRemoveRepoLegacyNoContent, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(204)
+	span.SetStatus(codes.Ok, http.StatusText(204))
 	return nil
 }
 
 func encodeTeamsUpdateDiscussionCommentInOrgResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -19992,6 +21599,7 @@ func encodeTeamsUpdateDiscussionCommentInOrgResponse(response TeamDiscussionComm
 func encodeTeamsUpdateDiscussionCommentLegacyResponse(response TeamDiscussionComment, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -20006,6 +21614,7 @@ func encodeTeamsUpdateDiscussionCommentLegacyResponse(response TeamDiscussionCom
 func encodeTeamsUpdateDiscussionInOrgResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -20020,6 +21629,7 @@ func encodeTeamsUpdateDiscussionInOrgResponse(response TeamDiscussion, w http.Re
 func encodeTeamsUpdateDiscussionLegacyResponse(response TeamDiscussion, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -20034,6 +21644,7 @@ func encodeTeamsUpdateDiscussionLegacyResponse(response TeamDiscussion, w http.R
 func encodeTeamsUpdateInOrgResponse(response TeamFull, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
+	span.SetStatus(codes.Ok, http.StatusText(201))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -20050,6 +21661,7 @@ func encodeTeamsUpdateLegacyResponse(response TeamsUpdateLegacyRes, w http.Respo
 	case *TeamsUpdateLegacyApplicationJSONOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20062,6 +21674,7 @@ func encodeTeamsUpdateLegacyResponse(response TeamsUpdateLegacyRes, w http.Respo
 	case *TeamsUpdateLegacyApplicationJSONCreated:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20074,6 +21687,7 @@ func encodeTeamsUpdateLegacyResponse(response TeamsUpdateLegacyRes, w http.Respo
 	case *TeamsUpdateLegacyApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20086,6 +21700,7 @@ func encodeTeamsUpdateLegacyResponse(response TeamsUpdateLegacyRes, w http.Respo
 	case *TeamsUpdateLegacyApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20098,6 +21713,7 @@ func encodeTeamsUpdateLegacyResponse(response TeamsUpdateLegacyRes, w http.Respo
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20117,6 +21733,7 @@ func encodeUsersAddEmailForAuthenticatedResponse(response UsersAddEmailForAuthen
 	case *UsersAddEmailForAuthenticatedCreatedApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20128,10 +21745,12 @@ func encodeUsersAddEmailForAuthenticatedResponse(response UsersAddEmailForAuthen
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersAddEmailForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20144,6 +21763,7 @@ func encodeUsersAddEmailForAuthenticatedResponse(response UsersAddEmailForAuthen
 	case *UsersAddEmailForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20156,6 +21776,7 @@ func encodeUsersAddEmailForAuthenticatedResponse(response UsersAddEmailForAuthen
 	case *UsersAddEmailForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20168,6 +21789,7 @@ func encodeUsersAddEmailForAuthenticatedResponse(response UsersAddEmailForAuthen
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20186,13 +21808,16 @@ func encodeUsersBlockResponse(response UsersBlockRes, w http.ResponseWriter, spa
 	switch response := response.(type) {
 	case *UsersBlockNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersBlockApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20205,6 +21830,7 @@ func encodeUsersBlockResponse(response UsersBlockRes, w http.ResponseWriter, spa
 	case *UsersBlockApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20217,6 +21843,7 @@ func encodeUsersBlockResponse(response UsersBlockRes, w http.ResponseWriter, spa
 	case *UsersBlockApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20229,6 +21856,7 @@ func encodeUsersBlockResponse(response UsersBlockRes, w http.ResponseWriter, spa
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20247,13 +21875,16 @@ func encodeUsersCheckBlockedResponse(response UsersCheckBlockedRes, w http.Respo
 	switch response := response.(type) {
 	case *UsersCheckBlockedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersCheckBlockedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20266,6 +21897,7 @@ func encodeUsersCheckBlockedResponse(response UsersCheckBlockedRes, w http.Respo
 	case *UsersCheckBlockedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20278,6 +21910,7 @@ func encodeUsersCheckBlockedResponse(response UsersCheckBlockedRes, w http.Respo
 	case *UsersCheckBlockedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20296,9 +21929,11 @@ func encodeUsersCheckFollowingForUserResponse(response UsersCheckFollowingForUse
 	switch response := response.(type) {
 	case *UsersCheckFollowingForUserNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *UsersCheckFollowingForUserNotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/users/{username}/following/{target_user}"+`: unexpected response type: %T`, response)
@@ -20309,13 +21944,16 @@ func encodeUsersCheckPersonIsFollowedByAuthenticatedResponse(response UsersCheck
 	switch response := response.(type) {
 	case *UsersCheckPersonIsFollowedByAuthenticatedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersCheckPersonIsFollowedByAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20328,6 +21966,7 @@ func encodeUsersCheckPersonIsFollowedByAuthenticatedResponse(response UsersCheck
 	case *UsersCheckPersonIsFollowedByAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20340,6 +21979,7 @@ func encodeUsersCheckPersonIsFollowedByAuthenticatedResponse(response UsersCheck
 	case *UsersCheckPersonIsFollowedByAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20359,6 +21999,7 @@ func encodeUsersCreateGpgKeyForAuthenticatedResponse(response UsersCreateGpgKeyF
 	case *GpgKey:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20370,10 +22011,12 @@ func encodeUsersCreateGpgKeyForAuthenticatedResponse(response UsersCreateGpgKeyF
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersCreateGpgKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20386,6 +22029,7 @@ func encodeUsersCreateGpgKeyForAuthenticatedResponse(response UsersCreateGpgKeyF
 	case *UsersCreateGpgKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20398,6 +22042,7 @@ func encodeUsersCreateGpgKeyForAuthenticatedResponse(response UsersCreateGpgKeyF
 	case *UsersCreateGpgKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20410,6 +22055,7 @@ func encodeUsersCreateGpgKeyForAuthenticatedResponse(response UsersCreateGpgKeyF
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20429,6 +22075,7 @@ func encodeUsersCreatePublicSSHKeyForAuthenticatedResponse(response UsersCreateP
 	case *Key:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20440,10 +22087,12 @@ func encodeUsersCreatePublicSSHKeyForAuthenticatedResponse(response UsersCreateP
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersCreatePublicSSHKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20456,6 +22105,7 @@ func encodeUsersCreatePublicSSHKeyForAuthenticatedResponse(response UsersCreateP
 	case *UsersCreatePublicSSHKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20468,6 +22118,7 @@ func encodeUsersCreatePublicSSHKeyForAuthenticatedResponse(response UsersCreateP
 	case *UsersCreatePublicSSHKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20480,6 +22131,7 @@ func encodeUsersCreatePublicSSHKeyForAuthenticatedResponse(response UsersCreateP
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20498,13 +22150,16 @@ func encodeUsersDeleteEmailForAuthenticatedResponse(response UsersDeleteEmailFor
 	switch response := response.(type) {
 	case *UsersDeleteEmailForAuthenticatedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersDeleteEmailForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20517,6 +22172,7 @@ func encodeUsersDeleteEmailForAuthenticatedResponse(response UsersDeleteEmailFor
 	case *UsersDeleteEmailForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20529,6 +22185,7 @@ func encodeUsersDeleteEmailForAuthenticatedResponse(response UsersDeleteEmailFor
 	case *UsersDeleteEmailForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20541,6 +22198,7 @@ func encodeUsersDeleteEmailForAuthenticatedResponse(response UsersDeleteEmailFor
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20559,13 +22217,16 @@ func encodeUsersDeleteGpgKeyForAuthenticatedResponse(response UsersDeleteGpgKeyF
 	switch response := response.(type) {
 	case *UsersDeleteGpgKeyForAuthenticatedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersDeleteGpgKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20578,6 +22239,7 @@ func encodeUsersDeleteGpgKeyForAuthenticatedResponse(response UsersDeleteGpgKeyF
 	case *UsersDeleteGpgKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20590,6 +22252,7 @@ func encodeUsersDeleteGpgKeyForAuthenticatedResponse(response UsersDeleteGpgKeyF
 	case *UsersDeleteGpgKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20602,6 +22265,7 @@ func encodeUsersDeleteGpgKeyForAuthenticatedResponse(response UsersDeleteGpgKeyF
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20620,13 +22284,16 @@ func encodeUsersDeletePublicSSHKeyForAuthenticatedResponse(response UsersDeleteP
 	switch response := response.(type) {
 	case *UsersDeletePublicSSHKeyForAuthenticatedNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersDeletePublicSSHKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20639,6 +22306,7 @@ func encodeUsersDeletePublicSSHKeyForAuthenticatedResponse(response UsersDeleteP
 	case *UsersDeletePublicSSHKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20651,6 +22319,7 @@ func encodeUsersDeletePublicSSHKeyForAuthenticatedResponse(response UsersDeleteP
 	case *UsersDeletePublicSSHKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20669,13 +22338,16 @@ func encodeUsersFollowResponse(response UsersFollowRes, w http.ResponseWriter, s
 	switch response := response.(type) {
 	case *UsersFollowNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersFollowApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20688,6 +22360,7 @@ func encodeUsersFollowResponse(response UsersFollowRes, w http.ResponseWriter, s
 	case *UsersFollowApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20700,6 +22373,7 @@ func encodeUsersFollowResponse(response UsersFollowRes, w http.ResponseWriter, s
 	case *UsersFollowApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20719,6 +22393,7 @@ func encodeUsersGetAuthenticatedResponse(response UsersGetAuthenticatedRes, w ht
 	case *UsersGetAuthenticatedOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20730,10 +22405,12 @@ func encodeUsersGetAuthenticatedResponse(response UsersGetAuthenticatedRes, w ht
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersGetAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20746,6 +22423,7 @@ func encodeUsersGetAuthenticatedResponse(response UsersGetAuthenticatedRes, w ht
 	case *UsersGetAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20765,6 +22443,7 @@ func encodeUsersGetByUsernameResponse(response UsersGetByUsernameRes, w http.Res
 	case *UsersGetByUsernameOK:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20777,6 +22456,7 @@ func encodeUsersGetByUsernameResponse(response UsersGetByUsernameRes, w http.Res
 	case *Accepted:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(202)
+		span.SetStatus(codes.Ok, http.StatusText(202))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20789,6 +22469,7 @@ func encodeUsersGetByUsernameResponse(response UsersGetByUsernameRes, w http.Res
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20808,6 +22489,7 @@ func encodeUsersGetContextForUserResponse(response UsersGetContextForUserRes, w 
 	case *Hovercard:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20820,6 +22502,7 @@ func encodeUsersGetContextForUserResponse(response UsersGetContextForUserRes, w 
 	case *BasicError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20832,6 +22515,7 @@ func encodeUsersGetContextForUserResponse(response UsersGetContextForUserRes, w 
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20851,6 +22535,7 @@ func encodeUsersGetGpgKeyForAuthenticatedResponse(response UsersGetGpgKeyForAuth
 	case *GpgKey:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20862,10 +22547,12 @@ func encodeUsersGetGpgKeyForAuthenticatedResponse(response UsersGetGpgKeyForAuth
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersGetGpgKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20878,6 +22565,7 @@ func encodeUsersGetGpgKeyForAuthenticatedResponse(response UsersGetGpgKeyForAuth
 	case *UsersGetGpgKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20890,6 +22578,7 @@ func encodeUsersGetGpgKeyForAuthenticatedResponse(response UsersGetGpgKeyForAuth
 	case *UsersGetGpgKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20909,6 +22598,7 @@ func encodeUsersGetPublicSSHKeyForAuthenticatedResponse(response UsersGetPublicS
 	case *Key:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20920,10 +22610,12 @@ func encodeUsersGetPublicSSHKeyForAuthenticatedResponse(response UsersGetPublicS
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersGetPublicSSHKeyForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20936,6 +22628,7 @@ func encodeUsersGetPublicSSHKeyForAuthenticatedResponse(response UsersGetPublicS
 	case *UsersGetPublicSSHKeyForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20948,6 +22641,7 @@ func encodeUsersGetPublicSSHKeyForAuthenticatedResponse(response UsersGetPublicS
 	case *UsersGetPublicSSHKeyForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20967,6 +22661,7 @@ func encodeUsersListResponse(response UsersListRes, w http.ResponseWriter, span 
 	case *UsersListOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -20978,6 +22673,7 @@ func encodeUsersListResponse(response UsersListRes, w http.ResponseWriter, span 
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	default:
 		return errors.Errorf("/users"+`: unexpected response type: %T`, response)
@@ -20989,6 +22685,7 @@ func encodeUsersListBlockedByAuthenticatedResponse(response UsersListBlockedByAu
 	case *UsersListBlockedByAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21000,10 +22697,12 @@ func encodeUsersListBlockedByAuthenticatedResponse(response UsersListBlockedByAu
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListBlockedByAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21016,6 +22715,7 @@ func encodeUsersListBlockedByAuthenticatedResponse(response UsersListBlockedByAu
 	case *UsersListBlockedByAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21028,6 +22728,7 @@ func encodeUsersListBlockedByAuthenticatedResponse(response UsersListBlockedByAu
 	case *UsersListBlockedByAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21040,6 +22741,7 @@ func encodeUsersListBlockedByAuthenticatedResponse(response UsersListBlockedByAu
 	case *PreviewHeaderMissing:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(415)
+		span.SetStatus(codes.Error, http.StatusText(415))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21059,6 +22761,7 @@ func encodeUsersListEmailsForAuthenticatedResponse(response UsersListEmailsForAu
 	case *UsersListEmailsForAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21070,10 +22773,12 @@ func encodeUsersListEmailsForAuthenticatedResponse(response UsersListEmailsForAu
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListEmailsForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21086,6 +22791,7 @@ func encodeUsersListEmailsForAuthenticatedResponse(response UsersListEmailsForAu
 	case *UsersListEmailsForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21098,6 +22804,7 @@ func encodeUsersListEmailsForAuthenticatedResponse(response UsersListEmailsForAu
 	case *UsersListEmailsForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21117,6 +22824,7 @@ func encodeUsersListFollowedByAuthenticatedResponse(response UsersListFollowedBy
 	case *UsersListFollowedByAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21128,10 +22836,12 @@ func encodeUsersListFollowedByAuthenticatedResponse(response UsersListFollowedBy
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListFollowedByAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21144,6 +22854,7 @@ func encodeUsersListFollowedByAuthenticatedResponse(response UsersListFollowedBy
 	case *UsersListFollowedByAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21163,6 +22874,7 @@ func encodeUsersListFollowersForAuthenticatedUserResponse(response UsersListFoll
 	case *UsersListFollowersForAuthenticatedUserOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21174,10 +22886,12 @@ func encodeUsersListFollowersForAuthenticatedUserResponse(response UsersListFoll
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListFollowersForAuthenticatedUserApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21190,6 +22904,7 @@ func encodeUsersListFollowersForAuthenticatedUserResponse(response UsersListFoll
 	case *UsersListFollowersForAuthenticatedUserApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21207,6 +22922,7 @@ func encodeUsersListFollowersForAuthenticatedUserResponse(response UsersListFoll
 func encodeUsersListFollowersForUserResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -21225,6 +22941,7 @@ func encodeUsersListFollowersForUserResponse(response []SimpleUser, w http.Respo
 func encodeUsersListFollowingForUserResponse(response []SimpleUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -21245,6 +22962,7 @@ func encodeUsersListGpgKeysForAuthenticatedResponse(response UsersListGpgKeysFor
 	case *UsersListGpgKeysForAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21256,10 +22974,12 @@ func encodeUsersListGpgKeysForAuthenticatedResponse(response UsersListGpgKeysFor
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListGpgKeysForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21272,6 +22992,7 @@ func encodeUsersListGpgKeysForAuthenticatedResponse(response UsersListGpgKeysFor
 	case *UsersListGpgKeysForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21284,6 +23005,7 @@ func encodeUsersListGpgKeysForAuthenticatedResponse(response UsersListGpgKeysFor
 	case *UsersListGpgKeysForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21301,6 +23023,7 @@ func encodeUsersListGpgKeysForAuthenticatedResponse(response UsersListGpgKeysFor
 func encodeUsersListGpgKeysForUserResponse(response []GpgKey, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -21321,6 +23044,7 @@ func encodeUsersListPublicEmailsForAuthenticatedResponse(response UsersListPubli
 	case *UsersListPublicEmailsForAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21332,10 +23056,12 @@ func encodeUsersListPublicEmailsForAuthenticatedResponse(response UsersListPubli
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListPublicEmailsForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21348,6 +23074,7 @@ func encodeUsersListPublicEmailsForAuthenticatedResponse(response UsersListPubli
 	case *UsersListPublicEmailsForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21360,6 +23087,7 @@ func encodeUsersListPublicEmailsForAuthenticatedResponse(response UsersListPubli
 	case *UsersListPublicEmailsForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21377,6 +23105,7 @@ func encodeUsersListPublicEmailsForAuthenticatedResponse(response UsersListPubli
 func encodeUsersListPublicKeysForUserResponse(response []KeySimple, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -21397,6 +23126,7 @@ func encodeUsersListPublicSSHKeysForAuthenticatedResponse(response UsersListPubl
 	case *UsersListPublicSSHKeysForAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21408,10 +23138,12 @@ func encodeUsersListPublicSSHKeysForAuthenticatedResponse(response UsersListPubl
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersListPublicSSHKeysForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21424,6 +23156,7 @@ func encodeUsersListPublicSSHKeysForAuthenticatedResponse(response UsersListPubl
 	case *UsersListPublicSSHKeysForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21436,6 +23169,7 @@ func encodeUsersListPublicSSHKeysForAuthenticatedResponse(response UsersListPubl
 	case *UsersListPublicSSHKeysForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21455,6 +23189,7 @@ func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedResponse(response Users
 	case *UsersSetPrimaryEmailVisibilityForAuthenticatedOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21466,10 +23201,12 @@ func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedResponse(response Users
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersSetPrimaryEmailVisibilityForAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21482,6 +23219,7 @@ func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedResponse(response Users
 	case *UsersSetPrimaryEmailVisibilityForAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21494,6 +23232,7 @@ func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedResponse(response Users
 	case *UsersSetPrimaryEmailVisibilityForAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21506,6 +23245,7 @@ func encodeUsersSetPrimaryEmailVisibilityForAuthenticatedResponse(response Users
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21524,13 +23264,16 @@ func encodeUsersUnblockResponse(response UsersUnblockRes, w http.ResponseWriter,
 	switch response := response.(type) {
 	case *UsersUnblockNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersUnblockApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21543,6 +23286,7 @@ func encodeUsersUnblockResponse(response UsersUnblockRes, w http.ResponseWriter,
 	case *UsersUnblockApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21555,6 +23299,7 @@ func encodeUsersUnblockResponse(response UsersUnblockRes, w http.ResponseWriter,
 	case *UsersUnblockApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21573,13 +23318,16 @@ func encodeUsersUnfollowResponse(response UsersUnfollowRes, w http.ResponseWrite
 	switch response := response.(type) {
 	case *UsersUnfollowNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersUnfollowApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21592,6 +23340,7 @@ func encodeUsersUnfollowResponse(response UsersUnfollowRes, w http.ResponseWrite
 	case *UsersUnfollowApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21604,6 +23353,7 @@ func encodeUsersUnfollowResponse(response UsersUnfollowRes, w http.ResponseWrite
 	case *UsersUnfollowApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21623,6 +23373,7 @@ func encodeUsersUpdateAuthenticatedResponse(response UsersUpdateAuthenticatedRes
 	case *PrivateUser:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21634,10 +23385,12 @@ func encodeUsersUpdateAuthenticatedResponse(response UsersUpdateAuthenticatedRes
 		return nil
 	case *NotModified:
 		w.WriteHeader(304)
+		span.SetStatus(codes.Ok, http.StatusText(304))
 		return nil
 	case *UsersUpdateAuthenticatedApplicationJSONUnauthorized:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21650,6 +23403,7 @@ func encodeUsersUpdateAuthenticatedResponse(response UsersUpdateAuthenticatedRes
 	case *UsersUpdateAuthenticatedApplicationJSONForbidden:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21662,6 +23416,7 @@ func encodeUsersUpdateAuthenticatedResponse(response UsersUpdateAuthenticatedRes
 	case *UsersUpdateAuthenticatedApplicationJSONNotFound:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -21674,6 +23429,7 @@ func encodeUsersUpdateAuthenticatedResponse(response UsersUpdateAuthenticatedRes
 	case *ValidationError:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/examples/ex_gotd/oas_handlers_gen.go
+++ b/examples/ex_gotd/oas_handlers_gen.go
@@ -116,7 +116,6 @@ func (s *Server) handleAddStickerToSetRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -167,7 +166,6 @@ func (s *Server) handleAnswerCallbackQueryRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -218,7 +216,6 @@ func (s *Server) handleAnswerInlineQueryRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -269,7 +266,6 @@ func (s *Server) handleAnswerPreCheckoutQueryRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -320,7 +316,6 @@ func (s *Server) handleAnswerShippingQueryRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -371,7 +366,6 @@ func (s *Server) handleApproveChatJoinRequestRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -422,7 +416,6 @@ func (s *Server) handleBanChatMemberRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -473,7 +466,6 @@ func (s *Server) handleBanChatSenderChatRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -519,7 +511,6 @@ func (s *Server) handleCloseRequest(args [0]string, w http.ResponseWriter, r *ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -570,7 +561,6 @@ func (s *Server) handleCopyMessageRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -621,7 +611,6 @@ func (s *Server) handleCreateChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -672,7 +661,6 @@ func (s *Server) handleCreateNewStickerSetRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -723,7 +711,6 @@ func (s *Server) handleDeclineChatJoinRequestRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -774,7 +761,6 @@ func (s *Server) handleDeleteChatPhotoRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -825,7 +811,6 @@ func (s *Server) handleDeleteChatStickerSetRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -876,7 +861,6 @@ func (s *Server) handleDeleteMessageRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -927,7 +911,6 @@ func (s *Server) handleDeleteMyCommandsRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -978,7 +961,6 @@ func (s *Server) handleDeleteStickerFromSetRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1029,7 +1011,6 @@ func (s *Server) handleDeleteWebhookRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1080,7 +1061,6 @@ func (s *Server) handleEditChatInviteLinkRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1131,7 +1111,6 @@ func (s *Server) handleEditMessageCaptionRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1182,7 +1161,6 @@ func (s *Server) handleEditMessageLiveLocationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1233,7 +1211,6 @@ func (s *Server) handleEditMessageMediaRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1284,7 +1261,6 @@ func (s *Server) handleEditMessageReplyMarkupRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1335,7 +1311,6 @@ func (s *Server) handleEditMessageTextRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1386,7 +1361,6 @@ func (s *Server) handleExportChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1437,7 +1411,6 @@ func (s *Server) handleForwardMessageRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1488,7 +1461,6 @@ func (s *Server) handleGetChatRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1539,7 +1511,6 @@ func (s *Server) handleGetChatAdministratorsRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1590,7 +1561,6 @@ func (s *Server) handleGetChatMemberRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1641,7 +1611,6 @@ func (s *Server) handleGetChatMemberCountRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1692,7 +1661,6 @@ func (s *Server) handleGetFileRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1743,7 +1711,6 @@ func (s *Server) handleGetGameHighScoresRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1789,7 +1756,6 @@ func (s *Server) handleGetMeRequest(args [0]string, w http.ResponseWriter, r *ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1840,7 +1806,6 @@ func (s *Server) handleGetMyCommandsRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1891,7 +1856,6 @@ func (s *Server) handleGetStickerSetRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1942,7 +1906,6 @@ func (s *Server) handleGetUpdatesRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1993,7 +1956,6 @@ func (s *Server) handleGetUserProfilePhotosRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2039,7 +2001,6 @@ func (s *Server) handleGetWebhookInfoRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2090,7 +2051,6 @@ func (s *Server) handleLeaveChatRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2136,7 +2096,6 @@ func (s *Server) handleLogOutRequest(args [0]string, w http.ResponseWriter, r *h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2187,7 +2146,6 @@ func (s *Server) handlePinChatMessageRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2238,7 +2196,6 @@ func (s *Server) handlePromoteChatMemberRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2289,7 +2246,6 @@ func (s *Server) handleRestrictChatMemberRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2340,7 +2296,6 @@ func (s *Server) handleRevokeChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2391,7 +2346,6 @@ func (s *Server) handleSendAnimationRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2442,7 +2396,6 @@ func (s *Server) handleSendAudioRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2493,7 +2446,6 @@ func (s *Server) handleSendChatActionRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2544,7 +2496,6 @@ func (s *Server) handleSendContactRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2595,7 +2546,6 @@ func (s *Server) handleSendDiceRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2646,7 +2596,6 @@ func (s *Server) handleSendDocumentRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2697,7 +2646,6 @@ func (s *Server) handleSendGameRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2748,7 +2696,6 @@ func (s *Server) handleSendInvoiceRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2799,7 +2746,6 @@ func (s *Server) handleSendLocationRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2850,7 +2796,6 @@ func (s *Server) handleSendMediaGroupRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2901,7 +2846,6 @@ func (s *Server) handleSendMessageRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2952,7 +2896,6 @@ func (s *Server) handleSendPhotoRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3003,7 +2946,6 @@ func (s *Server) handleSendPollRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3054,7 +2996,6 @@ func (s *Server) handleSendStickerRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3105,7 +3046,6 @@ func (s *Server) handleSendVenueRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3156,7 +3096,6 @@ func (s *Server) handleSendVideoRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3207,7 +3146,6 @@ func (s *Server) handleSendVideoNoteRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3258,7 +3196,6 @@ func (s *Server) handleSendVoiceRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3309,7 +3246,6 @@ func (s *Server) handleSetChatAdministratorCustomTitleRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3360,7 +3296,6 @@ func (s *Server) handleSetChatDescriptionRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3411,7 +3346,6 @@ func (s *Server) handleSetChatPermissionsRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3462,7 +3396,6 @@ func (s *Server) handleSetChatPhotoRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3513,7 +3446,6 @@ func (s *Server) handleSetChatStickerSetRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3564,7 +3496,6 @@ func (s *Server) handleSetChatTitleRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3615,7 +3546,6 @@ func (s *Server) handleSetGameScoreRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3666,7 +3596,6 @@ func (s *Server) handleSetMyCommandsRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3717,7 +3646,6 @@ func (s *Server) handleSetPassportDataErrorsRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3768,7 +3696,6 @@ func (s *Server) handleSetStickerPositionInSetRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3819,7 +3746,6 @@ func (s *Server) handleSetStickerSetThumbRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3870,7 +3796,6 @@ func (s *Server) handleSetWebhookRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3921,7 +3846,6 @@ func (s *Server) handleStopMessageLiveLocationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3972,7 +3896,6 @@ func (s *Server) handleStopPollRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4023,7 +3946,6 @@ func (s *Server) handleUnbanChatMemberRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4074,7 +3996,6 @@ func (s *Server) handleUnbanChatSenderChatRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4125,7 +4046,6 @@ func (s *Server) handleUnpinAllChatMessagesRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4176,7 +4096,6 @@ func (s *Server) handleUnpinChatMessageRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4227,7 +4146,6 @@ func (s *Server) handleUploadStickerFileRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_gotd/oas_res_enc_gen.go
+++ b/examples/ex_gotd/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeAddStickerToSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeAddStickerToSetResponse(response Result, w http.ResponseWriter, span 
 func encodeAnswerCallbackQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,7 @@ func encodeAnswerCallbackQueryResponse(response Result, w http.ResponseWriter, s
 func encodeAnswerInlineQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -115,6 +118,7 @@ func encodeAnswerInlineQueryResponse(response Result, w http.ResponseWriter, spa
 func encodeAnswerPreCheckoutQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -129,6 +133,7 @@ func encodeAnswerPreCheckoutQueryResponse(response Result, w http.ResponseWriter
 func encodeAnswerShippingQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -143,6 +148,7 @@ func encodeAnswerShippingQueryResponse(response Result, w http.ResponseWriter, s
 func encodeApproveChatJoinRequestResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -157,6 +163,7 @@ func encodeApproveChatJoinRequestResponse(response Result, w http.ResponseWriter
 func encodeBanChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -171,6 +178,7 @@ func encodeBanChatMemberResponse(response Result, w http.ResponseWriter, span tr
 func encodeBanChatSenderChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -185,6 +193,7 @@ func encodeBanChatSenderChatResponse(response Result, w http.ResponseWriter, spa
 func encodeCloseResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -199,6 +208,7 @@ func encodeCloseResponse(response Result, w http.ResponseWriter, span trace.Span
 func encodeCopyMessageResponse(response ResultMessageId, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -213,6 +223,7 @@ func encodeCopyMessageResponse(response ResultMessageId, w http.ResponseWriter, 
 func encodeCreateChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -227,6 +238,7 @@ func encodeCreateChatInviteLinkResponse(response ResultChatInviteLink, w http.Re
 func encodeCreateNewStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -241,6 +253,7 @@ func encodeCreateNewStickerSetResponse(response Result, w http.ResponseWriter, s
 func encodeDeclineChatJoinRequestResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -255,6 +268,7 @@ func encodeDeclineChatJoinRequestResponse(response Result, w http.ResponseWriter
 func encodeDeleteChatPhotoResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -269,6 +283,7 @@ func encodeDeleteChatPhotoResponse(response Result, w http.ResponseWriter, span 
 func encodeDeleteChatStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -283,6 +298,7 @@ func encodeDeleteChatStickerSetResponse(response Result, w http.ResponseWriter, 
 func encodeDeleteMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -297,6 +313,7 @@ func encodeDeleteMessageResponse(response Result, w http.ResponseWriter, span tr
 func encodeDeleteMyCommandsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -311,6 +328,7 @@ func encodeDeleteMyCommandsResponse(response Result, w http.ResponseWriter, span
 func encodeDeleteStickerFromSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -325,6 +343,7 @@ func encodeDeleteStickerFromSetResponse(response Result, w http.ResponseWriter, 
 func encodeDeleteWebhookResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -339,6 +358,7 @@ func encodeDeleteWebhookResponse(response Result, w http.ResponseWriter, span tr
 func encodeEditChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -353,6 +373,7 @@ func encodeEditChatInviteLinkResponse(response ResultChatInviteLink, w http.Resp
 func encodeEditMessageCaptionResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -367,6 +388,7 @@ func encodeEditMessageCaptionResponse(response ResultMessageOrBoolean, w http.Re
 func encodeEditMessageLiveLocationResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -381,6 +403,7 @@ func encodeEditMessageLiveLocationResponse(response ResultMessageOrBoolean, w ht
 func encodeEditMessageMediaResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -395,6 +418,7 @@ func encodeEditMessageMediaResponse(response ResultMessageOrBoolean, w http.Resp
 func encodeEditMessageReplyMarkupResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -409,6 +433,7 @@ func encodeEditMessageReplyMarkupResponse(response ResultMessageOrBoolean, w htt
 func encodeEditMessageTextResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -423,6 +448,7 @@ func encodeEditMessageTextResponse(response ResultMessageOrBoolean, w http.Respo
 func encodeExportChatInviteLinkResponse(response ResultString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -437,6 +463,7 @@ func encodeExportChatInviteLinkResponse(response ResultString, w http.ResponseWr
 func encodeForwardMessageResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -451,6 +478,7 @@ func encodeForwardMessageResponse(response ResultMessage, w http.ResponseWriter,
 func encodeGetChatResponse(response ResultChat, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -465,6 +493,7 @@ func encodeGetChatResponse(response ResultChat, w http.ResponseWriter, span trac
 func encodeGetChatAdministratorsResponse(response ResultArrayOfChatMember, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -479,6 +508,7 @@ func encodeGetChatAdministratorsResponse(response ResultArrayOfChatMember, w htt
 func encodeGetChatMemberResponse(response ResultChatMember, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -493,6 +523,7 @@ func encodeGetChatMemberResponse(response ResultChatMember, w http.ResponseWrite
 func encodeGetChatMemberCountResponse(response ResultInt, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -507,6 +538,7 @@ func encodeGetChatMemberCountResponse(response ResultInt, w http.ResponseWriter,
 func encodeGetFileResponse(response ResultFile, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -521,6 +553,7 @@ func encodeGetFileResponse(response ResultFile, w http.ResponseWriter, span trac
 func encodeGetGameHighScoresResponse(response ResultArrayOfGameHighScore, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -535,6 +568,7 @@ func encodeGetGameHighScoresResponse(response ResultArrayOfGameHighScore, w http
 func encodeGetMeResponse(response ResultUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -549,6 +583,7 @@ func encodeGetMeResponse(response ResultUser, w http.ResponseWriter, span trace.
 func encodeGetMyCommandsResponse(response ResultArrayOfBotCommand, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -563,6 +598,7 @@ func encodeGetMyCommandsResponse(response ResultArrayOfBotCommand, w http.Respon
 func encodeGetStickerSetResponse(response ResultStickerSet, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -577,6 +613,7 @@ func encodeGetStickerSetResponse(response ResultStickerSet, w http.ResponseWrite
 func encodeGetUpdatesResponse(response ResultArrayOfUpdate, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -591,6 +628,7 @@ func encodeGetUpdatesResponse(response ResultArrayOfUpdate, w http.ResponseWrite
 func encodeGetUserProfilePhotosResponse(response ResultUserProfilePhotos, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -605,6 +643,7 @@ func encodeGetUserProfilePhotosResponse(response ResultUserProfilePhotos, w http
 func encodeGetWebhookInfoResponse(response ResultWebhookInfo, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -619,6 +658,7 @@ func encodeGetWebhookInfoResponse(response ResultWebhookInfo, w http.ResponseWri
 func encodeLeaveChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -633,6 +673,7 @@ func encodeLeaveChatResponse(response Result, w http.ResponseWriter, span trace.
 func encodeLogOutResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -647,6 +688,7 @@ func encodeLogOutResponse(response Result, w http.ResponseWriter, span trace.Spa
 func encodePinChatMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -661,6 +703,7 @@ func encodePinChatMessageResponse(response Result, w http.ResponseWriter, span t
 func encodePromoteChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -675,6 +718,7 @@ func encodePromoteChatMemberResponse(response Result, w http.ResponseWriter, spa
 func encodeRestrictChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -689,6 +733,7 @@ func encodeRestrictChatMemberResponse(response Result, w http.ResponseWriter, sp
 func encodeRevokeChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -703,6 +748,7 @@ func encodeRevokeChatInviteLinkResponse(response ResultChatInviteLink, w http.Re
 func encodeSendAnimationResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -717,6 +763,7 @@ func encodeSendAnimationResponse(response ResultMessage, w http.ResponseWriter, 
 func encodeSendAudioResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -731,6 +778,7 @@ func encodeSendAudioResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendChatActionResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -745,6 +793,7 @@ func encodeSendChatActionResponse(response Result, w http.ResponseWriter, span t
 func encodeSendContactResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -759,6 +808,7 @@ func encodeSendContactResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendDiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -773,6 +823,7 @@ func encodeSendDiceResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendDocumentResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -787,6 +838,7 @@ func encodeSendDocumentResponse(response ResultMessage, w http.ResponseWriter, s
 func encodeSendGameResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -801,6 +853,7 @@ func encodeSendGameResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendInvoiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -815,6 +868,7 @@ func encodeSendInvoiceResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendLocationResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -829,6 +883,7 @@ func encodeSendLocationResponse(response ResultMessage, w http.ResponseWriter, s
 func encodeSendMediaGroupResponse(response ResultArrayOfMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -843,6 +898,7 @@ func encodeSendMediaGroupResponse(response ResultArrayOfMessage, w http.Response
 func encodeSendMessageResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -857,6 +913,7 @@ func encodeSendMessageResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendPhotoResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -871,6 +928,7 @@ func encodeSendPhotoResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendPollResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -885,6 +943,7 @@ func encodeSendPollResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendStickerResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -899,6 +958,7 @@ func encodeSendStickerResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendVenueResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -913,6 +973,7 @@ func encodeSendVenueResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendVideoResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -927,6 +988,7 @@ func encodeSendVideoResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendVideoNoteResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -941,6 +1003,7 @@ func encodeSendVideoNoteResponse(response ResultMessage, w http.ResponseWriter, 
 func encodeSendVoiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -955,6 +1018,7 @@ func encodeSendVoiceResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSetChatAdministratorCustomTitleResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -969,6 +1033,7 @@ func encodeSetChatAdministratorCustomTitleResponse(response Result, w http.Respo
 func encodeSetChatDescriptionResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -983,6 +1048,7 @@ func encodeSetChatDescriptionResponse(response Result, w http.ResponseWriter, sp
 func encodeSetChatPermissionsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -997,6 +1063,7 @@ func encodeSetChatPermissionsResponse(response Result, w http.ResponseWriter, sp
 func encodeSetChatPhotoResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1011,6 +1078,7 @@ func encodeSetChatPhotoResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetChatStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1025,6 +1093,7 @@ func encodeSetChatStickerSetResponse(response Result, w http.ResponseWriter, spa
 func encodeSetChatTitleResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1039,6 +1108,7 @@ func encodeSetChatTitleResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetGameScoreResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1053,6 +1123,7 @@ func encodeSetGameScoreResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetMyCommandsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1067,6 +1138,7 @@ func encodeSetMyCommandsResponse(response Result, w http.ResponseWriter, span tr
 func encodeSetPassportDataErrorsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1081,6 +1153,7 @@ func encodeSetPassportDataErrorsResponse(response Result, w http.ResponseWriter,
 func encodeSetStickerPositionInSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1095,6 +1168,7 @@ func encodeSetStickerPositionInSetResponse(response Result, w http.ResponseWrite
 func encodeSetStickerSetThumbResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1109,6 +1183,7 @@ func encodeSetStickerSetThumbResponse(response Result, w http.ResponseWriter, sp
 func encodeSetWebhookResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1123,6 +1198,7 @@ func encodeSetWebhookResponse(response Result, w http.ResponseWriter, span trace
 func encodeStopMessageLiveLocationResponse(response ResultMessageOrBoolean, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1137,6 +1213,7 @@ func encodeStopMessageLiveLocationResponse(response ResultMessageOrBoolean, w ht
 func encodeStopPollResponse(response ResultPoll, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1151,6 +1228,7 @@ func encodeStopPollResponse(response ResultPoll, w http.ResponseWriter, span tra
 func encodeUnbanChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1165,6 +1243,7 @@ func encodeUnbanChatMemberResponse(response Result, w http.ResponseWriter, span 
 func encodeUnbanChatSenderChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1179,6 +1258,7 @@ func encodeUnbanChatSenderChatResponse(response Result, w http.ResponseWriter, s
 func encodeUnpinAllChatMessagesResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1193,6 +1273,7 @@ func encodeUnpinAllChatMessagesResponse(response Result, w http.ResponseWriter, 
 func encodeUnpinChatMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1207,6 +1288,7 @@ func encodeUnpinChatMessageResponse(response Result, w http.ResponseWriter, span
 func encodeUploadStickerFileResponse(response ResultFile, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1220,6 +1302,12 @@ func encodeUploadStickerFileResponse(response ResultFile, w http.ResponseWriter,
 func encodeErrorResponse(response ErrorStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/examples/ex_k8s/oas_handlers_gen.go
+++ b/examples/ex_k8s/oas_handlers_gen.go
@@ -108,7 +108,6 @@ func (s *Server) handleGetAPIVersionsRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -151,7 +150,6 @@ func (s *Server) handleGetAdmissionregistrationAPIGroupRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -194,7 +192,6 @@ func (s *Server) handleGetAdmissionregistrationV1APIResourcesRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -237,7 +234,6 @@ func (s *Server) handleGetApiextensionsAPIGroupRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -280,7 +276,6 @@ func (s *Server) handleGetApiextensionsV1APIResourcesRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -323,7 +318,6 @@ func (s *Server) handleGetApiregistrationAPIGroupRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -366,7 +360,6 @@ func (s *Server) handleGetApiregistrationV1APIResourcesRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -409,7 +402,6 @@ func (s *Server) handleGetAppsAPIGroupRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -452,7 +444,6 @@ func (s *Server) handleGetAppsV1APIResourcesRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -495,7 +486,6 @@ func (s *Server) handleGetAuthenticationAPIGroupRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -538,7 +528,6 @@ func (s *Server) handleGetAuthenticationV1APIResourcesRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -581,7 +570,6 @@ func (s *Server) handleGetAuthorizationAPIGroupRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -624,7 +612,6 @@ func (s *Server) handleGetAuthorizationV1APIResourcesRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -667,7 +654,6 @@ func (s *Server) handleGetAutoscalingAPIGroupRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -710,7 +696,6 @@ func (s *Server) handleGetAutoscalingV1APIResourcesRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -753,7 +738,6 @@ func (s *Server) handleGetAutoscalingV2beta1APIResourcesRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -796,7 +780,6 @@ func (s *Server) handleGetAutoscalingV2beta2APIResourcesRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -839,7 +822,6 @@ func (s *Server) handleGetBatchAPIGroupRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -882,7 +864,6 @@ func (s *Server) handleGetBatchV1APIResourcesRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -925,7 +906,6 @@ func (s *Server) handleGetBatchV1beta1APIResourcesRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -968,7 +948,6 @@ func (s *Server) handleGetCertificatesAPIGroupRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1011,7 +990,6 @@ func (s *Server) handleGetCertificatesV1APIResourcesRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1054,7 +1032,6 @@ func (s *Server) handleGetCodeVersionRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1097,7 +1074,6 @@ func (s *Server) handleGetCoordinationAPIGroupRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1140,7 +1116,6 @@ func (s *Server) handleGetCoordinationV1APIResourcesRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1183,7 +1158,6 @@ func (s *Server) handleGetCoreAPIVersionsRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1226,7 +1200,6 @@ func (s *Server) handleGetCoreV1APIResourcesRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1269,7 +1242,6 @@ func (s *Server) handleGetDiscoveryAPIGroupRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1312,7 +1284,6 @@ func (s *Server) handleGetDiscoveryV1APIResourcesRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1355,7 +1326,6 @@ func (s *Server) handleGetDiscoveryV1beta1APIResourcesRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1398,7 +1368,6 @@ func (s *Server) handleGetEventsAPIGroupRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1441,7 +1410,6 @@ func (s *Server) handleGetEventsV1APIResourcesRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1484,7 +1452,6 @@ func (s *Server) handleGetEventsV1beta1APIResourcesRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1527,7 +1494,6 @@ func (s *Server) handleGetFlowcontrolApiserverAPIGroupRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1570,7 +1536,6 @@ func (s *Server) handleGetFlowcontrolApiserverV1beta1APIResourcesRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1613,7 +1578,6 @@ func (s *Server) handleGetFlowcontrolApiserverV1beta2APIResourcesRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1656,7 +1620,6 @@ func (s *Server) handleGetInternalApiserverAPIGroupRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1699,7 +1662,6 @@ func (s *Server) handleGetInternalApiserverV1alpha1APIResourcesRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1742,7 +1704,6 @@ func (s *Server) handleGetNetworkingAPIGroupRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1785,7 +1746,6 @@ func (s *Server) handleGetNetworkingV1APIResourcesRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1828,7 +1788,6 @@ func (s *Server) handleGetNodeAPIGroupRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1871,7 +1830,6 @@ func (s *Server) handleGetNodeV1APIResourcesRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1914,7 +1872,6 @@ func (s *Server) handleGetNodeV1alpha1APIResourcesRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1957,7 +1914,6 @@ func (s *Server) handleGetNodeV1beta1APIResourcesRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2000,7 +1956,6 @@ func (s *Server) handleGetPolicyAPIGroupRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2043,7 +1998,6 @@ func (s *Server) handleGetPolicyV1APIResourcesRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2086,7 +2040,6 @@ func (s *Server) handleGetPolicyV1beta1APIResourcesRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2129,7 +2082,6 @@ func (s *Server) handleGetRbacAuthorizationAPIGroupRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2172,7 +2124,6 @@ func (s *Server) handleGetRbacAuthorizationV1APIResourcesRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2215,7 +2166,6 @@ func (s *Server) handleGetSchedulingAPIGroupRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2258,7 +2208,6 @@ func (s *Server) handleGetSchedulingV1APIResourcesRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2301,7 +2250,6 @@ func (s *Server) handleGetServiceAccountIssuerOpenIDConfigurationRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2344,7 +2292,6 @@ func (s *Server) handleGetStorageAPIGroupRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2387,7 +2334,6 @@ func (s *Server) handleGetStorageV1APIResourcesRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2430,7 +2376,6 @@ func (s *Server) handleGetStorageV1alpha1APIResourcesRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2473,7 +2418,6 @@ func (s *Server) handleGetStorageV1beta1APIResourcesRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2521,7 +2465,6 @@ func (s *Server) handleListAdmissionregistrationV1MutatingWebhookConfigurationRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2569,7 +2512,6 @@ func (s *Server) handleListAdmissionregistrationV1ValidatingWebhookConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2617,7 +2559,6 @@ func (s *Server) handleListApiextensionsV1CustomResourceDefinitionRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2665,7 +2606,6 @@ func (s *Server) handleListApiregistrationV1APIServiceRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2713,7 +2653,6 @@ func (s *Server) handleListAppsV1ControllerRevisionForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2761,7 +2700,6 @@ func (s *Server) handleListAppsV1DaemonSetForAllNamespacesRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2809,7 +2747,6 @@ func (s *Server) handleListAppsV1DeploymentForAllNamespacesRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2857,7 +2794,6 @@ func (s *Server) handleListAppsV1NamespacedControllerRevisionRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2905,7 +2841,6 @@ func (s *Server) handleListAppsV1NamespacedDaemonSetRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2953,7 +2888,6 @@ func (s *Server) handleListAppsV1NamespacedDeploymentRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3001,7 +2935,6 @@ func (s *Server) handleListAppsV1NamespacedReplicaSetRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3049,7 +2982,6 @@ func (s *Server) handleListAppsV1NamespacedStatefulSetRequest(args [1]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3097,7 +3029,6 @@ func (s *Server) handleListAppsV1ReplicaSetForAllNamespacesRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3145,7 +3076,6 @@ func (s *Server) handleListAppsV1StatefulSetForAllNamespacesRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3193,7 +3123,6 @@ func (s *Server) handleListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3241,7 +3170,6 @@ func (s *Server) handleListAutoscalingV1NamespacedHorizontalPodAutoscalerRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3289,7 +3217,6 @@ func (s *Server) handleListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamesp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3337,7 +3264,6 @@ func (s *Server) handleListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3385,7 +3311,6 @@ func (s *Server) handleListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamesp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3433,7 +3358,6 @@ func (s *Server) handleListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3481,7 +3405,6 @@ func (s *Server) handleListBatchV1CronJobForAllNamespacesRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3529,7 +3452,6 @@ func (s *Server) handleListBatchV1JobForAllNamespacesRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3577,7 +3499,6 @@ func (s *Server) handleListBatchV1NamespacedCronJobRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3625,7 +3546,6 @@ func (s *Server) handleListBatchV1NamespacedJobRequest(args [1]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3673,7 +3593,6 @@ func (s *Server) handleListBatchV1beta1CronJobForAllNamespacesRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3721,7 +3640,6 @@ func (s *Server) handleListBatchV1beta1NamespacedCronJobRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3769,7 +3687,6 @@ func (s *Server) handleListCertificatesV1CertificateSigningRequestRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3817,7 +3734,6 @@ func (s *Server) handleListCoordinationV1LeaseForAllNamespacesRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3865,7 +3781,6 @@ func (s *Server) handleListCoordinationV1NamespacedLeaseRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3913,7 +3828,6 @@ func (s *Server) handleListCoreV1ComponentStatusRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3961,7 +3875,6 @@ func (s *Server) handleListCoreV1ConfigMapForAllNamespacesRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4009,7 +3922,6 @@ func (s *Server) handleListCoreV1EndpointsForAllNamespacesRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4057,7 +3969,6 @@ func (s *Server) handleListCoreV1EventForAllNamespacesRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4105,7 +4016,6 @@ func (s *Server) handleListCoreV1LimitRangeForAllNamespacesRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4153,7 +4063,6 @@ func (s *Server) handleListCoreV1NamespaceRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4201,7 +4110,6 @@ func (s *Server) handleListCoreV1NamespacedConfigMapRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4249,7 +4157,6 @@ func (s *Server) handleListCoreV1NamespacedEndpointsRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4297,7 +4204,6 @@ func (s *Server) handleListCoreV1NamespacedEventRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4345,7 +4251,6 @@ func (s *Server) handleListCoreV1NamespacedLimitRangeRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4393,7 +4298,6 @@ func (s *Server) handleListCoreV1NamespacedPersistentVolumeClaimRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4441,7 +4345,6 @@ func (s *Server) handleListCoreV1NamespacedPodRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4489,7 +4392,6 @@ func (s *Server) handleListCoreV1NamespacedPodTemplateRequest(args [1]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4537,7 +4439,6 @@ func (s *Server) handleListCoreV1NamespacedReplicationControllerRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4585,7 +4486,6 @@ func (s *Server) handleListCoreV1NamespacedResourceQuotaRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4633,7 +4533,6 @@ func (s *Server) handleListCoreV1NamespacedSecretRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4681,7 +4580,6 @@ func (s *Server) handleListCoreV1NamespacedServiceRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4729,7 +4627,6 @@ func (s *Server) handleListCoreV1NamespacedServiceAccountRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4777,7 +4674,6 @@ func (s *Server) handleListCoreV1NodeRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4825,7 +4721,6 @@ func (s *Server) handleListCoreV1PersistentVolumeRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4873,7 +4768,6 @@ func (s *Server) handleListCoreV1PersistentVolumeClaimForAllNamespacesRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4921,7 +4815,6 @@ func (s *Server) handleListCoreV1PodForAllNamespacesRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4969,7 +4862,6 @@ func (s *Server) handleListCoreV1PodTemplateForAllNamespacesRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5017,7 +4909,6 @@ func (s *Server) handleListCoreV1ReplicationControllerForAllNamespacesRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5065,7 +4956,6 @@ func (s *Server) handleListCoreV1ResourceQuotaForAllNamespacesRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5113,7 +5003,6 @@ func (s *Server) handleListCoreV1SecretForAllNamespacesRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5161,7 +5050,6 @@ func (s *Server) handleListCoreV1ServiceAccountForAllNamespacesRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5209,7 +5097,6 @@ func (s *Server) handleListCoreV1ServiceForAllNamespacesRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5257,7 +5144,6 @@ func (s *Server) handleListDiscoveryV1EndpointSliceForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5305,7 +5191,6 @@ func (s *Server) handleListDiscoveryV1NamespacedEndpointSliceRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5353,7 +5238,6 @@ func (s *Server) handleListDiscoveryV1beta1EndpointSliceForAllNamespacesRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5401,7 +5285,6 @@ func (s *Server) handleListDiscoveryV1beta1NamespacedEndpointSliceRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5449,7 +5332,6 @@ func (s *Server) handleListEventsV1EventForAllNamespacesRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5497,7 +5379,6 @@ func (s *Server) handleListEventsV1NamespacedEventRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5545,7 +5426,6 @@ func (s *Server) handleListEventsV1beta1EventForAllNamespacesRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5593,7 +5473,6 @@ func (s *Server) handleListEventsV1beta1NamespacedEventRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5641,7 +5520,6 @@ func (s *Server) handleListFlowcontrolApiserverV1beta1FlowSchemaRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5689,7 +5567,6 @@ func (s *Server) handleListFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5737,7 +5614,6 @@ func (s *Server) handleListFlowcontrolApiserverV1beta2FlowSchemaRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5785,7 +5661,6 @@ func (s *Server) handleListFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5833,7 +5708,6 @@ func (s *Server) handleListInternalApiserverV1alpha1StorageVersionRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5881,7 +5755,6 @@ func (s *Server) handleListNetworkingV1IngressClassRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5929,7 +5802,6 @@ func (s *Server) handleListNetworkingV1IngressForAllNamespacesRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5977,7 +5849,6 @@ func (s *Server) handleListNetworkingV1NamespacedIngressRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6025,7 +5896,6 @@ func (s *Server) handleListNetworkingV1NamespacedNetworkPolicyRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6073,7 +5943,6 @@ func (s *Server) handleListNetworkingV1NetworkPolicyForAllNamespacesRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6121,7 +5990,6 @@ func (s *Server) handleListNodeV1RuntimeClassRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6169,7 +6037,6 @@ func (s *Server) handleListNodeV1alpha1RuntimeClassRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6217,7 +6084,6 @@ func (s *Server) handleListNodeV1beta1RuntimeClassRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6265,7 +6131,6 @@ func (s *Server) handleListPolicyV1NamespacedPodDisruptionBudgetRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6313,7 +6178,6 @@ func (s *Server) handleListPolicyV1PodDisruptionBudgetForAllNamespacesRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6361,7 +6225,6 @@ func (s *Server) handleListPolicyV1beta1NamespacedPodDisruptionBudgetRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6409,7 +6272,6 @@ func (s *Server) handleListPolicyV1beta1PodDisruptionBudgetForAllNamespacesReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6457,7 +6319,6 @@ func (s *Server) handleListPolicyV1beta1PodSecurityPolicyRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6505,7 +6366,6 @@ func (s *Server) handleListRbacAuthorizationV1ClusterRoleRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6553,7 +6413,6 @@ func (s *Server) handleListRbacAuthorizationV1ClusterRoleBindingRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6601,7 +6460,6 @@ func (s *Server) handleListRbacAuthorizationV1NamespacedRoleRequest(args [1]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6649,7 +6507,6 @@ func (s *Server) handleListRbacAuthorizationV1NamespacedRoleBindingRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6697,7 +6554,6 @@ func (s *Server) handleListRbacAuthorizationV1RoleBindingForAllNamespacesRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6745,7 +6601,6 @@ func (s *Server) handleListRbacAuthorizationV1RoleForAllNamespacesRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6793,7 +6648,6 @@ func (s *Server) handleListSchedulingV1PriorityClassRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6841,7 +6695,6 @@ func (s *Server) handleListStorageV1CSIDriverRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6889,7 +6742,6 @@ func (s *Server) handleListStorageV1CSINodeRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6937,7 +6789,6 @@ func (s *Server) handleListStorageV1StorageClassRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6985,7 +6836,6 @@ func (s *Server) handleListStorageV1VolumeAttachmentRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7033,7 +6883,6 @@ func (s *Server) handleListStorageV1alpha1CSIStorageCapacityForAllNamespacesRequ
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7081,7 +6930,6 @@ func (s *Server) handleListStorageV1alpha1NamespacedCSIStorageCapacityRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7129,7 +6977,6 @@ func (s *Server) handleListStorageV1beta1CSIStorageCapacityForAllNamespacesReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7177,7 +7024,6 @@ func (s *Server) handleListStorageV1beta1NamespacedCSIStorageCapacityRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7225,7 +7071,6 @@ func (s *Server) handleLogFileHandlerRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7268,7 +7113,6 @@ func (s *Server) handleLogFileListHandlerRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7316,7 +7160,6 @@ func (s *Server) handleReadAdmissionregistrationV1MutatingWebhookConfigurationRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7364,7 +7207,6 @@ func (s *Server) handleReadAdmissionregistrationV1ValidatingWebhookConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7412,7 +7254,6 @@ func (s *Server) handleReadApiextensionsV1CustomResourceDefinitionRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7460,7 +7301,6 @@ func (s *Server) handleReadApiextensionsV1CustomResourceDefinitionStatusRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7508,7 +7348,6 @@ func (s *Server) handleReadApiregistrationV1APIServiceRequest(args [1]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7556,7 +7395,6 @@ func (s *Server) handleReadApiregistrationV1APIServiceStatusRequest(args [1]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7604,7 +7442,6 @@ func (s *Server) handleReadAppsV1NamespacedControllerRevisionRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7652,7 +7489,6 @@ func (s *Server) handleReadAppsV1NamespacedDaemonSetRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7700,7 +7536,6 @@ func (s *Server) handleReadAppsV1NamespacedDaemonSetStatusRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7748,7 +7583,6 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7796,7 +7630,6 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentScaleRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7844,7 +7677,6 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentStatusRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7892,7 +7724,6 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7940,7 +7771,6 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetScaleRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7988,7 +7818,6 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetStatusRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8036,7 +7865,6 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8084,7 +7912,6 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetScaleRequest(args [2]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8132,7 +7959,6 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetStatusRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8180,7 +8006,6 @@ func (s *Server) handleReadAutoscalingV1NamespacedHorizontalPodAutoscalerRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8228,7 +8053,6 @@ func (s *Server) handleReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8276,7 +8100,6 @@ func (s *Server) handleReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8324,7 +8147,6 @@ func (s *Server) handleReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerSt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8372,7 +8194,6 @@ func (s *Server) handleReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8420,7 +8241,6 @@ func (s *Server) handleReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerSt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8468,7 +8288,6 @@ func (s *Server) handleReadBatchV1NamespacedCronJobRequest(args [2]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8516,7 +8335,6 @@ func (s *Server) handleReadBatchV1NamespacedCronJobStatusRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8564,7 +8382,6 @@ func (s *Server) handleReadBatchV1NamespacedJobRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8612,7 +8429,6 @@ func (s *Server) handleReadBatchV1NamespacedJobStatusRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8660,7 +8476,6 @@ func (s *Server) handleReadBatchV1beta1NamespacedCronJobRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8708,7 +8523,6 @@ func (s *Server) handleReadBatchV1beta1NamespacedCronJobStatusRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8756,7 +8570,6 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8804,7 +8617,6 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestApprovalReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8852,7 +8664,6 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestStatusRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8900,7 +8711,6 @@ func (s *Server) handleReadCoordinationV1NamespacedLeaseRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8948,7 +8758,6 @@ func (s *Server) handleReadCoreV1ComponentStatusRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8996,7 +8805,6 @@ func (s *Server) handleReadCoreV1NamespaceRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9044,7 +8852,6 @@ func (s *Server) handleReadCoreV1NamespaceStatusRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9092,7 +8899,6 @@ func (s *Server) handleReadCoreV1NamespacedConfigMapRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9140,7 +8946,6 @@ func (s *Server) handleReadCoreV1NamespacedEndpointsRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9188,7 +8993,6 @@ func (s *Server) handleReadCoreV1NamespacedEventRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9236,7 +9040,6 @@ func (s *Server) handleReadCoreV1NamespacedLimitRangeRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9284,7 +9087,6 @@ func (s *Server) handleReadCoreV1NamespacedPersistentVolumeClaimRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9332,7 +9134,6 @@ func (s *Server) handleReadCoreV1NamespacedPersistentVolumeClaimStatusRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9380,7 +9181,6 @@ func (s *Server) handleReadCoreV1NamespacedPodRequest(args [2]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9428,7 +9228,6 @@ func (s *Server) handleReadCoreV1NamespacedPodEphemeralcontainersRequest(args [2
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9476,7 +9275,6 @@ func (s *Server) handleReadCoreV1NamespacedPodLogRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9524,7 +9322,6 @@ func (s *Server) handleReadCoreV1NamespacedPodStatusRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9572,7 +9369,6 @@ func (s *Server) handleReadCoreV1NamespacedPodTemplateRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9620,7 +9416,6 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9668,7 +9463,6 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerScaleRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9716,7 +9510,6 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerStatusRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9764,7 +9557,6 @@ func (s *Server) handleReadCoreV1NamespacedResourceQuotaRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9812,7 +9604,6 @@ func (s *Server) handleReadCoreV1NamespacedResourceQuotaStatusRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9860,7 +9651,6 @@ func (s *Server) handleReadCoreV1NamespacedSecretRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9908,7 +9698,6 @@ func (s *Server) handleReadCoreV1NamespacedServiceRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9956,7 +9745,6 @@ func (s *Server) handleReadCoreV1NamespacedServiceAccountRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10004,7 +9792,6 @@ func (s *Server) handleReadCoreV1NamespacedServiceStatusRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10052,7 +9839,6 @@ func (s *Server) handleReadCoreV1NodeRequest(args [1]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10100,7 +9886,6 @@ func (s *Server) handleReadCoreV1NodeStatusRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10148,7 +9933,6 @@ func (s *Server) handleReadCoreV1PersistentVolumeRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10196,7 +9980,6 @@ func (s *Server) handleReadCoreV1PersistentVolumeStatusRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10244,7 +10027,6 @@ func (s *Server) handleReadDiscoveryV1NamespacedEndpointSliceRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10292,7 +10074,6 @@ func (s *Server) handleReadDiscoveryV1beta1NamespacedEndpointSliceRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10340,7 +10121,6 @@ func (s *Server) handleReadEventsV1NamespacedEventRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10388,7 +10168,6 @@ func (s *Server) handleReadEventsV1beta1NamespacedEventRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10436,7 +10215,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1FlowSchemaRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10484,7 +10262,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1FlowSchemaStatusRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10532,7 +10309,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10580,7 +10356,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10628,7 +10403,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2FlowSchemaRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10676,7 +10450,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2FlowSchemaStatusRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10724,7 +10497,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10772,7 +10544,6 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10820,7 +10591,6 @@ func (s *Server) handleReadInternalApiserverV1alpha1StorageVersionRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10868,7 +10638,6 @@ func (s *Server) handleReadInternalApiserverV1alpha1StorageVersionStatusRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10916,7 +10685,6 @@ func (s *Server) handleReadNetworkingV1IngressClassRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10964,7 +10732,6 @@ func (s *Server) handleReadNetworkingV1NamespacedIngressRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11012,7 +10779,6 @@ func (s *Server) handleReadNetworkingV1NamespacedIngressStatusRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11060,7 +10826,6 @@ func (s *Server) handleReadNetworkingV1NamespacedNetworkPolicyRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11108,7 +10873,6 @@ func (s *Server) handleReadNodeV1RuntimeClassRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11156,7 +10920,6 @@ func (s *Server) handleReadNodeV1alpha1RuntimeClassRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11204,7 +10967,6 @@ func (s *Server) handleReadNodeV1beta1RuntimeClassRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11252,7 +11014,6 @@ func (s *Server) handleReadPolicyV1NamespacedPodDisruptionBudgetRequest(args [2]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11300,7 +11061,6 @@ func (s *Server) handleReadPolicyV1NamespacedPodDisruptionBudgetStatusRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11348,7 +11108,6 @@ func (s *Server) handleReadPolicyV1beta1NamespacedPodDisruptionBudgetRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11396,7 +11155,6 @@ func (s *Server) handleReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11444,7 +11202,6 @@ func (s *Server) handleReadPolicyV1beta1PodSecurityPolicyRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11492,7 +11249,6 @@ func (s *Server) handleReadRbacAuthorizationV1ClusterRoleRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11540,7 +11296,6 @@ func (s *Server) handleReadRbacAuthorizationV1ClusterRoleBindingRequest(args [1]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11588,7 +11343,6 @@ func (s *Server) handleReadRbacAuthorizationV1NamespacedRoleRequest(args [2]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11636,7 +11390,6 @@ func (s *Server) handleReadRbacAuthorizationV1NamespacedRoleBindingRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11684,7 +11437,6 @@ func (s *Server) handleReadSchedulingV1PriorityClassRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11732,7 +11484,6 @@ func (s *Server) handleReadStorageV1CSIDriverRequest(args [1]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11780,7 +11531,6 @@ func (s *Server) handleReadStorageV1CSINodeRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11828,7 +11578,6 @@ func (s *Server) handleReadStorageV1StorageClassRequest(args [1]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11876,7 +11625,6 @@ func (s *Server) handleReadStorageV1VolumeAttachmentRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11924,7 +11672,6 @@ func (s *Server) handleReadStorageV1VolumeAttachmentStatusRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11972,7 +11719,6 @@ func (s *Server) handleReadStorageV1alpha1NamespacedCSIStorageCapacityRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12020,7 +11766,6 @@ func (s *Server) handleReadStorageV1beta1NamespacedCSIStorageCapacityRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12068,7 +11813,6 @@ func (s *Server) handleWatchAdmissionregistrationV1MutatingWebhookConfigurationR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12116,7 +11860,6 @@ func (s *Server) handleWatchAdmissionregistrationV1MutatingWebhookConfigurationL
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12164,7 +11907,6 @@ func (s *Server) handleWatchAdmissionregistrationV1ValidatingWebhookConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12212,7 +11954,6 @@ func (s *Server) handleWatchAdmissionregistrationV1ValidatingWebhookConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12260,7 +12001,6 @@ func (s *Server) handleWatchApiextensionsV1CustomResourceDefinitionRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12308,7 +12048,6 @@ func (s *Server) handleWatchApiextensionsV1CustomResourceDefinitionListRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12356,7 +12095,6 @@ func (s *Server) handleWatchApiregistrationV1APIServiceRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12404,7 +12142,6 @@ func (s *Server) handleWatchApiregistrationV1APIServiceListRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12452,7 +12189,6 @@ func (s *Server) handleWatchAppsV1ControllerRevisionListForAllNamespacesRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12500,7 +12236,6 @@ func (s *Server) handleWatchAppsV1DaemonSetListForAllNamespacesRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12548,7 +12283,6 @@ func (s *Server) handleWatchAppsV1DeploymentListForAllNamespacesRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12596,7 +12330,6 @@ func (s *Server) handleWatchAppsV1NamespacedControllerRevisionRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12644,7 +12377,6 @@ func (s *Server) handleWatchAppsV1NamespacedControllerRevisionListRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12692,7 +12424,6 @@ func (s *Server) handleWatchAppsV1NamespacedDaemonSetRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12740,7 +12471,6 @@ func (s *Server) handleWatchAppsV1NamespacedDaemonSetListRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12788,7 +12518,6 @@ func (s *Server) handleWatchAppsV1NamespacedDeploymentRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12836,7 +12565,6 @@ func (s *Server) handleWatchAppsV1NamespacedDeploymentListRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12884,7 +12612,6 @@ func (s *Server) handleWatchAppsV1NamespacedReplicaSetRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12932,7 +12659,6 @@ func (s *Server) handleWatchAppsV1NamespacedReplicaSetListRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12980,7 +12706,6 @@ func (s *Server) handleWatchAppsV1NamespacedStatefulSetRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13028,7 +12753,6 @@ func (s *Server) handleWatchAppsV1NamespacedStatefulSetListRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13076,7 +12800,6 @@ func (s *Server) handleWatchAppsV1ReplicaSetListForAllNamespacesRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13124,7 +12847,6 @@ func (s *Server) handleWatchAppsV1StatefulSetListForAllNamespacesRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13172,7 +12894,6 @@ func (s *Server) handleWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamesp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13220,7 +12941,6 @@ func (s *Server) handleWatchAutoscalingV1NamespacedHorizontalPodAutoscalerReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13268,7 +12988,6 @@ func (s *Server) handleWatchAutoscalingV1NamespacedHorizontalPodAutoscalerListRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13316,7 +13035,6 @@ func (s *Server) handleWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllN
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13364,7 +13082,6 @@ func (s *Server) handleWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13412,7 +13129,6 @@ func (s *Server) handleWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerL
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13460,7 +13176,6 @@ func (s *Server) handleWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllN
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13508,7 +13223,6 @@ func (s *Server) handleWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerR
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13556,7 +13270,6 @@ func (s *Server) handleWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerL
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13604,7 +13317,6 @@ func (s *Server) handleWatchBatchV1CronJobListForAllNamespacesRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13652,7 +13364,6 @@ func (s *Server) handleWatchBatchV1JobListForAllNamespacesRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13700,7 +13411,6 @@ func (s *Server) handleWatchBatchV1NamespacedCronJobRequest(args [2]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13748,7 +13458,6 @@ func (s *Server) handleWatchBatchV1NamespacedCronJobListRequest(args [1]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13796,7 +13505,6 @@ func (s *Server) handleWatchBatchV1NamespacedJobRequest(args [2]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13844,7 +13552,6 @@ func (s *Server) handleWatchBatchV1NamespacedJobListRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13892,7 +13599,6 @@ func (s *Server) handleWatchBatchV1beta1CronJobListForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13940,7 +13646,6 @@ func (s *Server) handleWatchBatchV1beta1NamespacedCronJobRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13988,7 +13693,6 @@ func (s *Server) handleWatchBatchV1beta1NamespacedCronJobListRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14036,7 +13740,6 @@ func (s *Server) handleWatchCertificatesV1CertificateSigningRequestRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14084,7 +13787,6 @@ func (s *Server) handleWatchCertificatesV1CertificateSigningRequestListRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14132,7 +13834,6 @@ func (s *Server) handleWatchCoordinationV1LeaseListForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14180,7 +13881,6 @@ func (s *Server) handleWatchCoordinationV1NamespacedLeaseRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14228,7 +13928,6 @@ func (s *Server) handleWatchCoordinationV1NamespacedLeaseListRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14276,7 +13975,6 @@ func (s *Server) handleWatchCoreV1ConfigMapListForAllNamespacesRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14324,7 +14022,6 @@ func (s *Server) handleWatchCoreV1EndpointsListForAllNamespacesRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14372,7 +14069,6 @@ func (s *Server) handleWatchCoreV1EventListForAllNamespacesRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14420,7 +14116,6 @@ func (s *Server) handleWatchCoreV1LimitRangeListForAllNamespacesRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14468,7 +14163,6 @@ func (s *Server) handleWatchCoreV1NamespaceRequest(args [1]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14516,7 +14210,6 @@ func (s *Server) handleWatchCoreV1NamespaceListRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14564,7 +14257,6 @@ func (s *Server) handleWatchCoreV1NamespacedConfigMapRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14612,7 +14304,6 @@ func (s *Server) handleWatchCoreV1NamespacedConfigMapListRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14660,7 +14351,6 @@ func (s *Server) handleWatchCoreV1NamespacedEndpointsRequest(args [2]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14708,7 +14398,6 @@ func (s *Server) handleWatchCoreV1NamespacedEndpointsListRequest(args [1]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14756,7 +14445,6 @@ func (s *Server) handleWatchCoreV1NamespacedEventRequest(args [2]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14804,7 +14492,6 @@ func (s *Server) handleWatchCoreV1NamespacedEventListRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14852,7 +14539,6 @@ func (s *Server) handleWatchCoreV1NamespacedLimitRangeRequest(args [2]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14900,7 +14586,6 @@ func (s *Server) handleWatchCoreV1NamespacedLimitRangeListRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14948,7 +14633,6 @@ func (s *Server) handleWatchCoreV1NamespacedPersistentVolumeClaimRequest(args [2
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14996,7 +14680,6 @@ func (s *Server) handleWatchCoreV1NamespacedPersistentVolumeClaimListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15044,7 +14727,6 @@ func (s *Server) handleWatchCoreV1NamespacedPodRequest(args [2]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15092,7 +14774,6 @@ func (s *Server) handleWatchCoreV1NamespacedPodListRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15140,7 +14821,6 @@ func (s *Server) handleWatchCoreV1NamespacedPodTemplateRequest(args [2]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15188,7 +14868,6 @@ func (s *Server) handleWatchCoreV1NamespacedPodTemplateListRequest(args [1]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15236,7 +14915,6 @@ func (s *Server) handleWatchCoreV1NamespacedReplicationControllerRequest(args [2
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15284,7 +14962,6 @@ func (s *Server) handleWatchCoreV1NamespacedReplicationControllerListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15332,7 +15009,6 @@ func (s *Server) handleWatchCoreV1NamespacedResourceQuotaRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15380,7 +15056,6 @@ func (s *Server) handleWatchCoreV1NamespacedResourceQuotaListRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15428,7 +15103,6 @@ func (s *Server) handleWatchCoreV1NamespacedSecretRequest(args [2]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15476,7 +15150,6 @@ func (s *Server) handleWatchCoreV1NamespacedSecretListRequest(args [1]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15524,7 +15197,6 @@ func (s *Server) handleWatchCoreV1NamespacedServiceRequest(args [2]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15572,7 +15244,6 @@ func (s *Server) handleWatchCoreV1NamespacedServiceAccountRequest(args [2]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15620,7 +15291,6 @@ func (s *Server) handleWatchCoreV1NamespacedServiceAccountListRequest(args [1]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15668,7 +15338,6 @@ func (s *Server) handleWatchCoreV1NamespacedServiceListRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15716,7 +15385,6 @@ func (s *Server) handleWatchCoreV1NodeRequest(args [1]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15764,7 +15432,6 @@ func (s *Server) handleWatchCoreV1NodeListRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15812,7 +15479,6 @@ func (s *Server) handleWatchCoreV1PersistentVolumeRequest(args [1]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15860,7 +15526,6 @@ func (s *Server) handleWatchCoreV1PersistentVolumeClaimListForAllNamespacesReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15908,7 +15573,6 @@ func (s *Server) handleWatchCoreV1PersistentVolumeListRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15956,7 +15620,6 @@ func (s *Server) handleWatchCoreV1PodListForAllNamespacesRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16004,7 +15667,6 @@ func (s *Server) handleWatchCoreV1PodTemplateListForAllNamespacesRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16052,7 +15714,6 @@ func (s *Server) handleWatchCoreV1ReplicationControllerListForAllNamespacesReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16100,7 +15761,6 @@ func (s *Server) handleWatchCoreV1ResourceQuotaListForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16148,7 +15808,6 @@ func (s *Server) handleWatchCoreV1SecretListForAllNamespacesRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16196,7 +15855,6 @@ func (s *Server) handleWatchCoreV1ServiceAccountListForAllNamespacesRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16244,7 +15902,6 @@ func (s *Server) handleWatchCoreV1ServiceListForAllNamespacesRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16292,7 +15949,6 @@ func (s *Server) handleWatchDiscoveryV1EndpointSliceListForAllNamespacesRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16340,7 +15996,6 @@ func (s *Server) handleWatchDiscoveryV1NamespacedEndpointSliceRequest(args [2]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16388,7 +16043,6 @@ func (s *Server) handleWatchDiscoveryV1NamespacedEndpointSliceListRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16436,7 +16090,6 @@ func (s *Server) handleWatchDiscoveryV1beta1EndpointSliceListForAllNamespacesReq
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16484,7 +16137,6 @@ func (s *Server) handleWatchDiscoveryV1beta1NamespacedEndpointSliceRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16532,7 +16184,6 @@ func (s *Server) handleWatchDiscoveryV1beta1NamespacedEndpointSliceListRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16580,7 +16231,6 @@ func (s *Server) handleWatchEventsV1EventListForAllNamespacesRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16628,7 +16278,6 @@ func (s *Server) handleWatchEventsV1NamespacedEventRequest(args [2]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16676,7 +16325,6 @@ func (s *Server) handleWatchEventsV1NamespacedEventListRequest(args [1]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16724,7 +16372,6 @@ func (s *Server) handleWatchEventsV1beta1EventListForAllNamespacesRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16772,7 +16419,6 @@ func (s *Server) handleWatchEventsV1beta1NamespacedEventRequest(args [2]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16820,7 +16466,6 @@ func (s *Server) handleWatchEventsV1beta1NamespacedEventListRequest(args [1]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16868,7 +16513,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1FlowSchemaRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16916,7 +16560,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1FlowSchemaListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16964,7 +16607,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1PriorityLevelConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17012,7 +16654,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1PriorityLevelConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17060,7 +16701,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2FlowSchemaRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17108,7 +16748,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2FlowSchemaListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17156,7 +16795,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2PriorityLevelConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17204,7 +16842,6 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2PriorityLevelConfiguratio
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17252,7 +16889,6 @@ func (s *Server) handleWatchInternalApiserverV1alpha1StorageVersionRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17300,7 +16936,6 @@ func (s *Server) handleWatchInternalApiserverV1alpha1StorageVersionListRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17348,7 +16983,6 @@ func (s *Server) handleWatchNetworkingV1IngressClassRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17396,7 +17030,6 @@ func (s *Server) handleWatchNetworkingV1IngressClassListRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17444,7 +17077,6 @@ func (s *Server) handleWatchNetworkingV1IngressListForAllNamespacesRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17492,7 +17124,6 @@ func (s *Server) handleWatchNetworkingV1NamespacedIngressRequest(args [2]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17540,7 +17171,6 @@ func (s *Server) handleWatchNetworkingV1NamespacedIngressListRequest(args [1]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17588,7 +17218,6 @@ func (s *Server) handleWatchNetworkingV1NamespacedNetworkPolicyRequest(args [2]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17636,7 +17265,6 @@ func (s *Server) handleWatchNetworkingV1NamespacedNetworkPolicyListRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17684,7 +17312,6 @@ func (s *Server) handleWatchNetworkingV1NetworkPolicyListForAllNamespacesRequest
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17732,7 +17359,6 @@ func (s *Server) handleWatchNodeV1RuntimeClassRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17780,7 +17406,6 @@ func (s *Server) handleWatchNodeV1RuntimeClassListRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17828,7 +17453,6 @@ func (s *Server) handleWatchNodeV1alpha1RuntimeClassRequest(args [1]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17876,7 +17500,6 @@ func (s *Server) handleWatchNodeV1alpha1RuntimeClassListRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17924,7 +17547,6 @@ func (s *Server) handleWatchNodeV1beta1RuntimeClassRequest(args [1]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17972,7 +17594,6 @@ func (s *Server) handleWatchNodeV1beta1RuntimeClassListRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18020,7 +17641,6 @@ func (s *Server) handleWatchPolicyV1NamespacedPodDisruptionBudgetRequest(args [2
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18068,7 +17688,6 @@ func (s *Server) handleWatchPolicyV1NamespacedPodDisruptionBudgetListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18116,7 +17735,6 @@ func (s *Server) handleWatchPolicyV1PodDisruptionBudgetListForAllNamespacesReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18164,7 +17782,6 @@ func (s *Server) handleWatchPolicyV1beta1NamespacedPodDisruptionBudgetRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18212,7 +17829,6 @@ func (s *Server) handleWatchPolicyV1beta1NamespacedPodDisruptionBudgetListReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18260,7 +17876,6 @@ func (s *Server) handleWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18308,7 +17923,6 @@ func (s *Server) handleWatchPolicyV1beta1PodSecurityPolicyRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18356,7 +17970,6 @@ func (s *Server) handleWatchPolicyV1beta1PodSecurityPolicyListRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18404,7 +18017,6 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleRequest(args [1]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18452,7 +18064,6 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleBindingRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18500,7 +18111,6 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleBindingListRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18548,7 +18158,6 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleListRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18596,7 +18205,6 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleRequest(args [2]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18644,7 +18252,6 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleBindingRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18692,7 +18299,6 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleBindingListRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18740,7 +18346,6 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleListRequest(args [1
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18788,7 +18393,6 @@ func (s *Server) handleWatchRbacAuthorizationV1RoleBindingListForAllNamespacesRe
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18836,7 +18440,6 @@ func (s *Server) handleWatchRbacAuthorizationV1RoleListForAllNamespacesRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18884,7 +18487,6 @@ func (s *Server) handleWatchSchedulingV1PriorityClassRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18932,7 +18534,6 @@ func (s *Server) handleWatchSchedulingV1PriorityClassListRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18980,7 +18581,6 @@ func (s *Server) handleWatchStorageV1CSIDriverRequest(args [1]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19028,7 +18628,6 @@ func (s *Server) handleWatchStorageV1CSIDriverListRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19076,7 +18675,6 @@ func (s *Server) handleWatchStorageV1CSINodeRequest(args [1]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19124,7 +18722,6 @@ func (s *Server) handleWatchStorageV1CSINodeListRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19172,7 +18769,6 @@ func (s *Server) handleWatchStorageV1StorageClassRequest(args [1]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19220,7 +18816,6 @@ func (s *Server) handleWatchStorageV1StorageClassListRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19268,7 +18863,6 @@ func (s *Server) handleWatchStorageV1VolumeAttachmentRequest(args [1]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19316,7 +18910,6 @@ func (s *Server) handleWatchStorageV1VolumeAttachmentListRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19364,7 +18957,6 @@ func (s *Server) handleWatchStorageV1alpha1CSIStorageCapacityListForAllNamespace
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19412,7 +19004,6 @@ func (s *Server) handleWatchStorageV1alpha1NamespacedCSIStorageCapacityRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19460,7 +19051,6 @@ func (s *Server) handleWatchStorageV1alpha1NamespacedCSIStorageCapacityListReque
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19508,7 +19098,6 @@ func (s *Server) handleWatchStorageV1beta1CSIStorageCapacityListForAllNamespaces
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19556,7 +19145,6 @@ func (s *Server) handleWatchStorageV1beta1NamespacedCSIStorageCapacityRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -19604,7 +19192,6 @@ func (s *Server) handleWatchStorageV1beta1NamespacedCSIStorageCapacityListReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_k8s/oas_res_enc_gen.go
+++ b/examples/ex_k8s/oas_res_enc_gen.go
@@ -75,6 +75,7 @@ func encodeGetAPIVersionsResponse(response GetAPIVersionsRes, w http.ResponseWri
 	case *IoK8sApimachineryPkgApisMetaV1APIGroupList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -86,6 +87,7 @@ func encodeGetAPIVersionsResponse(response GetAPIVersionsRes, w http.ResponseWri
 		return nil
 	case *GetAPIVersionsUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/"+`: unexpected response type: %T`, response)
@@ -97,6 +99,7 @@ func encodeGetAdmissionregistrationAPIGroupResponse(response GetAdmissionregistr
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -108,6 +111,7 @@ func encodeGetAdmissionregistrationAPIGroupResponse(response GetAdmissionregistr
 		return nil
 	case *GetAdmissionregistrationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/"+`: unexpected response type: %T`, response)
@@ -119,6 +123,7 @@ func encodeGetAdmissionregistrationV1APIResourcesResponse(response GetAdmissionr
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -130,6 +135,7 @@ func encodeGetAdmissionregistrationV1APIResourcesResponse(response GetAdmissionr
 		return nil
 	case *GetAdmissionregistrationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -141,6 +147,7 @@ func encodeGetApiextensionsAPIGroupResponse(response GetApiextensionsAPIGroupRes
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -152,6 +159,7 @@ func encodeGetApiextensionsAPIGroupResponse(response GetApiextensionsAPIGroupRes
 		return nil
 	case *GetApiextensionsAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/"+`: unexpected response type: %T`, response)
@@ -163,6 +171,7 @@ func encodeGetApiextensionsV1APIResourcesResponse(response GetApiextensionsV1API
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -174,6 +183,7 @@ func encodeGetApiextensionsV1APIResourcesResponse(response GetApiextensionsV1API
 		return nil
 	case *GetApiextensionsV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -185,6 +195,7 @@ func encodeGetApiregistrationAPIGroupResponse(response GetApiregistrationAPIGrou
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -196,6 +207,7 @@ func encodeGetApiregistrationAPIGroupResponse(response GetApiregistrationAPIGrou
 		return nil
 	case *GetApiregistrationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/"+`: unexpected response type: %T`, response)
@@ -207,6 +219,7 @@ func encodeGetApiregistrationV1APIResourcesResponse(response GetApiregistrationV
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -218,6 +231,7 @@ func encodeGetApiregistrationV1APIResourcesResponse(response GetApiregistrationV
 		return nil
 	case *GetApiregistrationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -229,6 +243,7 @@ func encodeGetAppsAPIGroupResponse(response GetAppsAPIGroupRes, w http.ResponseW
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -240,6 +255,7 @@ func encodeGetAppsAPIGroupResponse(response GetAppsAPIGroupRes, w http.ResponseW
 		return nil
 	case *GetAppsAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/"+`: unexpected response type: %T`, response)
@@ -251,6 +267,7 @@ func encodeGetAppsV1APIResourcesResponse(response GetAppsV1APIResourcesRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -262,6 +279,7 @@ func encodeGetAppsV1APIResourcesResponse(response GetAppsV1APIResourcesRes, w ht
 		return nil
 	case *GetAppsV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/"+`: unexpected response type: %T`, response)
@@ -273,6 +291,7 @@ func encodeGetAuthenticationAPIGroupResponse(response GetAuthenticationAPIGroupR
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -284,6 +303,7 @@ func encodeGetAuthenticationAPIGroupResponse(response GetAuthenticationAPIGroupR
 		return nil
 	case *GetAuthenticationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/authentication.k8s.io/"+`: unexpected response type: %T`, response)
@@ -295,6 +315,7 @@ func encodeGetAuthenticationV1APIResourcesResponse(response GetAuthenticationV1A
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -306,6 +327,7 @@ func encodeGetAuthenticationV1APIResourcesResponse(response GetAuthenticationV1A
 		return nil
 	case *GetAuthenticationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/authentication.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -317,6 +339,7 @@ func encodeGetAuthorizationAPIGroupResponse(response GetAuthorizationAPIGroupRes
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -328,6 +351,7 @@ func encodeGetAuthorizationAPIGroupResponse(response GetAuthorizationAPIGroupRes
 		return nil
 	case *GetAuthorizationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/authorization.k8s.io/"+`: unexpected response type: %T`, response)
@@ -339,6 +363,7 @@ func encodeGetAuthorizationV1APIResourcesResponse(response GetAuthorizationV1API
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -350,6 +375,7 @@ func encodeGetAuthorizationV1APIResourcesResponse(response GetAuthorizationV1API
 		return nil
 	case *GetAuthorizationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/authorization.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -361,6 +387,7 @@ func encodeGetAutoscalingAPIGroupResponse(response GetAutoscalingAPIGroupRes, w 
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -372,6 +399,7 @@ func encodeGetAutoscalingAPIGroupResponse(response GetAutoscalingAPIGroupRes, w 
 		return nil
 	case *GetAutoscalingAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/"+`: unexpected response type: %T`, response)
@@ -383,6 +411,7 @@ func encodeGetAutoscalingV1APIResourcesResponse(response GetAutoscalingV1APIReso
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -394,6 +423,7 @@ func encodeGetAutoscalingV1APIResourcesResponse(response GetAutoscalingV1APIReso
 		return nil
 	case *GetAutoscalingV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/"+`: unexpected response type: %T`, response)
@@ -405,6 +435,7 @@ func encodeGetAutoscalingV2beta1APIResourcesResponse(response GetAutoscalingV2be
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -416,6 +447,7 @@ func encodeGetAutoscalingV2beta1APIResourcesResponse(response GetAutoscalingV2be
 		return nil
 	case *GetAutoscalingV2beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/"+`: unexpected response type: %T`, response)
@@ -427,6 +459,7 @@ func encodeGetAutoscalingV2beta2APIResourcesResponse(response GetAutoscalingV2be
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -438,6 +471,7 @@ func encodeGetAutoscalingV2beta2APIResourcesResponse(response GetAutoscalingV2be
 		return nil
 	case *GetAutoscalingV2beta2APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/"+`: unexpected response type: %T`, response)
@@ -449,6 +483,7 @@ func encodeGetBatchAPIGroupResponse(response GetBatchAPIGroupRes, w http.Respons
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -460,6 +495,7 @@ func encodeGetBatchAPIGroupResponse(response GetBatchAPIGroupRes, w http.Respons
 		return nil
 	case *GetBatchAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/"+`: unexpected response type: %T`, response)
@@ -471,6 +507,7 @@ func encodeGetBatchV1APIResourcesResponse(response GetBatchV1APIResourcesRes, w 
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -482,6 +519,7 @@ func encodeGetBatchV1APIResourcesResponse(response GetBatchV1APIResourcesRes, w 
 		return nil
 	case *GetBatchV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/"+`: unexpected response type: %T`, response)
@@ -493,6 +531,7 @@ func encodeGetBatchV1beta1APIResourcesResponse(response GetBatchV1beta1APIResour
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -504,6 +543,7 @@ func encodeGetBatchV1beta1APIResourcesResponse(response GetBatchV1beta1APIResour
 		return nil
 	case *GetBatchV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/"+`: unexpected response type: %T`, response)
@@ -515,6 +555,7 @@ func encodeGetCertificatesAPIGroupResponse(response GetCertificatesAPIGroupRes, 
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -526,6 +567,7 @@ func encodeGetCertificatesAPIGroupResponse(response GetCertificatesAPIGroupRes, 
 		return nil
 	case *GetCertificatesAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/"+`: unexpected response type: %T`, response)
@@ -537,6 +579,7 @@ func encodeGetCertificatesV1APIResourcesResponse(response GetCertificatesV1APIRe
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -548,6 +591,7 @@ func encodeGetCertificatesV1APIResourcesResponse(response GetCertificatesV1APIRe
 		return nil
 	case *GetCertificatesV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -559,6 +603,7 @@ func encodeGetCodeVersionResponse(response GetCodeVersionRes, w http.ResponseWri
 	case *IoK8sApimachineryPkgVersionInfo:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -570,6 +615,7 @@ func encodeGetCodeVersionResponse(response GetCodeVersionRes, w http.ResponseWri
 		return nil
 	case *GetCodeVersionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/version/"+`: unexpected response type: %T`, response)
@@ -581,6 +627,7 @@ func encodeGetCoordinationAPIGroupResponse(response GetCoordinationAPIGroupRes, 
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -592,6 +639,7 @@ func encodeGetCoordinationAPIGroupResponse(response GetCoordinationAPIGroupRes, 
 		return nil
 	case *GetCoordinationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/"+`: unexpected response type: %T`, response)
@@ -603,6 +651,7 @@ func encodeGetCoordinationV1APIResourcesResponse(response GetCoordinationV1APIRe
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -614,6 +663,7 @@ func encodeGetCoordinationV1APIResourcesResponse(response GetCoordinationV1APIRe
 		return nil
 	case *GetCoordinationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -625,6 +675,7 @@ func encodeGetCoreAPIVersionsResponse(response GetCoreAPIVersionsRes, w http.Res
 	case *IoK8sApimachineryPkgApisMetaV1APIVersions:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -636,6 +687,7 @@ func encodeGetCoreAPIVersionsResponse(response GetCoreAPIVersionsRes, w http.Res
 		return nil
 	case *GetCoreAPIVersionsUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/"+`: unexpected response type: %T`, response)
@@ -647,6 +699,7 @@ func encodeGetCoreV1APIResourcesResponse(response GetCoreV1APIResourcesRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -658,6 +711,7 @@ func encodeGetCoreV1APIResourcesResponse(response GetCoreV1APIResourcesRes, w ht
 		return nil
 	case *GetCoreV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/"+`: unexpected response type: %T`, response)
@@ -669,6 +723,7 @@ func encodeGetDiscoveryAPIGroupResponse(response GetDiscoveryAPIGroupRes, w http
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -680,6 +735,7 @@ func encodeGetDiscoveryAPIGroupResponse(response GetDiscoveryAPIGroupRes, w http
 		return nil
 	case *GetDiscoveryAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/"+`: unexpected response type: %T`, response)
@@ -691,6 +747,7 @@ func encodeGetDiscoveryV1APIResourcesResponse(response GetDiscoveryV1APIResource
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -702,6 +759,7 @@ func encodeGetDiscoveryV1APIResourcesResponse(response GetDiscoveryV1APIResource
 		return nil
 	case *GetDiscoveryV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -713,6 +771,7 @@ func encodeGetDiscoveryV1beta1APIResourcesResponse(response GetDiscoveryV1beta1A
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -724,6 +783,7 @@ func encodeGetDiscoveryV1beta1APIResourcesResponse(response GetDiscoveryV1beta1A
 		return nil
 	case *GetDiscoveryV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/"+`: unexpected response type: %T`, response)
@@ -735,6 +795,7 @@ func encodeGetEventsAPIGroupResponse(response GetEventsAPIGroupRes, w http.Respo
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -746,6 +807,7 @@ func encodeGetEventsAPIGroupResponse(response GetEventsAPIGroupRes, w http.Respo
 		return nil
 	case *GetEventsAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/"+`: unexpected response type: %T`, response)
@@ -757,6 +819,7 @@ func encodeGetEventsV1APIResourcesResponse(response GetEventsV1APIResourcesRes, 
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -768,6 +831,7 @@ func encodeGetEventsV1APIResourcesResponse(response GetEventsV1APIResourcesRes, 
 		return nil
 	case *GetEventsV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -779,6 +843,7 @@ func encodeGetEventsV1beta1APIResourcesResponse(response GetEventsV1beta1APIReso
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -790,6 +855,7 @@ func encodeGetEventsV1beta1APIResourcesResponse(response GetEventsV1beta1APIReso
 		return nil
 	case *GetEventsV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/"+`: unexpected response type: %T`, response)
@@ -801,6 +867,7 @@ func encodeGetFlowcontrolApiserverAPIGroupResponse(response GetFlowcontrolApiser
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -812,6 +879,7 @@ func encodeGetFlowcontrolApiserverAPIGroupResponse(response GetFlowcontrolApiser
 		return nil
 	case *GetFlowcontrolApiserverAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/"+`: unexpected response type: %T`, response)
@@ -823,6 +891,7 @@ func encodeGetFlowcontrolApiserverV1beta1APIResourcesResponse(response GetFlowco
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -834,6 +903,7 @@ func encodeGetFlowcontrolApiserverV1beta1APIResourcesResponse(response GetFlowco
 		return nil
 	case *GetFlowcontrolApiserverV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/"+`: unexpected response type: %T`, response)
@@ -845,6 +915,7 @@ func encodeGetFlowcontrolApiserverV1beta2APIResourcesResponse(response GetFlowco
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -856,6 +927,7 @@ func encodeGetFlowcontrolApiserverV1beta2APIResourcesResponse(response GetFlowco
 		return nil
 	case *GetFlowcontrolApiserverV1beta2APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/"+`: unexpected response type: %T`, response)
@@ -867,6 +939,7 @@ func encodeGetInternalApiserverAPIGroupResponse(response GetInternalApiserverAPI
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -878,6 +951,7 @@ func encodeGetInternalApiserverAPIGroupResponse(response GetInternalApiserverAPI
 		return nil
 	case *GetInternalApiserverAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/"+`: unexpected response type: %T`, response)
@@ -889,6 +963,7 @@ func encodeGetInternalApiserverV1alpha1APIResourcesResponse(response GetInternal
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -900,6 +975,7 @@ func encodeGetInternalApiserverV1alpha1APIResourcesResponse(response GetInternal
 		return nil
 	case *GetInternalApiserverV1alpha1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/"+`: unexpected response type: %T`, response)
@@ -911,6 +987,7 @@ func encodeGetNetworkingAPIGroupResponse(response GetNetworkingAPIGroupRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -922,6 +999,7 @@ func encodeGetNetworkingAPIGroupResponse(response GetNetworkingAPIGroupRes, w ht
 		return nil
 	case *GetNetworkingAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/"+`: unexpected response type: %T`, response)
@@ -933,6 +1011,7 @@ func encodeGetNetworkingV1APIResourcesResponse(response GetNetworkingV1APIResour
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -944,6 +1023,7 @@ func encodeGetNetworkingV1APIResourcesResponse(response GetNetworkingV1APIResour
 		return nil
 	case *GetNetworkingV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -955,6 +1035,7 @@ func encodeGetNodeAPIGroupResponse(response GetNodeAPIGroupRes, w http.ResponseW
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -966,6 +1047,7 @@ func encodeGetNodeAPIGroupResponse(response GetNodeAPIGroupRes, w http.ResponseW
 		return nil
 	case *GetNodeAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/"+`: unexpected response type: %T`, response)
@@ -977,6 +1059,7 @@ func encodeGetNodeV1APIResourcesResponse(response GetNodeV1APIResourcesRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -988,6 +1071,7 @@ func encodeGetNodeV1APIResourcesResponse(response GetNodeV1APIResourcesRes, w ht
 		return nil
 	case *GetNodeV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -999,6 +1083,7 @@ func encodeGetNodeV1alpha1APIResourcesResponse(response GetNodeV1alpha1APIResour
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1010,6 +1095,7 @@ func encodeGetNodeV1alpha1APIResourcesResponse(response GetNodeV1alpha1APIResour
 		return nil
 	case *GetNodeV1alpha1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1alpha1/"+`: unexpected response type: %T`, response)
@@ -1021,6 +1107,7 @@ func encodeGetNodeV1beta1APIResourcesResponse(response GetNodeV1beta1APIResource
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1032,6 +1119,7 @@ func encodeGetNodeV1beta1APIResourcesResponse(response GetNodeV1beta1APIResource
 		return nil
 	case *GetNodeV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1beta1/"+`: unexpected response type: %T`, response)
@@ -1043,6 +1131,7 @@ func encodeGetPolicyAPIGroupResponse(response GetPolicyAPIGroupRes, w http.Respo
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1054,6 +1143,7 @@ func encodeGetPolicyAPIGroupResponse(response GetPolicyAPIGroupRes, w http.Respo
 		return nil
 	case *GetPolicyAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/"+`: unexpected response type: %T`, response)
@@ -1065,6 +1155,7 @@ func encodeGetPolicyV1APIResourcesResponse(response GetPolicyV1APIResourcesRes, 
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1076,6 +1167,7 @@ func encodeGetPolicyV1APIResourcesResponse(response GetPolicyV1APIResourcesRes, 
 		return nil
 	case *GetPolicyV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/"+`: unexpected response type: %T`, response)
@@ -1087,6 +1179,7 @@ func encodeGetPolicyV1beta1APIResourcesResponse(response GetPolicyV1beta1APIReso
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1098,6 +1191,7 @@ func encodeGetPolicyV1beta1APIResourcesResponse(response GetPolicyV1beta1APIReso
 		return nil
 	case *GetPolicyV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/"+`: unexpected response type: %T`, response)
@@ -1109,6 +1203,7 @@ func encodeGetRbacAuthorizationAPIGroupResponse(response GetRbacAuthorizationAPI
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1120,6 +1215,7 @@ func encodeGetRbacAuthorizationAPIGroupResponse(response GetRbacAuthorizationAPI
 		return nil
 	case *GetRbacAuthorizationAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/"+`: unexpected response type: %T`, response)
@@ -1131,6 +1227,7 @@ func encodeGetRbacAuthorizationV1APIResourcesResponse(response GetRbacAuthorizat
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1142,6 +1239,7 @@ func encodeGetRbacAuthorizationV1APIResourcesResponse(response GetRbacAuthorizat
 		return nil
 	case *GetRbacAuthorizationV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -1153,6 +1251,7 @@ func encodeGetSchedulingAPIGroupResponse(response GetSchedulingAPIGroupRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1164,6 +1263,7 @@ func encodeGetSchedulingAPIGroupResponse(response GetSchedulingAPIGroupRes, w ht
 		return nil
 	case *GetSchedulingAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/"+`: unexpected response type: %T`, response)
@@ -1175,6 +1275,7 @@ func encodeGetSchedulingV1APIResourcesResponse(response GetSchedulingV1APIResour
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1186,6 +1287,7 @@ func encodeGetSchedulingV1APIResourcesResponse(response GetSchedulingV1APIResour
 		return nil
 	case *GetSchedulingV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -1197,6 +1299,7 @@ func encodeGetServiceAccountIssuerOpenIDConfigurationResponse(response GetServic
 	case *GetServiceAccountIssuerOpenIDConfigurationOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1208,6 +1311,7 @@ func encodeGetServiceAccountIssuerOpenIDConfigurationResponse(response GetServic
 		return nil
 	case *GetServiceAccountIssuerOpenIDConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/.well-known/openid-configuration/"+`: unexpected response type: %T`, response)
@@ -1219,6 +1323,7 @@ func encodeGetStorageAPIGroupResponse(response GetStorageAPIGroupRes, w http.Res
 	case *IoK8sApimachineryPkgApisMetaV1APIGroup:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1230,6 +1335,7 @@ func encodeGetStorageAPIGroupResponse(response GetStorageAPIGroupRes, w http.Res
 		return nil
 	case *GetStorageAPIGroupUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/"+`: unexpected response type: %T`, response)
@@ -1241,6 +1347,7 @@ func encodeGetStorageV1APIResourcesResponse(response GetStorageV1APIResourcesRes
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1252,6 +1359,7 @@ func encodeGetStorageV1APIResourcesResponse(response GetStorageV1APIResourcesRes
 		return nil
 	case *GetStorageV1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/"+`: unexpected response type: %T`, response)
@@ -1263,6 +1371,7 @@ func encodeGetStorageV1alpha1APIResourcesResponse(response GetStorageV1alpha1API
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1274,6 +1383,7 @@ func encodeGetStorageV1alpha1APIResourcesResponse(response GetStorageV1alpha1API
 		return nil
 	case *GetStorageV1alpha1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/"+`: unexpected response type: %T`, response)
@@ -1285,6 +1395,7 @@ func encodeGetStorageV1beta1APIResourcesResponse(response GetStorageV1beta1APIRe
 	case *IoK8sApimachineryPkgApisMetaV1APIResourceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1296,6 +1407,7 @@ func encodeGetStorageV1beta1APIResourcesResponse(response GetStorageV1beta1APIRe
 		return nil
 	case *GetStorageV1beta1APIResourcesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/"+`: unexpected response type: %T`, response)
@@ -1307,6 +1419,7 @@ func encodeListAdmissionregistrationV1MutatingWebhookConfigurationResponse(respo
 	case *IoK8sAPIAdmissionregistrationV1MutatingWebhookConfigurationList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1318,6 +1431,7 @@ func encodeListAdmissionregistrationV1MutatingWebhookConfigurationResponse(respo
 		return nil
 	case *ListAdmissionregistrationV1MutatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"+`: unexpected response type: %T`, response)
@@ -1329,6 +1443,7 @@ func encodeListAdmissionregistrationV1ValidatingWebhookConfigurationResponse(res
 	case *IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfigurationList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1340,6 +1455,7 @@ func encodeListAdmissionregistrationV1ValidatingWebhookConfigurationResponse(res
 		return nil
 	case *ListAdmissionregistrationV1ValidatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations"+`: unexpected response type: %T`, response)
@@ -1351,6 +1467,7 @@ func encodeListApiextensionsV1CustomResourceDefinitionResponse(response ListApie
 	case *IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitionList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1362,6 +1479,7 @@ func encodeListApiextensionsV1CustomResourceDefinitionResponse(response ListApie
 		return nil
 	case *ListApiextensionsV1CustomResourceDefinitionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/customresourcedefinitions"+`: unexpected response type: %T`, response)
@@ -1373,6 +1491,7 @@ func encodeListApiregistrationV1APIServiceResponse(response ListApiregistrationV
 	case *IoK8sKubeAggregatorPkgApisApiregistrationV1APIServiceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1384,6 +1503,7 @@ func encodeListApiregistrationV1APIServiceResponse(response ListApiregistrationV
 		return nil
 	case *ListApiregistrationV1APIServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/apiservices"+`: unexpected response type: %T`, response)
@@ -1395,6 +1515,7 @@ func encodeListAppsV1ControllerRevisionForAllNamespacesResponse(response ListApp
 	case *IoK8sAPIAppsV1ControllerRevisionList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1406,6 +1527,7 @@ func encodeListAppsV1ControllerRevisionForAllNamespacesResponse(response ListApp
 		return nil
 	case *ListAppsV1ControllerRevisionForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/controllerrevisions"+`: unexpected response type: %T`, response)
@@ -1417,6 +1539,7 @@ func encodeListAppsV1DaemonSetForAllNamespacesResponse(response ListAppsV1Daemon
 	case *IoK8sAPIAppsV1DaemonSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1428,6 +1551,7 @@ func encodeListAppsV1DaemonSetForAllNamespacesResponse(response ListAppsV1Daemon
 		return nil
 	case *ListAppsV1DaemonSetForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/daemonsets"+`: unexpected response type: %T`, response)
@@ -1439,6 +1563,7 @@ func encodeListAppsV1DeploymentForAllNamespacesResponse(response ListAppsV1Deplo
 	case *IoK8sAPIAppsV1DeploymentList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1450,6 +1575,7 @@ func encodeListAppsV1DeploymentForAllNamespacesResponse(response ListAppsV1Deplo
 		return nil
 	case *ListAppsV1DeploymentForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/deployments"+`: unexpected response type: %T`, response)
@@ -1461,6 +1587,7 @@ func encodeListAppsV1NamespacedControllerRevisionResponse(response ListAppsV1Nam
 	case *IoK8sAPIAppsV1ControllerRevisionList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1472,6 +1599,7 @@ func encodeListAppsV1NamespacedControllerRevisionResponse(response ListAppsV1Nam
 		return nil
 	case *ListAppsV1NamespacedControllerRevisionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/controllerrevisions"+`: unexpected response type: %T`, response)
@@ -1483,6 +1611,7 @@ func encodeListAppsV1NamespacedDaemonSetResponse(response ListAppsV1NamespacedDa
 	case *IoK8sAPIAppsV1DaemonSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1494,6 +1623,7 @@ func encodeListAppsV1NamespacedDaemonSetResponse(response ListAppsV1NamespacedDa
 		return nil
 	case *ListAppsV1NamespacedDaemonSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/daemonsets"+`: unexpected response type: %T`, response)
@@ -1505,6 +1635,7 @@ func encodeListAppsV1NamespacedDeploymentResponse(response ListAppsV1NamespacedD
 	case *IoK8sAPIAppsV1DeploymentList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1516,6 +1647,7 @@ func encodeListAppsV1NamespacedDeploymentResponse(response ListAppsV1NamespacedD
 		return nil
 	case *ListAppsV1NamespacedDeploymentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/deployments"+`: unexpected response type: %T`, response)
@@ -1527,6 +1659,7 @@ func encodeListAppsV1NamespacedReplicaSetResponse(response ListAppsV1NamespacedR
 	case *IoK8sAPIAppsV1ReplicaSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1538,6 +1671,7 @@ func encodeListAppsV1NamespacedReplicaSetResponse(response ListAppsV1NamespacedR
 		return nil
 	case *ListAppsV1NamespacedReplicaSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/replicasets"+`: unexpected response type: %T`, response)
@@ -1549,6 +1683,7 @@ func encodeListAppsV1NamespacedStatefulSetResponse(response ListAppsV1Namespaced
 	case *IoK8sAPIAppsV1StatefulSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1560,6 +1695,7 @@ func encodeListAppsV1NamespacedStatefulSetResponse(response ListAppsV1Namespaced
 		return nil
 	case *ListAppsV1NamespacedStatefulSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/statefulsets"+`: unexpected response type: %T`, response)
@@ -1571,6 +1707,7 @@ func encodeListAppsV1ReplicaSetForAllNamespacesResponse(response ListAppsV1Repli
 	case *IoK8sAPIAppsV1ReplicaSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1582,6 +1719,7 @@ func encodeListAppsV1ReplicaSetForAllNamespacesResponse(response ListAppsV1Repli
 		return nil
 	case *ListAppsV1ReplicaSetForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/replicasets"+`: unexpected response type: %T`, response)
@@ -1593,6 +1731,7 @@ func encodeListAppsV1StatefulSetForAllNamespacesResponse(response ListAppsV1Stat
 	case *IoK8sAPIAppsV1StatefulSetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1604,6 +1743,7 @@ func encodeListAppsV1StatefulSetForAllNamespacesResponse(response ListAppsV1Stat
 		return nil
 	case *ListAppsV1StatefulSetForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/statefulsets"+`: unexpected response type: %T`, response)
@@ -1615,6 +1755,7 @@ func encodeListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesResponse(resp
 	case *IoK8sAPIAutoscalingV1HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1626,6 +1767,7 @@ func encodeListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesResponse(resp
 		return nil
 	case *ListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1637,6 +1779,7 @@ func encodeListAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response L
 	case *IoK8sAPIAutoscalingV1HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1648,6 +1791,7 @@ func encodeListAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response L
 		return nil
 	case *ListAutoscalingV1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1659,6 +1803,7 @@ func encodeListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesResponse
 	case *IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1670,6 +1815,7 @@ func encodeListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesResponse
 		return nil
 	case *ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1681,6 +1827,7 @@ func encodeListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(respo
 	case *IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1692,6 +1839,7 @@ func encodeListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(respo
 		return nil
 	case *ListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1703,6 +1851,7 @@ func encodeListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesResponse
 	case *IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1714,6 +1863,7 @@ func encodeListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesResponse
 		return nil
 	case *ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1725,6 +1875,7 @@ func encodeListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(respo
 	case *IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscalerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1736,6 +1887,7 @@ func encodeListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(respo
 		return nil
 	case *ListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -1747,6 +1899,7 @@ func encodeListBatchV1CronJobForAllNamespacesResponse(response ListBatchV1CronJo
 	case *IoK8sAPIBatchV1CronJobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1758,6 +1911,7 @@ func encodeListBatchV1CronJobForAllNamespacesResponse(response ListBatchV1CronJo
 		return nil
 	case *ListBatchV1CronJobForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/cronjobs"+`: unexpected response type: %T`, response)
@@ -1769,6 +1923,7 @@ func encodeListBatchV1JobForAllNamespacesResponse(response ListBatchV1JobForAllN
 	case *IoK8sAPIBatchV1JobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1780,6 +1935,7 @@ func encodeListBatchV1JobForAllNamespacesResponse(response ListBatchV1JobForAllN
 		return nil
 	case *ListBatchV1JobForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/jobs"+`: unexpected response type: %T`, response)
@@ -1791,6 +1947,7 @@ func encodeListBatchV1NamespacedCronJobResponse(response ListBatchV1NamespacedCr
 	case *IoK8sAPIBatchV1CronJobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1802,6 +1959,7 @@ func encodeListBatchV1NamespacedCronJobResponse(response ListBatchV1NamespacedCr
 		return nil
 	case *ListBatchV1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/cronjobs"+`: unexpected response type: %T`, response)
@@ -1813,6 +1971,7 @@ func encodeListBatchV1NamespacedJobResponse(response ListBatchV1NamespacedJobRes
 	case *IoK8sAPIBatchV1JobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1824,6 +1983,7 @@ func encodeListBatchV1NamespacedJobResponse(response ListBatchV1NamespacedJobRes
 		return nil
 	case *ListBatchV1NamespacedJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/jobs"+`: unexpected response type: %T`, response)
@@ -1835,6 +1995,7 @@ func encodeListBatchV1beta1CronJobForAllNamespacesResponse(response ListBatchV1b
 	case *IoK8sAPIBatchV1beta1CronJobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1846,6 +2007,7 @@ func encodeListBatchV1beta1CronJobForAllNamespacesResponse(response ListBatchV1b
 		return nil
 	case *ListBatchV1beta1CronJobForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/cronjobs"+`: unexpected response type: %T`, response)
@@ -1857,6 +2019,7 @@ func encodeListBatchV1beta1NamespacedCronJobResponse(response ListBatchV1beta1Na
 	case *IoK8sAPIBatchV1beta1CronJobList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1868,6 +2031,7 @@ func encodeListBatchV1beta1NamespacedCronJobResponse(response ListBatchV1beta1Na
 		return nil
 	case *ListBatchV1beta1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs"+`: unexpected response type: %T`, response)
@@ -1879,6 +2043,7 @@ func encodeListCertificatesV1CertificateSigningRequestResponse(response ListCert
 	case *IoK8sAPICertificatesV1CertificateSigningRequestList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1890,6 +2055,7 @@ func encodeListCertificatesV1CertificateSigningRequestResponse(response ListCert
 		return nil
 	case *ListCertificatesV1CertificateSigningRequestUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/certificatesigningrequests"+`: unexpected response type: %T`, response)
@@ -1901,6 +2067,7 @@ func encodeListCoordinationV1LeaseForAllNamespacesResponse(response ListCoordina
 	case *IoK8sAPICoordinationV1LeaseList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1912,6 +2079,7 @@ func encodeListCoordinationV1LeaseForAllNamespacesResponse(response ListCoordina
 		return nil
 	case *ListCoordinationV1LeaseForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/leases"+`: unexpected response type: %T`, response)
@@ -1923,6 +2091,7 @@ func encodeListCoordinationV1NamespacedLeaseResponse(response ListCoordinationV1
 	case *IoK8sAPICoordinationV1LeaseList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1934,6 +2103,7 @@ func encodeListCoordinationV1NamespacedLeaseResponse(response ListCoordinationV1
 		return nil
 	case *ListCoordinationV1NamespacedLeaseUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/namespaces/{namespace}/leases"+`: unexpected response type: %T`, response)
@@ -1945,6 +2115,7 @@ func encodeListCoreV1ComponentStatusResponse(response ListCoreV1ComponentStatusR
 	case *IoK8sAPICoreV1ComponentStatusList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1956,6 +2127,7 @@ func encodeListCoreV1ComponentStatusResponse(response ListCoreV1ComponentStatusR
 		return nil
 	case *ListCoreV1ComponentStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/componentstatuses"+`: unexpected response type: %T`, response)
@@ -1967,6 +2139,7 @@ func encodeListCoreV1ConfigMapForAllNamespacesResponse(response ListCoreV1Config
 	case *IoK8sAPICoreV1ConfigMapList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -1978,6 +2151,7 @@ func encodeListCoreV1ConfigMapForAllNamespacesResponse(response ListCoreV1Config
 		return nil
 	case *ListCoreV1ConfigMapForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/configmaps"+`: unexpected response type: %T`, response)
@@ -1989,6 +2163,7 @@ func encodeListCoreV1EndpointsForAllNamespacesResponse(response ListCoreV1Endpoi
 	case *IoK8sAPICoreV1EndpointsList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2000,6 +2175,7 @@ func encodeListCoreV1EndpointsForAllNamespacesResponse(response ListCoreV1Endpoi
 		return nil
 	case *ListCoreV1EndpointsForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/endpoints"+`: unexpected response type: %T`, response)
@@ -2011,6 +2187,7 @@ func encodeListCoreV1EventForAllNamespacesResponse(response ListCoreV1EventForAl
 	case *IoK8sAPICoreV1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2022,6 +2199,7 @@ func encodeListCoreV1EventForAllNamespacesResponse(response ListCoreV1EventForAl
 		return nil
 	case *ListCoreV1EventForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/events"+`: unexpected response type: %T`, response)
@@ -2033,6 +2211,7 @@ func encodeListCoreV1LimitRangeForAllNamespacesResponse(response ListCoreV1Limit
 	case *IoK8sAPICoreV1LimitRangeList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2044,6 +2223,7 @@ func encodeListCoreV1LimitRangeForAllNamespacesResponse(response ListCoreV1Limit
 		return nil
 	case *ListCoreV1LimitRangeForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/limitranges"+`: unexpected response type: %T`, response)
@@ -2055,6 +2235,7 @@ func encodeListCoreV1NamespaceResponse(response ListCoreV1NamespaceRes, w http.R
 	case *IoK8sAPICoreV1NamespaceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2066,6 +2247,7 @@ func encodeListCoreV1NamespaceResponse(response ListCoreV1NamespaceRes, w http.R
 		return nil
 	case *ListCoreV1NamespaceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces"+`: unexpected response type: %T`, response)
@@ -2077,6 +2259,7 @@ func encodeListCoreV1NamespacedConfigMapResponse(response ListCoreV1NamespacedCo
 	case *IoK8sAPICoreV1ConfigMapList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2088,6 +2271,7 @@ func encodeListCoreV1NamespacedConfigMapResponse(response ListCoreV1NamespacedCo
 		return nil
 	case *ListCoreV1NamespacedConfigMapUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/configmaps"+`: unexpected response type: %T`, response)
@@ -2099,6 +2283,7 @@ func encodeListCoreV1NamespacedEndpointsResponse(response ListCoreV1NamespacedEn
 	case *IoK8sAPICoreV1EndpointsList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2110,6 +2295,7 @@ func encodeListCoreV1NamespacedEndpointsResponse(response ListCoreV1NamespacedEn
 		return nil
 	case *ListCoreV1NamespacedEndpointsUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/endpoints"+`: unexpected response type: %T`, response)
@@ -2121,6 +2307,7 @@ func encodeListCoreV1NamespacedEventResponse(response ListCoreV1NamespacedEventR
 	case *IoK8sAPICoreV1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2132,6 +2319,7 @@ func encodeListCoreV1NamespacedEventResponse(response ListCoreV1NamespacedEventR
 		return nil
 	case *ListCoreV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -2143,6 +2331,7 @@ func encodeListCoreV1NamespacedLimitRangeResponse(response ListCoreV1NamespacedL
 	case *IoK8sAPICoreV1LimitRangeList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2154,6 +2343,7 @@ func encodeListCoreV1NamespacedLimitRangeResponse(response ListCoreV1NamespacedL
 		return nil
 	case *ListCoreV1NamespacedLimitRangeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/limitranges"+`: unexpected response type: %T`, response)
@@ -2165,6 +2355,7 @@ func encodeListCoreV1NamespacedPersistentVolumeClaimResponse(response ListCoreV1
 	case *IoK8sAPICoreV1PersistentVolumeClaimList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2176,6 +2367,7 @@ func encodeListCoreV1NamespacedPersistentVolumeClaimResponse(response ListCoreV1
 		return nil
 	case *ListCoreV1NamespacedPersistentVolumeClaimUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/persistentvolumeclaims"+`: unexpected response type: %T`, response)
@@ -2187,6 +2379,7 @@ func encodeListCoreV1NamespacedPodResponse(response ListCoreV1NamespacedPodRes, 
 	case *IoK8sAPICoreV1PodList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2198,6 +2391,7 @@ func encodeListCoreV1NamespacedPodResponse(response ListCoreV1NamespacedPodRes, 
 		return nil
 	case *ListCoreV1NamespacedPodUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/pods"+`: unexpected response type: %T`, response)
@@ -2209,6 +2403,7 @@ func encodeListCoreV1NamespacedPodTemplateResponse(response ListCoreV1Namespaced
 	case *IoK8sAPICoreV1PodTemplateList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2220,6 +2415,7 @@ func encodeListCoreV1NamespacedPodTemplateResponse(response ListCoreV1Namespaced
 		return nil
 	case *ListCoreV1NamespacedPodTemplateUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/podtemplates"+`: unexpected response type: %T`, response)
@@ -2231,6 +2427,7 @@ func encodeListCoreV1NamespacedReplicationControllerResponse(response ListCoreV1
 	case *IoK8sAPICoreV1ReplicationControllerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2242,6 +2439,7 @@ func encodeListCoreV1NamespacedReplicationControllerResponse(response ListCoreV1
 		return nil
 	case *ListCoreV1NamespacedReplicationControllerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/replicationcontrollers"+`: unexpected response type: %T`, response)
@@ -2253,6 +2451,7 @@ func encodeListCoreV1NamespacedResourceQuotaResponse(response ListCoreV1Namespac
 	case *IoK8sAPICoreV1ResourceQuotaList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2264,6 +2463,7 @@ func encodeListCoreV1NamespacedResourceQuotaResponse(response ListCoreV1Namespac
 		return nil
 	case *ListCoreV1NamespacedResourceQuotaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/resourcequotas"+`: unexpected response type: %T`, response)
@@ -2275,6 +2475,7 @@ func encodeListCoreV1NamespacedSecretResponse(response ListCoreV1NamespacedSecre
 	case *IoK8sAPICoreV1SecretList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2286,6 +2487,7 @@ func encodeListCoreV1NamespacedSecretResponse(response ListCoreV1NamespacedSecre
 		return nil
 	case *ListCoreV1NamespacedSecretUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/secrets"+`: unexpected response type: %T`, response)
@@ -2297,6 +2499,7 @@ func encodeListCoreV1NamespacedServiceResponse(response ListCoreV1NamespacedServ
 	case *IoK8sAPICoreV1ServiceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2308,6 +2511,7 @@ func encodeListCoreV1NamespacedServiceResponse(response ListCoreV1NamespacedServ
 		return nil
 	case *ListCoreV1NamespacedServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/services"+`: unexpected response type: %T`, response)
@@ -2319,6 +2523,7 @@ func encodeListCoreV1NamespacedServiceAccountResponse(response ListCoreV1Namespa
 	case *IoK8sAPICoreV1ServiceAccountList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2330,6 +2535,7 @@ func encodeListCoreV1NamespacedServiceAccountResponse(response ListCoreV1Namespa
 		return nil
 	case *ListCoreV1NamespacedServiceAccountUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/serviceaccounts"+`: unexpected response type: %T`, response)
@@ -2341,6 +2547,7 @@ func encodeListCoreV1NodeResponse(response ListCoreV1NodeRes, w http.ResponseWri
 	case *IoK8sAPICoreV1NodeList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2352,6 +2559,7 @@ func encodeListCoreV1NodeResponse(response ListCoreV1NodeRes, w http.ResponseWri
 		return nil
 	case *ListCoreV1NodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/nodes"+`: unexpected response type: %T`, response)
@@ -2363,6 +2571,7 @@ func encodeListCoreV1PersistentVolumeResponse(response ListCoreV1PersistentVolum
 	case *IoK8sAPICoreV1PersistentVolumeList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2374,6 +2583,7 @@ func encodeListCoreV1PersistentVolumeResponse(response ListCoreV1PersistentVolum
 		return nil
 	case *ListCoreV1PersistentVolumeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/persistentvolumes"+`: unexpected response type: %T`, response)
@@ -2385,6 +2595,7 @@ func encodeListCoreV1PersistentVolumeClaimForAllNamespacesResponse(response List
 	case *IoK8sAPICoreV1PersistentVolumeClaimList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2396,6 +2607,7 @@ func encodeListCoreV1PersistentVolumeClaimForAllNamespacesResponse(response List
 		return nil
 	case *ListCoreV1PersistentVolumeClaimForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/persistentvolumeclaims"+`: unexpected response type: %T`, response)
@@ -2407,6 +2619,7 @@ func encodeListCoreV1PodForAllNamespacesResponse(response ListCoreV1PodForAllNam
 	case *IoK8sAPICoreV1PodList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2418,6 +2631,7 @@ func encodeListCoreV1PodForAllNamespacesResponse(response ListCoreV1PodForAllNam
 		return nil
 	case *ListCoreV1PodForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/pods"+`: unexpected response type: %T`, response)
@@ -2429,6 +2643,7 @@ func encodeListCoreV1PodTemplateForAllNamespacesResponse(response ListCoreV1PodT
 	case *IoK8sAPICoreV1PodTemplateList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2440,6 +2655,7 @@ func encodeListCoreV1PodTemplateForAllNamespacesResponse(response ListCoreV1PodT
 		return nil
 	case *ListCoreV1PodTemplateForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/podtemplates"+`: unexpected response type: %T`, response)
@@ -2451,6 +2667,7 @@ func encodeListCoreV1ReplicationControllerForAllNamespacesResponse(response List
 	case *IoK8sAPICoreV1ReplicationControllerList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2462,6 +2679,7 @@ func encodeListCoreV1ReplicationControllerForAllNamespacesResponse(response List
 		return nil
 	case *ListCoreV1ReplicationControllerForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/replicationcontrollers"+`: unexpected response type: %T`, response)
@@ -2473,6 +2691,7 @@ func encodeListCoreV1ResourceQuotaForAllNamespacesResponse(response ListCoreV1Re
 	case *IoK8sAPICoreV1ResourceQuotaList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2484,6 +2703,7 @@ func encodeListCoreV1ResourceQuotaForAllNamespacesResponse(response ListCoreV1Re
 		return nil
 	case *ListCoreV1ResourceQuotaForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/resourcequotas"+`: unexpected response type: %T`, response)
@@ -2495,6 +2715,7 @@ func encodeListCoreV1SecretForAllNamespacesResponse(response ListCoreV1SecretFor
 	case *IoK8sAPICoreV1SecretList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2506,6 +2727,7 @@ func encodeListCoreV1SecretForAllNamespacesResponse(response ListCoreV1SecretFor
 		return nil
 	case *ListCoreV1SecretForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/secrets"+`: unexpected response type: %T`, response)
@@ -2517,6 +2739,7 @@ func encodeListCoreV1ServiceAccountForAllNamespacesResponse(response ListCoreV1S
 	case *IoK8sAPICoreV1ServiceAccountList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2528,6 +2751,7 @@ func encodeListCoreV1ServiceAccountForAllNamespacesResponse(response ListCoreV1S
 		return nil
 	case *ListCoreV1ServiceAccountForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/serviceaccounts"+`: unexpected response type: %T`, response)
@@ -2539,6 +2763,7 @@ func encodeListCoreV1ServiceForAllNamespacesResponse(response ListCoreV1ServiceF
 	case *IoK8sAPICoreV1ServiceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2550,6 +2775,7 @@ func encodeListCoreV1ServiceForAllNamespacesResponse(response ListCoreV1ServiceF
 		return nil
 	case *ListCoreV1ServiceForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/services"+`: unexpected response type: %T`, response)
@@ -2561,6 +2787,7 @@ func encodeListDiscoveryV1EndpointSliceForAllNamespacesResponse(response ListDis
 	case *IoK8sAPIDiscoveryV1EndpointSliceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2572,6 +2799,7 @@ func encodeListDiscoveryV1EndpointSliceForAllNamespacesResponse(response ListDis
 		return nil
 	case *ListDiscoveryV1EndpointSliceForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/endpointslices"+`: unexpected response type: %T`, response)
@@ -2583,6 +2811,7 @@ func encodeListDiscoveryV1NamespacedEndpointSliceResponse(response ListDiscovery
 	case *IoK8sAPIDiscoveryV1EndpointSliceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2594,6 +2823,7 @@ func encodeListDiscoveryV1NamespacedEndpointSliceResponse(response ListDiscovery
 		return nil
 	case *ListDiscoveryV1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/namespaces/{namespace}/endpointslices"+`: unexpected response type: %T`, response)
@@ -2605,6 +2835,7 @@ func encodeListDiscoveryV1beta1EndpointSliceForAllNamespacesResponse(response Li
 	case *IoK8sAPIDiscoveryV1beta1EndpointSliceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2616,6 +2847,7 @@ func encodeListDiscoveryV1beta1EndpointSliceForAllNamespacesResponse(response Li
 		return nil
 	case *ListDiscoveryV1beta1EndpointSliceForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/endpointslices"+`: unexpected response type: %T`, response)
@@ -2627,6 +2859,7 @@ func encodeListDiscoveryV1beta1NamespacedEndpointSliceResponse(response ListDisc
 	case *IoK8sAPIDiscoveryV1beta1EndpointSliceList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2638,6 +2871,7 @@ func encodeListDiscoveryV1beta1NamespacedEndpointSliceResponse(response ListDisc
 		return nil
 	case *ListDiscoveryV1beta1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices"+`: unexpected response type: %T`, response)
@@ -2649,6 +2883,7 @@ func encodeListEventsV1EventForAllNamespacesResponse(response ListEventsV1EventF
 	case *IoK8sAPIEventsV1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2660,6 +2895,7 @@ func encodeListEventsV1EventForAllNamespacesResponse(response ListEventsV1EventF
 		return nil
 	case *ListEventsV1EventForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/events"+`: unexpected response type: %T`, response)
@@ -2671,6 +2907,7 @@ func encodeListEventsV1NamespacedEventResponse(response ListEventsV1NamespacedEv
 	case *IoK8sAPIEventsV1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2682,6 +2919,7 @@ func encodeListEventsV1NamespacedEventResponse(response ListEventsV1NamespacedEv
 		return nil
 	case *ListEventsV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -2693,6 +2931,7 @@ func encodeListEventsV1beta1EventForAllNamespacesResponse(response ListEventsV1b
 	case *IoK8sAPIEventsV1beta1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2704,6 +2943,7 @@ func encodeListEventsV1beta1EventForAllNamespacesResponse(response ListEventsV1b
 		return nil
 	case *ListEventsV1beta1EventForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/events"+`: unexpected response type: %T`, response)
@@ -2715,6 +2955,7 @@ func encodeListEventsV1beta1NamespacedEventResponse(response ListEventsV1beta1Na
 	case *IoK8sAPIEventsV1beta1EventList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2726,6 +2967,7 @@ func encodeListEventsV1beta1NamespacedEventResponse(response ListEventsV1beta1Na
 		return nil
 	case *ListEventsV1beta1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -2737,6 +2979,7 @@ func encodeListFlowcontrolApiserverV1beta1FlowSchemaResponse(response ListFlowco
 	case *IoK8sAPIFlowcontrolV1beta1FlowSchemaList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2748,6 +2991,7 @@ func encodeListFlowcontrolApiserverV1beta1FlowSchemaResponse(response ListFlowco
 		return nil
 	case *ListFlowcontrolApiserverV1beta1FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas"+`: unexpected response type: %T`, response)
@@ -2759,6 +3003,7 @@ func encodeListFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(res
 	case *IoK8sAPIFlowcontrolV1beta1PriorityLevelConfigurationList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2770,6 +3015,7 @@ func encodeListFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(res
 		return nil
 	case *ListFlowcontrolApiserverV1beta1PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations"+`: unexpected response type: %T`, response)
@@ -2781,6 +3027,7 @@ func encodeListFlowcontrolApiserverV1beta2FlowSchemaResponse(response ListFlowco
 	case *IoK8sAPIFlowcontrolV1beta2FlowSchemaList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2792,6 +3039,7 @@ func encodeListFlowcontrolApiserverV1beta2FlowSchemaResponse(response ListFlowco
 		return nil
 	case *ListFlowcontrolApiserverV1beta2FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas"+`: unexpected response type: %T`, response)
@@ -2803,6 +3051,7 @@ func encodeListFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(res
 	case *IoK8sAPIFlowcontrolV1beta2PriorityLevelConfigurationList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2814,6 +3063,7 @@ func encodeListFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(res
 		return nil
 	case *ListFlowcontrolApiserverV1beta2PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations"+`: unexpected response type: %T`, response)
@@ -2825,6 +3075,7 @@ func encodeListInternalApiserverV1alpha1StorageVersionResponse(response ListInte
 	case *IoK8sAPIApiserverinternalV1alpha1StorageVersionList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2836,6 +3087,7 @@ func encodeListInternalApiserverV1alpha1StorageVersionResponse(response ListInte
 		return nil
 	case *ListInternalApiserverV1alpha1StorageVersionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions"+`: unexpected response type: %T`, response)
@@ -2847,6 +3099,7 @@ func encodeListNetworkingV1IngressClassResponse(response ListNetworkingV1Ingress
 	case *IoK8sAPINetworkingV1IngressClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2858,6 +3111,7 @@ func encodeListNetworkingV1IngressClassResponse(response ListNetworkingV1Ingress
 		return nil
 	case *ListNetworkingV1IngressClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/ingressclasses"+`: unexpected response type: %T`, response)
@@ -2869,6 +3123,7 @@ func encodeListNetworkingV1IngressForAllNamespacesResponse(response ListNetworki
 	case *IoK8sAPINetworkingV1IngressList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2880,6 +3135,7 @@ func encodeListNetworkingV1IngressForAllNamespacesResponse(response ListNetworki
 		return nil
 	case *ListNetworkingV1IngressForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/ingresses"+`: unexpected response type: %T`, response)
@@ -2891,6 +3147,7 @@ func encodeListNetworkingV1NamespacedIngressResponse(response ListNetworkingV1Na
 	case *IoK8sAPINetworkingV1IngressList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2902,6 +3159,7 @@ func encodeListNetworkingV1NamespacedIngressResponse(response ListNetworkingV1Na
 		return nil
 	case *ListNetworkingV1NamespacedIngressUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses"+`: unexpected response type: %T`, response)
@@ -2913,6 +3171,7 @@ func encodeListNetworkingV1NamespacedNetworkPolicyResponse(response ListNetworki
 	case *IoK8sAPINetworkingV1NetworkPolicyList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2924,6 +3183,7 @@ func encodeListNetworkingV1NamespacedNetworkPolicyResponse(response ListNetworki
 		return nil
 	case *ListNetworkingV1NamespacedNetworkPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies"+`: unexpected response type: %T`, response)
@@ -2935,6 +3195,7 @@ func encodeListNetworkingV1NetworkPolicyForAllNamespacesResponse(response ListNe
 	case *IoK8sAPINetworkingV1NetworkPolicyList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2946,6 +3207,7 @@ func encodeListNetworkingV1NetworkPolicyForAllNamespacesResponse(response ListNe
 		return nil
 	case *ListNetworkingV1NetworkPolicyForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/networkpolicies"+`: unexpected response type: %T`, response)
@@ -2957,6 +3219,7 @@ func encodeListNodeV1RuntimeClassResponse(response ListNodeV1RuntimeClassRes, w 
 	case *IoK8sAPINodeV1RuntimeClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2968,6 +3231,7 @@ func encodeListNodeV1RuntimeClassResponse(response ListNodeV1RuntimeClassRes, w 
 		return nil
 	case *ListNodeV1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -2979,6 +3243,7 @@ func encodeListNodeV1alpha1RuntimeClassResponse(response ListNodeV1alpha1Runtime
 	case *IoK8sAPINodeV1alpha1RuntimeClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -2990,6 +3255,7 @@ func encodeListNodeV1alpha1RuntimeClassResponse(response ListNodeV1alpha1Runtime
 		return nil
 	case *ListNodeV1alpha1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1alpha1/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -3001,6 +3267,7 @@ func encodeListNodeV1beta1RuntimeClassResponse(response ListNodeV1beta1RuntimeCl
 	case *IoK8sAPINodeV1beta1RuntimeClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3012,6 +3279,7 @@ func encodeListNodeV1beta1RuntimeClassResponse(response ListNodeV1beta1RuntimeCl
 		return nil
 	case *ListNodeV1beta1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1beta1/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -3023,6 +3291,7 @@ func encodeListPolicyV1NamespacedPodDisruptionBudgetResponse(response ListPolicy
 	case *IoK8sAPIPolicyV1PodDisruptionBudgetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3034,6 +3303,7 @@ func encodeListPolicyV1NamespacedPodDisruptionBudgetResponse(response ListPolicy
 		return nil
 	case *ListPolicyV1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -3045,6 +3315,7 @@ func encodeListPolicyV1PodDisruptionBudgetForAllNamespacesResponse(response List
 	case *IoK8sAPIPolicyV1PodDisruptionBudgetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3056,6 +3327,7 @@ func encodeListPolicyV1PodDisruptionBudgetForAllNamespacesResponse(response List
 		return nil
 	case *ListPolicyV1PodDisruptionBudgetForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -3067,6 +3339,7 @@ func encodeListPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response ListP
 	case *IoK8sAPIPolicyV1beta1PodDisruptionBudgetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3078,6 +3351,7 @@ func encodeListPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response ListP
 		return nil
 	case *ListPolicyV1beta1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -3089,6 +3363,7 @@ func encodeListPolicyV1beta1PodDisruptionBudgetForAllNamespacesResponse(response
 	case *IoK8sAPIPolicyV1beta1PodDisruptionBudgetList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3100,6 +3375,7 @@ func encodeListPolicyV1beta1PodDisruptionBudgetForAllNamespacesResponse(response
 		return nil
 	case *ListPolicyV1beta1PodDisruptionBudgetForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -3111,6 +3387,7 @@ func encodeListPolicyV1beta1PodSecurityPolicyResponse(response ListPolicyV1beta1
 	case *IoK8sAPIPolicyV1beta1PodSecurityPolicyList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3122,6 +3399,7 @@ func encodeListPolicyV1beta1PodSecurityPolicyResponse(response ListPolicyV1beta1
 		return nil
 	case *ListPolicyV1beta1PodSecurityPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/podsecuritypolicies"+`: unexpected response type: %T`, response)
@@ -3133,6 +3411,7 @@ func encodeListRbacAuthorizationV1ClusterRoleResponse(response ListRbacAuthoriza
 	case *IoK8sAPIRbacV1ClusterRoleList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3144,6 +3423,7 @@ func encodeListRbacAuthorizationV1ClusterRoleResponse(response ListRbacAuthoriza
 		return nil
 	case *ListRbacAuthorizationV1ClusterRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/clusterroles"+`: unexpected response type: %T`, response)
@@ -3155,6 +3435,7 @@ func encodeListRbacAuthorizationV1ClusterRoleBindingResponse(response ListRbacAu
 	case *IoK8sAPIRbacV1ClusterRoleBindingList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3166,6 +3447,7 @@ func encodeListRbacAuthorizationV1ClusterRoleBindingResponse(response ListRbacAu
 		return nil
 	case *ListRbacAuthorizationV1ClusterRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings"+`: unexpected response type: %T`, response)
@@ -3177,6 +3459,7 @@ func encodeListRbacAuthorizationV1NamespacedRoleResponse(response ListRbacAuthor
 	case *IoK8sAPIRbacV1RoleList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3188,6 +3471,7 @@ func encodeListRbacAuthorizationV1NamespacedRoleResponse(response ListRbacAuthor
 		return nil
 	case *ListRbacAuthorizationV1NamespacedRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles"+`: unexpected response type: %T`, response)
@@ -3199,6 +3483,7 @@ func encodeListRbacAuthorizationV1NamespacedRoleBindingResponse(response ListRba
 	case *IoK8sAPIRbacV1RoleBindingList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3210,6 +3495,7 @@ func encodeListRbacAuthorizationV1NamespacedRoleBindingResponse(response ListRba
 		return nil
 	case *ListRbacAuthorizationV1NamespacedRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings"+`: unexpected response type: %T`, response)
@@ -3221,6 +3507,7 @@ func encodeListRbacAuthorizationV1RoleBindingForAllNamespacesResponse(response L
 	case *IoK8sAPIRbacV1RoleBindingList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3232,6 +3519,7 @@ func encodeListRbacAuthorizationV1RoleBindingForAllNamespacesResponse(response L
 		return nil
 	case *ListRbacAuthorizationV1RoleBindingForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/rolebindings"+`: unexpected response type: %T`, response)
@@ -3243,6 +3531,7 @@ func encodeListRbacAuthorizationV1RoleForAllNamespacesResponse(response ListRbac
 	case *IoK8sAPIRbacV1RoleList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3254,6 +3543,7 @@ func encodeListRbacAuthorizationV1RoleForAllNamespacesResponse(response ListRbac
 		return nil
 	case *ListRbacAuthorizationV1RoleForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/roles"+`: unexpected response type: %T`, response)
@@ -3265,6 +3555,7 @@ func encodeListSchedulingV1PriorityClassResponse(response ListSchedulingV1Priori
 	case *IoK8sAPISchedulingV1PriorityClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3276,6 +3567,7 @@ func encodeListSchedulingV1PriorityClassResponse(response ListSchedulingV1Priori
 		return nil
 	case *ListSchedulingV1PriorityClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/v1/priorityclasses"+`: unexpected response type: %T`, response)
@@ -3287,6 +3579,7 @@ func encodeListStorageV1CSIDriverResponse(response ListStorageV1CSIDriverRes, w 
 	case *IoK8sAPIStorageV1CSIDriverList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3298,6 +3591,7 @@ func encodeListStorageV1CSIDriverResponse(response ListStorageV1CSIDriverRes, w 
 		return nil
 	case *ListStorageV1CSIDriverUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/csidrivers"+`: unexpected response type: %T`, response)
@@ -3309,6 +3603,7 @@ func encodeListStorageV1CSINodeResponse(response ListStorageV1CSINodeRes, w http
 	case *IoK8sAPIStorageV1CSINodeList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3320,6 +3615,7 @@ func encodeListStorageV1CSINodeResponse(response ListStorageV1CSINodeRes, w http
 		return nil
 	case *ListStorageV1CSINodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/csinodes"+`: unexpected response type: %T`, response)
@@ -3331,6 +3627,7 @@ func encodeListStorageV1StorageClassResponse(response ListStorageV1StorageClassR
 	case *IoK8sAPIStorageV1StorageClassList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3342,6 +3639,7 @@ func encodeListStorageV1StorageClassResponse(response ListStorageV1StorageClassR
 		return nil
 	case *ListStorageV1StorageClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/storageclasses"+`: unexpected response type: %T`, response)
@@ -3353,6 +3651,7 @@ func encodeListStorageV1VolumeAttachmentResponse(response ListStorageV1VolumeAtt
 	case *IoK8sAPIStorageV1VolumeAttachmentList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3364,6 +3663,7 @@ func encodeListStorageV1VolumeAttachmentResponse(response ListStorageV1VolumeAtt
 		return nil
 	case *ListStorageV1VolumeAttachmentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/volumeattachments"+`: unexpected response type: %T`, response)
@@ -3375,6 +3675,7 @@ func encodeListStorageV1alpha1CSIStorageCapacityForAllNamespacesResponse(respons
 	case *IoK8sAPIStorageV1alpha1CSIStorageCapacityList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3386,6 +3687,7 @@ func encodeListStorageV1alpha1CSIStorageCapacityForAllNamespacesResponse(respons
 		return nil
 	case *ListStorageV1alpha1CSIStorageCapacityForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -3397,6 +3699,7 @@ func encodeListStorageV1alpha1NamespacedCSIStorageCapacityResponse(response List
 	case *IoK8sAPIStorageV1alpha1CSIStorageCapacityList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3408,6 +3711,7 @@ func encodeListStorageV1alpha1NamespacedCSIStorageCapacityResponse(response List
 		return nil
 	case *ListStorageV1alpha1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/namespaces/{namespace}/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -3419,6 +3723,7 @@ func encodeListStorageV1beta1CSIStorageCapacityForAllNamespacesResponse(response
 	case *IoK8sAPIStorageV1beta1CSIStorageCapacityList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3430,6 +3735,7 @@ func encodeListStorageV1beta1CSIStorageCapacityForAllNamespacesResponse(response
 		return nil
 	case *ListStorageV1beta1CSIStorageCapacityForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -3441,6 +3747,7 @@ func encodeListStorageV1beta1NamespacedCSIStorageCapacityResponse(response ListS
 	case *IoK8sAPIStorageV1beta1CSIStorageCapacityList:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3452,6 +3759,7 @@ func encodeListStorageV1beta1NamespacedCSIStorageCapacityResponse(response ListS
 		return nil
 	case *ListStorageV1beta1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/namespaces/{namespace}/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -3460,11 +3768,13 @@ func encodeListStorageV1beta1NamespacedCSIStorageCapacityResponse(response ListS
 
 func encodeLogFileHandlerResponse(response LogFileHandlerUnauthorized, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(401)
+	span.SetStatus(codes.Error, http.StatusText(401))
 	return nil
 }
 
 func encodeLogFileListHandlerResponse(response LogFileListHandlerUnauthorized, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(401)
+	span.SetStatus(codes.Error, http.StatusText(401))
 	return nil
 }
 
@@ -3473,6 +3783,7 @@ func encodeReadAdmissionregistrationV1MutatingWebhookConfigurationResponse(respo
 	case *IoK8sAPIAdmissionregistrationV1MutatingWebhookConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3484,6 +3795,7 @@ func encodeReadAdmissionregistrationV1MutatingWebhookConfigurationResponse(respo
 		return nil
 	case *ReadAdmissionregistrationV1MutatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -3495,6 +3807,7 @@ func encodeReadAdmissionregistrationV1ValidatingWebhookConfigurationResponse(res
 	case *IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3506,6 +3819,7 @@ func encodeReadAdmissionregistrationV1ValidatingWebhookConfigurationResponse(res
 		return nil
 	case *ReadAdmissionregistrationV1ValidatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -3517,6 +3831,7 @@ func encodeReadApiextensionsV1CustomResourceDefinitionResponse(response ReadApie
 	case *IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinition:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3528,6 +3843,7 @@ func encodeReadApiextensionsV1CustomResourceDefinitionResponse(response ReadApie
 		return nil
 	case *ReadApiextensionsV1CustomResourceDefinitionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}"+`: unexpected response type: %T`, response)
@@ -3539,6 +3855,7 @@ func encodeReadApiextensionsV1CustomResourceDefinitionStatusResponse(response Re
 	case *IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinition:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3550,6 +3867,7 @@ func encodeReadApiextensionsV1CustomResourceDefinitionStatusResponse(response Re
 		return nil
 	case *ReadApiextensionsV1CustomResourceDefinitionStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status"+`: unexpected response type: %T`, response)
@@ -3561,6 +3879,7 @@ func encodeReadApiregistrationV1APIServiceResponse(response ReadApiregistrationV
 	case *IoK8sKubeAggregatorPkgApisApiregistrationV1APIService:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3572,6 +3891,7 @@ func encodeReadApiregistrationV1APIServiceResponse(response ReadApiregistrationV
 		return nil
 	case *ReadApiregistrationV1APIServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/apiservices/{name}"+`: unexpected response type: %T`, response)
@@ -3583,6 +3903,7 @@ func encodeReadApiregistrationV1APIServiceStatusResponse(response ReadApiregistr
 	case *IoK8sKubeAggregatorPkgApisApiregistrationV1APIService:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3594,6 +3915,7 @@ func encodeReadApiregistrationV1APIServiceStatusResponse(response ReadApiregistr
 		return nil
 	case *ReadApiregistrationV1APIServiceStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/apiservices/{name}/status"+`: unexpected response type: %T`, response)
@@ -3605,6 +3927,7 @@ func encodeReadAppsV1NamespacedControllerRevisionResponse(response ReadAppsV1Nam
 	case *IoK8sAPIAppsV1ControllerRevision:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3616,6 +3939,7 @@ func encodeReadAppsV1NamespacedControllerRevisionResponse(response ReadAppsV1Nam
 		return nil
 	case *ReadAppsV1NamespacedControllerRevisionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}"+`: unexpected response type: %T`, response)
@@ -3627,6 +3951,7 @@ func encodeReadAppsV1NamespacedDaemonSetResponse(response ReadAppsV1NamespacedDa
 	case *IoK8sAPIAppsV1DaemonSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3638,6 +3963,7 @@ func encodeReadAppsV1NamespacedDaemonSetResponse(response ReadAppsV1NamespacedDa
 		return nil
 	case *ReadAppsV1NamespacedDaemonSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}"+`: unexpected response type: %T`, response)
@@ -3649,6 +3975,7 @@ func encodeReadAppsV1NamespacedDaemonSetStatusResponse(response ReadAppsV1Namesp
 	case *IoK8sAPIAppsV1DaemonSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3660,6 +3987,7 @@ func encodeReadAppsV1NamespacedDaemonSetStatusResponse(response ReadAppsV1Namesp
 		return nil
 	case *ReadAppsV1NamespacedDaemonSetStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status"+`: unexpected response type: %T`, response)
@@ -3671,6 +3999,7 @@ func encodeReadAppsV1NamespacedDeploymentResponse(response ReadAppsV1NamespacedD
 	case *IoK8sAPIAppsV1Deployment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3682,6 +4011,7 @@ func encodeReadAppsV1NamespacedDeploymentResponse(response ReadAppsV1NamespacedD
 		return nil
 	case *ReadAppsV1NamespacedDeploymentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/deployments/{name}"+`: unexpected response type: %T`, response)
@@ -3693,6 +4023,7 @@ func encodeReadAppsV1NamespacedDeploymentScaleResponse(response ReadAppsV1Namesp
 	case *IoK8sAPIAutoscalingV1Scale:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3704,6 +4035,7 @@ func encodeReadAppsV1NamespacedDeploymentScaleResponse(response ReadAppsV1Namesp
 		return nil
 	case *ReadAppsV1NamespacedDeploymentScaleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale"+`: unexpected response type: %T`, response)
@@ -3715,6 +4047,7 @@ func encodeReadAppsV1NamespacedDeploymentStatusResponse(response ReadAppsV1Names
 	case *IoK8sAPIAppsV1Deployment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3726,6 +4059,7 @@ func encodeReadAppsV1NamespacedDeploymentStatusResponse(response ReadAppsV1Names
 		return nil
 	case *ReadAppsV1NamespacedDeploymentStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status"+`: unexpected response type: %T`, response)
@@ -3737,6 +4071,7 @@ func encodeReadAppsV1NamespacedReplicaSetResponse(response ReadAppsV1NamespacedR
 	case *IoK8sAPIAppsV1ReplicaSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3748,6 +4083,7 @@ func encodeReadAppsV1NamespacedReplicaSetResponse(response ReadAppsV1NamespacedR
 		return nil
 	case *ReadAppsV1NamespacedReplicaSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}"+`: unexpected response type: %T`, response)
@@ -3759,6 +4095,7 @@ func encodeReadAppsV1NamespacedReplicaSetScaleResponse(response ReadAppsV1Namesp
 	case *IoK8sAPIAutoscalingV1Scale:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3770,6 +4107,7 @@ func encodeReadAppsV1NamespacedReplicaSetScaleResponse(response ReadAppsV1Namesp
 		return nil
 	case *ReadAppsV1NamespacedReplicaSetScaleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale"+`: unexpected response type: %T`, response)
@@ -3781,6 +4119,7 @@ func encodeReadAppsV1NamespacedReplicaSetStatusResponse(response ReadAppsV1Names
 	case *IoK8sAPIAppsV1ReplicaSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3792,6 +4131,7 @@ func encodeReadAppsV1NamespacedReplicaSetStatusResponse(response ReadAppsV1Names
 		return nil
 	case *ReadAppsV1NamespacedReplicaSetStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status"+`: unexpected response type: %T`, response)
@@ -3803,6 +4143,7 @@ func encodeReadAppsV1NamespacedStatefulSetResponse(response ReadAppsV1Namespaced
 	case *IoK8sAPIAppsV1StatefulSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3814,6 +4155,7 @@ func encodeReadAppsV1NamespacedStatefulSetResponse(response ReadAppsV1Namespaced
 		return nil
 	case *ReadAppsV1NamespacedStatefulSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}"+`: unexpected response type: %T`, response)
@@ -3825,6 +4167,7 @@ func encodeReadAppsV1NamespacedStatefulSetScaleResponse(response ReadAppsV1Names
 	case *IoK8sAPIAutoscalingV1Scale:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3836,6 +4179,7 @@ func encodeReadAppsV1NamespacedStatefulSetScaleResponse(response ReadAppsV1Names
 		return nil
 	case *ReadAppsV1NamespacedStatefulSetScaleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale"+`: unexpected response type: %T`, response)
@@ -3847,6 +4191,7 @@ func encodeReadAppsV1NamespacedStatefulSetStatusResponse(response ReadAppsV1Name
 	case *IoK8sAPIAppsV1StatefulSet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3858,6 +4203,7 @@ func encodeReadAppsV1NamespacedStatefulSetStatusResponse(response ReadAppsV1Name
 		return nil
 	case *ReadAppsV1NamespacedStatefulSetStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status"+`: unexpected response type: %T`, response)
@@ -3869,6 +4215,7 @@ func encodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response R
 	case *IoK8sAPIAutoscalingV1HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3880,6 +4227,7 @@ func encodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response R
 		return nil
 	case *ReadAutoscalingV1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -3891,6 +4239,7 @@ func encodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusResponse(resp
 	case *IoK8sAPIAutoscalingV1HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3902,6 +4251,7 @@ func encodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusResponse(resp
 		return nil
 	case *ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"+`: unexpected response type: %T`, response)
@@ -3913,6 +4263,7 @@ func encodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(respo
 	case *IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3924,6 +4275,7 @@ func encodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(respo
 		return nil
 	case *ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -3935,6 +4287,7 @@ func encodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusResponse
 	case *IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3946,6 +4299,7 @@ func encodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusResponse
 		return nil
 	case *ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"+`: unexpected response type: %T`, response)
@@ -3957,6 +4311,7 @@ func encodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(respo
 	case *IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3968,6 +4323,7 @@ func encodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(respo
 		return nil
 	case *ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -3979,6 +4335,7 @@ func encodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusResponse
 	case *IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscaler:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -3990,6 +4347,7 @@ func encodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusResponse
 		return nil
 	case *ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"+`: unexpected response type: %T`, response)
@@ -4001,6 +4359,7 @@ func encodeReadBatchV1NamespacedCronJobResponse(response ReadBatchV1NamespacedCr
 	case *IoK8sAPIBatchV1CronJob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4012,6 +4371,7 @@ func encodeReadBatchV1NamespacedCronJobResponse(response ReadBatchV1NamespacedCr
 		return nil
 	case *ReadBatchV1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/cronjobs/{name}"+`: unexpected response type: %T`, response)
@@ -4023,6 +4383,7 @@ func encodeReadBatchV1NamespacedCronJobStatusResponse(response ReadBatchV1Namesp
 	case *IoK8sAPIBatchV1CronJob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4034,6 +4395,7 @@ func encodeReadBatchV1NamespacedCronJobStatusResponse(response ReadBatchV1Namesp
 		return nil
 	case *ReadBatchV1NamespacedCronJobStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/cronjobs/{name}/status"+`: unexpected response type: %T`, response)
@@ -4045,6 +4407,7 @@ func encodeReadBatchV1NamespacedJobResponse(response ReadBatchV1NamespacedJobRes
 	case *IoK8sAPIBatchV1Job:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4056,6 +4419,7 @@ func encodeReadBatchV1NamespacedJobResponse(response ReadBatchV1NamespacedJobRes
 		return nil
 	case *ReadBatchV1NamespacedJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/jobs/{name}"+`: unexpected response type: %T`, response)
@@ -4067,6 +4431,7 @@ func encodeReadBatchV1NamespacedJobStatusResponse(response ReadBatchV1Namespaced
 	case *IoK8sAPIBatchV1Job:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4078,6 +4443,7 @@ func encodeReadBatchV1NamespacedJobStatusResponse(response ReadBatchV1Namespaced
 		return nil
 	case *ReadBatchV1NamespacedJobStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status"+`: unexpected response type: %T`, response)
@@ -4089,6 +4455,7 @@ func encodeReadBatchV1beta1NamespacedCronJobResponse(response ReadBatchV1beta1Na
 	case *IoK8sAPIBatchV1beta1CronJob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4100,6 +4467,7 @@ func encodeReadBatchV1beta1NamespacedCronJobResponse(response ReadBatchV1beta1Na
 		return nil
 	case *ReadBatchV1beta1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}"+`: unexpected response type: %T`, response)
@@ -4111,6 +4479,7 @@ func encodeReadBatchV1beta1NamespacedCronJobStatusResponse(response ReadBatchV1b
 	case *IoK8sAPIBatchV1beta1CronJob:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4122,6 +4491,7 @@ func encodeReadBatchV1beta1NamespacedCronJobStatusResponse(response ReadBatchV1b
 		return nil
 	case *ReadBatchV1beta1NamespacedCronJobStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status"+`: unexpected response type: %T`, response)
@@ -4133,6 +4503,7 @@ func encodeReadCertificatesV1CertificateSigningRequestResponse(response ReadCert
 	case *IoK8sAPICertificatesV1CertificateSigningRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4144,6 +4515,7 @@ func encodeReadCertificatesV1CertificateSigningRequestResponse(response ReadCert
 		return nil
 	case *ReadCertificatesV1CertificateSigningRequestUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}"+`: unexpected response type: %T`, response)
@@ -4155,6 +4527,7 @@ func encodeReadCertificatesV1CertificateSigningRequestApprovalResponse(response 
 	case *IoK8sAPICertificatesV1CertificateSigningRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4166,6 +4539,7 @@ func encodeReadCertificatesV1CertificateSigningRequestApprovalResponse(response 
 		return nil
 	case *ReadCertificatesV1CertificateSigningRequestApprovalUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/approval"+`: unexpected response type: %T`, response)
@@ -4177,6 +4551,7 @@ func encodeReadCertificatesV1CertificateSigningRequestStatusResponse(response Re
 	case *IoK8sAPICertificatesV1CertificateSigningRequest:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4188,6 +4563,7 @@ func encodeReadCertificatesV1CertificateSigningRequestStatusResponse(response Re
 		return nil
 	case *ReadCertificatesV1CertificateSigningRequestStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/status"+`: unexpected response type: %T`, response)
@@ -4199,6 +4575,7 @@ func encodeReadCoordinationV1NamespacedLeaseResponse(response ReadCoordinationV1
 	case *IoK8sAPICoordinationV1Lease:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4210,6 +4587,7 @@ func encodeReadCoordinationV1NamespacedLeaseResponse(response ReadCoordinationV1
 		return nil
 	case *ReadCoordinationV1NamespacedLeaseUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}"+`: unexpected response type: %T`, response)
@@ -4221,6 +4599,7 @@ func encodeReadCoreV1ComponentStatusResponse(response ReadCoreV1ComponentStatusR
 	case *IoK8sAPICoreV1ComponentStatus:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4232,6 +4611,7 @@ func encodeReadCoreV1ComponentStatusResponse(response ReadCoreV1ComponentStatusR
 		return nil
 	case *ReadCoreV1ComponentStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/componentstatuses/{name}"+`: unexpected response type: %T`, response)
@@ -4243,6 +4623,7 @@ func encodeReadCoreV1NamespaceResponse(response ReadCoreV1NamespaceRes, w http.R
 	case *IoK8sAPICoreV1Namespace:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4254,6 +4635,7 @@ func encodeReadCoreV1NamespaceResponse(response ReadCoreV1NamespaceRes, w http.R
 		return nil
 	case *ReadCoreV1NamespaceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{name}"+`: unexpected response type: %T`, response)
@@ -4265,6 +4647,7 @@ func encodeReadCoreV1NamespaceStatusResponse(response ReadCoreV1NamespaceStatusR
 	case *IoK8sAPICoreV1Namespace:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4276,6 +4659,7 @@ func encodeReadCoreV1NamespaceStatusResponse(response ReadCoreV1NamespaceStatusR
 		return nil
 	case *ReadCoreV1NamespaceStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{name}/status"+`: unexpected response type: %T`, response)
@@ -4287,6 +4671,7 @@ func encodeReadCoreV1NamespacedConfigMapResponse(response ReadCoreV1NamespacedCo
 	case *IoK8sAPICoreV1ConfigMap:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4298,6 +4683,7 @@ func encodeReadCoreV1NamespacedConfigMapResponse(response ReadCoreV1NamespacedCo
 		return nil
 	case *ReadCoreV1NamespacedConfigMapUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/configmaps/{name}"+`: unexpected response type: %T`, response)
@@ -4309,6 +4695,7 @@ func encodeReadCoreV1NamespacedEndpointsResponse(response ReadCoreV1NamespacedEn
 	case *IoK8sAPICoreV1Endpoints:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4320,6 +4707,7 @@ func encodeReadCoreV1NamespacedEndpointsResponse(response ReadCoreV1NamespacedEn
 		return nil
 	case *ReadCoreV1NamespacedEndpointsUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/endpoints/{name}"+`: unexpected response type: %T`, response)
@@ -4331,6 +4719,7 @@ func encodeReadCoreV1NamespacedEventResponse(response ReadCoreV1NamespacedEventR
 	case *IoK8sAPICoreV1Event:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4342,6 +4731,7 @@ func encodeReadCoreV1NamespacedEventResponse(response ReadCoreV1NamespacedEventR
 		return nil
 	case *ReadCoreV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -4353,6 +4743,7 @@ func encodeReadCoreV1NamespacedLimitRangeResponse(response ReadCoreV1NamespacedL
 	case *IoK8sAPICoreV1LimitRange:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4364,6 +4755,7 @@ func encodeReadCoreV1NamespacedLimitRangeResponse(response ReadCoreV1NamespacedL
 		return nil
 	case *ReadCoreV1NamespacedLimitRangeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/limitranges/{name}"+`: unexpected response type: %T`, response)
@@ -4375,6 +4767,7 @@ func encodeReadCoreV1NamespacedPersistentVolumeClaimResponse(response ReadCoreV1
 	case *IoK8sAPICoreV1PersistentVolumeClaim:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4386,6 +4779,7 @@ func encodeReadCoreV1NamespacedPersistentVolumeClaimResponse(response ReadCoreV1
 		return nil
 	case *ReadCoreV1NamespacedPersistentVolumeClaimUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}"+`: unexpected response type: %T`, response)
@@ -4397,6 +4791,7 @@ func encodeReadCoreV1NamespacedPersistentVolumeClaimStatusResponse(response Read
 	case *IoK8sAPICoreV1PersistentVolumeClaim:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4408,6 +4803,7 @@ func encodeReadCoreV1NamespacedPersistentVolumeClaimStatusResponse(response Read
 		return nil
 	case *ReadCoreV1NamespacedPersistentVolumeClaimStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status"+`: unexpected response type: %T`, response)
@@ -4419,6 +4815,7 @@ func encodeReadCoreV1NamespacedPodResponse(response ReadCoreV1NamespacedPodRes, 
 	case *IoK8sAPICoreV1Pod:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4430,6 +4827,7 @@ func encodeReadCoreV1NamespacedPodResponse(response ReadCoreV1NamespacedPodRes, 
 		return nil
 	case *ReadCoreV1NamespacedPodUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/pods/{name}"+`: unexpected response type: %T`, response)
@@ -4441,6 +4839,7 @@ func encodeReadCoreV1NamespacedPodEphemeralcontainersResponse(response ReadCoreV
 	case *IoK8sAPICoreV1Pod:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4452,6 +4851,7 @@ func encodeReadCoreV1NamespacedPodEphemeralcontainersResponse(response ReadCoreV
 		return nil
 	case *ReadCoreV1NamespacedPodEphemeralcontainersUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/pods/{name}/ephemeralcontainers"+`: unexpected response type: %T`, response)
@@ -4463,6 +4863,7 @@ func encodeReadCoreV1NamespacedPodLogResponse(response ReadCoreV1NamespacedPodLo
 	case *ReadCoreV1NamespacedPodLogOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4474,6 +4875,7 @@ func encodeReadCoreV1NamespacedPodLogResponse(response ReadCoreV1NamespacedPodLo
 		return nil
 	case *ReadCoreV1NamespacedPodLogUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/pods/{name}/log"+`: unexpected response type: %T`, response)
@@ -4485,6 +4887,7 @@ func encodeReadCoreV1NamespacedPodStatusResponse(response ReadCoreV1NamespacedPo
 	case *IoK8sAPICoreV1Pod:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4496,6 +4899,7 @@ func encodeReadCoreV1NamespacedPodStatusResponse(response ReadCoreV1NamespacedPo
 		return nil
 	case *ReadCoreV1NamespacedPodStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/pods/{name}/status"+`: unexpected response type: %T`, response)
@@ -4507,6 +4911,7 @@ func encodeReadCoreV1NamespacedPodTemplateResponse(response ReadCoreV1Namespaced
 	case *IoK8sAPICoreV1PodTemplate:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4518,6 +4923,7 @@ func encodeReadCoreV1NamespacedPodTemplateResponse(response ReadCoreV1Namespaced
 		return nil
 	case *ReadCoreV1NamespacedPodTemplateUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/podtemplates/{name}"+`: unexpected response type: %T`, response)
@@ -4529,6 +4935,7 @@ func encodeReadCoreV1NamespacedReplicationControllerResponse(response ReadCoreV1
 	case *IoK8sAPICoreV1ReplicationController:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4540,6 +4947,7 @@ func encodeReadCoreV1NamespacedReplicationControllerResponse(response ReadCoreV1
 		return nil
 	case *ReadCoreV1NamespacedReplicationControllerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}"+`: unexpected response type: %T`, response)
@@ -4551,6 +4959,7 @@ func encodeReadCoreV1NamespacedReplicationControllerScaleResponse(response ReadC
 	case *IoK8sAPIAutoscalingV1Scale:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4562,6 +4971,7 @@ func encodeReadCoreV1NamespacedReplicationControllerScaleResponse(response ReadC
 		return nil
 	case *ReadCoreV1NamespacedReplicationControllerScaleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale"+`: unexpected response type: %T`, response)
@@ -4573,6 +4983,7 @@ func encodeReadCoreV1NamespacedReplicationControllerStatusResponse(response Read
 	case *IoK8sAPICoreV1ReplicationController:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4584,6 +4995,7 @@ func encodeReadCoreV1NamespacedReplicationControllerStatusResponse(response Read
 		return nil
 	case *ReadCoreV1NamespacedReplicationControllerStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status"+`: unexpected response type: %T`, response)
@@ -4595,6 +5007,7 @@ func encodeReadCoreV1NamespacedResourceQuotaResponse(response ReadCoreV1Namespac
 	case *IoK8sAPICoreV1ResourceQuota:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4606,6 +5019,7 @@ func encodeReadCoreV1NamespacedResourceQuotaResponse(response ReadCoreV1Namespac
 		return nil
 	case *ReadCoreV1NamespacedResourceQuotaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/resourcequotas/{name}"+`: unexpected response type: %T`, response)
@@ -4617,6 +5031,7 @@ func encodeReadCoreV1NamespacedResourceQuotaStatusResponse(response ReadCoreV1Na
 	case *IoK8sAPICoreV1ResourceQuota:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4628,6 +5043,7 @@ func encodeReadCoreV1NamespacedResourceQuotaStatusResponse(response ReadCoreV1Na
 		return nil
 	case *ReadCoreV1NamespacedResourceQuotaStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/resourcequotas/{name}/status"+`: unexpected response type: %T`, response)
@@ -4639,6 +5055,7 @@ func encodeReadCoreV1NamespacedSecretResponse(response ReadCoreV1NamespacedSecre
 	case *IoK8sAPICoreV1Secret:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4650,6 +5067,7 @@ func encodeReadCoreV1NamespacedSecretResponse(response ReadCoreV1NamespacedSecre
 		return nil
 	case *ReadCoreV1NamespacedSecretUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/secrets/{name}"+`: unexpected response type: %T`, response)
@@ -4661,6 +5079,7 @@ func encodeReadCoreV1NamespacedServiceResponse(response ReadCoreV1NamespacedServ
 	case *IoK8sAPICoreV1Service:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4672,6 +5091,7 @@ func encodeReadCoreV1NamespacedServiceResponse(response ReadCoreV1NamespacedServ
 		return nil
 	case *ReadCoreV1NamespacedServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/services/{name}"+`: unexpected response type: %T`, response)
@@ -4683,6 +5103,7 @@ func encodeReadCoreV1NamespacedServiceAccountResponse(response ReadCoreV1Namespa
 	case *IoK8sAPICoreV1ServiceAccount:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4694,6 +5115,7 @@ func encodeReadCoreV1NamespacedServiceAccountResponse(response ReadCoreV1Namespa
 		return nil
 	case *ReadCoreV1NamespacedServiceAccountUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/serviceaccounts/{name}"+`: unexpected response type: %T`, response)
@@ -4705,6 +5127,7 @@ func encodeReadCoreV1NamespacedServiceStatusResponse(response ReadCoreV1Namespac
 	case *IoK8sAPICoreV1Service:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4716,6 +5139,7 @@ func encodeReadCoreV1NamespacedServiceStatusResponse(response ReadCoreV1Namespac
 		return nil
 	case *ReadCoreV1NamespacedServiceStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/namespaces/{namespace}/services/{name}/status"+`: unexpected response type: %T`, response)
@@ -4727,6 +5151,7 @@ func encodeReadCoreV1NodeResponse(response ReadCoreV1NodeRes, w http.ResponseWri
 	case *IoK8sAPICoreV1Node:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4738,6 +5163,7 @@ func encodeReadCoreV1NodeResponse(response ReadCoreV1NodeRes, w http.ResponseWri
 		return nil
 	case *ReadCoreV1NodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/nodes/{name}"+`: unexpected response type: %T`, response)
@@ -4749,6 +5175,7 @@ func encodeReadCoreV1NodeStatusResponse(response ReadCoreV1NodeStatusRes, w http
 	case *IoK8sAPICoreV1Node:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4760,6 +5187,7 @@ func encodeReadCoreV1NodeStatusResponse(response ReadCoreV1NodeStatusRes, w http
 		return nil
 	case *ReadCoreV1NodeStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/nodes/{name}/status"+`: unexpected response type: %T`, response)
@@ -4771,6 +5199,7 @@ func encodeReadCoreV1PersistentVolumeResponse(response ReadCoreV1PersistentVolum
 	case *IoK8sAPICoreV1PersistentVolume:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4782,6 +5211,7 @@ func encodeReadCoreV1PersistentVolumeResponse(response ReadCoreV1PersistentVolum
 		return nil
 	case *ReadCoreV1PersistentVolumeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/persistentvolumes/{name}"+`: unexpected response type: %T`, response)
@@ -4793,6 +5223,7 @@ func encodeReadCoreV1PersistentVolumeStatusResponse(response ReadCoreV1Persisten
 	case *IoK8sAPICoreV1PersistentVolume:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4804,6 +5235,7 @@ func encodeReadCoreV1PersistentVolumeStatusResponse(response ReadCoreV1Persisten
 		return nil
 	case *ReadCoreV1PersistentVolumeStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/persistentvolumes/{name}/status"+`: unexpected response type: %T`, response)
@@ -4815,6 +5247,7 @@ func encodeReadDiscoveryV1NamespacedEndpointSliceResponse(response ReadDiscovery
 	case *IoK8sAPIDiscoveryV1EndpointSlice:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4826,6 +5259,7 @@ func encodeReadDiscoveryV1NamespacedEndpointSliceResponse(response ReadDiscovery
 		return nil
 	case *ReadDiscoveryV1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/namespaces/{namespace}/endpointslices/{name}"+`: unexpected response type: %T`, response)
@@ -4837,6 +5271,7 @@ func encodeReadDiscoveryV1beta1NamespacedEndpointSliceResponse(response ReadDisc
 	case *IoK8sAPIDiscoveryV1beta1EndpointSlice:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4848,6 +5283,7 @@ func encodeReadDiscoveryV1beta1NamespacedEndpointSliceResponse(response ReadDisc
 		return nil
 	case *ReadDiscoveryV1beta1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}"+`: unexpected response type: %T`, response)
@@ -4859,6 +5295,7 @@ func encodeReadEventsV1NamespacedEventResponse(response ReadEventsV1NamespacedEv
 	case *IoK8sAPIEventsV1Event:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4870,6 +5307,7 @@ func encodeReadEventsV1NamespacedEventResponse(response ReadEventsV1NamespacedEv
 		return nil
 	case *ReadEventsV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -4881,6 +5319,7 @@ func encodeReadEventsV1beta1NamespacedEventResponse(response ReadEventsV1beta1Na
 	case *IoK8sAPIEventsV1beta1Event:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4892,6 +5331,7 @@ func encodeReadEventsV1beta1NamespacedEventResponse(response ReadEventsV1beta1Na
 		return nil
 	case *ReadEventsV1beta1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -4903,6 +5343,7 @@ func encodeReadFlowcontrolApiserverV1beta1FlowSchemaResponse(response ReadFlowco
 	case *IoK8sAPIFlowcontrolV1beta1FlowSchema:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4914,6 +5355,7 @@ func encodeReadFlowcontrolApiserverV1beta1FlowSchemaResponse(response ReadFlowco
 		return nil
 	case *ReadFlowcontrolApiserverV1beta1FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}"+`: unexpected response type: %T`, response)
@@ -4925,6 +5367,7 @@ func encodeReadFlowcontrolApiserverV1beta1FlowSchemaStatusResponse(response Read
 	case *IoK8sAPIFlowcontrolV1beta1FlowSchema:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4936,6 +5379,7 @@ func encodeReadFlowcontrolApiserverV1beta1FlowSchemaStatusResponse(response Read
 		return nil
 	case *ReadFlowcontrolApiserverV1beta1FlowSchemaStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}/status"+`: unexpected response type: %T`, response)
@@ -4947,6 +5391,7 @@ func encodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(res
 	case *IoK8sAPIFlowcontrolV1beta1PriorityLevelConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4958,6 +5403,7 @@ func encodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(res
 		return nil
 	case *ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -4969,6 +5415,7 @@ func encodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusRespon
 	case *IoK8sAPIFlowcontrolV1beta1PriorityLevelConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -4980,6 +5427,7 @@ func encodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusRespon
 		return nil
 	case *ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}/status"+`: unexpected response type: %T`, response)
@@ -4991,6 +5439,7 @@ func encodeReadFlowcontrolApiserverV1beta2FlowSchemaResponse(response ReadFlowco
 	case *IoK8sAPIFlowcontrolV1beta2FlowSchema:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5002,6 +5451,7 @@ func encodeReadFlowcontrolApiserverV1beta2FlowSchemaResponse(response ReadFlowco
 		return nil
 	case *ReadFlowcontrolApiserverV1beta2FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/{name}"+`: unexpected response type: %T`, response)
@@ -5013,6 +5463,7 @@ func encodeReadFlowcontrolApiserverV1beta2FlowSchemaStatusResponse(response Read
 	case *IoK8sAPIFlowcontrolV1beta2FlowSchema:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5024,6 +5475,7 @@ func encodeReadFlowcontrolApiserverV1beta2FlowSchemaStatusResponse(response Read
 		return nil
 	case *ReadFlowcontrolApiserverV1beta2FlowSchemaStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/{name}/status"+`: unexpected response type: %T`, response)
@@ -5035,6 +5487,7 @@ func encodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(res
 	case *IoK8sAPIFlowcontrolV1beta2PriorityLevelConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5046,6 +5499,7 @@ func encodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(res
 		return nil
 	case *ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -5057,6 +5511,7 @@ func encodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusRespon
 	case *IoK8sAPIFlowcontrolV1beta2PriorityLevelConfiguration:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5068,6 +5523,7 @@ func encodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusRespon
 		return nil
 	case *ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations/{name}/status"+`: unexpected response type: %T`, response)
@@ -5079,6 +5535,7 @@ func encodeReadInternalApiserverV1alpha1StorageVersionResponse(response ReadInte
 	case *IoK8sAPIApiserverinternalV1alpha1StorageVersion:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5090,6 +5547,7 @@ func encodeReadInternalApiserverV1alpha1StorageVersionResponse(response ReadInte
 		return nil
 	case *ReadInternalApiserverV1alpha1StorageVersionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{name}"+`: unexpected response type: %T`, response)
@@ -5101,6 +5559,7 @@ func encodeReadInternalApiserverV1alpha1StorageVersionStatusResponse(response Re
 	case *IoK8sAPIApiserverinternalV1alpha1StorageVersion:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5112,6 +5571,7 @@ func encodeReadInternalApiserverV1alpha1StorageVersionStatusResponse(response Re
 		return nil
 	case *ReadInternalApiserverV1alpha1StorageVersionStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{name}/status"+`: unexpected response type: %T`, response)
@@ -5123,6 +5583,7 @@ func encodeReadNetworkingV1IngressClassResponse(response ReadNetworkingV1Ingress
 	case *IoK8sAPINetworkingV1IngressClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5134,6 +5595,7 @@ func encodeReadNetworkingV1IngressClassResponse(response ReadNetworkingV1Ingress
 		return nil
 	case *ReadNetworkingV1IngressClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/ingressclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5145,6 +5607,7 @@ func encodeReadNetworkingV1NamespacedIngressResponse(response ReadNetworkingV1Na
 	case *IoK8sAPINetworkingV1Ingress:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5156,6 +5619,7 @@ func encodeReadNetworkingV1NamespacedIngressResponse(response ReadNetworkingV1Na
 		return nil
 	case *ReadNetworkingV1NamespacedIngressUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}"+`: unexpected response type: %T`, response)
@@ -5167,6 +5631,7 @@ func encodeReadNetworkingV1NamespacedIngressStatusResponse(response ReadNetworki
 	case *IoK8sAPINetworkingV1Ingress:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5178,6 +5643,7 @@ func encodeReadNetworkingV1NamespacedIngressStatusResponse(response ReadNetworki
 		return nil
 	case *ReadNetworkingV1NamespacedIngressStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}/status"+`: unexpected response type: %T`, response)
@@ -5189,6 +5655,7 @@ func encodeReadNetworkingV1NamespacedNetworkPolicyResponse(response ReadNetworki
 	case *IoK8sAPINetworkingV1NetworkPolicy:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5200,6 +5667,7 @@ func encodeReadNetworkingV1NamespacedNetworkPolicyResponse(response ReadNetworki
 		return nil
 	case *ReadNetworkingV1NamespacedNetworkPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}"+`: unexpected response type: %T`, response)
@@ -5211,6 +5679,7 @@ func encodeReadNodeV1RuntimeClassResponse(response ReadNodeV1RuntimeClassRes, w 
 	case *IoK8sAPINodeV1RuntimeClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5222,6 +5691,7 @@ func encodeReadNodeV1RuntimeClassResponse(response ReadNodeV1RuntimeClassRes, w 
 		return nil
 	case *ReadNodeV1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5233,6 +5703,7 @@ func encodeReadNodeV1alpha1RuntimeClassResponse(response ReadNodeV1alpha1Runtime
 	case *IoK8sAPINodeV1alpha1RuntimeClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5244,6 +5715,7 @@ func encodeReadNodeV1alpha1RuntimeClassResponse(response ReadNodeV1alpha1Runtime
 		return nil
 	case *ReadNodeV1alpha1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1alpha1/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5255,6 +5727,7 @@ func encodeReadNodeV1beta1RuntimeClassResponse(response ReadNodeV1beta1RuntimeCl
 	case *IoK8sAPINodeV1beta1RuntimeClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5266,6 +5739,7 @@ func encodeReadNodeV1beta1RuntimeClassResponse(response ReadNodeV1beta1RuntimeCl
 		return nil
 	case *ReadNodeV1beta1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1beta1/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5277,6 +5751,7 @@ func encodeReadPolicyV1NamespacedPodDisruptionBudgetResponse(response ReadPolicy
 	case *IoK8sAPIPolicyV1PodDisruptionBudget:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5288,6 +5763,7 @@ func encodeReadPolicyV1NamespacedPodDisruptionBudgetResponse(response ReadPolicy
 		return nil
 	case *ReadPolicyV1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets/{name}"+`: unexpected response type: %T`, response)
@@ -5299,6 +5775,7 @@ func encodeReadPolicyV1NamespacedPodDisruptionBudgetStatusResponse(response Read
 	case *IoK8sAPIPolicyV1PodDisruptionBudget:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5310,6 +5787,7 @@ func encodeReadPolicyV1NamespacedPodDisruptionBudgetStatusResponse(response Read
 		return nil
 	case *ReadPolicyV1NamespacedPodDisruptionBudgetStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets/{name}/status"+`: unexpected response type: %T`, response)
@@ -5321,6 +5799,7 @@ func encodeReadPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response ReadP
 	case *IoK8sAPIPolicyV1beta1PodDisruptionBudget:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5332,6 +5811,7 @@ func encodeReadPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response ReadP
 		return nil
 	case *ReadPolicyV1beta1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}"+`: unexpected response type: %T`, response)
@@ -5343,6 +5823,7 @@ func encodeReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusResponse(response
 	case *IoK8sAPIPolicyV1beta1PodDisruptionBudget:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5354,6 +5835,7 @@ func encodeReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusResponse(response
 		return nil
 	case *ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status"+`: unexpected response type: %T`, response)
@@ -5365,6 +5847,7 @@ func encodeReadPolicyV1beta1PodSecurityPolicyResponse(response ReadPolicyV1beta1
 	case *IoK8sAPIPolicyV1beta1PodSecurityPolicy:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5376,6 +5859,7 @@ func encodeReadPolicyV1beta1PodSecurityPolicyResponse(response ReadPolicyV1beta1
 		return nil
 	case *ReadPolicyV1beta1PodSecurityPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/podsecuritypolicies/{name}"+`: unexpected response type: %T`, response)
@@ -5387,6 +5871,7 @@ func encodeReadRbacAuthorizationV1ClusterRoleResponse(response ReadRbacAuthoriza
 	case *IoK8sAPIRbacV1ClusterRole:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5398,6 +5883,7 @@ func encodeReadRbacAuthorizationV1ClusterRoleResponse(response ReadRbacAuthoriza
 		return nil
 	case *ReadRbacAuthorizationV1ClusterRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}"+`: unexpected response type: %T`, response)
@@ -5409,6 +5895,7 @@ func encodeReadRbacAuthorizationV1ClusterRoleBindingResponse(response ReadRbacAu
 	case *IoK8sAPIRbacV1ClusterRoleBinding:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5420,6 +5907,7 @@ func encodeReadRbacAuthorizationV1ClusterRoleBindingResponse(response ReadRbacAu
 		return nil
 	case *ReadRbacAuthorizationV1ClusterRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}"+`: unexpected response type: %T`, response)
@@ -5431,6 +5919,7 @@ func encodeReadRbacAuthorizationV1NamespacedRoleResponse(response ReadRbacAuthor
 	case *IoK8sAPIRbacV1Role:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5442,6 +5931,7 @@ func encodeReadRbacAuthorizationV1NamespacedRoleResponse(response ReadRbacAuthor
 		return nil
 	case *ReadRbacAuthorizationV1NamespacedRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}"+`: unexpected response type: %T`, response)
@@ -5453,6 +5943,7 @@ func encodeReadRbacAuthorizationV1NamespacedRoleBindingResponse(response ReadRba
 	case *IoK8sAPIRbacV1RoleBinding:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5464,6 +5955,7 @@ func encodeReadRbacAuthorizationV1NamespacedRoleBindingResponse(response ReadRba
 		return nil
 	case *ReadRbacAuthorizationV1NamespacedRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}"+`: unexpected response type: %T`, response)
@@ -5475,6 +5967,7 @@ func encodeReadSchedulingV1PriorityClassResponse(response ReadSchedulingV1Priori
 	case *IoK8sAPISchedulingV1PriorityClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5486,6 +5979,7 @@ func encodeReadSchedulingV1PriorityClassResponse(response ReadSchedulingV1Priori
 		return nil
 	case *ReadSchedulingV1PriorityClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/v1/priorityclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5497,6 +5991,7 @@ func encodeReadStorageV1CSIDriverResponse(response ReadStorageV1CSIDriverRes, w 
 	case *IoK8sAPIStorageV1CSIDriver:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5508,6 +6003,7 @@ func encodeReadStorageV1CSIDriverResponse(response ReadStorageV1CSIDriverRes, w 
 		return nil
 	case *ReadStorageV1CSIDriverUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/csidrivers/{name}"+`: unexpected response type: %T`, response)
@@ -5519,6 +6015,7 @@ func encodeReadStorageV1CSINodeResponse(response ReadStorageV1CSINodeRes, w http
 	case *IoK8sAPIStorageV1CSINode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5530,6 +6027,7 @@ func encodeReadStorageV1CSINodeResponse(response ReadStorageV1CSINodeRes, w http
 		return nil
 	case *ReadStorageV1CSINodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/csinodes/{name}"+`: unexpected response type: %T`, response)
@@ -5541,6 +6039,7 @@ func encodeReadStorageV1StorageClassResponse(response ReadStorageV1StorageClassR
 	case *IoK8sAPIStorageV1StorageClass:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5552,6 +6051,7 @@ func encodeReadStorageV1StorageClassResponse(response ReadStorageV1StorageClassR
 		return nil
 	case *ReadStorageV1StorageClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/storageclasses/{name}"+`: unexpected response type: %T`, response)
@@ -5563,6 +6063,7 @@ func encodeReadStorageV1VolumeAttachmentResponse(response ReadStorageV1VolumeAtt
 	case *IoK8sAPIStorageV1VolumeAttachment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5574,6 +6075,7 @@ func encodeReadStorageV1VolumeAttachmentResponse(response ReadStorageV1VolumeAtt
 		return nil
 	case *ReadStorageV1VolumeAttachmentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/volumeattachments/{name}"+`: unexpected response type: %T`, response)
@@ -5585,6 +6087,7 @@ func encodeReadStorageV1VolumeAttachmentStatusResponse(response ReadStorageV1Vol
 	case *IoK8sAPIStorageV1VolumeAttachment:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5596,6 +6099,7 @@ func encodeReadStorageV1VolumeAttachmentStatusResponse(response ReadStorageV1Vol
 		return nil
 	case *ReadStorageV1VolumeAttachmentStatusUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/volumeattachments/{name}/status"+`: unexpected response type: %T`, response)
@@ -5607,6 +6111,7 @@ func encodeReadStorageV1alpha1NamespacedCSIStorageCapacityResponse(response Read
 	case *IoK8sAPIStorageV1alpha1CSIStorageCapacity:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5618,6 +6123,7 @@ func encodeReadStorageV1alpha1NamespacedCSIStorageCapacityResponse(response Read
 		return nil
 	case *ReadStorageV1alpha1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/namespaces/{namespace}/csistoragecapacities/{name}"+`: unexpected response type: %T`, response)
@@ -5629,6 +6135,7 @@ func encodeReadStorageV1beta1NamespacedCSIStorageCapacityResponse(response ReadS
 	case *IoK8sAPIStorageV1beta1CSIStorageCapacity:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5640,6 +6147,7 @@ func encodeReadStorageV1beta1NamespacedCSIStorageCapacityResponse(response ReadS
 		return nil
 	case *ReadStorageV1beta1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/namespaces/{namespace}/csistoragecapacities/{name}"+`: unexpected response type: %T`, response)
@@ -5651,6 +6159,7 @@ func encodeWatchAdmissionregistrationV1MutatingWebhookConfigurationResponse(resp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5662,6 +6171,7 @@ func encodeWatchAdmissionregistrationV1MutatingWebhookConfigurationResponse(resp
 		return nil
 	case *WatchAdmissionregistrationV1MutatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/watch/mutatingwebhookconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -5673,6 +6183,7 @@ func encodeWatchAdmissionregistrationV1MutatingWebhookConfigurationListResponse(
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5684,6 +6195,7 @@ func encodeWatchAdmissionregistrationV1MutatingWebhookConfigurationListResponse(
 		return nil
 	case *WatchAdmissionregistrationV1MutatingWebhookConfigurationListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/watch/mutatingwebhookconfigurations"+`: unexpected response type: %T`, response)
@@ -5695,6 +6207,7 @@ func encodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationResponse(re
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5706,6 +6219,7 @@ func encodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationResponse(re
 		return nil
 	case *WatchAdmissionregistrationV1ValidatingWebhookConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/watch/validatingwebhookconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -5717,6 +6231,7 @@ func encodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationListRespons
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5728,6 +6243,7 @@ func encodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationListRespons
 		return nil
 	case *WatchAdmissionregistrationV1ValidatingWebhookConfigurationListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/admissionregistration.k8s.io/v1/watch/validatingwebhookconfigurations"+`: unexpected response type: %T`, response)
@@ -5739,6 +6255,7 @@ func encodeWatchApiextensionsV1CustomResourceDefinitionResponse(response WatchAp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5750,6 +6267,7 @@ func encodeWatchApiextensionsV1CustomResourceDefinitionResponse(response WatchAp
 		return nil
 	case *WatchApiextensionsV1CustomResourceDefinitionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions/{name}"+`: unexpected response type: %T`, response)
@@ -5761,6 +6279,7 @@ func encodeWatchApiextensionsV1CustomResourceDefinitionListResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5772,6 +6291,7 @@ func encodeWatchApiextensionsV1CustomResourceDefinitionListResponse(response Wat
 		return nil
 	case *WatchApiextensionsV1CustomResourceDefinitionListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions"+`: unexpected response type: %T`, response)
@@ -5783,6 +6303,7 @@ func encodeWatchApiregistrationV1APIServiceResponse(response WatchApiregistratio
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5794,6 +6315,7 @@ func encodeWatchApiregistrationV1APIServiceResponse(response WatchApiregistratio
 		return nil
 	case *WatchApiregistrationV1APIServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/watch/apiservices/{name}"+`: unexpected response type: %T`, response)
@@ -5805,6 +6327,7 @@ func encodeWatchApiregistrationV1APIServiceListResponse(response WatchApiregistr
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5816,6 +6339,7 @@ func encodeWatchApiregistrationV1APIServiceListResponse(response WatchApiregistr
 		return nil
 	case *WatchApiregistrationV1APIServiceListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apiregistration.k8s.io/v1/watch/apiservices"+`: unexpected response type: %T`, response)
@@ -5827,6 +6351,7 @@ func encodeWatchAppsV1ControllerRevisionListForAllNamespacesResponse(response Wa
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5838,6 +6363,7 @@ func encodeWatchAppsV1ControllerRevisionListForAllNamespacesResponse(response Wa
 		return nil
 	case *WatchAppsV1ControllerRevisionListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/controllerrevisions"+`: unexpected response type: %T`, response)
@@ -5849,6 +6375,7 @@ func encodeWatchAppsV1DaemonSetListForAllNamespacesResponse(response WatchAppsV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5860,6 +6387,7 @@ func encodeWatchAppsV1DaemonSetListForAllNamespacesResponse(response WatchAppsV1
 		return nil
 	case *WatchAppsV1DaemonSetListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/daemonsets"+`: unexpected response type: %T`, response)
@@ -5871,6 +6399,7 @@ func encodeWatchAppsV1DeploymentListForAllNamespacesResponse(response WatchAppsV
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5882,6 +6411,7 @@ func encodeWatchAppsV1DeploymentListForAllNamespacesResponse(response WatchAppsV
 		return nil
 	case *WatchAppsV1DeploymentListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/deployments"+`: unexpected response type: %T`, response)
@@ -5893,6 +6423,7 @@ func encodeWatchAppsV1NamespacedControllerRevisionResponse(response WatchAppsV1N
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5904,6 +6435,7 @@ func encodeWatchAppsV1NamespacedControllerRevisionResponse(response WatchAppsV1N
 		return nil
 	case *WatchAppsV1NamespacedControllerRevisionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions/{name}"+`: unexpected response type: %T`, response)
@@ -5915,6 +6447,7 @@ func encodeWatchAppsV1NamespacedControllerRevisionListResponse(response WatchApp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5926,6 +6459,7 @@ func encodeWatchAppsV1NamespacedControllerRevisionListResponse(response WatchApp
 		return nil
 	case *WatchAppsV1NamespacedControllerRevisionListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions"+`: unexpected response type: %T`, response)
@@ -5937,6 +6471,7 @@ func encodeWatchAppsV1NamespacedDaemonSetResponse(response WatchAppsV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5948,6 +6483,7 @@ func encodeWatchAppsV1NamespacedDaemonSetResponse(response WatchAppsV1Namespaced
 		return nil
 	case *WatchAppsV1NamespacedDaemonSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/daemonsets/{name}"+`: unexpected response type: %T`, response)
@@ -5959,6 +6495,7 @@ func encodeWatchAppsV1NamespacedDaemonSetListResponse(response WatchAppsV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5970,6 +6507,7 @@ func encodeWatchAppsV1NamespacedDaemonSetListResponse(response WatchAppsV1Namesp
 		return nil
 	case *WatchAppsV1NamespacedDaemonSetListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/daemonsets"+`: unexpected response type: %T`, response)
@@ -5981,6 +6519,7 @@ func encodeWatchAppsV1NamespacedDeploymentResponse(response WatchAppsV1Namespace
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -5992,6 +6531,7 @@ func encodeWatchAppsV1NamespacedDeploymentResponse(response WatchAppsV1Namespace
 		return nil
 	case *WatchAppsV1NamespacedDeploymentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/deployments/{name}"+`: unexpected response type: %T`, response)
@@ -6003,6 +6543,7 @@ func encodeWatchAppsV1NamespacedDeploymentListResponse(response WatchAppsV1Names
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6014,6 +6555,7 @@ func encodeWatchAppsV1NamespacedDeploymentListResponse(response WatchAppsV1Names
 		return nil
 	case *WatchAppsV1NamespacedDeploymentListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/deployments"+`: unexpected response type: %T`, response)
@@ -6025,6 +6567,7 @@ func encodeWatchAppsV1NamespacedReplicaSetResponse(response WatchAppsV1Namespace
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6036,6 +6579,7 @@ func encodeWatchAppsV1NamespacedReplicaSetResponse(response WatchAppsV1Namespace
 		return nil
 	case *WatchAppsV1NamespacedReplicaSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/replicasets/{name}"+`: unexpected response type: %T`, response)
@@ -6047,6 +6591,7 @@ func encodeWatchAppsV1NamespacedReplicaSetListResponse(response WatchAppsV1Names
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6058,6 +6603,7 @@ func encodeWatchAppsV1NamespacedReplicaSetListResponse(response WatchAppsV1Names
 		return nil
 	case *WatchAppsV1NamespacedReplicaSetListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/replicasets"+`: unexpected response type: %T`, response)
@@ -6069,6 +6615,7 @@ func encodeWatchAppsV1NamespacedStatefulSetResponse(response WatchAppsV1Namespac
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6080,6 +6627,7 @@ func encodeWatchAppsV1NamespacedStatefulSetResponse(response WatchAppsV1Namespac
 		return nil
 	case *WatchAppsV1NamespacedStatefulSetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/statefulsets/{name}"+`: unexpected response type: %T`, response)
@@ -6091,6 +6639,7 @@ func encodeWatchAppsV1NamespacedStatefulSetListResponse(response WatchAppsV1Name
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6102,6 +6651,7 @@ func encodeWatchAppsV1NamespacedStatefulSetListResponse(response WatchAppsV1Name
 		return nil
 	case *WatchAppsV1NamespacedStatefulSetListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/namespaces/{namespace}/statefulsets"+`: unexpected response type: %T`, response)
@@ -6113,6 +6663,7 @@ func encodeWatchAppsV1ReplicaSetListForAllNamespacesResponse(response WatchAppsV
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6124,6 +6675,7 @@ func encodeWatchAppsV1ReplicaSetListForAllNamespacesResponse(response WatchAppsV
 		return nil
 	case *WatchAppsV1ReplicaSetListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/replicasets"+`: unexpected response type: %T`, response)
@@ -6135,6 +6687,7 @@ func encodeWatchAppsV1StatefulSetListForAllNamespacesResponse(response WatchApps
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6146,6 +6699,7 @@ func encodeWatchAppsV1StatefulSetListForAllNamespacesResponse(response WatchApps
 		return nil
 	case *WatchAppsV1StatefulSetListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/apps/v1/watch/statefulsets"+`: unexpected response type: %T`, response)
@@ -6157,6 +6711,7 @@ func encodeWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesResponse
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6168,6 +6723,7 @@ func encodeWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesResponse
 		return nil
 	case *WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/watch/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6179,6 +6735,7 @@ func encodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response 
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6190,6 +6747,7 @@ func encodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerResponse(response 
 		return nil
 	case *WatchAutoscalingV1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -6201,6 +6759,7 @@ func encodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerListResponse(respo
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6212,6 +6771,7 @@ func encodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerListResponse(respo
 		return nil
 	case *WatchAutoscalingV1NamespacedHorizontalPodAutoscalerListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6223,6 +6783,7 @@ func encodeWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesRes
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6234,6 +6795,7 @@ func encodeWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesRes
 		return nil
 	case *WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/watch/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6245,6 +6807,7 @@ func encodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(resp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6256,6 +6819,7 @@ func encodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerResponse(resp
 		return nil
 	case *WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -6267,6 +6831,7 @@ func encodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListResponse(
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6278,6 +6843,7 @@ func encodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListResponse(
 		return nil
 	case *WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6289,6 +6855,7 @@ func encodeWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesRes
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6300,6 +6867,7 @@ func encodeWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesRes
 		return nil
 	case *WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/watch/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6311,6 +6879,7 @@ func encodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(resp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6322,6 +6891,7 @@ func encodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerResponse(resp
 		return nil
 	case *WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"+`: unexpected response type: %T`, response)
@@ -6333,6 +6903,7 @@ func encodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListResponse(
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6344,6 +6915,7 @@ func encodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListResponse(
 		return nil
 	case *WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/autoscaling/v2beta2/watch/namespaces/{namespace}/horizontalpodautoscalers"+`: unexpected response type: %T`, response)
@@ -6355,6 +6927,7 @@ func encodeWatchBatchV1CronJobListForAllNamespacesResponse(response WatchBatchV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6366,6 +6939,7 @@ func encodeWatchBatchV1CronJobListForAllNamespacesResponse(response WatchBatchV1
 		return nil
 	case *WatchBatchV1CronJobListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/cronjobs"+`: unexpected response type: %T`, response)
@@ -6377,6 +6951,7 @@ func encodeWatchBatchV1JobListForAllNamespacesResponse(response WatchBatchV1JobL
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6388,6 +6963,7 @@ func encodeWatchBatchV1JobListForAllNamespacesResponse(response WatchBatchV1JobL
 		return nil
 	case *WatchBatchV1JobListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/jobs"+`: unexpected response type: %T`, response)
@@ -6399,6 +6975,7 @@ func encodeWatchBatchV1NamespacedCronJobResponse(response WatchBatchV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6410,6 +6987,7 @@ func encodeWatchBatchV1NamespacedCronJobResponse(response WatchBatchV1Namespaced
 		return nil
 	case *WatchBatchV1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/namespaces/{namespace}/cronjobs/{name}"+`: unexpected response type: %T`, response)
@@ -6421,6 +6999,7 @@ func encodeWatchBatchV1NamespacedCronJobListResponse(response WatchBatchV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6432,6 +7011,7 @@ func encodeWatchBatchV1NamespacedCronJobListResponse(response WatchBatchV1Namesp
 		return nil
 	case *WatchBatchV1NamespacedCronJobListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/namespaces/{namespace}/cronjobs"+`: unexpected response type: %T`, response)
@@ -6443,6 +7023,7 @@ func encodeWatchBatchV1NamespacedJobResponse(response WatchBatchV1NamespacedJobR
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6454,6 +7035,7 @@ func encodeWatchBatchV1NamespacedJobResponse(response WatchBatchV1NamespacedJobR
 		return nil
 	case *WatchBatchV1NamespacedJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/namespaces/{namespace}/jobs/{name}"+`: unexpected response type: %T`, response)
@@ -6465,6 +7047,7 @@ func encodeWatchBatchV1NamespacedJobListResponse(response WatchBatchV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6476,6 +7059,7 @@ func encodeWatchBatchV1NamespacedJobListResponse(response WatchBatchV1Namespaced
 		return nil
 	case *WatchBatchV1NamespacedJobListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1/watch/namespaces/{namespace}/jobs"+`: unexpected response type: %T`, response)
@@ -6487,6 +7071,7 @@ func encodeWatchBatchV1beta1CronJobListForAllNamespacesResponse(response WatchBa
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6498,6 +7083,7 @@ func encodeWatchBatchV1beta1CronJobListForAllNamespacesResponse(response WatchBa
 		return nil
 	case *WatchBatchV1beta1CronJobListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/watch/cronjobs"+`: unexpected response type: %T`, response)
@@ -6509,6 +7095,7 @@ func encodeWatchBatchV1beta1NamespacedCronJobResponse(response WatchBatchV1beta1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6520,6 +7107,7 @@ func encodeWatchBatchV1beta1NamespacedCronJobResponse(response WatchBatchV1beta1
 		return nil
 	case *WatchBatchV1beta1NamespacedCronJobUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs/{name}"+`: unexpected response type: %T`, response)
@@ -6531,6 +7119,7 @@ func encodeWatchBatchV1beta1NamespacedCronJobListResponse(response WatchBatchV1b
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6542,6 +7131,7 @@ func encodeWatchBatchV1beta1NamespacedCronJobListResponse(response WatchBatchV1b
 		return nil
 	case *WatchBatchV1beta1NamespacedCronJobListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs"+`: unexpected response type: %T`, response)
@@ -6553,6 +7143,7 @@ func encodeWatchCertificatesV1CertificateSigningRequestResponse(response WatchCe
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6564,6 +7155,7 @@ func encodeWatchCertificatesV1CertificateSigningRequestResponse(response WatchCe
 		return nil
 	case *WatchCertificatesV1CertificateSigningRequestUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/watch/certificatesigningrequests/{name}"+`: unexpected response type: %T`, response)
@@ -6575,6 +7167,7 @@ func encodeWatchCertificatesV1CertificateSigningRequestListResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6586,6 +7179,7 @@ func encodeWatchCertificatesV1CertificateSigningRequestListResponse(response Wat
 		return nil
 	case *WatchCertificatesV1CertificateSigningRequestListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/certificates.k8s.io/v1/watch/certificatesigningrequests"+`: unexpected response type: %T`, response)
@@ -6597,6 +7191,7 @@ func encodeWatchCoordinationV1LeaseListForAllNamespacesResponse(response WatchCo
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6608,6 +7203,7 @@ func encodeWatchCoordinationV1LeaseListForAllNamespacesResponse(response WatchCo
 		return nil
 	case *WatchCoordinationV1LeaseListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/watch/leases"+`: unexpected response type: %T`, response)
@@ -6619,6 +7215,7 @@ func encodeWatchCoordinationV1NamespacedLeaseResponse(response WatchCoordination
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6630,6 +7227,7 @@ func encodeWatchCoordinationV1NamespacedLeaseResponse(response WatchCoordination
 		return nil
 	case *WatchCoordinationV1NamespacedLeaseUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/watch/namespaces/{namespace}/leases/{name}"+`: unexpected response type: %T`, response)
@@ -6641,6 +7239,7 @@ func encodeWatchCoordinationV1NamespacedLeaseListResponse(response WatchCoordina
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6652,6 +7251,7 @@ func encodeWatchCoordinationV1NamespacedLeaseListResponse(response WatchCoordina
 		return nil
 	case *WatchCoordinationV1NamespacedLeaseListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/coordination.k8s.io/v1/watch/namespaces/{namespace}/leases"+`: unexpected response type: %T`, response)
@@ -6663,6 +7263,7 @@ func encodeWatchCoreV1ConfigMapListForAllNamespacesResponse(response WatchCoreV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6674,6 +7275,7 @@ func encodeWatchCoreV1ConfigMapListForAllNamespacesResponse(response WatchCoreV1
 		return nil
 	case *WatchCoreV1ConfigMapListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/configmaps"+`: unexpected response type: %T`, response)
@@ -6685,6 +7287,7 @@ func encodeWatchCoreV1EndpointsListForAllNamespacesResponse(response WatchCoreV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6696,6 +7299,7 @@ func encodeWatchCoreV1EndpointsListForAllNamespacesResponse(response WatchCoreV1
 		return nil
 	case *WatchCoreV1EndpointsListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/endpoints"+`: unexpected response type: %T`, response)
@@ -6707,6 +7311,7 @@ func encodeWatchCoreV1EventListForAllNamespacesResponse(response WatchCoreV1Even
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6718,6 +7323,7 @@ func encodeWatchCoreV1EventListForAllNamespacesResponse(response WatchCoreV1Even
 		return nil
 	case *WatchCoreV1EventListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/events"+`: unexpected response type: %T`, response)
@@ -6729,6 +7335,7 @@ func encodeWatchCoreV1LimitRangeListForAllNamespacesResponse(response WatchCoreV
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6740,6 +7347,7 @@ func encodeWatchCoreV1LimitRangeListForAllNamespacesResponse(response WatchCoreV
 		return nil
 	case *WatchCoreV1LimitRangeListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/limitranges"+`: unexpected response type: %T`, response)
@@ -6751,6 +7359,7 @@ func encodeWatchCoreV1NamespaceResponse(response WatchCoreV1NamespaceRes, w http
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6762,6 +7371,7 @@ func encodeWatchCoreV1NamespaceResponse(response WatchCoreV1NamespaceRes, w http
 		return nil
 	case *WatchCoreV1NamespaceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{name}"+`: unexpected response type: %T`, response)
@@ -6773,6 +7383,7 @@ func encodeWatchCoreV1NamespaceListResponse(response WatchCoreV1NamespaceListRes
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6784,6 +7395,7 @@ func encodeWatchCoreV1NamespaceListResponse(response WatchCoreV1NamespaceListRes
 		return nil
 	case *WatchCoreV1NamespaceListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces"+`: unexpected response type: %T`, response)
@@ -6795,6 +7407,7 @@ func encodeWatchCoreV1NamespacedConfigMapResponse(response WatchCoreV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6806,6 +7419,7 @@ func encodeWatchCoreV1NamespacedConfigMapResponse(response WatchCoreV1Namespaced
 		return nil
 	case *WatchCoreV1NamespacedConfigMapUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/configmaps/{name}"+`: unexpected response type: %T`, response)
@@ -6817,6 +7431,7 @@ func encodeWatchCoreV1NamespacedConfigMapListResponse(response WatchCoreV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6828,6 +7443,7 @@ func encodeWatchCoreV1NamespacedConfigMapListResponse(response WatchCoreV1Namesp
 		return nil
 	case *WatchCoreV1NamespacedConfigMapListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/configmaps"+`: unexpected response type: %T`, response)
@@ -6839,6 +7455,7 @@ func encodeWatchCoreV1NamespacedEndpointsResponse(response WatchCoreV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6850,6 +7467,7 @@ func encodeWatchCoreV1NamespacedEndpointsResponse(response WatchCoreV1Namespaced
 		return nil
 	case *WatchCoreV1NamespacedEndpointsUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/endpoints/{name}"+`: unexpected response type: %T`, response)
@@ -6861,6 +7479,7 @@ func encodeWatchCoreV1NamespacedEndpointsListResponse(response WatchCoreV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6872,6 +7491,7 @@ func encodeWatchCoreV1NamespacedEndpointsListResponse(response WatchCoreV1Namesp
 		return nil
 	case *WatchCoreV1NamespacedEndpointsListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/endpoints"+`: unexpected response type: %T`, response)
@@ -6883,6 +7503,7 @@ func encodeWatchCoreV1NamespacedEventResponse(response WatchCoreV1NamespacedEven
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6894,6 +7515,7 @@ func encodeWatchCoreV1NamespacedEventResponse(response WatchCoreV1NamespacedEven
 		return nil
 	case *WatchCoreV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -6905,6 +7527,7 @@ func encodeWatchCoreV1NamespacedEventListResponse(response WatchCoreV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6916,6 +7539,7 @@ func encodeWatchCoreV1NamespacedEventListResponse(response WatchCoreV1Namespaced
 		return nil
 	case *WatchCoreV1NamespacedEventListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -6927,6 +7551,7 @@ func encodeWatchCoreV1NamespacedLimitRangeResponse(response WatchCoreV1Namespace
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6938,6 +7563,7 @@ func encodeWatchCoreV1NamespacedLimitRangeResponse(response WatchCoreV1Namespace
 		return nil
 	case *WatchCoreV1NamespacedLimitRangeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/limitranges/{name}"+`: unexpected response type: %T`, response)
@@ -6949,6 +7575,7 @@ func encodeWatchCoreV1NamespacedLimitRangeListResponse(response WatchCoreV1Names
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6960,6 +7587,7 @@ func encodeWatchCoreV1NamespacedLimitRangeListResponse(response WatchCoreV1Names
 		return nil
 	case *WatchCoreV1NamespacedLimitRangeListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/limitranges"+`: unexpected response type: %T`, response)
@@ -6971,6 +7599,7 @@ func encodeWatchCoreV1NamespacedPersistentVolumeClaimResponse(response WatchCore
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -6982,6 +7611,7 @@ func encodeWatchCoreV1NamespacedPersistentVolumeClaimResponse(response WatchCore
 		return nil
 	case *WatchCoreV1NamespacedPersistentVolumeClaimUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims/{name}"+`: unexpected response type: %T`, response)
@@ -6993,6 +7623,7 @@ func encodeWatchCoreV1NamespacedPersistentVolumeClaimListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7004,6 +7635,7 @@ func encodeWatchCoreV1NamespacedPersistentVolumeClaimListResponse(response Watch
 		return nil
 	case *WatchCoreV1NamespacedPersistentVolumeClaimListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims"+`: unexpected response type: %T`, response)
@@ -7015,6 +7647,7 @@ func encodeWatchCoreV1NamespacedPodResponse(response WatchCoreV1NamespacedPodRes
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7026,6 +7659,7 @@ func encodeWatchCoreV1NamespacedPodResponse(response WatchCoreV1NamespacedPodRes
 		return nil
 	case *WatchCoreV1NamespacedPodUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/pods/{name}"+`: unexpected response type: %T`, response)
@@ -7037,6 +7671,7 @@ func encodeWatchCoreV1NamespacedPodListResponse(response WatchCoreV1NamespacedPo
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7048,6 +7683,7 @@ func encodeWatchCoreV1NamespacedPodListResponse(response WatchCoreV1NamespacedPo
 		return nil
 	case *WatchCoreV1NamespacedPodListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/pods"+`: unexpected response type: %T`, response)
@@ -7059,6 +7695,7 @@ func encodeWatchCoreV1NamespacedPodTemplateResponse(response WatchCoreV1Namespac
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7070,6 +7707,7 @@ func encodeWatchCoreV1NamespacedPodTemplateResponse(response WatchCoreV1Namespac
 		return nil
 	case *WatchCoreV1NamespacedPodTemplateUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/podtemplates/{name}"+`: unexpected response type: %T`, response)
@@ -7081,6 +7719,7 @@ func encodeWatchCoreV1NamespacedPodTemplateListResponse(response WatchCoreV1Name
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7092,6 +7731,7 @@ func encodeWatchCoreV1NamespacedPodTemplateListResponse(response WatchCoreV1Name
 		return nil
 	case *WatchCoreV1NamespacedPodTemplateListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/podtemplates"+`: unexpected response type: %T`, response)
@@ -7103,6 +7743,7 @@ func encodeWatchCoreV1NamespacedReplicationControllerResponse(response WatchCore
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7114,6 +7755,7 @@ func encodeWatchCoreV1NamespacedReplicationControllerResponse(response WatchCore
 		return nil
 	case *WatchCoreV1NamespacedReplicationControllerUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/replicationcontrollers/{name}"+`: unexpected response type: %T`, response)
@@ -7125,6 +7767,7 @@ func encodeWatchCoreV1NamespacedReplicationControllerListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7136,6 +7779,7 @@ func encodeWatchCoreV1NamespacedReplicationControllerListResponse(response Watch
 		return nil
 	case *WatchCoreV1NamespacedReplicationControllerListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/replicationcontrollers"+`: unexpected response type: %T`, response)
@@ -7147,6 +7791,7 @@ func encodeWatchCoreV1NamespacedResourceQuotaResponse(response WatchCoreV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7158,6 +7803,7 @@ func encodeWatchCoreV1NamespacedResourceQuotaResponse(response WatchCoreV1Namesp
 		return nil
 	case *WatchCoreV1NamespacedResourceQuotaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/resourcequotas/{name}"+`: unexpected response type: %T`, response)
@@ -7169,6 +7815,7 @@ func encodeWatchCoreV1NamespacedResourceQuotaListResponse(response WatchCoreV1Na
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7180,6 +7827,7 @@ func encodeWatchCoreV1NamespacedResourceQuotaListResponse(response WatchCoreV1Na
 		return nil
 	case *WatchCoreV1NamespacedResourceQuotaListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/resourcequotas"+`: unexpected response type: %T`, response)
@@ -7191,6 +7839,7 @@ func encodeWatchCoreV1NamespacedSecretResponse(response WatchCoreV1NamespacedSec
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7202,6 +7851,7 @@ func encodeWatchCoreV1NamespacedSecretResponse(response WatchCoreV1NamespacedSec
 		return nil
 	case *WatchCoreV1NamespacedSecretUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/secrets/{name}"+`: unexpected response type: %T`, response)
@@ -7213,6 +7863,7 @@ func encodeWatchCoreV1NamespacedSecretListResponse(response WatchCoreV1Namespace
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7224,6 +7875,7 @@ func encodeWatchCoreV1NamespacedSecretListResponse(response WatchCoreV1Namespace
 		return nil
 	case *WatchCoreV1NamespacedSecretListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/secrets"+`: unexpected response type: %T`, response)
@@ -7235,6 +7887,7 @@ func encodeWatchCoreV1NamespacedServiceResponse(response WatchCoreV1NamespacedSe
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7246,6 +7899,7 @@ func encodeWatchCoreV1NamespacedServiceResponse(response WatchCoreV1NamespacedSe
 		return nil
 	case *WatchCoreV1NamespacedServiceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/services/{name}"+`: unexpected response type: %T`, response)
@@ -7257,6 +7911,7 @@ func encodeWatchCoreV1NamespacedServiceAccountResponse(response WatchCoreV1Names
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7268,6 +7923,7 @@ func encodeWatchCoreV1NamespacedServiceAccountResponse(response WatchCoreV1Names
 		return nil
 	case *WatchCoreV1NamespacedServiceAccountUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/serviceaccounts/{name}"+`: unexpected response type: %T`, response)
@@ -7279,6 +7935,7 @@ func encodeWatchCoreV1NamespacedServiceAccountListResponse(response WatchCoreV1N
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7290,6 +7947,7 @@ func encodeWatchCoreV1NamespacedServiceAccountListResponse(response WatchCoreV1N
 		return nil
 	case *WatchCoreV1NamespacedServiceAccountListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/serviceaccounts"+`: unexpected response type: %T`, response)
@@ -7301,6 +7959,7 @@ func encodeWatchCoreV1NamespacedServiceListResponse(response WatchCoreV1Namespac
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7312,6 +7971,7 @@ func encodeWatchCoreV1NamespacedServiceListResponse(response WatchCoreV1Namespac
 		return nil
 	case *WatchCoreV1NamespacedServiceListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/namespaces/{namespace}/services"+`: unexpected response type: %T`, response)
@@ -7323,6 +7983,7 @@ func encodeWatchCoreV1NodeResponse(response WatchCoreV1NodeRes, w http.ResponseW
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7334,6 +7995,7 @@ func encodeWatchCoreV1NodeResponse(response WatchCoreV1NodeRes, w http.ResponseW
 		return nil
 	case *WatchCoreV1NodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/nodes/{name}"+`: unexpected response type: %T`, response)
@@ -7345,6 +8007,7 @@ func encodeWatchCoreV1NodeListResponse(response WatchCoreV1NodeListRes, w http.R
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7356,6 +8019,7 @@ func encodeWatchCoreV1NodeListResponse(response WatchCoreV1NodeListRes, w http.R
 		return nil
 	case *WatchCoreV1NodeListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/nodes"+`: unexpected response type: %T`, response)
@@ -7367,6 +8031,7 @@ func encodeWatchCoreV1PersistentVolumeResponse(response WatchCoreV1PersistentVol
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7378,6 +8043,7 @@ func encodeWatchCoreV1PersistentVolumeResponse(response WatchCoreV1PersistentVol
 		return nil
 	case *WatchCoreV1PersistentVolumeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/persistentvolumes/{name}"+`: unexpected response type: %T`, response)
@@ -7389,6 +8055,7 @@ func encodeWatchCoreV1PersistentVolumeClaimListForAllNamespacesResponse(response
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7400,6 +8067,7 @@ func encodeWatchCoreV1PersistentVolumeClaimListForAllNamespacesResponse(response
 		return nil
 	case *WatchCoreV1PersistentVolumeClaimListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/persistentvolumeclaims"+`: unexpected response type: %T`, response)
@@ -7411,6 +8079,7 @@ func encodeWatchCoreV1PersistentVolumeListResponse(response WatchCoreV1Persisten
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7422,6 +8091,7 @@ func encodeWatchCoreV1PersistentVolumeListResponse(response WatchCoreV1Persisten
 		return nil
 	case *WatchCoreV1PersistentVolumeListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/persistentvolumes"+`: unexpected response type: %T`, response)
@@ -7433,6 +8103,7 @@ func encodeWatchCoreV1PodListForAllNamespacesResponse(response WatchCoreV1PodLis
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7444,6 +8115,7 @@ func encodeWatchCoreV1PodListForAllNamespacesResponse(response WatchCoreV1PodLis
 		return nil
 	case *WatchCoreV1PodListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/pods"+`: unexpected response type: %T`, response)
@@ -7455,6 +8127,7 @@ func encodeWatchCoreV1PodTemplateListForAllNamespacesResponse(response WatchCore
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7466,6 +8139,7 @@ func encodeWatchCoreV1PodTemplateListForAllNamespacesResponse(response WatchCore
 		return nil
 	case *WatchCoreV1PodTemplateListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/podtemplates"+`: unexpected response type: %T`, response)
@@ -7477,6 +8151,7 @@ func encodeWatchCoreV1ReplicationControllerListForAllNamespacesResponse(response
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7488,6 +8163,7 @@ func encodeWatchCoreV1ReplicationControllerListForAllNamespacesResponse(response
 		return nil
 	case *WatchCoreV1ReplicationControllerListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/replicationcontrollers"+`: unexpected response type: %T`, response)
@@ -7499,6 +8175,7 @@ func encodeWatchCoreV1ResourceQuotaListForAllNamespacesResponse(response WatchCo
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7510,6 +8187,7 @@ func encodeWatchCoreV1ResourceQuotaListForAllNamespacesResponse(response WatchCo
 		return nil
 	case *WatchCoreV1ResourceQuotaListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/resourcequotas"+`: unexpected response type: %T`, response)
@@ -7521,6 +8199,7 @@ func encodeWatchCoreV1SecretListForAllNamespacesResponse(response WatchCoreV1Sec
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7532,6 +8211,7 @@ func encodeWatchCoreV1SecretListForAllNamespacesResponse(response WatchCoreV1Sec
 		return nil
 	case *WatchCoreV1SecretListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/secrets"+`: unexpected response type: %T`, response)
@@ -7543,6 +8223,7 @@ func encodeWatchCoreV1ServiceAccountListForAllNamespacesResponse(response WatchC
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7554,6 +8235,7 @@ func encodeWatchCoreV1ServiceAccountListForAllNamespacesResponse(response WatchC
 		return nil
 	case *WatchCoreV1ServiceAccountListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/serviceaccounts"+`: unexpected response type: %T`, response)
@@ -7565,6 +8247,7 @@ func encodeWatchCoreV1ServiceListForAllNamespacesResponse(response WatchCoreV1Se
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7576,6 +8259,7 @@ func encodeWatchCoreV1ServiceListForAllNamespacesResponse(response WatchCoreV1Se
 		return nil
 	case *WatchCoreV1ServiceListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/api/v1/watch/services"+`: unexpected response type: %T`, response)
@@ -7587,6 +8271,7 @@ func encodeWatchDiscoveryV1EndpointSliceListForAllNamespacesResponse(response Wa
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7598,6 +8283,7 @@ func encodeWatchDiscoveryV1EndpointSliceListForAllNamespacesResponse(response Wa
 		return nil
 	case *WatchDiscoveryV1EndpointSliceListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/watch/endpointslices"+`: unexpected response type: %T`, response)
@@ -7609,6 +8295,7 @@ func encodeWatchDiscoveryV1NamespacedEndpointSliceResponse(response WatchDiscove
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7620,6 +8307,7 @@ func encodeWatchDiscoveryV1NamespacedEndpointSliceResponse(response WatchDiscove
 		return nil
 	case *WatchDiscoveryV1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/watch/namespaces/{namespace}/endpointslices/{name}"+`: unexpected response type: %T`, response)
@@ -7631,6 +8319,7 @@ func encodeWatchDiscoveryV1NamespacedEndpointSliceListResponse(response WatchDis
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7642,6 +8331,7 @@ func encodeWatchDiscoveryV1NamespacedEndpointSliceListResponse(response WatchDis
 		return nil
 	case *WatchDiscoveryV1NamespacedEndpointSliceListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1/watch/namespaces/{namespace}/endpointslices"+`: unexpected response type: %T`, response)
@@ -7653,6 +8343,7 @@ func encodeWatchDiscoveryV1beta1EndpointSliceListForAllNamespacesResponse(respon
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7664,6 +8355,7 @@ func encodeWatchDiscoveryV1beta1EndpointSliceListForAllNamespacesResponse(respon
 		return nil
 	case *WatchDiscoveryV1beta1EndpointSliceListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/watch/endpointslices"+`: unexpected response type: %T`, response)
@@ -7675,6 +8367,7 @@ func encodeWatchDiscoveryV1beta1NamespacedEndpointSliceResponse(response WatchDi
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7686,6 +8379,7 @@ func encodeWatchDiscoveryV1beta1NamespacedEndpointSliceResponse(response WatchDi
 		return nil
 	case *WatchDiscoveryV1beta1NamespacedEndpointSliceUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/watch/namespaces/{namespace}/endpointslices/{name}"+`: unexpected response type: %T`, response)
@@ -7697,6 +8391,7 @@ func encodeWatchDiscoveryV1beta1NamespacedEndpointSliceListResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7708,6 +8403,7 @@ func encodeWatchDiscoveryV1beta1NamespacedEndpointSliceListResponse(response Wat
 		return nil
 	case *WatchDiscoveryV1beta1NamespacedEndpointSliceListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/discovery.k8s.io/v1beta1/watch/namespaces/{namespace}/endpointslices"+`: unexpected response type: %T`, response)
@@ -7719,6 +8415,7 @@ func encodeWatchEventsV1EventListForAllNamespacesResponse(response WatchEventsV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7730,6 +8427,7 @@ func encodeWatchEventsV1EventListForAllNamespacesResponse(response WatchEventsV1
 		return nil
 	case *WatchEventsV1EventListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/watch/events"+`: unexpected response type: %T`, response)
@@ -7741,6 +8439,7 @@ func encodeWatchEventsV1NamespacedEventResponse(response WatchEventsV1Namespaced
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7752,6 +8451,7 @@ func encodeWatchEventsV1NamespacedEventResponse(response WatchEventsV1Namespaced
 		return nil
 	case *WatchEventsV1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/watch/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -7763,6 +8463,7 @@ func encodeWatchEventsV1NamespacedEventListResponse(response WatchEventsV1Namesp
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7774,6 +8475,7 @@ func encodeWatchEventsV1NamespacedEventListResponse(response WatchEventsV1Namesp
 		return nil
 	case *WatchEventsV1NamespacedEventListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1/watch/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -7785,6 +8487,7 @@ func encodeWatchEventsV1beta1EventListForAllNamespacesResponse(response WatchEve
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7796,6 +8499,7 @@ func encodeWatchEventsV1beta1EventListForAllNamespacesResponse(response WatchEve
 		return nil
 	case *WatchEventsV1beta1EventListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/watch/events"+`: unexpected response type: %T`, response)
@@ -7807,6 +8511,7 @@ func encodeWatchEventsV1beta1NamespacedEventResponse(response WatchEventsV1beta1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7818,6 +8523,7 @@ func encodeWatchEventsV1beta1NamespacedEventResponse(response WatchEventsV1beta1
 		return nil
 	case *WatchEventsV1beta1NamespacedEventUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events/{name}"+`: unexpected response type: %T`, response)
@@ -7829,6 +8535,7 @@ func encodeWatchEventsV1beta1NamespacedEventListResponse(response WatchEventsV1b
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7840,6 +8547,7 @@ func encodeWatchEventsV1beta1NamespacedEventListResponse(response WatchEventsV1b
 		return nil
 	case *WatchEventsV1beta1NamespacedEventListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events"+`: unexpected response type: %T`, response)
@@ -7851,6 +8559,7 @@ func encodeWatchFlowcontrolApiserverV1beta1FlowSchemaResponse(response WatchFlow
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7862,6 +8571,7 @@ func encodeWatchFlowcontrolApiserverV1beta1FlowSchemaResponse(response WatchFlow
 		return nil
 	case *WatchFlowcontrolApiserverV1beta1FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/flowschemas/{name}"+`: unexpected response type: %T`, response)
@@ -7873,6 +8583,7 @@ func encodeWatchFlowcontrolApiserverV1beta1FlowSchemaListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7884,6 +8595,7 @@ func encodeWatchFlowcontrolApiserverV1beta1FlowSchemaListResponse(response Watch
 		return nil
 	case *WatchFlowcontrolApiserverV1beta1FlowSchemaListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/flowschemas"+`: unexpected response type: %T`, response)
@@ -7895,6 +8607,7 @@ func encodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(re
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7906,6 +8619,7 @@ func encodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationResponse(re
 		return nil
 	case *WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/prioritylevelconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -7917,6 +8631,7 @@ func encodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListRespons
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7928,6 +8643,7 @@ func encodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListRespons
 		return nil
 	case *WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/prioritylevelconfigurations"+`: unexpected response type: %T`, response)
@@ -7939,6 +8655,7 @@ func encodeWatchFlowcontrolApiserverV1beta2FlowSchemaResponse(response WatchFlow
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7950,6 +8667,7 @@ func encodeWatchFlowcontrolApiserverV1beta2FlowSchemaResponse(response WatchFlow
 		return nil
 	case *WatchFlowcontrolApiserverV1beta2FlowSchemaUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/flowschemas/{name}"+`: unexpected response type: %T`, response)
@@ -7961,6 +8679,7 @@ func encodeWatchFlowcontrolApiserverV1beta2FlowSchemaListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7972,6 +8691,7 @@ func encodeWatchFlowcontrolApiserverV1beta2FlowSchemaListResponse(response Watch
 		return nil
 	case *WatchFlowcontrolApiserverV1beta2FlowSchemaListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/flowschemas"+`: unexpected response type: %T`, response)
@@ -7983,6 +8703,7 @@ func encodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(re
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -7994,6 +8715,7 @@ func encodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationResponse(re
 		return nil
 	case *WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/prioritylevelconfigurations/{name}"+`: unexpected response type: %T`, response)
@@ -8005,6 +8727,7 @@ func encodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListRespons
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8016,6 +8739,7 @@ func encodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListRespons
 		return nil
 	case *WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/prioritylevelconfigurations"+`: unexpected response type: %T`, response)
@@ -8027,6 +8751,7 @@ func encodeWatchInternalApiserverV1alpha1StorageVersionResponse(response WatchIn
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8038,6 +8763,7 @@ func encodeWatchInternalApiserverV1alpha1StorageVersionResponse(response WatchIn
 		return nil
 	case *WatchInternalApiserverV1alpha1StorageVersionUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/watch/storageversions/{name}"+`: unexpected response type: %T`, response)
@@ -8049,6 +8775,7 @@ func encodeWatchInternalApiserverV1alpha1StorageVersionListResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8060,6 +8787,7 @@ func encodeWatchInternalApiserverV1alpha1StorageVersionListResponse(response Wat
 		return nil
 	case *WatchInternalApiserverV1alpha1StorageVersionListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/internal.apiserver.k8s.io/v1alpha1/watch/storageversions"+`: unexpected response type: %T`, response)
@@ -8071,6 +8799,7 @@ func encodeWatchNetworkingV1IngressClassResponse(response WatchNetworkingV1Ingre
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8082,6 +8811,7 @@ func encodeWatchNetworkingV1IngressClassResponse(response WatchNetworkingV1Ingre
 		return nil
 	case *WatchNetworkingV1IngressClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/ingressclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8093,6 +8823,7 @@ func encodeWatchNetworkingV1IngressClassListResponse(response WatchNetworkingV1I
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8104,6 +8835,7 @@ func encodeWatchNetworkingV1IngressClassListResponse(response WatchNetworkingV1I
 		return nil
 	case *WatchNetworkingV1IngressClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/ingressclasses"+`: unexpected response type: %T`, response)
@@ -8115,6 +8847,7 @@ func encodeWatchNetworkingV1IngressListForAllNamespacesResponse(response WatchNe
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8126,6 +8859,7 @@ func encodeWatchNetworkingV1IngressListForAllNamespacesResponse(response WatchNe
 		return nil
 	case *WatchNetworkingV1IngressListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/ingresses"+`: unexpected response type: %T`, response)
@@ -8137,6 +8871,7 @@ func encodeWatchNetworkingV1NamespacedIngressResponse(response WatchNetworkingV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8148,6 +8883,7 @@ func encodeWatchNetworkingV1NamespacedIngressResponse(response WatchNetworkingV1
 		return nil
 	case *WatchNetworkingV1NamespacedIngressUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/ingresses/{name}"+`: unexpected response type: %T`, response)
@@ -8159,6 +8895,7 @@ func encodeWatchNetworkingV1NamespacedIngressListResponse(response WatchNetworki
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8170,6 +8907,7 @@ func encodeWatchNetworkingV1NamespacedIngressListResponse(response WatchNetworki
 		return nil
 	case *WatchNetworkingV1NamespacedIngressListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/ingresses"+`: unexpected response type: %T`, response)
@@ -8181,6 +8919,7 @@ func encodeWatchNetworkingV1NamespacedNetworkPolicyResponse(response WatchNetwor
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8192,6 +8931,7 @@ func encodeWatchNetworkingV1NamespacedNetworkPolicyResponse(response WatchNetwor
 		return nil
 	case *WatchNetworkingV1NamespacedNetworkPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies/{name}"+`: unexpected response type: %T`, response)
@@ -8203,6 +8943,7 @@ func encodeWatchNetworkingV1NamespacedNetworkPolicyListResponse(response WatchNe
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8214,6 +8955,7 @@ func encodeWatchNetworkingV1NamespacedNetworkPolicyListResponse(response WatchNe
 		return nil
 	case *WatchNetworkingV1NamespacedNetworkPolicyListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies"+`: unexpected response type: %T`, response)
@@ -8225,6 +8967,7 @@ func encodeWatchNetworkingV1NetworkPolicyListForAllNamespacesResponse(response W
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8236,6 +8979,7 @@ func encodeWatchNetworkingV1NetworkPolicyListForAllNamespacesResponse(response W
 		return nil
 	case *WatchNetworkingV1NetworkPolicyListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/networking.k8s.io/v1/watch/networkpolicies"+`: unexpected response type: %T`, response)
@@ -8247,6 +8991,7 @@ func encodeWatchNodeV1RuntimeClassResponse(response WatchNodeV1RuntimeClassRes, 
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8258,6 +9003,7 @@ func encodeWatchNodeV1RuntimeClassResponse(response WatchNodeV1RuntimeClassRes, 
 		return nil
 	case *WatchNodeV1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1/watch/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8269,6 +9015,7 @@ func encodeWatchNodeV1RuntimeClassListResponse(response WatchNodeV1RuntimeClassL
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8280,6 +9027,7 @@ func encodeWatchNodeV1RuntimeClassListResponse(response WatchNodeV1RuntimeClassL
 		return nil
 	case *WatchNodeV1RuntimeClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1/watch/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -8291,6 +9039,7 @@ func encodeWatchNodeV1alpha1RuntimeClassResponse(response WatchNodeV1alpha1Runti
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8302,6 +9051,7 @@ func encodeWatchNodeV1alpha1RuntimeClassResponse(response WatchNodeV1alpha1Runti
 		return nil
 	case *WatchNodeV1alpha1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1alpha1/watch/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8313,6 +9063,7 @@ func encodeWatchNodeV1alpha1RuntimeClassListResponse(response WatchNodeV1alpha1R
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8324,6 +9075,7 @@ func encodeWatchNodeV1alpha1RuntimeClassListResponse(response WatchNodeV1alpha1R
 		return nil
 	case *WatchNodeV1alpha1RuntimeClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1alpha1/watch/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -8335,6 +9087,7 @@ func encodeWatchNodeV1beta1RuntimeClassResponse(response WatchNodeV1beta1Runtime
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8346,6 +9099,7 @@ func encodeWatchNodeV1beta1RuntimeClassResponse(response WatchNodeV1beta1Runtime
 		return nil
 	case *WatchNodeV1beta1RuntimeClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1beta1/watch/runtimeclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8357,6 +9111,7 @@ func encodeWatchNodeV1beta1RuntimeClassListResponse(response WatchNodeV1beta1Run
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8368,6 +9123,7 @@ func encodeWatchNodeV1beta1RuntimeClassListResponse(response WatchNodeV1beta1Run
 		return nil
 	case *WatchNodeV1beta1RuntimeClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/node.k8s.io/v1beta1/watch/runtimeclasses"+`: unexpected response type: %T`, response)
@@ -8379,6 +9135,7 @@ func encodeWatchPolicyV1NamespacedPodDisruptionBudgetResponse(response WatchPoli
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8390,6 +9147,7 @@ func encodeWatchPolicyV1NamespacedPodDisruptionBudgetResponse(response WatchPoli
 		return nil
 	case *WatchPolicyV1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}"+`: unexpected response type: %T`, response)
@@ -8401,6 +9159,7 @@ func encodeWatchPolicyV1NamespacedPodDisruptionBudgetListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8412,6 +9171,7 @@ func encodeWatchPolicyV1NamespacedPodDisruptionBudgetListResponse(response Watch
 		return nil
 	case *WatchPolicyV1NamespacedPodDisruptionBudgetListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/watch/namespaces/{namespace}/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -8423,6 +9183,7 @@ func encodeWatchPolicyV1PodDisruptionBudgetListForAllNamespacesResponse(response
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8434,6 +9195,7 @@ func encodeWatchPolicyV1PodDisruptionBudgetListForAllNamespacesResponse(response
 		return nil
 	case *WatchPolicyV1PodDisruptionBudgetListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1/watch/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -8445,6 +9207,7 @@ func encodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response Watc
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8456,6 +9219,7 @@ func encodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetResponse(response Watc
 		return nil
 	case *WatchPolicyV1beta1NamespacedPodDisruptionBudgetUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}"+`: unexpected response type: %T`, response)
@@ -8467,6 +9231,7 @@ func encodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetListResponse(response 
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8478,6 +9243,7 @@ func encodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetListResponse(response 
 		return nil
 	case *WatchPolicyV1beta1NamespacedPodDisruptionBudgetListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -8489,6 +9255,7 @@ func encodeWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesResponse(res
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8500,6 +9267,7 @@ func encodeWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesResponse(res
 		return nil
 	case *WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/watch/poddisruptionbudgets"+`: unexpected response type: %T`, response)
@@ -8511,6 +9279,7 @@ func encodeWatchPolicyV1beta1PodSecurityPolicyResponse(response WatchPolicyV1bet
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8522,6 +9291,7 @@ func encodeWatchPolicyV1beta1PodSecurityPolicyResponse(response WatchPolicyV1bet
 		return nil
 	case *WatchPolicyV1beta1PodSecurityPolicyUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/watch/podsecuritypolicies/{name}"+`: unexpected response type: %T`, response)
@@ -8533,6 +9303,7 @@ func encodeWatchPolicyV1beta1PodSecurityPolicyListResponse(response WatchPolicyV
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8544,6 +9315,7 @@ func encodeWatchPolicyV1beta1PodSecurityPolicyListResponse(response WatchPolicyV
 		return nil
 	case *WatchPolicyV1beta1PodSecurityPolicyListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/policy/v1beta1/watch/podsecuritypolicies"+`: unexpected response type: %T`, response)
@@ -8555,6 +9327,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleResponse(response WatchRbacAuthori
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8566,6 +9339,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleResponse(response WatchRbacAuthori
 		return nil
 	case *WatchRbacAuthorizationV1ClusterRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/clusterroles/{name}"+`: unexpected response type: %T`, response)
@@ -8577,6 +9351,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleBindingResponse(response WatchRbac
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8588,6 +9363,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleBindingResponse(response WatchRbac
 		return nil
 	case *WatchRbacAuthorizationV1ClusterRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings/{name}"+`: unexpected response type: %T`, response)
@@ -8599,6 +9375,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleBindingListResponse(response Watch
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8610,6 +9387,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleBindingListResponse(response Watch
 		return nil
 	case *WatchRbacAuthorizationV1ClusterRoleBindingListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings"+`: unexpected response type: %T`, response)
@@ -8621,6 +9399,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleListResponse(response WatchRbacAut
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8632,6 +9411,7 @@ func encodeWatchRbacAuthorizationV1ClusterRoleListResponse(response WatchRbacAut
 		return nil
 	case *WatchRbacAuthorizationV1ClusterRoleListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/clusterroles"+`: unexpected response type: %T`, response)
@@ -8643,6 +9423,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleResponse(response WatchRbacAuth
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8654,6 +9435,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleResponse(response WatchRbacAuth
 		return nil
 	case *WatchRbacAuthorizationV1NamespacedRoleUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles/{name}"+`: unexpected response type: %T`, response)
@@ -8665,6 +9447,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleBindingResponse(response WatchR
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8676,6 +9459,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleBindingResponse(response WatchR
 		return nil
 	case *WatchRbacAuthorizationV1NamespacedRoleBindingUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings/{name}"+`: unexpected response type: %T`, response)
@@ -8687,6 +9471,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleBindingListResponse(response Wa
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8698,6 +9483,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleBindingListResponse(response Wa
 		return nil
 	case *WatchRbacAuthorizationV1NamespacedRoleBindingListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings"+`: unexpected response type: %T`, response)
@@ -8709,6 +9495,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleListResponse(response WatchRbac
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8720,6 +9507,7 @@ func encodeWatchRbacAuthorizationV1NamespacedRoleListResponse(response WatchRbac
 		return nil
 	case *WatchRbacAuthorizationV1NamespacedRoleListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles"+`: unexpected response type: %T`, response)
@@ -8731,6 +9519,7 @@ func encodeWatchRbacAuthorizationV1RoleBindingListForAllNamespacesResponse(respo
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8742,6 +9531,7 @@ func encodeWatchRbacAuthorizationV1RoleBindingListForAllNamespacesResponse(respo
 		return nil
 	case *WatchRbacAuthorizationV1RoleBindingListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/rolebindings"+`: unexpected response type: %T`, response)
@@ -8753,6 +9543,7 @@ func encodeWatchRbacAuthorizationV1RoleListForAllNamespacesResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8764,6 +9555,7 @@ func encodeWatchRbacAuthorizationV1RoleListForAllNamespacesResponse(response Wat
 		return nil
 	case *WatchRbacAuthorizationV1RoleListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/rbac.authorization.k8s.io/v1/watch/roles"+`: unexpected response type: %T`, response)
@@ -8775,6 +9567,7 @@ func encodeWatchSchedulingV1PriorityClassResponse(response WatchSchedulingV1Prio
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8786,6 +9579,7 @@ func encodeWatchSchedulingV1PriorityClassResponse(response WatchSchedulingV1Prio
 		return nil
 	case *WatchSchedulingV1PriorityClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/v1/watch/priorityclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8797,6 +9591,7 @@ func encodeWatchSchedulingV1PriorityClassListResponse(response WatchSchedulingV1
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8808,6 +9603,7 @@ func encodeWatchSchedulingV1PriorityClassListResponse(response WatchSchedulingV1
 		return nil
 	case *WatchSchedulingV1PriorityClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/scheduling.k8s.io/v1/watch/priorityclasses"+`: unexpected response type: %T`, response)
@@ -8819,6 +9615,7 @@ func encodeWatchStorageV1CSIDriverResponse(response WatchStorageV1CSIDriverRes, 
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8830,6 +9627,7 @@ func encodeWatchStorageV1CSIDriverResponse(response WatchStorageV1CSIDriverRes, 
 		return nil
 	case *WatchStorageV1CSIDriverUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/csidrivers/{name}"+`: unexpected response type: %T`, response)
@@ -8841,6 +9639,7 @@ func encodeWatchStorageV1CSIDriverListResponse(response WatchStorageV1CSIDriverL
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8852,6 +9651,7 @@ func encodeWatchStorageV1CSIDriverListResponse(response WatchStorageV1CSIDriverL
 		return nil
 	case *WatchStorageV1CSIDriverListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/csidrivers"+`: unexpected response type: %T`, response)
@@ -8863,6 +9663,7 @@ func encodeWatchStorageV1CSINodeResponse(response WatchStorageV1CSINodeRes, w ht
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8874,6 +9675,7 @@ func encodeWatchStorageV1CSINodeResponse(response WatchStorageV1CSINodeRes, w ht
 		return nil
 	case *WatchStorageV1CSINodeUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/csinodes/{name}"+`: unexpected response type: %T`, response)
@@ -8885,6 +9687,7 @@ func encodeWatchStorageV1CSINodeListResponse(response WatchStorageV1CSINodeListR
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8896,6 +9699,7 @@ func encodeWatchStorageV1CSINodeListResponse(response WatchStorageV1CSINodeListR
 		return nil
 	case *WatchStorageV1CSINodeListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/csinodes"+`: unexpected response type: %T`, response)
@@ -8907,6 +9711,7 @@ func encodeWatchStorageV1StorageClassResponse(response WatchStorageV1StorageClas
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8918,6 +9723,7 @@ func encodeWatchStorageV1StorageClassResponse(response WatchStorageV1StorageClas
 		return nil
 	case *WatchStorageV1StorageClassUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/storageclasses/{name}"+`: unexpected response type: %T`, response)
@@ -8929,6 +9735,7 @@ func encodeWatchStorageV1StorageClassListResponse(response WatchStorageV1Storage
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8940,6 +9747,7 @@ func encodeWatchStorageV1StorageClassListResponse(response WatchStorageV1Storage
 		return nil
 	case *WatchStorageV1StorageClassListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/storageclasses"+`: unexpected response type: %T`, response)
@@ -8951,6 +9759,7 @@ func encodeWatchStorageV1VolumeAttachmentResponse(response WatchStorageV1VolumeA
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8962,6 +9771,7 @@ func encodeWatchStorageV1VolumeAttachmentResponse(response WatchStorageV1VolumeA
 		return nil
 	case *WatchStorageV1VolumeAttachmentUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/volumeattachments/{name}"+`: unexpected response type: %T`, response)
@@ -8973,6 +9783,7 @@ func encodeWatchStorageV1VolumeAttachmentListResponse(response WatchStorageV1Vol
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -8984,6 +9795,7 @@ func encodeWatchStorageV1VolumeAttachmentListResponse(response WatchStorageV1Vol
 		return nil
 	case *WatchStorageV1VolumeAttachmentListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1/watch/volumeattachments"+`: unexpected response type: %T`, response)
@@ -8995,6 +9807,7 @@ func encodeWatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesResponse(re
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9006,6 +9819,7 @@ func encodeWatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesResponse(re
 		return nil
 	case *WatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/watch/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -9017,6 +9831,7 @@ func encodeWatchStorageV1alpha1NamespacedCSIStorageCapacityResponse(response Wat
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9028,6 +9843,7 @@ func encodeWatchStorageV1alpha1NamespacedCSIStorageCapacityResponse(response Wat
 		return nil
 	case *WatchStorageV1alpha1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/watch/namespaces/{namespace}/csistoragecapacities/{name}"+`: unexpected response type: %T`, response)
@@ -9039,6 +9855,7 @@ func encodeWatchStorageV1alpha1NamespacedCSIStorageCapacityListResponse(response
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9050,6 +9867,7 @@ func encodeWatchStorageV1alpha1NamespacedCSIStorageCapacityListResponse(response
 		return nil
 	case *WatchStorageV1alpha1NamespacedCSIStorageCapacityListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1alpha1/watch/namespaces/{namespace}/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -9061,6 +9879,7 @@ func encodeWatchStorageV1beta1CSIStorageCapacityListForAllNamespacesResponse(res
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9072,6 +9891,7 @@ func encodeWatchStorageV1beta1CSIStorageCapacityListForAllNamespacesResponse(res
 		return nil
 	case *WatchStorageV1beta1CSIStorageCapacityListForAllNamespacesUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/watch/csistoragecapacities"+`: unexpected response type: %T`, response)
@@ -9083,6 +9903,7 @@ func encodeWatchStorageV1beta1NamespacedCSIStorageCapacityResponse(response Watc
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9094,6 +9915,7 @@ func encodeWatchStorageV1beta1NamespacedCSIStorageCapacityResponse(response Watc
 		return nil
 	case *WatchStorageV1beta1NamespacedCSIStorageCapacityUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/watch/namespaces/{namespace}/csistoragecapacities/{name}"+`: unexpected response type: %T`, response)
@@ -9105,6 +9927,7 @@ func encodeWatchStorageV1beta1NamespacedCSIStorageCapacityListResponse(response 
 	case *IoK8sApimachineryPkgApisMetaV1WatchEvent:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -9116,6 +9939,7 @@ func encodeWatchStorageV1beta1NamespacedCSIStorageCapacityListResponse(response 
 		return nil
 	case *WatchStorageV1beta1NamespacedCSIStorageCapacityListUnauthorized:
 		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
 		return nil
 	default:
 		return errors.Errorf("/apis/storage.k8s.io/v1beta1/watch/namespaces/{namespace}/csistoragecapacities"+`: unexpected response type: %T`, response)

--- a/examples/ex_manga/oas_handlers_gen.go
+++ b/examples/ex_manga/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleGetBookRequest(args [1]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -149,7 +148,6 @@ func (s *Server) handleSearchRequest(args [0]string, w http.ResponseWriter, r *h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -191,7 +189,6 @@ func (s *Server) handleSearchByTagIDRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_manga/oas_res_enc_gen.go
+++ b/examples/ex_manga/oas_res_enc_gen.go
@@ -75,6 +75,7 @@ func encodeGetBookResponse(response GetBookRes, w http.ResponseWriter, span trac
 	case *Book:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -86,6 +87,7 @@ func encodeGetBookResponse(response GetBookRes, w http.ResponseWriter, span trac
 		return nil
 	case *GetBookForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/api/gallery/{book_id}"+`: unexpected response type: %T`, response)
@@ -97,6 +99,7 @@ func encodeSearchResponse(response SearchRes, w http.ResponseWriter, span trace.
 	case *SearchOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -108,6 +111,7 @@ func encodeSearchResponse(response SearchRes, w http.ResponseWriter, span trace.
 		return nil
 	case *SearchForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/api/galleries/search"+`: unexpected response type: %T`, response)
@@ -119,6 +123,7 @@ func encodeSearchByTagIDResponse(response SearchByTagIDRes, w http.ResponseWrite
 	case *SearchByTagIDOKApplicationJSON:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -130,6 +135,7 @@ func encodeSearchByTagIDResponse(response SearchByTagIDRes, w http.ResponseWrite
 		return nil
 	case *SearchByTagIDForbidden:
 		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
 		return nil
 	default:
 		return errors.Errorf("/api/galleries/tagged"+`: unexpected response type: %T`, response)

--- a/examples/ex_petstore/oas_handlers_gen.go
+++ b/examples/ex_petstore/oas_handlers_gen.go
@@ -102,7 +102,6 @@ func (s *Server) handleCreatePetsRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -144,7 +143,6 @@ func (s *Server) handleListPetsRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -186,7 +184,6 @@ func (s *Server) handleShowPetByIdRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_petstore/oas_res_enc_gen.go
+++ b/examples/ex_petstore/oas_res_enc_gen.go
@@ -74,10 +74,17 @@ func encodeCreatePetsResponse(response CreatePetsRes, w http.ResponseWriter, spa
 	switch response := response.(type) {
 	case *CreatePetsCreated:
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -97,6 +104,7 @@ func encodeListPetsResponse(response ListPetsRes, w http.ResponseWriter, span tr
 	case *Pets:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -109,6 +117,12 @@ func encodeListPetsResponse(response ListPetsRes, w http.ResponseWriter, span tr
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -128,6 +142,7 @@ func encodeShowPetByIdResponse(response ShowPetByIdRes, w http.ResponseWriter, s
 	case *Pet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -140,6 +155,12 @@ func encodeShowPetByIdResponse(response ShowPetByIdRes, w http.ResponseWriter, s
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/examples/ex_petstore_expanded/oas_handlers_gen.go
+++ b/examples/ex_petstore_expanded/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleDeletePetRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_petstore_expanded/oas_res_enc_gen.go
+++ b/examples/ex_petstore_expanded/oas_res_enc_gen.go
@@ -74,10 +74,17 @@ func encodeDeletePetResponse(response DeletePetRes, w http.ResponseWriter, span 
 	switch response := response.(type) {
 	case *DeletePetNoContent:
 		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/examples/ex_route_params/oas_handlers_gen.go
+++ b/examples/ex_route_params/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleDataGetRequest(args [2]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -144,7 +143,6 @@ func (s *Server) handleDataGetAnyRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -186,7 +184,6 @@ func (s *Server) handleDataGetIDRequest(args [1]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_route_params/oas_res_enc_gen.go
+++ b/examples/ex_route_params/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeDataGetResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeDataGetResponse(response string, w http.ResponseWriter, span trace.Sp
 func encodeDataGetAnyResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,7 @@ func encodeDataGetAnyResponse(response string, w http.ResponseWriter, span trace
 func encodeDataGetIDResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/examples/ex_telegram/oas_handlers_gen.go
+++ b/examples/ex_telegram/oas_handlers_gen.go
@@ -116,7 +116,6 @@ func (s *Server) handleAddStickerToSetRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -167,7 +166,6 @@ func (s *Server) handleAnswerCallbackQueryRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -218,7 +216,6 @@ func (s *Server) handleAnswerInlineQueryRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -269,7 +266,6 @@ func (s *Server) handleAnswerPreCheckoutQueryRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -320,7 +316,6 @@ func (s *Server) handleAnswerShippingQueryRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -371,7 +366,6 @@ func (s *Server) handleApproveChatJoinRequestRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -422,7 +416,6 @@ func (s *Server) handleBanChatMemberRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -473,7 +466,6 @@ func (s *Server) handleBanChatSenderChatRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -519,7 +511,6 @@ func (s *Server) handleCloseRequest(args [0]string, w http.ResponseWriter, r *ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -570,7 +561,6 @@ func (s *Server) handleCopyMessageRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -621,7 +611,6 @@ func (s *Server) handleCreateChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -672,7 +661,6 @@ func (s *Server) handleCreateNewStickerSetRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -723,7 +711,6 @@ func (s *Server) handleDeclineChatJoinRequestRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -774,7 +761,6 @@ func (s *Server) handleDeleteChatPhotoRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -825,7 +811,6 @@ func (s *Server) handleDeleteChatStickerSetRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -876,7 +861,6 @@ func (s *Server) handleDeleteMessageRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -927,7 +911,6 @@ func (s *Server) handleDeleteMyCommandsRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -978,7 +961,6 @@ func (s *Server) handleDeleteStickerFromSetRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1029,7 +1011,6 @@ func (s *Server) handleDeleteWebhookRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1080,7 +1061,6 @@ func (s *Server) handleEditChatInviteLinkRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1131,7 +1111,6 @@ func (s *Server) handleEditMessageCaptionRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1182,7 +1161,6 @@ func (s *Server) handleEditMessageLiveLocationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1233,7 +1211,6 @@ func (s *Server) handleEditMessageMediaRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1284,7 +1261,6 @@ func (s *Server) handleEditMessageReplyMarkupRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1335,7 +1311,6 @@ func (s *Server) handleEditMessageTextRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1386,7 +1361,6 @@ func (s *Server) handleExportChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1437,7 +1411,6 @@ func (s *Server) handleForwardMessageRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1488,7 +1461,6 @@ func (s *Server) handleGetChatRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1539,7 +1511,6 @@ func (s *Server) handleGetChatAdministratorsRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1590,7 +1561,6 @@ func (s *Server) handleGetChatMemberRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1641,7 +1611,6 @@ func (s *Server) handleGetChatMemberCountRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1692,7 +1661,6 @@ func (s *Server) handleGetFileRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1743,7 +1711,6 @@ func (s *Server) handleGetGameHighScoresRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1789,7 +1756,6 @@ func (s *Server) handleGetMeRequest(args [0]string, w http.ResponseWriter, r *ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1840,7 +1806,6 @@ func (s *Server) handleGetMyCommandsRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1891,7 +1856,6 @@ func (s *Server) handleGetStickerSetRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1942,7 +1906,6 @@ func (s *Server) handleGetUpdatesRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1993,7 +1956,6 @@ func (s *Server) handleGetUserProfilePhotosRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2039,7 +2001,6 @@ func (s *Server) handleGetWebhookInfoRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2090,7 +2051,6 @@ func (s *Server) handleLeaveChatRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2136,7 +2096,6 @@ func (s *Server) handleLogOutRequest(args [0]string, w http.ResponseWriter, r *h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2187,7 +2146,6 @@ func (s *Server) handlePinChatMessageRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2238,7 +2196,6 @@ func (s *Server) handlePromoteChatMemberRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2289,7 +2246,6 @@ func (s *Server) handleRestrictChatMemberRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2340,7 +2296,6 @@ func (s *Server) handleRevokeChatInviteLinkRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2391,7 +2346,6 @@ func (s *Server) handleSendAnimationRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2442,7 +2396,6 @@ func (s *Server) handleSendAudioRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2493,7 +2446,6 @@ func (s *Server) handleSendChatActionRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2544,7 +2496,6 @@ func (s *Server) handleSendContactRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2595,7 +2546,6 @@ func (s *Server) handleSendDiceRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2646,7 +2596,6 @@ func (s *Server) handleSendDocumentRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2697,7 +2646,6 @@ func (s *Server) handleSendGameRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2748,7 +2696,6 @@ func (s *Server) handleSendInvoiceRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2799,7 +2746,6 @@ func (s *Server) handleSendLocationRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2850,7 +2796,6 @@ func (s *Server) handleSendMediaGroupRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2901,7 +2846,6 @@ func (s *Server) handleSendMessageRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2952,7 +2896,6 @@ func (s *Server) handleSendPhotoRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3003,7 +2946,6 @@ func (s *Server) handleSendPollRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3054,7 +2996,6 @@ func (s *Server) handleSendStickerRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3105,7 +3046,6 @@ func (s *Server) handleSendVenueRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3156,7 +3096,6 @@ func (s *Server) handleSendVideoRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3207,7 +3146,6 @@ func (s *Server) handleSendVideoNoteRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3258,7 +3196,6 @@ func (s *Server) handleSendVoiceRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3309,7 +3246,6 @@ func (s *Server) handleSetChatAdministratorCustomTitleRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3360,7 +3296,6 @@ func (s *Server) handleSetChatDescriptionRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3411,7 +3346,6 @@ func (s *Server) handleSetChatPermissionsRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3462,7 +3396,6 @@ func (s *Server) handleSetChatPhotoRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3513,7 +3446,6 @@ func (s *Server) handleSetChatStickerSetRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3564,7 +3496,6 @@ func (s *Server) handleSetChatTitleRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3615,7 +3546,6 @@ func (s *Server) handleSetGameScoreRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3666,7 +3596,6 @@ func (s *Server) handleSetMyCommandsRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3717,7 +3646,6 @@ func (s *Server) handleSetPassportDataErrorsRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3768,7 +3696,6 @@ func (s *Server) handleSetStickerPositionInSetRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3819,7 +3746,6 @@ func (s *Server) handleSetStickerSetThumbRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3870,7 +3796,6 @@ func (s *Server) handleSetWebhookRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3921,7 +3846,6 @@ func (s *Server) handleStopMessageLiveLocationRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3972,7 +3896,6 @@ func (s *Server) handleStopPollRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4023,7 +3946,6 @@ func (s *Server) handleUnbanChatMemberRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4074,7 +3996,6 @@ func (s *Server) handleUnbanChatSenderChatRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4125,7 +4046,6 @@ func (s *Server) handleUnpinAllChatMessagesRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4176,7 +4096,6 @@ func (s *Server) handleUnpinChatMessageRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4227,7 +4146,6 @@ func (s *Server) handleUploadStickerFileRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_telegram/oas_res_enc_gen.go
+++ b/examples/ex_telegram/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeAddStickerToSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeAddStickerToSetResponse(response Result, w http.ResponseWriter, span 
 func encodeAnswerCallbackQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,7 @@ func encodeAnswerCallbackQueryResponse(response Result, w http.ResponseWriter, s
 func encodeAnswerInlineQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -115,6 +118,7 @@ func encodeAnswerInlineQueryResponse(response Result, w http.ResponseWriter, spa
 func encodeAnswerPreCheckoutQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -129,6 +133,7 @@ func encodeAnswerPreCheckoutQueryResponse(response Result, w http.ResponseWriter
 func encodeAnswerShippingQueryResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -143,6 +148,7 @@ func encodeAnswerShippingQueryResponse(response Result, w http.ResponseWriter, s
 func encodeApproveChatJoinRequestResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -157,6 +163,7 @@ func encodeApproveChatJoinRequestResponse(response Result, w http.ResponseWriter
 func encodeBanChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -171,6 +178,7 @@ func encodeBanChatMemberResponse(response Result, w http.ResponseWriter, span tr
 func encodeBanChatSenderChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -185,6 +193,7 @@ func encodeBanChatSenderChatResponse(response Result, w http.ResponseWriter, spa
 func encodeCloseResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -199,6 +208,7 @@ func encodeCloseResponse(response Result, w http.ResponseWriter, span trace.Span
 func encodeCopyMessageResponse(response ResultMessageId, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -213,6 +223,7 @@ func encodeCopyMessageResponse(response ResultMessageId, w http.ResponseWriter, 
 func encodeCreateChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -227,6 +238,7 @@ func encodeCreateChatInviteLinkResponse(response ResultChatInviteLink, w http.Re
 func encodeCreateNewStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -241,6 +253,7 @@ func encodeCreateNewStickerSetResponse(response Result, w http.ResponseWriter, s
 func encodeDeclineChatJoinRequestResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -255,6 +268,7 @@ func encodeDeclineChatJoinRequestResponse(response Result, w http.ResponseWriter
 func encodeDeleteChatPhotoResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -269,6 +283,7 @@ func encodeDeleteChatPhotoResponse(response Result, w http.ResponseWriter, span 
 func encodeDeleteChatStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -283,6 +298,7 @@ func encodeDeleteChatStickerSetResponse(response Result, w http.ResponseWriter, 
 func encodeDeleteMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -297,6 +313,7 @@ func encodeDeleteMessageResponse(response Result, w http.ResponseWriter, span tr
 func encodeDeleteMyCommandsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -311,6 +328,7 @@ func encodeDeleteMyCommandsResponse(response Result, w http.ResponseWriter, span
 func encodeDeleteStickerFromSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -325,6 +343,7 @@ func encodeDeleteStickerFromSetResponse(response Result, w http.ResponseWriter, 
 func encodeDeleteWebhookResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -339,6 +358,7 @@ func encodeDeleteWebhookResponse(response Result, w http.ResponseWriter, span tr
 func encodeEditChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -353,6 +373,7 @@ func encodeEditChatInviteLinkResponse(response ResultChatInviteLink, w http.Resp
 func encodeEditMessageCaptionResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -367,6 +388,7 @@ func encodeEditMessageCaptionResponse(response Result, w http.ResponseWriter, sp
 func encodeEditMessageLiveLocationResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -381,6 +403,7 @@ func encodeEditMessageLiveLocationResponse(response Result, w http.ResponseWrite
 func encodeEditMessageMediaResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -395,6 +418,7 @@ func encodeEditMessageMediaResponse(response Result, w http.ResponseWriter, span
 func encodeEditMessageReplyMarkupResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -409,6 +433,7 @@ func encodeEditMessageReplyMarkupResponse(response Result, w http.ResponseWriter
 func encodeEditMessageTextResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -423,6 +448,7 @@ func encodeEditMessageTextResponse(response Result, w http.ResponseWriter, span 
 func encodeExportChatInviteLinkResponse(response ResultString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -437,6 +463,7 @@ func encodeExportChatInviteLinkResponse(response ResultString, w http.ResponseWr
 func encodeForwardMessageResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -451,6 +478,7 @@ func encodeForwardMessageResponse(response ResultMessage, w http.ResponseWriter,
 func encodeGetChatResponse(response ResultChat, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -465,6 +493,7 @@ func encodeGetChatResponse(response ResultChat, w http.ResponseWriter, span trac
 func encodeGetChatAdministratorsResponse(response ResultArrayOfChatMember, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -479,6 +508,7 @@ func encodeGetChatAdministratorsResponse(response ResultArrayOfChatMember, w htt
 func encodeGetChatMemberResponse(response ResultChatMember, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -493,6 +523,7 @@ func encodeGetChatMemberResponse(response ResultChatMember, w http.ResponseWrite
 func encodeGetChatMemberCountResponse(response ResultInt, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -507,6 +538,7 @@ func encodeGetChatMemberCountResponse(response ResultInt, w http.ResponseWriter,
 func encodeGetFileResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -521,6 +553,7 @@ func encodeGetFileResponse(response Result, w http.ResponseWriter, span trace.Sp
 func encodeGetGameHighScoresResponse(response ResultArrayOfGameHighScore, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -535,6 +568,7 @@ func encodeGetGameHighScoresResponse(response ResultArrayOfGameHighScore, w http
 func encodeGetMeResponse(response ResultUser, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -549,6 +583,7 @@ func encodeGetMeResponse(response ResultUser, w http.ResponseWriter, span trace.
 func encodeGetMyCommandsResponse(response ResultArrayOfBotCommand, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -563,6 +598,7 @@ func encodeGetMyCommandsResponse(response ResultArrayOfBotCommand, w http.Respon
 func encodeGetStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -577,6 +613,7 @@ func encodeGetStickerSetResponse(response Result, w http.ResponseWriter, span tr
 func encodeGetUpdatesResponse(response ResultArrayOfUpdate, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -591,6 +628,7 @@ func encodeGetUpdatesResponse(response ResultArrayOfUpdate, w http.ResponseWrite
 func encodeGetUserProfilePhotosResponse(response ResultUserProfilePhotos, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -605,6 +643,7 @@ func encodeGetUserProfilePhotosResponse(response ResultUserProfilePhotos, w http
 func encodeGetWebhookInfoResponse(response ResultWebhookInfo, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -619,6 +658,7 @@ func encodeGetWebhookInfoResponse(response ResultWebhookInfo, w http.ResponseWri
 func encodeLeaveChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -633,6 +673,7 @@ func encodeLeaveChatResponse(response Result, w http.ResponseWriter, span trace.
 func encodeLogOutResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -647,6 +688,7 @@ func encodeLogOutResponse(response Result, w http.ResponseWriter, span trace.Spa
 func encodePinChatMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -661,6 +703,7 @@ func encodePinChatMessageResponse(response Result, w http.ResponseWriter, span t
 func encodePromoteChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -675,6 +718,7 @@ func encodePromoteChatMemberResponse(response Result, w http.ResponseWriter, spa
 func encodeRestrictChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -689,6 +733,7 @@ func encodeRestrictChatMemberResponse(response Result, w http.ResponseWriter, sp
 func encodeRevokeChatInviteLinkResponse(response ResultChatInviteLink, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -703,6 +748,7 @@ func encodeRevokeChatInviteLinkResponse(response ResultChatInviteLink, w http.Re
 func encodeSendAnimationResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -717,6 +763,7 @@ func encodeSendAnimationResponse(response ResultMessage, w http.ResponseWriter, 
 func encodeSendAudioResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -731,6 +778,7 @@ func encodeSendAudioResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendChatActionResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -745,6 +793,7 @@ func encodeSendChatActionResponse(response Result, w http.ResponseWriter, span t
 func encodeSendContactResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -759,6 +808,7 @@ func encodeSendContactResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendDiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -773,6 +823,7 @@ func encodeSendDiceResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendDocumentResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -787,6 +838,7 @@ func encodeSendDocumentResponse(response ResultMessage, w http.ResponseWriter, s
 func encodeSendGameResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -801,6 +853,7 @@ func encodeSendGameResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendInvoiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -815,6 +868,7 @@ func encodeSendInvoiceResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendLocationResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -829,6 +883,7 @@ func encodeSendLocationResponse(response ResultMessage, w http.ResponseWriter, s
 func encodeSendMediaGroupResponse(response ResultArrayOfMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -843,6 +898,7 @@ func encodeSendMediaGroupResponse(response ResultArrayOfMessage, w http.Response
 func encodeSendMessageResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -857,6 +913,7 @@ func encodeSendMessageResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendPhotoResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -871,6 +928,7 @@ func encodeSendPhotoResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendPollResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -885,6 +943,7 @@ func encodeSendPollResponse(response ResultMessage, w http.ResponseWriter, span 
 func encodeSendStickerResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -899,6 +958,7 @@ func encodeSendStickerResponse(response ResultMessage, w http.ResponseWriter, sp
 func encodeSendVenueResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -913,6 +973,7 @@ func encodeSendVenueResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendVideoResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -927,6 +988,7 @@ func encodeSendVideoResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSendVideoNoteResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -941,6 +1003,7 @@ func encodeSendVideoNoteResponse(response ResultMessage, w http.ResponseWriter, 
 func encodeSendVoiceResponse(response ResultMessage, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -955,6 +1018,7 @@ func encodeSendVoiceResponse(response ResultMessage, w http.ResponseWriter, span
 func encodeSetChatAdministratorCustomTitleResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -969,6 +1033,7 @@ func encodeSetChatAdministratorCustomTitleResponse(response Result, w http.Respo
 func encodeSetChatDescriptionResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -983,6 +1048,7 @@ func encodeSetChatDescriptionResponse(response Result, w http.ResponseWriter, sp
 func encodeSetChatPermissionsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -997,6 +1063,7 @@ func encodeSetChatPermissionsResponse(response Result, w http.ResponseWriter, sp
 func encodeSetChatPhotoResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1011,6 +1078,7 @@ func encodeSetChatPhotoResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetChatStickerSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1025,6 +1093,7 @@ func encodeSetChatStickerSetResponse(response Result, w http.ResponseWriter, spa
 func encodeSetChatTitleResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1039,6 +1108,7 @@ func encodeSetChatTitleResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetGameScoreResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1053,6 +1123,7 @@ func encodeSetGameScoreResponse(response Result, w http.ResponseWriter, span tra
 func encodeSetMyCommandsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1067,6 +1138,7 @@ func encodeSetMyCommandsResponse(response Result, w http.ResponseWriter, span tr
 func encodeSetPassportDataErrorsResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1081,6 +1153,7 @@ func encodeSetPassportDataErrorsResponse(response Result, w http.ResponseWriter,
 func encodeSetStickerPositionInSetResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1095,6 +1168,7 @@ func encodeSetStickerPositionInSetResponse(response Result, w http.ResponseWrite
 func encodeSetStickerSetThumbResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1109,6 +1183,7 @@ func encodeSetStickerSetThumbResponse(response Result, w http.ResponseWriter, sp
 func encodeSetWebhookResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1123,6 +1198,7 @@ func encodeSetWebhookResponse(response Result, w http.ResponseWriter, span trace
 func encodeStopMessageLiveLocationResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1137,6 +1213,7 @@ func encodeStopMessageLiveLocationResponse(response Result, w http.ResponseWrite
 func encodeStopPollResponse(response ResultPoll, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1151,6 +1228,7 @@ func encodeStopPollResponse(response ResultPoll, w http.ResponseWriter, span tra
 func encodeUnbanChatMemberResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1165,6 +1243,7 @@ func encodeUnbanChatMemberResponse(response Result, w http.ResponseWriter, span 
 func encodeUnbanChatSenderChatResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1179,6 +1258,7 @@ func encodeUnbanChatSenderChatResponse(response Result, w http.ResponseWriter, s
 func encodeUnpinAllChatMessagesResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1193,6 +1273,7 @@ func encodeUnpinAllChatMessagesResponse(response Result, w http.ResponseWriter, 
 func encodeUnpinChatMessageResponse(response Result, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1207,6 +1288,7 @@ func encodeUnpinChatMessageResponse(response Result, w http.ResponseWriter, span
 func encodeUploadStickerFileResponse(response ResultFile, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1220,6 +1302,12 @@ func encodeUploadStickerFileResponse(response ResultFile, w http.ResponseWriter,
 func encodeErrorResponse(response ErrorStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/examples/ex_test_format/oas_handlers_gen.go
+++ b/examples/ex_test_format/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleTestRequestAnyRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -149,7 +148,6 @@ func (s *Server) handleTestRequestBooleanRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -191,7 +189,6 @@ func (s *Server) handleTestRequestBooleanArrayRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -233,7 +230,6 @@ func (s *Server) handleTestRequestBooleanArrayArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -275,7 +271,6 @@ func (s *Server) handleTestRequestBooleanNullableRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -317,7 +312,6 @@ func (s *Server) handleTestRequestBooleanNullableArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -359,7 +353,6 @@ func (s *Server) handleTestRequestBooleanNullableArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -401,7 +394,6 @@ func (s *Server) handleTestRequestEmptyStructRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -443,7 +435,6 @@ func (s *Server) handleTestRequestFormatTestRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -485,7 +476,6 @@ func (s *Server) handleTestRequestIntegerRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -527,7 +517,6 @@ func (s *Server) handleTestRequestIntegerArrayRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -569,7 +558,6 @@ func (s *Server) handleTestRequestIntegerArrayArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -611,7 +599,6 @@ func (s *Server) handleTestRequestIntegerInt32Request(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -653,7 +640,6 @@ func (s *Server) handleTestRequestIntegerInt32ArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -695,7 +681,6 @@ func (s *Server) handleTestRequestIntegerInt32ArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -737,7 +722,6 @@ func (s *Server) handleTestRequestIntegerInt32NullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -779,7 +763,6 @@ func (s *Server) handleTestRequestIntegerInt32NullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -821,7 +804,6 @@ func (s *Server) handleTestRequestIntegerInt32NullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -863,7 +845,6 @@ func (s *Server) handleTestRequestIntegerInt64Request(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -905,7 +886,6 @@ func (s *Server) handleTestRequestIntegerInt64ArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -947,7 +927,6 @@ func (s *Server) handleTestRequestIntegerInt64ArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -989,7 +968,6 @@ func (s *Server) handleTestRequestIntegerInt64NullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1031,7 +1009,6 @@ func (s *Server) handleTestRequestIntegerInt64NullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1073,7 +1050,6 @@ func (s *Server) handleTestRequestIntegerInt64NullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1115,7 +1091,6 @@ func (s *Server) handleTestRequestIntegerNullableRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1157,7 +1132,6 @@ func (s *Server) handleTestRequestIntegerNullableArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1199,7 +1173,6 @@ func (s *Server) handleTestRequestIntegerNullableArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1241,7 +1214,6 @@ func (s *Server) handleTestRequestNumberRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1283,7 +1255,6 @@ func (s *Server) handleTestRequestNumberArrayRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1325,7 +1296,6 @@ func (s *Server) handleTestRequestNumberArrayArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1367,7 +1337,6 @@ func (s *Server) handleTestRequestNumberDoubleRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1409,7 +1378,6 @@ func (s *Server) handleTestRequestNumberDoubleArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1451,7 +1419,6 @@ func (s *Server) handleTestRequestNumberDoubleArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1493,7 +1460,6 @@ func (s *Server) handleTestRequestNumberDoubleNullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1535,7 +1501,6 @@ func (s *Server) handleTestRequestNumberDoubleNullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1577,7 +1542,6 @@ func (s *Server) handleTestRequestNumberDoubleNullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1619,7 +1583,6 @@ func (s *Server) handleTestRequestNumberFloatRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1661,7 +1624,6 @@ func (s *Server) handleTestRequestNumberFloatArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1703,7 +1665,6 @@ func (s *Server) handleTestRequestNumberFloatArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1745,7 +1706,6 @@ func (s *Server) handleTestRequestNumberFloatNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1787,7 +1747,6 @@ func (s *Server) handleTestRequestNumberFloatNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1829,7 +1788,6 @@ func (s *Server) handleTestRequestNumberFloatNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1871,7 +1829,6 @@ func (s *Server) handleTestRequestNumberInt32Request(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1913,7 +1870,6 @@ func (s *Server) handleTestRequestNumberInt32ArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1955,7 +1911,6 @@ func (s *Server) handleTestRequestNumberInt32ArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1997,7 +1952,6 @@ func (s *Server) handleTestRequestNumberInt32NullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2039,7 +1993,6 @@ func (s *Server) handleTestRequestNumberInt32NullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2081,7 +2034,6 @@ func (s *Server) handleTestRequestNumberInt32NullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2123,7 +2075,6 @@ func (s *Server) handleTestRequestNumberInt64Request(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2165,7 +2116,6 @@ func (s *Server) handleTestRequestNumberInt64ArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2207,7 +2157,6 @@ func (s *Server) handleTestRequestNumberInt64ArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2249,7 +2198,6 @@ func (s *Server) handleTestRequestNumberInt64NullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2291,7 +2239,6 @@ func (s *Server) handleTestRequestNumberInt64NullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2333,7 +2280,6 @@ func (s *Server) handleTestRequestNumberInt64NullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2375,7 +2321,6 @@ func (s *Server) handleTestRequestNumberNullableRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2417,7 +2362,6 @@ func (s *Server) handleTestRequestNumberNullableArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2459,7 +2403,6 @@ func (s *Server) handleTestRequestNumberNullableArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2501,7 +2444,6 @@ func (s *Server) handleTestRequestRequiredAnyRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2543,7 +2485,6 @@ func (s *Server) handleTestRequestRequiredBooleanRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2585,7 +2526,6 @@ func (s *Server) handleTestRequestRequiredBooleanArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2627,7 +2567,6 @@ func (s *Server) handleTestRequestRequiredBooleanArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2669,7 +2608,6 @@ func (s *Server) handleTestRequestRequiredBooleanNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2711,7 +2649,6 @@ func (s *Server) handleTestRequestRequiredBooleanNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2753,7 +2690,6 @@ func (s *Server) handleTestRequestRequiredBooleanNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2795,7 +2731,6 @@ func (s *Server) handleTestRequestRequiredEmptyStructRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2837,7 +2772,6 @@ func (s *Server) handleTestRequestRequiredFormatTestRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2879,7 +2813,6 @@ func (s *Server) handleTestRequestRequiredIntegerRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2921,7 +2854,6 @@ func (s *Server) handleTestRequestRequiredIntegerArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -2963,7 +2895,6 @@ func (s *Server) handleTestRequestRequiredIntegerArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3005,7 +2936,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32Request(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3047,7 +2977,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32ArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3089,7 +3018,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32ArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3131,7 +3059,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3173,7 +3100,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3215,7 +3141,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableArrayArrayRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3257,7 +3182,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64Request(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3299,7 +3223,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64ArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3341,7 +3264,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64ArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3383,7 +3305,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3425,7 +3346,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3467,7 +3387,6 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableArrayArrayRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3509,7 +3428,6 @@ func (s *Server) handleTestRequestRequiredIntegerNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3551,7 +3469,6 @@ func (s *Server) handleTestRequestRequiredIntegerNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3593,7 +3510,6 @@ func (s *Server) handleTestRequestRequiredIntegerNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3635,7 +3551,6 @@ func (s *Server) handleTestRequestRequiredNumberRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3677,7 +3592,6 @@ func (s *Server) handleTestRequestRequiredNumberArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3719,7 +3633,6 @@ func (s *Server) handleTestRequestRequiredNumberArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3761,7 +3674,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3803,7 +3715,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3845,7 +3756,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3887,7 +3797,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3929,7 +3838,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -3971,7 +3879,6 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableArrayArrayRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4013,7 +3920,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4055,7 +3961,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4097,7 +4002,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4139,7 +4043,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4181,7 +4084,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4223,7 +4125,6 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableArrayArrayRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4265,7 +4166,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32Request(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4307,7 +4207,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32ArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4349,7 +4248,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32ArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4391,7 +4289,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4433,7 +4330,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4475,7 +4371,6 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableArrayArrayRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4517,7 +4412,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64Request(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4559,7 +4453,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64ArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4601,7 +4494,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64ArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4643,7 +4535,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4685,7 +4576,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4727,7 +4617,6 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableArrayArrayRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4769,7 +4658,6 @@ func (s *Server) handleTestRequestRequiredNumberNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4811,7 +4699,6 @@ func (s *Server) handleTestRequestRequiredNumberNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4853,7 +4740,6 @@ func (s *Server) handleTestRequestRequiredNumberNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4895,7 +4781,6 @@ func (s *Server) handleTestRequestRequiredStringRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4937,7 +4822,6 @@ func (s *Server) handleTestRequestRequiredStringArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -4979,7 +4863,6 @@ func (s *Server) handleTestRequestRequiredStringArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5021,7 +4904,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5063,7 +4945,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5105,7 +4986,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5147,7 +5027,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5189,7 +5068,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5231,7 +5109,6 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableArrayArrayRequest(
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5273,7 +5150,6 @@ func (s *Server) handleTestRequestRequiredStringByteRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5315,7 +5191,6 @@ func (s *Server) handleTestRequestRequiredStringByteArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5357,7 +5232,6 @@ func (s *Server) handleTestRequestRequiredStringByteArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5399,7 +5273,6 @@ func (s *Server) handleTestRequestRequiredStringByteNullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5441,7 +5314,6 @@ func (s *Server) handleTestRequestRequiredStringByteNullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5483,7 +5355,6 @@ func (s *Server) handleTestRequestRequiredStringByteNullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5525,7 +5396,6 @@ func (s *Server) handleTestRequestRequiredStringDateRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5567,7 +5437,6 @@ func (s *Server) handleTestRequestRequiredStringDateArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5609,7 +5478,6 @@ func (s *Server) handleTestRequestRequiredStringDateArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5651,7 +5519,6 @@ func (s *Server) handleTestRequestRequiredStringDateNullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5693,7 +5560,6 @@ func (s *Server) handleTestRequestRequiredStringDateNullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5735,7 +5601,6 @@ func (s *Server) handleTestRequestRequiredStringDateNullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5777,7 +5642,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5819,7 +5683,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5861,7 +5724,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5903,7 +5765,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5945,7 +5806,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableArrayRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -5987,7 +5847,6 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableArrayArrayReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6029,7 +5888,6 @@ func (s *Server) handleTestRequestRequiredStringDurationRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6071,7 +5929,6 @@ func (s *Server) handleTestRequestRequiredStringDurationArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6113,7 +5970,6 @@ func (s *Server) handleTestRequestRequiredStringDurationArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6155,7 +6011,6 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6197,7 +6052,6 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableArrayRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6239,7 +6093,6 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableArrayArrayReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6281,7 +6134,6 @@ func (s *Server) handleTestRequestRequiredStringEmailRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6323,7 +6175,6 @@ func (s *Server) handleTestRequestRequiredStringEmailArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6365,7 +6216,6 @@ func (s *Server) handleTestRequestRequiredStringEmailArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6407,7 +6257,6 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6449,7 +6298,6 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6491,7 +6339,6 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableArrayArrayRequest(a
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6533,7 +6380,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6575,7 +6421,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6617,7 +6462,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6659,7 +6503,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6701,7 +6544,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableArrayRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6743,7 +6585,6 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableArrayArrayReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6785,7 +6626,6 @@ func (s *Server) handleTestRequestRequiredStringIPRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6827,7 +6667,6 @@ func (s *Server) handleTestRequestRequiredStringIPArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6869,7 +6708,6 @@ func (s *Server) handleTestRequestRequiredStringIPArrayArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6911,7 +6749,6 @@ func (s *Server) handleTestRequestRequiredStringIPNullableRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6953,7 +6790,6 @@ func (s *Server) handleTestRequestRequiredStringIPNullableArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -6995,7 +6831,6 @@ func (s *Server) handleTestRequestRequiredStringIPNullableArrayArrayRequest(args
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7037,7 +6872,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4Request(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7079,7 +6913,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4ArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7121,7 +6954,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4ArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7163,7 +6995,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7205,7 +7036,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7247,7 +7077,6 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7289,7 +7118,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6Request(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7331,7 +7159,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6ArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7373,7 +7200,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6ArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7415,7 +7241,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7457,7 +7282,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7499,7 +7323,6 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7541,7 +7364,6 @@ func (s *Server) handleTestRequestRequiredStringNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7583,7 +7405,6 @@ func (s *Server) handleTestRequestRequiredStringNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7625,7 +7446,6 @@ func (s *Server) handleTestRequestRequiredStringNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7667,7 +7487,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7709,7 +7528,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7751,7 +7569,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7793,7 +7610,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7835,7 +7651,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableArrayRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7877,7 +7692,6 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableArrayArrayReques
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7919,7 +7733,6 @@ func (s *Server) handleTestRequestRequiredStringTimeRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -7961,7 +7774,6 @@ func (s *Server) handleTestRequestRequiredStringTimeArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8003,7 +7815,6 @@ func (s *Server) handleTestRequestRequiredStringTimeArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8045,7 +7856,6 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8087,7 +7897,6 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8129,7 +7938,6 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8171,7 +7979,6 @@ func (s *Server) handleTestRequestRequiredStringURIRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8213,7 +8020,6 @@ func (s *Server) handleTestRequestRequiredStringURIArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8255,7 +8061,6 @@ func (s *Server) handleTestRequestRequiredStringURIArrayArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8297,7 +8102,6 @@ func (s *Server) handleTestRequestRequiredStringURINullableRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8339,7 +8143,6 @@ func (s *Server) handleTestRequestRequiredStringURINullableArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8381,7 +8184,6 @@ func (s *Server) handleTestRequestRequiredStringURINullableArrayArrayRequest(arg
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8423,7 +8225,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8465,7 +8266,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8507,7 +8307,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8549,7 +8348,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8591,7 +8389,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8633,7 +8430,6 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableArrayArrayRequest(ar
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8675,7 +8471,6 @@ func (s *Server) handleTestRequestStringRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8717,7 +8512,6 @@ func (s *Server) handleTestRequestStringArrayRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8759,7 +8553,6 @@ func (s *Server) handleTestRequestStringArrayArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8801,7 +8594,6 @@ func (s *Server) handleTestRequestStringBinaryRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8843,7 +8635,6 @@ func (s *Server) handleTestRequestStringBinaryArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8885,7 +8676,6 @@ func (s *Server) handleTestRequestStringBinaryArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8927,7 +8717,6 @@ func (s *Server) handleTestRequestStringBinaryNullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -8969,7 +8758,6 @@ func (s *Server) handleTestRequestStringBinaryNullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9011,7 +8799,6 @@ func (s *Server) handleTestRequestStringBinaryNullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9053,7 +8840,6 @@ func (s *Server) handleTestRequestStringByteRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9095,7 +8881,6 @@ func (s *Server) handleTestRequestStringByteArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9137,7 +8922,6 @@ func (s *Server) handleTestRequestStringByteArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9179,7 +8963,6 @@ func (s *Server) handleTestRequestStringByteNullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9221,7 +9004,6 @@ func (s *Server) handleTestRequestStringByteNullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9263,7 +9045,6 @@ func (s *Server) handleTestRequestStringByteNullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9305,7 +9086,6 @@ func (s *Server) handleTestRequestStringDateRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9347,7 +9127,6 @@ func (s *Server) handleTestRequestStringDateArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9389,7 +9168,6 @@ func (s *Server) handleTestRequestStringDateArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9431,7 +9209,6 @@ func (s *Server) handleTestRequestStringDateNullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9473,7 +9250,6 @@ func (s *Server) handleTestRequestStringDateNullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9515,7 +9291,6 @@ func (s *Server) handleTestRequestStringDateNullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9557,7 +9332,6 @@ func (s *Server) handleTestRequestStringDateTimeRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9599,7 +9373,6 @@ func (s *Server) handleTestRequestStringDateTimeArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9641,7 +9414,6 @@ func (s *Server) handleTestRequestStringDateTimeArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9683,7 +9455,6 @@ func (s *Server) handleTestRequestStringDateTimeNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9725,7 +9496,6 @@ func (s *Server) handleTestRequestStringDateTimeNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9767,7 +9537,6 @@ func (s *Server) handleTestRequestStringDateTimeNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9809,7 +9578,6 @@ func (s *Server) handleTestRequestStringDurationRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9851,7 +9619,6 @@ func (s *Server) handleTestRequestStringDurationArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9893,7 +9660,6 @@ func (s *Server) handleTestRequestStringDurationArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9935,7 +9701,6 @@ func (s *Server) handleTestRequestStringDurationNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -9977,7 +9742,6 @@ func (s *Server) handleTestRequestStringDurationNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10019,7 +9783,6 @@ func (s *Server) handleTestRequestStringDurationNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10061,7 +9824,6 @@ func (s *Server) handleTestRequestStringEmailRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10103,7 +9865,6 @@ func (s *Server) handleTestRequestStringEmailArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10145,7 +9906,6 @@ func (s *Server) handleTestRequestStringEmailArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10187,7 +9947,6 @@ func (s *Server) handleTestRequestStringEmailNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10229,7 +9988,6 @@ func (s *Server) handleTestRequestStringEmailNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10271,7 +10029,6 @@ func (s *Server) handleTestRequestStringEmailNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10313,7 +10070,6 @@ func (s *Server) handleTestRequestStringHostnameRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10355,7 +10111,6 @@ func (s *Server) handleTestRequestStringHostnameArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10397,7 +10152,6 @@ func (s *Server) handleTestRequestStringHostnameArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10439,7 +10193,6 @@ func (s *Server) handleTestRequestStringHostnameNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10481,7 +10234,6 @@ func (s *Server) handleTestRequestStringHostnameNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10523,7 +10275,6 @@ func (s *Server) handleTestRequestStringHostnameNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10565,7 +10316,6 @@ func (s *Server) handleTestRequestStringIPRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10607,7 +10357,6 @@ func (s *Server) handleTestRequestStringIPArrayRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10649,7 +10398,6 @@ func (s *Server) handleTestRequestStringIPArrayArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10691,7 +10439,6 @@ func (s *Server) handleTestRequestStringIPNullableRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10733,7 +10480,6 @@ func (s *Server) handleTestRequestStringIPNullableArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10775,7 +10521,6 @@ func (s *Server) handleTestRequestStringIPNullableArrayArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10817,7 +10562,6 @@ func (s *Server) handleTestRequestStringIpv4Request(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10859,7 +10603,6 @@ func (s *Server) handleTestRequestStringIpv4ArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10901,7 +10644,6 @@ func (s *Server) handleTestRequestStringIpv4ArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10943,7 +10685,6 @@ func (s *Server) handleTestRequestStringIpv4NullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -10985,7 +10726,6 @@ func (s *Server) handleTestRequestStringIpv4NullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11027,7 +10767,6 @@ func (s *Server) handleTestRequestStringIpv4NullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11069,7 +10808,6 @@ func (s *Server) handleTestRequestStringIpv6Request(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11111,7 +10849,6 @@ func (s *Server) handleTestRequestStringIpv6ArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11153,7 +10890,6 @@ func (s *Server) handleTestRequestStringIpv6ArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11195,7 +10931,6 @@ func (s *Server) handleTestRequestStringIpv6NullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11237,7 +10972,6 @@ func (s *Server) handleTestRequestStringIpv6NullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11279,7 +11013,6 @@ func (s *Server) handleTestRequestStringIpv6NullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11321,7 +11054,6 @@ func (s *Server) handleTestRequestStringNullableRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11363,7 +11095,6 @@ func (s *Server) handleTestRequestStringNullableArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11405,7 +11136,6 @@ func (s *Server) handleTestRequestStringNullableArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11447,7 +11177,6 @@ func (s *Server) handleTestRequestStringPasswordRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11489,7 +11218,6 @@ func (s *Server) handleTestRequestStringPasswordArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11531,7 +11259,6 @@ func (s *Server) handleTestRequestStringPasswordArrayArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11573,7 +11300,6 @@ func (s *Server) handleTestRequestStringPasswordNullableRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11615,7 +11341,6 @@ func (s *Server) handleTestRequestStringPasswordNullableArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11657,7 +11382,6 @@ func (s *Server) handleTestRequestStringPasswordNullableArrayArrayRequest(args [
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11699,7 +11423,6 @@ func (s *Server) handleTestRequestStringTimeRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11741,7 +11464,6 @@ func (s *Server) handleTestRequestStringTimeArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11783,7 +11505,6 @@ func (s *Server) handleTestRequestStringTimeArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11825,7 +11546,6 @@ func (s *Server) handleTestRequestStringTimeNullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11867,7 +11587,6 @@ func (s *Server) handleTestRequestStringTimeNullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11909,7 +11628,6 @@ func (s *Server) handleTestRequestStringTimeNullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11951,7 +11669,6 @@ func (s *Server) handleTestRequestStringURIRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -11993,7 +11710,6 @@ func (s *Server) handleTestRequestStringURIArrayRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12035,7 +11751,6 @@ func (s *Server) handleTestRequestStringURIArrayArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12077,7 +11792,6 @@ func (s *Server) handleTestRequestStringURINullableRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12119,7 +11833,6 @@ func (s *Server) handleTestRequestStringURINullableArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12161,7 +11874,6 @@ func (s *Server) handleTestRequestStringURINullableArrayArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12203,7 +11915,6 @@ func (s *Server) handleTestRequestStringUUIDRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12245,7 +11956,6 @@ func (s *Server) handleTestRequestStringUUIDArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12287,7 +11997,6 @@ func (s *Server) handleTestRequestStringUUIDArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12329,7 +12038,6 @@ func (s *Server) handleTestRequestStringUUIDNullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12371,7 +12079,6 @@ func (s *Server) handleTestRequestStringUUIDNullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12413,7 +12120,6 @@ func (s *Server) handleTestRequestStringUUIDNullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12455,7 +12161,6 @@ func (s *Server) handleTestResponseAnyRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12497,7 +12202,6 @@ func (s *Server) handleTestResponseBooleanRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12539,7 +12243,6 @@ func (s *Server) handleTestResponseBooleanArrayRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12581,7 +12284,6 @@ func (s *Server) handleTestResponseBooleanArrayArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12623,7 +12325,6 @@ func (s *Server) handleTestResponseBooleanNullableRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12665,7 +12366,6 @@ func (s *Server) handleTestResponseBooleanNullableArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12707,7 +12407,6 @@ func (s *Server) handleTestResponseBooleanNullableArrayArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12749,7 +12448,6 @@ func (s *Server) handleTestResponseEmptyStructRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12791,7 +12489,6 @@ func (s *Server) handleTestResponseFormatTestRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12833,7 +12530,6 @@ func (s *Server) handleTestResponseIntegerRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12875,7 +12571,6 @@ func (s *Server) handleTestResponseIntegerArrayRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12917,7 +12612,6 @@ func (s *Server) handleTestResponseIntegerArrayArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -12959,7 +12653,6 @@ func (s *Server) handleTestResponseIntegerInt32Request(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13001,7 +12694,6 @@ func (s *Server) handleTestResponseIntegerInt32ArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13043,7 +12735,6 @@ func (s *Server) handleTestResponseIntegerInt32ArrayArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13085,7 +12776,6 @@ func (s *Server) handleTestResponseIntegerInt32NullableRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13127,7 +12817,6 @@ func (s *Server) handleTestResponseIntegerInt32NullableArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13169,7 +12858,6 @@ func (s *Server) handleTestResponseIntegerInt32NullableArrayArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13211,7 +12899,6 @@ func (s *Server) handleTestResponseIntegerInt64Request(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13253,7 +12940,6 @@ func (s *Server) handleTestResponseIntegerInt64ArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13295,7 +12981,6 @@ func (s *Server) handleTestResponseIntegerInt64ArrayArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13337,7 +13022,6 @@ func (s *Server) handleTestResponseIntegerInt64NullableRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13379,7 +13063,6 @@ func (s *Server) handleTestResponseIntegerInt64NullableArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13421,7 +13104,6 @@ func (s *Server) handleTestResponseIntegerInt64NullableArrayArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13463,7 +13145,6 @@ func (s *Server) handleTestResponseIntegerNullableRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13505,7 +13186,6 @@ func (s *Server) handleTestResponseIntegerNullableArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13547,7 +13227,6 @@ func (s *Server) handleTestResponseIntegerNullableArrayArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13589,7 +13268,6 @@ func (s *Server) handleTestResponseNumberRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13631,7 +13309,6 @@ func (s *Server) handleTestResponseNumberArrayRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13673,7 +13350,6 @@ func (s *Server) handleTestResponseNumberArrayArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13715,7 +13391,6 @@ func (s *Server) handleTestResponseNumberDoubleRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13757,7 +13432,6 @@ func (s *Server) handleTestResponseNumberDoubleArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13799,7 +13473,6 @@ func (s *Server) handleTestResponseNumberDoubleArrayArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13841,7 +13514,6 @@ func (s *Server) handleTestResponseNumberDoubleNullableRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13883,7 +13555,6 @@ func (s *Server) handleTestResponseNumberDoubleNullableArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13925,7 +13596,6 @@ func (s *Server) handleTestResponseNumberDoubleNullableArrayArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -13967,7 +13637,6 @@ func (s *Server) handleTestResponseNumberFloatRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14009,7 +13678,6 @@ func (s *Server) handleTestResponseNumberFloatArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14051,7 +13719,6 @@ func (s *Server) handleTestResponseNumberFloatArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14093,7 +13760,6 @@ func (s *Server) handleTestResponseNumberFloatNullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14135,7 +13801,6 @@ func (s *Server) handleTestResponseNumberFloatNullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14177,7 +13842,6 @@ func (s *Server) handleTestResponseNumberFloatNullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14219,7 +13883,6 @@ func (s *Server) handleTestResponseNumberInt32Request(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14261,7 +13924,6 @@ func (s *Server) handleTestResponseNumberInt32ArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14303,7 +13965,6 @@ func (s *Server) handleTestResponseNumberInt32ArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14345,7 +14006,6 @@ func (s *Server) handleTestResponseNumberInt32NullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14387,7 +14047,6 @@ func (s *Server) handleTestResponseNumberInt32NullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14429,7 +14088,6 @@ func (s *Server) handleTestResponseNumberInt32NullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14471,7 +14129,6 @@ func (s *Server) handleTestResponseNumberInt64Request(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14513,7 +14170,6 @@ func (s *Server) handleTestResponseNumberInt64ArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14555,7 +14211,6 @@ func (s *Server) handleTestResponseNumberInt64ArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14597,7 +14252,6 @@ func (s *Server) handleTestResponseNumberInt64NullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14639,7 +14293,6 @@ func (s *Server) handleTestResponseNumberInt64NullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14681,7 +14334,6 @@ func (s *Server) handleTestResponseNumberInt64NullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14723,7 +14375,6 @@ func (s *Server) handleTestResponseNumberNullableRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14765,7 +14416,6 @@ func (s *Server) handleTestResponseNumberNullableArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14807,7 +14457,6 @@ func (s *Server) handleTestResponseNumberNullableArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14849,7 +14498,6 @@ func (s *Server) handleTestResponseStringRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14891,7 +14539,6 @@ func (s *Server) handleTestResponseStringArrayRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14933,7 +14580,6 @@ func (s *Server) handleTestResponseStringArrayArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -14975,7 +14621,6 @@ func (s *Server) handleTestResponseStringBinaryRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15017,7 +14662,6 @@ func (s *Server) handleTestResponseStringBinaryArrayRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15059,7 +14703,6 @@ func (s *Server) handleTestResponseStringBinaryArrayArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15101,7 +14744,6 @@ func (s *Server) handleTestResponseStringBinaryNullableRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15143,7 +14785,6 @@ func (s *Server) handleTestResponseStringBinaryNullableArrayRequest(args [0]stri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15185,7 +14826,6 @@ func (s *Server) handleTestResponseStringBinaryNullableArrayArrayRequest(args [0
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15227,7 +14867,6 @@ func (s *Server) handleTestResponseStringByteRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15269,7 +14908,6 @@ func (s *Server) handleTestResponseStringByteArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15311,7 +14949,6 @@ func (s *Server) handleTestResponseStringByteArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15353,7 +14990,6 @@ func (s *Server) handleTestResponseStringByteNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15395,7 +15031,6 @@ func (s *Server) handleTestResponseStringByteNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15437,7 +15072,6 @@ func (s *Server) handleTestResponseStringByteNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15479,7 +15113,6 @@ func (s *Server) handleTestResponseStringDateRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15521,7 +15154,6 @@ func (s *Server) handleTestResponseStringDateArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15563,7 +15195,6 @@ func (s *Server) handleTestResponseStringDateArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15605,7 +15236,6 @@ func (s *Server) handleTestResponseStringDateNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15647,7 +15277,6 @@ func (s *Server) handleTestResponseStringDateNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15689,7 +15318,6 @@ func (s *Server) handleTestResponseStringDateNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15731,7 +15359,6 @@ func (s *Server) handleTestResponseStringDateTimeRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15773,7 +15400,6 @@ func (s *Server) handleTestResponseStringDateTimeArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15815,7 +15441,6 @@ func (s *Server) handleTestResponseStringDateTimeArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15857,7 +15482,6 @@ func (s *Server) handleTestResponseStringDateTimeNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15899,7 +15523,6 @@ func (s *Server) handleTestResponseStringDateTimeNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15941,7 +15564,6 @@ func (s *Server) handleTestResponseStringDateTimeNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -15983,7 +15605,6 @@ func (s *Server) handleTestResponseStringDurationRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16025,7 +15646,6 @@ func (s *Server) handleTestResponseStringDurationArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16067,7 +15687,6 @@ func (s *Server) handleTestResponseStringDurationArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16109,7 +15728,6 @@ func (s *Server) handleTestResponseStringDurationNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16151,7 +15769,6 @@ func (s *Server) handleTestResponseStringDurationNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16193,7 +15810,6 @@ func (s *Server) handleTestResponseStringDurationNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16235,7 +15851,6 @@ func (s *Server) handleTestResponseStringEmailRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16277,7 +15892,6 @@ func (s *Server) handleTestResponseStringEmailArrayRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16319,7 +15933,6 @@ func (s *Server) handleTestResponseStringEmailArrayArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16361,7 +15974,6 @@ func (s *Server) handleTestResponseStringEmailNullableRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16403,7 +16015,6 @@ func (s *Server) handleTestResponseStringEmailNullableArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16445,7 +16056,6 @@ func (s *Server) handleTestResponseStringEmailNullableArrayArrayRequest(args [0]
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16487,7 +16097,6 @@ func (s *Server) handleTestResponseStringHostnameRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16529,7 +16138,6 @@ func (s *Server) handleTestResponseStringHostnameArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16571,7 +16179,6 @@ func (s *Server) handleTestResponseStringHostnameArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16613,7 +16220,6 @@ func (s *Server) handleTestResponseStringHostnameNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16655,7 +16261,6 @@ func (s *Server) handleTestResponseStringHostnameNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16697,7 +16302,6 @@ func (s *Server) handleTestResponseStringHostnameNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16739,7 +16343,6 @@ func (s *Server) handleTestResponseStringIPRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16781,7 +16384,6 @@ func (s *Server) handleTestResponseStringIPArrayRequest(args [0]string, w http.R
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16823,7 +16425,6 @@ func (s *Server) handleTestResponseStringIPArrayArrayRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16865,7 +16466,6 @@ func (s *Server) handleTestResponseStringIPNullableRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16907,7 +16507,6 @@ func (s *Server) handleTestResponseStringIPNullableArrayRequest(args [0]string, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16949,7 +16548,6 @@ func (s *Server) handleTestResponseStringIPNullableArrayArrayRequest(args [0]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -16991,7 +16589,6 @@ func (s *Server) handleTestResponseStringIpv4Request(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17033,7 +16630,6 @@ func (s *Server) handleTestResponseStringIpv4ArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17075,7 +16671,6 @@ func (s *Server) handleTestResponseStringIpv4ArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17117,7 +16712,6 @@ func (s *Server) handleTestResponseStringIpv4NullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17159,7 +16753,6 @@ func (s *Server) handleTestResponseStringIpv4NullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17201,7 +16794,6 @@ func (s *Server) handleTestResponseStringIpv4NullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17243,7 +16835,6 @@ func (s *Server) handleTestResponseStringIpv6Request(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17285,7 +16876,6 @@ func (s *Server) handleTestResponseStringIpv6ArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17327,7 +16917,6 @@ func (s *Server) handleTestResponseStringIpv6ArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17369,7 +16958,6 @@ func (s *Server) handleTestResponseStringIpv6NullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17411,7 +16999,6 @@ func (s *Server) handleTestResponseStringIpv6NullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17453,7 +17040,6 @@ func (s *Server) handleTestResponseStringIpv6NullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17495,7 +17081,6 @@ func (s *Server) handleTestResponseStringNullableRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17537,7 +17122,6 @@ func (s *Server) handleTestResponseStringNullableArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17579,7 +17163,6 @@ func (s *Server) handleTestResponseStringNullableArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17621,7 +17204,6 @@ func (s *Server) handleTestResponseStringPasswordRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17663,7 +17245,6 @@ func (s *Server) handleTestResponseStringPasswordArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17705,7 +17286,6 @@ func (s *Server) handleTestResponseStringPasswordArrayArrayRequest(args [0]strin
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17747,7 +17327,6 @@ func (s *Server) handleTestResponseStringPasswordNullableRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17789,7 +17368,6 @@ func (s *Server) handleTestResponseStringPasswordNullableArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17831,7 +17409,6 @@ func (s *Server) handleTestResponseStringPasswordNullableArrayArrayRequest(args 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17873,7 +17450,6 @@ func (s *Server) handleTestResponseStringTimeRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17915,7 +17491,6 @@ func (s *Server) handleTestResponseStringTimeArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17957,7 +17532,6 @@ func (s *Server) handleTestResponseStringTimeArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -17999,7 +17573,6 @@ func (s *Server) handleTestResponseStringTimeNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18041,7 +17614,6 @@ func (s *Server) handleTestResponseStringTimeNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18083,7 +17655,6 @@ func (s *Server) handleTestResponseStringTimeNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18125,7 +17696,6 @@ func (s *Server) handleTestResponseStringURIRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18167,7 +17737,6 @@ func (s *Server) handleTestResponseStringURIArrayRequest(args [0]string, w http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18209,7 +17778,6 @@ func (s *Server) handleTestResponseStringURIArrayArrayRequest(args [0]string, w 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18251,7 +17819,6 @@ func (s *Server) handleTestResponseStringURINullableRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18293,7 +17860,6 @@ func (s *Server) handleTestResponseStringURINullableArrayRequest(args [0]string,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18335,7 +17901,6 @@ func (s *Server) handleTestResponseStringURINullableArrayArrayRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18377,7 +17942,6 @@ func (s *Server) handleTestResponseStringUUIDRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18419,7 +17983,6 @@ func (s *Server) handleTestResponseStringUUIDArrayRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18461,7 +18024,6 @@ func (s *Server) handleTestResponseStringUUIDArrayArrayRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18503,7 +18065,6 @@ func (s *Server) handleTestResponseStringUUIDNullableRequest(args [0]string, w h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18545,7 +18106,6 @@ func (s *Server) handleTestResponseStringUUIDNullableArrayRequest(args [0]string
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -18587,7 +18147,6 @@ func (s *Server) handleTestResponseStringUUIDNullableArrayArrayRequest(args [0]s
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_test_format/oas_res_enc_gen.go
+++ b/examples/ex_test_format/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeTestRequestAnyResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeTestRequestAnyResponse(response Error, w http.ResponseWriter, span tr
 func encodeTestRequestBooleanResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,7 @@ func encodeTestRequestBooleanResponse(response Error, w http.ResponseWriter, spa
 func encodeTestRequestBooleanArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -115,6 +118,7 @@ func encodeTestRequestBooleanArrayResponse(response Error, w http.ResponseWriter
 func encodeTestRequestBooleanArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -129,6 +133,7 @@ func encodeTestRequestBooleanArrayArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestBooleanNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -143,6 +148,7 @@ func encodeTestRequestBooleanNullableResponse(response Error, w http.ResponseWri
 func encodeTestRequestBooleanNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -157,6 +163,7 @@ func encodeTestRequestBooleanNullableArrayResponse(response Error, w http.Respon
 func encodeTestRequestBooleanNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -171,6 +178,7 @@ func encodeTestRequestBooleanNullableArrayArrayResponse(response Error, w http.R
 func encodeTestRequestEmptyStructResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -185,6 +193,7 @@ func encodeTestRequestEmptyStructResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestFormatTestResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -199,6 +208,7 @@ func encodeTestRequestFormatTestResponse(response Error, w http.ResponseWriter, 
 func encodeTestRequestIntegerResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -213,6 +223,7 @@ func encodeTestRequestIntegerResponse(response Error, w http.ResponseWriter, spa
 func encodeTestRequestIntegerArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -227,6 +238,7 @@ func encodeTestRequestIntegerArrayResponse(response Error, w http.ResponseWriter
 func encodeTestRequestIntegerArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -241,6 +253,7 @@ func encodeTestRequestIntegerArrayArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestIntegerInt32Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -255,6 +268,7 @@ func encodeTestRequestIntegerInt32Response(response Error, w http.ResponseWriter
 func encodeTestRequestIntegerInt32ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -269,6 +283,7 @@ func encodeTestRequestIntegerInt32ArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestIntegerInt32ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -283,6 +298,7 @@ func encodeTestRequestIntegerInt32ArrayArrayResponse(response Error, w http.Resp
 func encodeTestRequestIntegerInt32NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -297,6 +313,7 @@ func encodeTestRequestIntegerInt32NullableResponse(response Error, w http.Respon
 func encodeTestRequestIntegerInt32NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -311,6 +328,7 @@ func encodeTestRequestIntegerInt32NullableArrayResponse(response Error, w http.R
 func encodeTestRequestIntegerInt32NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -325,6 +343,7 @@ func encodeTestRequestIntegerInt32NullableArrayArrayResponse(response Error, w h
 func encodeTestRequestIntegerInt64Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -339,6 +358,7 @@ func encodeTestRequestIntegerInt64Response(response Error, w http.ResponseWriter
 func encodeTestRequestIntegerInt64ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -353,6 +373,7 @@ func encodeTestRequestIntegerInt64ArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestIntegerInt64ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -367,6 +388,7 @@ func encodeTestRequestIntegerInt64ArrayArrayResponse(response Error, w http.Resp
 func encodeTestRequestIntegerInt64NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -381,6 +403,7 @@ func encodeTestRequestIntegerInt64NullableResponse(response Error, w http.Respon
 func encodeTestRequestIntegerInt64NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -395,6 +418,7 @@ func encodeTestRequestIntegerInt64NullableArrayResponse(response Error, w http.R
 func encodeTestRequestIntegerInt64NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -409,6 +433,7 @@ func encodeTestRequestIntegerInt64NullableArrayArrayResponse(response Error, w h
 func encodeTestRequestIntegerNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -423,6 +448,7 @@ func encodeTestRequestIntegerNullableResponse(response Error, w http.ResponseWri
 func encodeTestRequestIntegerNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -437,6 +463,7 @@ func encodeTestRequestIntegerNullableArrayResponse(response Error, w http.Respon
 func encodeTestRequestIntegerNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -451,6 +478,7 @@ func encodeTestRequestIntegerNullableArrayArrayResponse(response Error, w http.R
 func encodeTestRequestNumberResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -465,6 +493,7 @@ func encodeTestRequestNumberResponse(response Error, w http.ResponseWriter, span
 func encodeTestRequestNumberArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -479,6 +508,7 @@ func encodeTestRequestNumberArrayResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestNumberArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -493,6 +523,7 @@ func encodeTestRequestNumberArrayArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestNumberDoubleResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -507,6 +538,7 @@ func encodeTestRequestNumberDoubleResponse(response Error, w http.ResponseWriter
 func encodeTestRequestNumberDoubleArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -521,6 +553,7 @@ func encodeTestRequestNumberDoubleArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestNumberDoubleArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -535,6 +568,7 @@ func encodeTestRequestNumberDoubleArrayArrayResponse(response Error, w http.Resp
 func encodeTestRequestNumberDoubleNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -549,6 +583,7 @@ func encodeTestRequestNumberDoubleNullableResponse(response Error, w http.Respon
 func encodeTestRequestNumberDoubleNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -563,6 +598,7 @@ func encodeTestRequestNumberDoubleNullableArrayResponse(response Error, w http.R
 func encodeTestRequestNumberDoubleNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -577,6 +613,7 @@ func encodeTestRequestNumberDoubleNullableArrayArrayResponse(response Error, w h
 func encodeTestRequestNumberFloatResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -591,6 +628,7 @@ func encodeTestRequestNumberFloatResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestNumberFloatArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -605,6 +643,7 @@ func encodeTestRequestNumberFloatArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestNumberFloatArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -619,6 +658,7 @@ func encodeTestRequestNumberFloatArrayArrayResponse(response Error, w http.Respo
 func encodeTestRequestNumberFloatNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -633,6 +673,7 @@ func encodeTestRequestNumberFloatNullableResponse(response Error, w http.Respons
 func encodeTestRequestNumberFloatNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -647,6 +688,7 @@ func encodeTestRequestNumberFloatNullableArrayResponse(response Error, w http.Re
 func encodeTestRequestNumberFloatNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -661,6 +703,7 @@ func encodeTestRequestNumberFloatNullableArrayArrayResponse(response Error, w ht
 func encodeTestRequestNumberInt32Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -675,6 +718,7 @@ func encodeTestRequestNumberInt32Response(response Error, w http.ResponseWriter,
 func encodeTestRequestNumberInt32ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -689,6 +733,7 @@ func encodeTestRequestNumberInt32ArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestNumberInt32ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -703,6 +748,7 @@ func encodeTestRequestNumberInt32ArrayArrayResponse(response Error, w http.Respo
 func encodeTestRequestNumberInt32NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -717,6 +763,7 @@ func encodeTestRequestNumberInt32NullableResponse(response Error, w http.Respons
 func encodeTestRequestNumberInt32NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -731,6 +778,7 @@ func encodeTestRequestNumberInt32NullableArrayResponse(response Error, w http.Re
 func encodeTestRequestNumberInt32NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -745,6 +793,7 @@ func encodeTestRequestNumberInt32NullableArrayArrayResponse(response Error, w ht
 func encodeTestRequestNumberInt64Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -759,6 +808,7 @@ func encodeTestRequestNumberInt64Response(response Error, w http.ResponseWriter,
 func encodeTestRequestNumberInt64ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -773,6 +823,7 @@ func encodeTestRequestNumberInt64ArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestNumberInt64ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -787,6 +838,7 @@ func encodeTestRequestNumberInt64ArrayArrayResponse(response Error, w http.Respo
 func encodeTestRequestNumberInt64NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -801,6 +853,7 @@ func encodeTestRequestNumberInt64NullableResponse(response Error, w http.Respons
 func encodeTestRequestNumberInt64NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -815,6 +868,7 @@ func encodeTestRequestNumberInt64NullableArrayResponse(response Error, w http.Re
 func encodeTestRequestNumberInt64NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -829,6 +883,7 @@ func encodeTestRequestNumberInt64NullableArrayArrayResponse(response Error, w ht
 func encodeTestRequestNumberNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -843,6 +898,7 @@ func encodeTestRequestNumberNullableResponse(response Error, w http.ResponseWrit
 func encodeTestRequestNumberNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -857,6 +913,7 @@ func encodeTestRequestNumberNullableArrayResponse(response Error, w http.Respons
 func encodeTestRequestNumberNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -871,6 +928,7 @@ func encodeTestRequestNumberNullableArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredAnyResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -885,6 +943,7 @@ func encodeTestRequestRequiredAnyResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestRequiredBooleanResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -899,6 +958,7 @@ func encodeTestRequestRequiredBooleanResponse(response Error, w http.ResponseWri
 func encodeTestRequestRequiredBooleanArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -913,6 +973,7 @@ func encodeTestRequestRequiredBooleanArrayResponse(response Error, w http.Respon
 func encodeTestRequestRequiredBooleanArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -927,6 +988,7 @@ func encodeTestRequestRequiredBooleanArrayArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredBooleanNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -941,6 +1003,7 @@ func encodeTestRequestRequiredBooleanNullableResponse(response Error, w http.Res
 func encodeTestRequestRequiredBooleanNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -955,6 +1018,7 @@ func encodeTestRequestRequiredBooleanNullableArrayResponse(response Error, w htt
 func encodeTestRequestRequiredBooleanNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -969,6 +1033,7 @@ func encodeTestRequestRequiredBooleanNullableArrayArrayResponse(response Error, 
 func encodeTestRequestRequiredEmptyStructResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -983,6 +1048,7 @@ func encodeTestRequestRequiredEmptyStructResponse(response Error, w http.Respons
 func encodeTestRequestRequiredFormatTestResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -997,6 +1063,7 @@ func encodeTestRequestRequiredFormatTestResponse(response Error, w http.Response
 func encodeTestRequestRequiredIntegerResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1011,6 +1078,7 @@ func encodeTestRequestRequiredIntegerResponse(response Error, w http.ResponseWri
 func encodeTestRequestRequiredIntegerArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1025,6 +1093,7 @@ func encodeTestRequestRequiredIntegerArrayResponse(response Error, w http.Respon
 func encodeTestRequestRequiredIntegerArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1039,6 +1108,7 @@ func encodeTestRequestRequiredIntegerArrayArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredIntegerInt32Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1053,6 +1123,7 @@ func encodeTestRequestRequiredIntegerInt32Response(response Error, w http.Respon
 func encodeTestRequestRequiredIntegerInt32ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1067,6 +1138,7 @@ func encodeTestRequestRequiredIntegerInt32ArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredIntegerInt32ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1081,6 +1153,7 @@ func encodeTestRequestRequiredIntegerInt32ArrayArrayResponse(response Error, w h
 func encodeTestRequestRequiredIntegerInt32NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1095,6 +1168,7 @@ func encodeTestRequestRequiredIntegerInt32NullableResponse(response Error, w htt
 func encodeTestRequestRequiredIntegerInt32NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1109,6 +1183,7 @@ func encodeTestRequestRequiredIntegerInt32NullableArrayResponse(response Error, 
 func encodeTestRequestRequiredIntegerInt32NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1123,6 +1198,7 @@ func encodeTestRequestRequiredIntegerInt32NullableArrayArrayResponse(response Er
 func encodeTestRequestRequiredIntegerInt64Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1137,6 +1213,7 @@ func encodeTestRequestRequiredIntegerInt64Response(response Error, w http.Respon
 func encodeTestRequestRequiredIntegerInt64ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1151,6 +1228,7 @@ func encodeTestRequestRequiredIntegerInt64ArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredIntegerInt64ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1165,6 +1243,7 @@ func encodeTestRequestRequiredIntegerInt64ArrayArrayResponse(response Error, w h
 func encodeTestRequestRequiredIntegerInt64NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1179,6 +1258,7 @@ func encodeTestRequestRequiredIntegerInt64NullableResponse(response Error, w htt
 func encodeTestRequestRequiredIntegerInt64NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1193,6 +1273,7 @@ func encodeTestRequestRequiredIntegerInt64NullableArrayResponse(response Error, 
 func encodeTestRequestRequiredIntegerInt64NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1207,6 +1288,7 @@ func encodeTestRequestRequiredIntegerInt64NullableArrayArrayResponse(response Er
 func encodeTestRequestRequiredIntegerNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1221,6 +1303,7 @@ func encodeTestRequestRequiredIntegerNullableResponse(response Error, w http.Res
 func encodeTestRequestRequiredIntegerNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1235,6 +1318,7 @@ func encodeTestRequestRequiredIntegerNullableArrayResponse(response Error, w htt
 func encodeTestRequestRequiredIntegerNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1249,6 +1333,7 @@ func encodeTestRequestRequiredIntegerNullableArrayArrayResponse(response Error, 
 func encodeTestRequestRequiredNumberResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1263,6 +1348,7 @@ func encodeTestRequestRequiredNumberResponse(response Error, w http.ResponseWrit
 func encodeTestRequestRequiredNumberArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1277,6 +1363,7 @@ func encodeTestRequestRequiredNumberArrayResponse(response Error, w http.Respons
 func encodeTestRequestRequiredNumberArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1291,6 +1378,7 @@ func encodeTestRequestRequiredNumberArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredNumberDoubleResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1305,6 +1393,7 @@ func encodeTestRequestRequiredNumberDoubleResponse(response Error, w http.Respon
 func encodeTestRequestRequiredNumberDoubleArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1319,6 +1408,7 @@ func encodeTestRequestRequiredNumberDoubleArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredNumberDoubleArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1333,6 +1423,7 @@ func encodeTestRequestRequiredNumberDoubleArrayArrayResponse(response Error, w h
 func encodeTestRequestRequiredNumberDoubleNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1347,6 +1438,7 @@ func encodeTestRequestRequiredNumberDoubleNullableResponse(response Error, w htt
 func encodeTestRequestRequiredNumberDoubleNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1361,6 +1453,7 @@ func encodeTestRequestRequiredNumberDoubleNullableArrayResponse(response Error, 
 func encodeTestRequestRequiredNumberDoubleNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1375,6 +1468,7 @@ func encodeTestRequestRequiredNumberDoubleNullableArrayArrayResponse(response Er
 func encodeTestRequestRequiredNumberFloatResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1389,6 +1483,7 @@ func encodeTestRequestRequiredNumberFloatResponse(response Error, w http.Respons
 func encodeTestRequestRequiredNumberFloatArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1403,6 +1498,7 @@ func encodeTestRequestRequiredNumberFloatArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredNumberFloatArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1417,6 +1513,7 @@ func encodeTestRequestRequiredNumberFloatArrayArrayResponse(response Error, w ht
 func encodeTestRequestRequiredNumberFloatNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1431,6 +1528,7 @@ func encodeTestRequestRequiredNumberFloatNullableResponse(response Error, w http
 func encodeTestRequestRequiredNumberFloatNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1445,6 +1543,7 @@ func encodeTestRequestRequiredNumberFloatNullableArrayResponse(response Error, w
 func encodeTestRequestRequiredNumberFloatNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1459,6 +1558,7 @@ func encodeTestRequestRequiredNumberFloatNullableArrayArrayResponse(response Err
 func encodeTestRequestRequiredNumberInt32Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1473,6 +1573,7 @@ func encodeTestRequestRequiredNumberInt32Response(response Error, w http.Respons
 func encodeTestRequestRequiredNumberInt32ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1487,6 +1588,7 @@ func encodeTestRequestRequiredNumberInt32ArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredNumberInt32ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1501,6 +1603,7 @@ func encodeTestRequestRequiredNumberInt32ArrayArrayResponse(response Error, w ht
 func encodeTestRequestRequiredNumberInt32NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1515,6 +1618,7 @@ func encodeTestRequestRequiredNumberInt32NullableResponse(response Error, w http
 func encodeTestRequestRequiredNumberInt32NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1529,6 +1633,7 @@ func encodeTestRequestRequiredNumberInt32NullableArrayResponse(response Error, w
 func encodeTestRequestRequiredNumberInt32NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1543,6 +1648,7 @@ func encodeTestRequestRequiredNumberInt32NullableArrayArrayResponse(response Err
 func encodeTestRequestRequiredNumberInt64Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1557,6 +1663,7 @@ func encodeTestRequestRequiredNumberInt64Response(response Error, w http.Respons
 func encodeTestRequestRequiredNumberInt64ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1571,6 +1678,7 @@ func encodeTestRequestRequiredNumberInt64ArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredNumberInt64ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1585,6 +1693,7 @@ func encodeTestRequestRequiredNumberInt64ArrayArrayResponse(response Error, w ht
 func encodeTestRequestRequiredNumberInt64NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1599,6 +1708,7 @@ func encodeTestRequestRequiredNumberInt64NullableResponse(response Error, w http
 func encodeTestRequestRequiredNumberInt64NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1613,6 +1723,7 @@ func encodeTestRequestRequiredNumberInt64NullableArrayResponse(response Error, w
 func encodeTestRequestRequiredNumberInt64NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1627,6 +1738,7 @@ func encodeTestRequestRequiredNumberInt64NullableArrayArrayResponse(response Err
 func encodeTestRequestRequiredNumberNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1641,6 +1753,7 @@ func encodeTestRequestRequiredNumberNullableResponse(response Error, w http.Resp
 func encodeTestRequestRequiredNumberNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1655,6 +1768,7 @@ func encodeTestRequestRequiredNumberNullableArrayResponse(response Error, w http
 func encodeTestRequestRequiredNumberNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1669,6 +1783,7 @@ func encodeTestRequestRequiredNumberNullableArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1683,6 +1798,7 @@ func encodeTestRequestRequiredStringResponse(response Error, w http.ResponseWrit
 func encodeTestRequestRequiredStringArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1697,6 +1813,7 @@ func encodeTestRequestRequiredStringArrayResponse(response Error, w http.Respons
 func encodeTestRequestRequiredStringArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1711,6 +1828,7 @@ func encodeTestRequestRequiredStringArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredStringBinaryResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1725,6 +1843,7 @@ func encodeTestRequestRequiredStringBinaryResponse(response Error, w http.Respon
 func encodeTestRequestRequiredStringBinaryArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1739,6 +1858,7 @@ func encodeTestRequestRequiredStringBinaryArrayResponse(response Error, w http.R
 func encodeTestRequestRequiredStringBinaryArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1753,6 +1873,7 @@ func encodeTestRequestRequiredStringBinaryArrayArrayResponse(response Error, w h
 func encodeTestRequestRequiredStringBinaryNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1767,6 +1888,7 @@ func encodeTestRequestRequiredStringBinaryNullableResponse(response Error, w htt
 func encodeTestRequestRequiredStringBinaryNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1781,6 +1903,7 @@ func encodeTestRequestRequiredStringBinaryNullableArrayResponse(response Error, 
 func encodeTestRequestRequiredStringBinaryNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1795,6 +1918,7 @@ func encodeTestRequestRequiredStringBinaryNullableArrayArrayResponse(response Er
 func encodeTestRequestRequiredStringByteResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1809,6 +1933,7 @@ func encodeTestRequestRequiredStringByteResponse(response Error, w http.Response
 func encodeTestRequestRequiredStringByteArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1823,6 +1948,7 @@ func encodeTestRequestRequiredStringByteArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringByteArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1837,6 +1963,7 @@ func encodeTestRequestRequiredStringByteArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringByteNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1851,6 +1978,7 @@ func encodeTestRequestRequiredStringByteNullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringByteNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1865,6 +1993,7 @@ func encodeTestRequestRequiredStringByteNullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringByteNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1879,6 +2008,7 @@ func encodeTestRequestRequiredStringByteNullableArrayArrayResponse(response Erro
 func encodeTestRequestRequiredStringDateResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1893,6 +2023,7 @@ func encodeTestRequestRequiredStringDateResponse(response Error, w http.Response
 func encodeTestRequestRequiredStringDateArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1907,6 +2038,7 @@ func encodeTestRequestRequiredStringDateArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringDateArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1921,6 +2053,7 @@ func encodeTestRequestRequiredStringDateArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringDateNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1935,6 +2068,7 @@ func encodeTestRequestRequiredStringDateNullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringDateNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1949,6 +2083,7 @@ func encodeTestRequestRequiredStringDateNullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringDateNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1963,6 +2098,7 @@ func encodeTestRequestRequiredStringDateNullableArrayArrayResponse(response Erro
 func encodeTestRequestRequiredStringDateTimeResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1977,6 +2113,7 @@ func encodeTestRequestRequiredStringDateTimeResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringDateTimeArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -1991,6 +2128,7 @@ func encodeTestRequestRequiredStringDateTimeArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringDateTimeArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2005,6 +2143,7 @@ func encodeTestRequestRequiredStringDateTimeArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringDateTimeNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2019,6 +2158,7 @@ func encodeTestRequestRequiredStringDateTimeNullableResponse(response Error, w h
 func encodeTestRequestRequiredStringDateTimeNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2033,6 +2173,7 @@ func encodeTestRequestRequiredStringDateTimeNullableArrayResponse(response Error
 func encodeTestRequestRequiredStringDateTimeNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2047,6 +2188,7 @@ func encodeTestRequestRequiredStringDateTimeNullableArrayArrayResponse(response 
 func encodeTestRequestRequiredStringDurationResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2061,6 +2203,7 @@ func encodeTestRequestRequiredStringDurationResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringDurationArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2075,6 +2218,7 @@ func encodeTestRequestRequiredStringDurationArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringDurationArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2089,6 +2233,7 @@ func encodeTestRequestRequiredStringDurationArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringDurationNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2103,6 +2248,7 @@ func encodeTestRequestRequiredStringDurationNullableResponse(response Error, w h
 func encodeTestRequestRequiredStringDurationNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2117,6 +2263,7 @@ func encodeTestRequestRequiredStringDurationNullableArrayResponse(response Error
 func encodeTestRequestRequiredStringDurationNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2131,6 +2278,7 @@ func encodeTestRequestRequiredStringDurationNullableArrayArrayResponse(response 
 func encodeTestRequestRequiredStringEmailResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2145,6 +2293,7 @@ func encodeTestRequestRequiredStringEmailResponse(response Error, w http.Respons
 func encodeTestRequestRequiredStringEmailArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2159,6 +2308,7 @@ func encodeTestRequestRequiredStringEmailArrayResponse(response Error, w http.Re
 func encodeTestRequestRequiredStringEmailArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2173,6 +2323,7 @@ func encodeTestRequestRequiredStringEmailArrayArrayResponse(response Error, w ht
 func encodeTestRequestRequiredStringEmailNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2187,6 +2338,7 @@ func encodeTestRequestRequiredStringEmailNullableResponse(response Error, w http
 func encodeTestRequestRequiredStringEmailNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2201,6 +2353,7 @@ func encodeTestRequestRequiredStringEmailNullableArrayResponse(response Error, w
 func encodeTestRequestRequiredStringEmailNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2215,6 +2368,7 @@ func encodeTestRequestRequiredStringEmailNullableArrayArrayResponse(response Err
 func encodeTestRequestRequiredStringHostnameResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2229,6 +2383,7 @@ func encodeTestRequestRequiredStringHostnameResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringHostnameArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2243,6 +2398,7 @@ func encodeTestRequestRequiredStringHostnameArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringHostnameArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2257,6 +2413,7 @@ func encodeTestRequestRequiredStringHostnameArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringHostnameNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2271,6 +2428,7 @@ func encodeTestRequestRequiredStringHostnameNullableResponse(response Error, w h
 func encodeTestRequestRequiredStringHostnameNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2285,6 +2443,7 @@ func encodeTestRequestRequiredStringHostnameNullableArrayResponse(response Error
 func encodeTestRequestRequiredStringHostnameNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2299,6 +2458,7 @@ func encodeTestRequestRequiredStringHostnameNullableArrayArrayResponse(response 
 func encodeTestRequestRequiredStringIPResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2313,6 +2473,7 @@ func encodeTestRequestRequiredStringIPResponse(response Error, w http.ResponseWr
 func encodeTestRequestRequiredStringIPArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2327,6 +2488,7 @@ func encodeTestRequestRequiredStringIPArrayResponse(response Error, w http.Respo
 func encodeTestRequestRequiredStringIPArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2341,6 +2503,7 @@ func encodeTestRequestRequiredStringIPArrayArrayResponse(response Error, w http.
 func encodeTestRequestRequiredStringIPNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2355,6 +2518,7 @@ func encodeTestRequestRequiredStringIPNullableResponse(response Error, w http.Re
 func encodeTestRequestRequiredStringIPNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2369,6 +2533,7 @@ func encodeTestRequestRequiredStringIPNullableArrayResponse(response Error, w ht
 func encodeTestRequestRequiredStringIPNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2383,6 +2548,7 @@ func encodeTestRequestRequiredStringIPNullableArrayArrayResponse(response Error,
 func encodeTestRequestRequiredStringIpv4Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2397,6 +2563,7 @@ func encodeTestRequestRequiredStringIpv4Response(response Error, w http.Response
 func encodeTestRequestRequiredStringIpv4ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2411,6 +2578,7 @@ func encodeTestRequestRequiredStringIpv4ArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringIpv4ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2425,6 +2593,7 @@ func encodeTestRequestRequiredStringIpv4ArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringIpv4NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2439,6 +2608,7 @@ func encodeTestRequestRequiredStringIpv4NullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringIpv4NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2453,6 +2623,7 @@ func encodeTestRequestRequiredStringIpv4NullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringIpv4NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2467,6 +2638,7 @@ func encodeTestRequestRequiredStringIpv4NullableArrayArrayResponse(response Erro
 func encodeTestRequestRequiredStringIpv6Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2481,6 +2653,7 @@ func encodeTestRequestRequiredStringIpv6Response(response Error, w http.Response
 func encodeTestRequestRequiredStringIpv6ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2495,6 +2668,7 @@ func encodeTestRequestRequiredStringIpv6ArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringIpv6ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2509,6 +2683,7 @@ func encodeTestRequestRequiredStringIpv6ArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringIpv6NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2523,6 +2698,7 @@ func encodeTestRequestRequiredStringIpv6NullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringIpv6NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2537,6 +2713,7 @@ func encodeTestRequestRequiredStringIpv6NullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringIpv6NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2551,6 +2728,7 @@ func encodeTestRequestRequiredStringIpv6NullableArrayArrayResponse(response Erro
 func encodeTestRequestRequiredStringNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2565,6 +2743,7 @@ func encodeTestRequestRequiredStringNullableResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2579,6 +2758,7 @@ func encodeTestRequestRequiredStringNullableArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2593,6 +2773,7 @@ func encodeTestRequestRequiredStringNullableArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringPasswordResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2607,6 +2788,7 @@ func encodeTestRequestRequiredStringPasswordResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringPasswordArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2621,6 +2803,7 @@ func encodeTestRequestRequiredStringPasswordArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringPasswordArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2635,6 +2818,7 @@ func encodeTestRequestRequiredStringPasswordArrayArrayResponse(response Error, w
 func encodeTestRequestRequiredStringPasswordNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2649,6 +2833,7 @@ func encodeTestRequestRequiredStringPasswordNullableResponse(response Error, w h
 func encodeTestRequestRequiredStringPasswordNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2663,6 +2848,7 @@ func encodeTestRequestRequiredStringPasswordNullableArrayResponse(response Error
 func encodeTestRequestRequiredStringPasswordNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2677,6 +2863,7 @@ func encodeTestRequestRequiredStringPasswordNullableArrayArrayResponse(response 
 func encodeTestRequestRequiredStringTimeResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2691,6 +2878,7 @@ func encodeTestRequestRequiredStringTimeResponse(response Error, w http.Response
 func encodeTestRequestRequiredStringTimeArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2705,6 +2893,7 @@ func encodeTestRequestRequiredStringTimeArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringTimeArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2719,6 +2908,7 @@ func encodeTestRequestRequiredStringTimeArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringTimeNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2733,6 +2923,7 @@ func encodeTestRequestRequiredStringTimeNullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringTimeNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2747,6 +2938,7 @@ func encodeTestRequestRequiredStringTimeNullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringTimeNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2761,6 +2953,7 @@ func encodeTestRequestRequiredStringTimeNullableArrayArrayResponse(response Erro
 func encodeTestRequestRequiredStringURIResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2775,6 +2968,7 @@ func encodeTestRequestRequiredStringURIResponse(response Error, w http.ResponseW
 func encodeTestRequestRequiredStringURIArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2789,6 +2983,7 @@ func encodeTestRequestRequiredStringURIArrayResponse(response Error, w http.Resp
 func encodeTestRequestRequiredStringURIArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2803,6 +2998,7 @@ func encodeTestRequestRequiredStringURIArrayArrayResponse(response Error, w http
 func encodeTestRequestRequiredStringURINullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2817,6 +3013,7 @@ func encodeTestRequestRequiredStringURINullableResponse(response Error, w http.R
 func encodeTestRequestRequiredStringURINullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2831,6 +3028,7 @@ func encodeTestRequestRequiredStringURINullableArrayResponse(response Error, w h
 func encodeTestRequestRequiredStringURINullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2845,6 +3043,7 @@ func encodeTestRequestRequiredStringURINullableArrayArrayResponse(response Error
 func encodeTestRequestRequiredStringUUIDResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2859,6 +3058,7 @@ func encodeTestRequestRequiredStringUUIDResponse(response Error, w http.Response
 func encodeTestRequestRequiredStringUUIDArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2873,6 +3073,7 @@ func encodeTestRequestRequiredStringUUIDArrayResponse(response Error, w http.Res
 func encodeTestRequestRequiredStringUUIDArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2887,6 +3088,7 @@ func encodeTestRequestRequiredStringUUIDArrayArrayResponse(response Error, w htt
 func encodeTestRequestRequiredStringUUIDNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2901,6 +3103,7 @@ func encodeTestRequestRequiredStringUUIDNullableResponse(response Error, w http.
 func encodeTestRequestRequiredStringUUIDNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2915,6 +3118,7 @@ func encodeTestRequestRequiredStringUUIDNullableArrayResponse(response Error, w 
 func encodeTestRequestRequiredStringUUIDNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2929,6 +3133,7 @@ func encodeTestRequestRequiredStringUUIDNullableArrayArrayResponse(response Erro
 func encodeTestRequestStringResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2943,6 +3148,7 @@ func encodeTestRequestStringResponse(response Error, w http.ResponseWriter, span
 func encodeTestRequestStringArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2957,6 +3163,7 @@ func encodeTestRequestStringArrayResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestStringArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2971,6 +3178,7 @@ func encodeTestRequestStringArrayArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestStringBinaryResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2985,6 +3193,7 @@ func encodeTestRequestStringBinaryResponse(response Error, w http.ResponseWriter
 func encodeTestRequestStringBinaryArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -2999,6 +3208,7 @@ func encodeTestRequestStringBinaryArrayResponse(response Error, w http.ResponseW
 func encodeTestRequestStringBinaryArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3013,6 +3223,7 @@ func encodeTestRequestStringBinaryArrayArrayResponse(response Error, w http.Resp
 func encodeTestRequestStringBinaryNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3027,6 +3238,7 @@ func encodeTestRequestStringBinaryNullableResponse(response Error, w http.Respon
 func encodeTestRequestStringBinaryNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3041,6 +3253,7 @@ func encodeTestRequestStringBinaryNullableArrayResponse(response Error, w http.R
 func encodeTestRequestStringBinaryNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3055,6 +3268,7 @@ func encodeTestRequestStringBinaryNullableArrayArrayResponse(response Error, w h
 func encodeTestRequestStringByteResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3069,6 +3283,7 @@ func encodeTestRequestStringByteResponse(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringByteArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3083,6 +3298,7 @@ func encodeTestRequestStringByteArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringByteArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3097,6 +3313,7 @@ func encodeTestRequestStringByteArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringByteNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3111,6 +3328,7 @@ func encodeTestRequestStringByteNullableResponse(response Error, w http.Response
 func encodeTestRequestStringByteNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3125,6 +3343,7 @@ func encodeTestRequestStringByteNullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringByteNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3139,6 +3358,7 @@ func encodeTestRequestStringByteNullableArrayArrayResponse(response Error, w htt
 func encodeTestRequestStringDateResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3153,6 +3373,7 @@ func encodeTestRequestStringDateResponse(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringDateArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3167,6 +3388,7 @@ func encodeTestRequestStringDateArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringDateArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3181,6 +3403,7 @@ func encodeTestRequestStringDateArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringDateNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3195,6 +3418,7 @@ func encodeTestRequestStringDateNullableResponse(response Error, w http.Response
 func encodeTestRequestStringDateNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3209,6 +3433,7 @@ func encodeTestRequestStringDateNullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringDateNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3223,6 +3448,7 @@ func encodeTestRequestStringDateNullableArrayArrayResponse(response Error, w htt
 func encodeTestRequestStringDateTimeResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3237,6 +3463,7 @@ func encodeTestRequestStringDateTimeResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringDateTimeArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3251,6 +3478,7 @@ func encodeTestRequestStringDateTimeArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringDateTimeArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3265,6 +3493,7 @@ func encodeTestRequestStringDateTimeArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestStringDateTimeNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3279,6 +3508,7 @@ func encodeTestRequestStringDateTimeNullableResponse(response Error, w http.Resp
 func encodeTestRequestStringDateTimeNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3293,6 +3523,7 @@ func encodeTestRequestStringDateTimeNullableArrayResponse(response Error, w http
 func encodeTestRequestStringDateTimeNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3307,6 +3538,7 @@ func encodeTestRequestStringDateTimeNullableArrayArrayResponse(response Error, w
 func encodeTestRequestStringDurationResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3321,6 +3553,7 @@ func encodeTestRequestStringDurationResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringDurationArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3335,6 +3568,7 @@ func encodeTestRequestStringDurationArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringDurationArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3349,6 +3583,7 @@ func encodeTestRequestStringDurationArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestStringDurationNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3363,6 +3598,7 @@ func encodeTestRequestStringDurationNullableResponse(response Error, w http.Resp
 func encodeTestRequestStringDurationNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3377,6 +3613,7 @@ func encodeTestRequestStringDurationNullableArrayResponse(response Error, w http
 func encodeTestRequestStringDurationNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3391,6 +3628,7 @@ func encodeTestRequestStringDurationNullableArrayArrayResponse(response Error, w
 func encodeTestRequestStringEmailResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3405,6 +3643,7 @@ func encodeTestRequestStringEmailResponse(response Error, w http.ResponseWriter,
 func encodeTestRequestStringEmailArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3419,6 +3658,7 @@ func encodeTestRequestStringEmailArrayResponse(response Error, w http.ResponseWr
 func encodeTestRequestStringEmailArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3433,6 +3673,7 @@ func encodeTestRequestStringEmailArrayArrayResponse(response Error, w http.Respo
 func encodeTestRequestStringEmailNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3447,6 +3688,7 @@ func encodeTestRequestStringEmailNullableResponse(response Error, w http.Respons
 func encodeTestRequestStringEmailNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3461,6 +3703,7 @@ func encodeTestRequestStringEmailNullableArrayResponse(response Error, w http.Re
 func encodeTestRequestStringEmailNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3475,6 +3718,7 @@ func encodeTestRequestStringEmailNullableArrayArrayResponse(response Error, w ht
 func encodeTestRequestStringHostnameResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3489,6 +3733,7 @@ func encodeTestRequestStringHostnameResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringHostnameArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3503,6 +3748,7 @@ func encodeTestRequestStringHostnameArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringHostnameArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3517,6 +3763,7 @@ func encodeTestRequestStringHostnameArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestStringHostnameNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3531,6 +3778,7 @@ func encodeTestRequestStringHostnameNullableResponse(response Error, w http.Resp
 func encodeTestRequestStringHostnameNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3545,6 +3793,7 @@ func encodeTestRequestStringHostnameNullableArrayResponse(response Error, w http
 func encodeTestRequestStringHostnameNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3559,6 +3808,7 @@ func encodeTestRequestStringHostnameNullableArrayArrayResponse(response Error, w
 func encodeTestRequestStringIPResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3573,6 +3823,7 @@ func encodeTestRequestStringIPResponse(response Error, w http.ResponseWriter, sp
 func encodeTestRequestStringIPArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3587,6 +3838,7 @@ func encodeTestRequestStringIPArrayResponse(response Error, w http.ResponseWrite
 func encodeTestRequestStringIPArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3601,6 +3853,7 @@ func encodeTestRequestStringIPArrayArrayResponse(response Error, w http.Response
 func encodeTestRequestStringIPNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3615,6 +3868,7 @@ func encodeTestRequestStringIPNullableResponse(response Error, w http.ResponseWr
 func encodeTestRequestStringIPNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3629,6 +3883,7 @@ func encodeTestRequestStringIPNullableArrayResponse(response Error, w http.Respo
 func encodeTestRequestStringIPNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3643,6 +3898,7 @@ func encodeTestRequestStringIPNullableArrayArrayResponse(response Error, w http.
 func encodeTestRequestStringIpv4Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3657,6 +3913,7 @@ func encodeTestRequestStringIpv4Response(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringIpv4ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3671,6 +3928,7 @@ func encodeTestRequestStringIpv4ArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringIpv4ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3685,6 +3943,7 @@ func encodeTestRequestStringIpv4ArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringIpv4NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3699,6 +3958,7 @@ func encodeTestRequestStringIpv4NullableResponse(response Error, w http.Response
 func encodeTestRequestStringIpv4NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3713,6 +3973,7 @@ func encodeTestRequestStringIpv4NullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringIpv4NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3727,6 +3988,7 @@ func encodeTestRequestStringIpv4NullableArrayArrayResponse(response Error, w htt
 func encodeTestRequestStringIpv6Response(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3741,6 +4003,7 @@ func encodeTestRequestStringIpv6Response(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringIpv6ArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3755,6 +4018,7 @@ func encodeTestRequestStringIpv6ArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringIpv6ArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3769,6 +4033,7 @@ func encodeTestRequestStringIpv6ArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringIpv6NullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3783,6 +4048,7 @@ func encodeTestRequestStringIpv6NullableResponse(response Error, w http.Response
 func encodeTestRequestStringIpv6NullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3797,6 +4063,7 @@ func encodeTestRequestStringIpv6NullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringIpv6NullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3811,6 +4078,7 @@ func encodeTestRequestStringIpv6NullableArrayArrayResponse(response Error, w htt
 func encodeTestRequestStringNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3825,6 +4093,7 @@ func encodeTestRequestStringNullableResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3839,6 +4108,7 @@ func encodeTestRequestStringNullableArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3853,6 +4123,7 @@ func encodeTestRequestStringNullableArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestStringPasswordResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3867,6 +4138,7 @@ func encodeTestRequestStringPasswordResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringPasswordArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3881,6 +4153,7 @@ func encodeTestRequestStringPasswordArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringPasswordArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3895,6 +4168,7 @@ func encodeTestRequestStringPasswordArrayArrayResponse(response Error, w http.Re
 func encodeTestRequestStringPasswordNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3909,6 +4183,7 @@ func encodeTestRequestStringPasswordNullableResponse(response Error, w http.Resp
 func encodeTestRequestStringPasswordNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3923,6 +4198,7 @@ func encodeTestRequestStringPasswordNullableArrayResponse(response Error, w http
 func encodeTestRequestStringPasswordNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3937,6 +4213,7 @@ func encodeTestRequestStringPasswordNullableArrayArrayResponse(response Error, w
 func encodeTestRequestStringTimeResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3951,6 +4228,7 @@ func encodeTestRequestStringTimeResponse(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringTimeArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3965,6 +4243,7 @@ func encodeTestRequestStringTimeArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringTimeArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3979,6 +4258,7 @@ func encodeTestRequestStringTimeArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringTimeNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -3993,6 +4273,7 @@ func encodeTestRequestStringTimeNullableResponse(response Error, w http.Response
 func encodeTestRequestStringTimeNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4007,6 +4288,7 @@ func encodeTestRequestStringTimeNullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringTimeNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4021,6 +4303,7 @@ func encodeTestRequestStringTimeNullableArrayArrayResponse(response Error, w htt
 func encodeTestRequestStringURIResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4035,6 +4318,7 @@ func encodeTestRequestStringURIResponse(response Error, w http.ResponseWriter, s
 func encodeTestRequestStringURIArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4049,6 +4333,7 @@ func encodeTestRequestStringURIArrayResponse(response Error, w http.ResponseWrit
 func encodeTestRequestStringURIArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4063,6 +4348,7 @@ func encodeTestRequestStringURIArrayArrayResponse(response Error, w http.Respons
 func encodeTestRequestStringURINullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4077,6 +4363,7 @@ func encodeTestRequestStringURINullableResponse(response Error, w http.ResponseW
 func encodeTestRequestStringURINullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4091,6 +4378,7 @@ func encodeTestRequestStringURINullableArrayResponse(response Error, w http.Resp
 func encodeTestRequestStringURINullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4105,6 +4393,7 @@ func encodeTestRequestStringURINullableArrayArrayResponse(response Error, w http
 func encodeTestRequestStringUUIDResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4119,6 +4408,7 @@ func encodeTestRequestStringUUIDResponse(response Error, w http.ResponseWriter, 
 func encodeTestRequestStringUUIDArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4133,6 +4423,7 @@ func encodeTestRequestStringUUIDArrayResponse(response Error, w http.ResponseWri
 func encodeTestRequestStringUUIDArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4147,6 +4438,7 @@ func encodeTestRequestStringUUIDArrayArrayResponse(response Error, w http.Respon
 func encodeTestRequestStringUUIDNullableResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4161,6 +4453,7 @@ func encodeTestRequestStringUUIDNullableResponse(response Error, w http.Response
 func encodeTestRequestStringUUIDNullableArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4175,6 +4468,7 @@ func encodeTestRequestStringUUIDNullableArrayResponse(response Error, w http.Res
 func encodeTestRequestStringUUIDNullableArrayArrayResponse(response Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4189,6 +4483,7 @@ func encodeTestRequestStringUUIDNullableArrayArrayResponse(response Error, w htt
 func encodeTestResponseAnyResponse(response jx.Raw, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4205,6 +4500,7 @@ func encodeTestResponseAnyResponse(response jx.Raw, w http.ResponseWriter, span 
 func encodeTestResponseBooleanResponse(response bool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4219,6 +4515,7 @@ func encodeTestResponseBooleanResponse(response bool, w http.ResponseWriter, spa
 func encodeTestResponseBooleanArrayResponse(response []bool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4237,6 +4534,7 @@ func encodeTestResponseBooleanArrayResponse(response []bool, w http.ResponseWrit
 func encodeTestResponseBooleanArrayArrayResponse(response [][]bool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4259,6 +4557,7 @@ func encodeTestResponseBooleanArrayArrayResponse(response [][]bool, w http.Respo
 func encodeTestResponseBooleanNullableResponse(response NilBool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4273,6 +4572,7 @@ func encodeTestResponseBooleanNullableResponse(response NilBool, w http.Response
 func encodeTestResponseBooleanNullableArrayResponse(response []bool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4291,6 +4591,7 @@ func encodeTestResponseBooleanNullableArrayResponse(response []bool, w http.Resp
 func encodeTestResponseBooleanNullableArrayArrayResponse(response [][]bool, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4313,6 +4614,7 @@ func encodeTestResponseBooleanNullableArrayArrayResponse(response [][]bool, w ht
 func encodeTestResponseEmptyStructResponse(response TestResponseEmptyStructOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4327,6 +4629,7 @@ func encodeTestResponseEmptyStructResponse(response TestResponseEmptyStructOK, w
 func encodeTestResponseFormatTestResponse(response TestResponseFormatTestOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4341,6 +4644,7 @@ func encodeTestResponseFormatTestResponse(response TestResponseFormatTestOK, w h
 func encodeTestResponseIntegerResponse(response int, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4355,6 +4659,7 @@ func encodeTestResponseIntegerResponse(response int, w http.ResponseWriter, span
 func encodeTestResponseIntegerArrayResponse(response []int, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4373,6 +4678,7 @@ func encodeTestResponseIntegerArrayResponse(response []int, w http.ResponseWrite
 func encodeTestResponseIntegerArrayArrayResponse(response [][]int, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4395,6 +4701,7 @@ func encodeTestResponseIntegerArrayArrayResponse(response [][]int, w http.Respon
 func encodeTestResponseIntegerInt32Response(response int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4409,6 +4716,7 @@ func encodeTestResponseIntegerInt32Response(response int32, w http.ResponseWrite
 func encodeTestResponseIntegerInt32ArrayResponse(response []int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4427,6 +4735,7 @@ func encodeTestResponseIntegerInt32ArrayResponse(response []int32, w http.Respon
 func encodeTestResponseIntegerInt32ArrayArrayResponse(response [][]int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4449,6 +4758,7 @@ func encodeTestResponseIntegerInt32ArrayArrayResponse(response [][]int32, w http
 func encodeTestResponseIntegerInt32NullableResponse(response NilInt32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4463,6 +4773,7 @@ func encodeTestResponseIntegerInt32NullableResponse(response NilInt32, w http.Re
 func encodeTestResponseIntegerInt32NullableArrayResponse(response []int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4481,6 +4792,7 @@ func encodeTestResponseIntegerInt32NullableArrayResponse(response []int32, w htt
 func encodeTestResponseIntegerInt32NullableArrayArrayResponse(response [][]int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4503,6 +4815,7 @@ func encodeTestResponseIntegerInt32NullableArrayArrayResponse(response [][]int32
 func encodeTestResponseIntegerInt64Response(response int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4517,6 +4830,7 @@ func encodeTestResponseIntegerInt64Response(response int64, w http.ResponseWrite
 func encodeTestResponseIntegerInt64ArrayResponse(response []int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4535,6 +4849,7 @@ func encodeTestResponseIntegerInt64ArrayResponse(response []int64, w http.Respon
 func encodeTestResponseIntegerInt64ArrayArrayResponse(response [][]int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4557,6 +4872,7 @@ func encodeTestResponseIntegerInt64ArrayArrayResponse(response [][]int64, w http
 func encodeTestResponseIntegerInt64NullableResponse(response NilInt64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4571,6 +4887,7 @@ func encodeTestResponseIntegerInt64NullableResponse(response NilInt64, w http.Re
 func encodeTestResponseIntegerInt64NullableArrayResponse(response []int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4589,6 +4906,7 @@ func encodeTestResponseIntegerInt64NullableArrayResponse(response []int64, w htt
 func encodeTestResponseIntegerInt64NullableArrayArrayResponse(response [][]int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4611,6 +4929,7 @@ func encodeTestResponseIntegerInt64NullableArrayArrayResponse(response [][]int64
 func encodeTestResponseIntegerNullableResponse(response NilInt, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4625,6 +4944,7 @@ func encodeTestResponseIntegerNullableResponse(response NilInt, w http.ResponseW
 func encodeTestResponseIntegerNullableArrayResponse(response []int, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4643,6 +4963,7 @@ func encodeTestResponseIntegerNullableArrayResponse(response []int, w http.Respo
 func encodeTestResponseIntegerNullableArrayArrayResponse(response [][]int, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4665,6 +4986,7 @@ func encodeTestResponseIntegerNullableArrayArrayResponse(response [][]int, w htt
 func encodeTestResponseNumberResponse(response float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4679,6 +5001,7 @@ func encodeTestResponseNumberResponse(response float64, w http.ResponseWriter, s
 func encodeTestResponseNumberArrayResponse(response []float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4697,6 +5020,7 @@ func encodeTestResponseNumberArrayResponse(response []float64, w http.ResponseWr
 func encodeTestResponseNumberArrayArrayResponse(response [][]float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4719,6 +5043,7 @@ func encodeTestResponseNumberArrayArrayResponse(response [][]float64, w http.Res
 func encodeTestResponseNumberDoubleResponse(response float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4733,6 +5058,7 @@ func encodeTestResponseNumberDoubleResponse(response float64, w http.ResponseWri
 func encodeTestResponseNumberDoubleArrayResponse(response []float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4751,6 +5077,7 @@ func encodeTestResponseNumberDoubleArrayResponse(response []float64, w http.Resp
 func encodeTestResponseNumberDoubleArrayArrayResponse(response [][]float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4773,6 +5100,7 @@ func encodeTestResponseNumberDoubleArrayArrayResponse(response [][]float64, w ht
 func encodeTestResponseNumberDoubleNullableResponse(response NilFloat64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4787,6 +5115,7 @@ func encodeTestResponseNumberDoubleNullableResponse(response NilFloat64, w http.
 func encodeTestResponseNumberDoubleNullableArrayResponse(response []float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4805,6 +5134,7 @@ func encodeTestResponseNumberDoubleNullableArrayResponse(response []float64, w h
 func encodeTestResponseNumberDoubleNullableArrayArrayResponse(response [][]float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4827,6 +5157,7 @@ func encodeTestResponseNumberDoubleNullableArrayArrayResponse(response [][]float
 func encodeTestResponseNumberFloatResponse(response float32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4841,6 +5172,7 @@ func encodeTestResponseNumberFloatResponse(response float32, w http.ResponseWrit
 func encodeTestResponseNumberFloatArrayResponse(response []float32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4859,6 +5191,7 @@ func encodeTestResponseNumberFloatArrayResponse(response []float32, w http.Respo
 func encodeTestResponseNumberFloatArrayArrayResponse(response [][]float32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4881,6 +5214,7 @@ func encodeTestResponseNumberFloatArrayArrayResponse(response [][]float32, w htt
 func encodeTestResponseNumberFloatNullableResponse(response NilFloat32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4895,6 +5229,7 @@ func encodeTestResponseNumberFloatNullableResponse(response NilFloat32, w http.R
 func encodeTestResponseNumberFloatNullableArrayResponse(response []float32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4913,6 +5248,7 @@ func encodeTestResponseNumberFloatNullableArrayResponse(response []float32, w ht
 func encodeTestResponseNumberFloatNullableArrayArrayResponse(response [][]float32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4935,6 +5271,7 @@ func encodeTestResponseNumberFloatNullableArrayArrayResponse(response [][]float3
 func encodeTestResponseNumberInt32Response(response int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4949,6 +5286,7 @@ func encodeTestResponseNumberInt32Response(response int32, w http.ResponseWriter
 func encodeTestResponseNumberInt32ArrayResponse(response []int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4967,6 +5305,7 @@ func encodeTestResponseNumberInt32ArrayResponse(response []int32, w http.Respons
 func encodeTestResponseNumberInt32ArrayArrayResponse(response [][]int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -4989,6 +5328,7 @@ func encodeTestResponseNumberInt32ArrayArrayResponse(response [][]int32, w http.
 func encodeTestResponseNumberInt32NullableResponse(response NilInt32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5003,6 +5343,7 @@ func encodeTestResponseNumberInt32NullableResponse(response NilInt32, w http.Res
 func encodeTestResponseNumberInt32NullableArrayResponse(response []int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5021,6 +5362,7 @@ func encodeTestResponseNumberInt32NullableArrayResponse(response []int32, w http
 func encodeTestResponseNumberInt32NullableArrayArrayResponse(response [][]int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5043,6 +5385,7 @@ func encodeTestResponseNumberInt32NullableArrayArrayResponse(response [][]int32,
 func encodeTestResponseNumberInt64Response(response int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5057,6 +5400,7 @@ func encodeTestResponseNumberInt64Response(response int64, w http.ResponseWriter
 func encodeTestResponseNumberInt64ArrayResponse(response []int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5075,6 +5419,7 @@ func encodeTestResponseNumberInt64ArrayResponse(response []int64, w http.Respons
 func encodeTestResponseNumberInt64ArrayArrayResponse(response [][]int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5097,6 +5442,7 @@ func encodeTestResponseNumberInt64ArrayArrayResponse(response [][]int64, w http.
 func encodeTestResponseNumberInt64NullableResponse(response NilInt64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5111,6 +5457,7 @@ func encodeTestResponseNumberInt64NullableResponse(response NilInt64, w http.Res
 func encodeTestResponseNumberInt64NullableArrayResponse(response []int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5129,6 +5476,7 @@ func encodeTestResponseNumberInt64NullableArrayResponse(response []int64, w http
 func encodeTestResponseNumberInt64NullableArrayArrayResponse(response [][]int64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5151,6 +5499,7 @@ func encodeTestResponseNumberInt64NullableArrayArrayResponse(response [][]int64,
 func encodeTestResponseNumberNullableResponse(response NilFloat64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5165,6 +5514,7 @@ func encodeTestResponseNumberNullableResponse(response NilFloat64, w http.Respon
 func encodeTestResponseNumberNullableArrayResponse(response []float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5183,6 +5533,7 @@ func encodeTestResponseNumberNullableArrayResponse(response []float64, w http.Re
 func encodeTestResponseNumberNullableArrayArrayResponse(response [][]float64, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5205,6 +5556,7 @@ func encodeTestResponseNumberNullableArrayArrayResponse(response [][]float64, w 
 func encodeTestResponseStringResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5219,6 +5571,7 @@ func encodeTestResponseStringResponse(response string, w http.ResponseWriter, sp
 func encodeTestResponseStringArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5237,6 +5590,7 @@ func encodeTestResponseStringArrayResponse(response []string, w http.ResponseWri
 func encodeTestResponseStringArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5259,6 +5613,7 @@ func encodeTestResponseStringArrayArrayResponse(response [][]string, w http.Resp
 func encodeTestResponseStringBinaryResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5273,6 +5628,7 @@ func encodeTestResponseStringBinaryResponse(response string, w http.ResponseWrit
 func encodeTestResponseStringBinaryArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5291,6 +5647,7 @@ func encodeTestResponseStringBinaryArrayResponse(response []string, w http.Respo
 func encodeTestResponseStringBinaryArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5313,6 +5670,7 @@ func encodeTestResponseStringBinaryArrayArrayResponse(response [][]string, w htt
 func encodeTestResponseStringBinaryNullableResponse(response NilString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5327,6 +5685,7 @@ func encodeTestResponseStringBinaryNullableResponse(response NilString, w http.R
 func encodeTestResponseStringBinaryNullableArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5345,6 +5704,7 @@ func encodeTestResponseStringBinaryNullableArrayResponse(response []string, w ht
 func encodeTestResponseStringBinaryNullableArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5367,6 +5727,7 @@ func encodeTestResponseStringBinaryNullableArrayArrayResponse(response [][]strin
 func encodeTestResponseStringByteResponse(response []byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5381,6 +5742,7 @@ func encodeTestResponseStringByteResponse(response []byte, w http.ResponseWriter
 func encodeTestResponseStringByteArrayResponse(response [][]byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5399,6 +5761,7 @@ func encodeTestResponseStringByteArrayResponse(response [][]byte, w http.Respons
 func encodeTestResponseStringByteArrayArrayResponse(response [][][]byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5421,6 +5784,7 @@ func encodeTestResponseStringByteArrayArrayResponse(response [][][]byte, w http.
 func encodeTestResponseStringByteNullableResponse(response []byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5435,6 +5799,7 @@ func encodeTestResponseStringByteNullableResponse(response []byte, w http.Respon
 func encodeTestResponseStringByteNullableArrayResponse(response [][]byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5453,6 +5818,7 @@ func encodeTestResponseStringByteNullableArrayResponse(response [][]byte, w http
 func encodeTestResponseStringByteNullableArrayArrayResponse(response [][][]byte, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5475,6 +5841,7 @@ func encodeTestResponseStringByteNullableArrayArrayResponse(response [][][]byte,
 func encodeTestResponseStringDateResponse(response time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5489,6 +5856,7 @@ func encodeTestResponseStringDateResponse(response time.Time, w http.ResponseWri
 func encodeTestResponseStringDateArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5507,6 +5875,7 @@ func encodeTestResponseStringDateArrayResponse(response []time.Time, w http.Resp
 func encodeTestResponseStringDateArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5529,6 +5898,7 @@ func encodeTestResponseStringDateArrayArrayResponse(response [][]time.Time, w ht
 func encodeTestResponseStringDateNullableResponse(response NilDate, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5543,6 +5913,7 @@ func encodeTestResponseStringDateNullableResponse(response NilDate, w http.Respo
 func encodeTestResponseStringDateNullableArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5561,6 +5932,7 @@ func encodeTestResponseStringDateNullableArrayResponse(response []time.Time, w h
 func encodeTestResponseStringDateNullableArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5583,6 +5955,7 @@ func encodeTestResponseStringDateNullableArrayArrayResponse(response [][]time.Ti
 func encodeTestResponseStringDateTimeResponse(response time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5597,6 +5970,7 @@ func encodeTestResponseStringDateTimeResponse(response time.Time, w http.Respons
 func encodeTestResponseStringDateTimeArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5615,6 +5989,7 @@ func encodeTestResponseStringDateTimeArrayResponse(response []time.Time, w http.
 func encodeTestResponseStringDateTimeArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5637,6 +6012,7 @@ func encodeTestResponseStringDateTimeArrayArrayResponse(response [][]time.Time, 
 func encodeTestResponseStringDateTimeNullableResponse(response NilDateTime, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5651,6 +6027,7 @@ func encodeTestResponseStringDateTimeNullableResponse(response NilDateTime, w ht
 func encodeTestResponseStringDateTimeNullableArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5669,6 +6046,7 @@ func encodeTestResponseStringDateTimeNullableArrayResponse(response []time.Time,
 func encodeTestResponseStringDateTimeNullableArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5691,6 +6069,7 @@ func encodeTestResponseStringDateTimeNullableArrayArrayResponse(response [][]tim
 func encodeTestResponseStringDurationResponse(response time.Duration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5705,6 +6084,7 @@ func encodeTestResponseStringDurationResponse(response time.Duration, w http.Res
 func encodeTestResponseStringDurationArrayResponse(response []time.Duration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5723,6 +6103,7 @@ func encodeTestResponseStringDurationArrayResponse(response []time.Duration, w h
 func encodeTestResponseStringDurationArrayArrayResponse(response [][]time.Duration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5745,6 +6126,7 @@ func encodeTestResponseStringDurationArrayArrayResponse(response [][]time.Durati
 func encodeTestResponseStringDurationNullableResponse(response NilDuration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5759,6 +6141,7 @@ func encodeTestResponseStringDurationNullableResponse(response NilDuration, w ht
 func encodeTestResponseStringDurationNullableArrayResponse(response []time.Duration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5777,6 +6160,7 @@ func encodeTestResponseStringDurationNullableArrayResponse(response []time.Durat
 func encodeTestResponseStringDurationNullableArrayArrayResponse(response [][]time.Duration, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5799,6 +6183,7 @@ func encodeTestResponseStringDurationNullableArrayArrayResponse(response [][]tim
 func encodeTestResponseStringEmailResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5813,6 +6198,7 @@ func encodeTestResponseStringEmailResponse(response string, w http.ResponseWrite
 func encodeTestResponseStringEmailArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5831,6 +6217,7 @@ func encodeTestResponseStringEmailArrayResponse(response []string, w http.Respon
 func encodeTestResponseStringEmailArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5853,6 +6240,7 @@ func encodeTestResponseStringEmailArrayArrayResponse(response [][]string, w http
 func encodeTestResponseStringEmailNullableResponse(response NilString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5867,6 +6255,7 @@ func encodeTestResponseStringEmailNullableResponse(response NilString, w http.Re
 func encodeTestResponseStringEmailNullableArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5885,6 +6274,7 @@ func encodeTestResponseStringEmailNullableArrayResponse(response []string, w htt
 func encodeTestResponseStringEmailNullableArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5907,6 +6297,7 @@ func encodeTestResponseStringEmailNullableArrayArrayResponse(response [][]string
 func encodeTestResponseStringHostnameResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5921,6 +6312,7 @@ func encodeTestResponseStringHostnameResponse(response string, w http.ResponseWr
 func encodeTestResponseStringHostnameArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5939,6 +6331,7 @@ func encodeTestResponseStringHostnameArrayResponse(response []string, w http.Res
 func encodeTestResponseStringHostnameArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5961,6 +6354,7 @@ func encodeTestResponseStringHostnameArrayArrayResponse(response [][]string, w h
 func encodeTestResponseStringHostnameNullableResponse(response NilString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5975,6 +6369,7 @@ func encodeTestResponseStringHostnameNullableResponse(response NilString, w http
 func encodeTestResponseStringHostnameNullableArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -5993,6 +6388,7 @@ func encodeTestResponseStringHostnameNullableArrayResponse(response []string, w 
 func encodeTestResponseStringHostnameNullableArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6015,6 +6411,7 @@ func encodeTestResponseStringHostnameNullableArrayArrayResponse(response [][]str
 func encodeTestResponseStringIPResponse(response net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6029,6 +6426,7 @@ func encodeTestResponseStringIPResponse(response net.IP, w http.ResponseWriter, 
 func encodeTestResponseStringIPArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6047,6 +6445,7 @@ func encodeTestResponseStringIPArrayResponse(response []net.IP, w http.ResponseW
 func encodeTestResponseStringIPArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6069,6 +6468,7 @@ func encodeTestResponseStringIPArrayArrayResponse(response [][]net.IP, w http.Re
 func encodeTestResponseStringIPNullableResponse(response NilIP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6083,6 +6483,7 @@ func encodeTestResponseStringIPNullableResponse(response NilIP, w http.ResponseW
 func encodeTestResponseStringIPNullableArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6101,6 +6502,7 @@ func encodeTestResponseStringIPNullableArrayResponse(response []net.IP, w http.R
 func encodeTestResponseStringIPNullableArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6123,6 +6525,7 @@ func encodeTestResponseStringIPNullableArrayArrayResponse(response [][]net.IP, w
 func encodeTestResponseStringIpv4Response(response net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6137,6 +6540,7 @@ func encodeTestResponseStringIpv4Response(response net.IP, w http.ResponseWriter
 func encodeTestResponseStringIpv4ArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6155,6 +6559,7 @@ func encodeTestResponseStringIpv4ArrayResponse(response []net.IP, w http.Respons
 func encodeTestResponseStringIpv4ArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6177,6 +6582,7 @@ func encodeTestResponseStringIpv4ArrayArrayResponse(response [][]net.IP, w http.
 func encodeTestResponseStringIpv4NullableResponse(response NilIPv4, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6191,6 +6597,7 @@ func encodeTestResponseStringIpv4NullableResponse(response NilIPv4, w http.Respo
 func encodeTestResponseStringIpv4NullableArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6209,6 +6616,7 @@ func encodeTestResponseStringIpv4NullableArrayResponse(response []net.IP, w http
 func encodeTestResponseStringIpv4NullableArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6231,6 +6639,7 @@ func encodeTestResponseStringIpv4NullableArrayArrayResponse(response [][]net.IP,
 func encodeTestResponseStringIpv6Response(response net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6245,6 +6654,7 @@ func encodeTestResponseStringIpv6Response(response net.IP, w http.ResponseWriter
 func encodeTestResponseStringIpv6ArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6263,6 +6673,7 @@ func encodeTestResponseStringIpv6ArrayResponse(response []net.IP, w http.Respons
 func encodeTestResponseStringIpv6ArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6285,6 +6696,7 @@ func encodeTestResponseStringIpv6ArrayArrayResponse(response [][]net.IP, w http.
 func encodeTestResponseStringIpv6NullableResponse(response NilIPv6, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6299,6 +6711,7 @@ func encodeTestResponseStringIpv6NullableResponse(response NilIPv6, w http.Respo
 func encodeTestResponseStringIpv6NullableArrayResponse(response []net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6317,6 +6730,7 @@ func encodeTestResponseStringIpv6NullableArrayResponse(response []net.IP, w http
 func encodeTestResponseStringIpv6NullableArrayArrayResponse(response [][]net.IP, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6339,6 +6753,7 @@ func encodeTestResponseStringIpv6NullableArrayArrayResponse(response [][]net.IP,
 func encodeTestResponseStringNullableResponse(response NilString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6353,6 +6768,7 @@ func encodeTestResponseStringNullableResponse(response NilString, w http.Respons
 func encodeTestResponseStringNullableArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6371,6 +6787,7 @@ func encodeTestResponseStringNullableArrayResponse(response []string, w http.Res
 func encodeTestResponseStringNullableArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6393,6 +6810,7 @@ func encodeTestResponseStringNullableArrayArrayResponse(response [][]string, w h
 func encodeTestResponseStringPasswordResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6407,6 +6825,7 @@ func encodeTestResponseStringPasswordResponse(response string, w http.ResponseWr
 func encodeTestResponseStringPasswordArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6425,6 +6844,7 @@ func encodeTestResponseStringPasswordArrayResponse(response []string, w http.Res
 func encodeTestResponseStringPasswordArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6447,6 +6867,7 @@ func encodeTestResponseStringPasswordArrayArrayResponse(response [][]string, w h
 func encodeTestResponseStringPasswordNullableResponse(response NilString, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6461,6 +6882,7 @@ func encodeTestResponseStringPasswordNullableResponse(response NilString, w http
 func encodeTestResponseStringPasswordNullableArrayResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6479,6 +6901,7 @@ func encodeTestResponseStringPasswordNullableArrayResponse(response []string, w 
 func encodeTestResponseStringPasswordNullableArrayArrayResponse(response [][]string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6501,6 +6924,7 @@ func encodeTestResponseStringPasswordNullableArrayArrayResponse(response [][]str
 func encodeTestResponseStringTimeResponse(response time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6515,6 +6939,7 @@ func encodeTestResponseStringTimeResponse(response time.Time, w http.ResponseWri
 func encodeTestResponseStringTimeArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6533,6 +6958,7 @@ func encodeTestResponseStringTimeArrayResponse(response []time.Time, w http.Resp
 func encodeTestResponseStringTimeArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6555,6 +6981,7 @@ func encodeTestResponseStringTimeArrayArrayResponse(response [][]time.Time, w ht
 func encodeTestResponseStringTimeNullableResponse(response NilTime, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6569,6 +6996,7 @@ func encodeTestResponseStringTimeNullableResponse(response NilTime, w http.Respo
 func encodeTestResponseStringTimeNullableArrayResponse(response []time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6587,6 +7015,7 @@ func encodeTestResponseStringTimeNullableArrayResponse(response []time.Time, w h
 func encodeTestResponseStringTimeNullableArrayArrayResponse(response [][]time.Time, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6609,6 +7038,7 @@ func encodeTestResponseStringTimeNullableArrayArrayResponse(response [][]time.Ti
 func encodeTestResponseStringURIResponse(response url.URL, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6623,6 +7053,7 @@ func encodeTestResponseStringURIResponse(response url.URL, w http.ResponseWriter
 func encodeTestResponseStringURIArrayResponse(response []url.URL, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6641,6 +7072,7 @@ func encodeTestResponseStringURIArrayResponse(response []url.URL, w http.Respons
 func encodeTestResponseStringURIArrayArrayResponse(response [][]url.URL, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6663,6 +7095,7 @@ func encodeTestResponseStringURIArrayArrayResponse(response [][]url.URL, w http.
 func encodeTestResponseStringURINullableResponse(response NilURI, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6677,6 +7110,7 @@ func encodeTestResponseStringURINullableResponse(response NilURI, w http.Respons
 func encodeTestResponseStringURINullableArrayResponse(response []url.URL, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6695,6 +7129,7 @@ func encodeTestResponseStringURINullableArrayResponse(response []url.URL, w http
 func encodeTestResponseStringURINullableArrayArrayResponse(response [][]url.URL, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6717,6 +7152,7 @@ func encodeTestResponseStringURINullableArrayArrayResponse(response [][]url.URL,
 func encodeTestResponseStringUUIDResponse(response uuid.UUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6731,6 +7167,7 @@ func encodeTestResponseStringUUIDResponse(response uuid.UUID, w http.ResponseWri
 func encodeTestResponseStringUUIDArrayResponse(response []uuid.UUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6749,6 +7186,7 @@ func encodeTestResponseStringUUIDArrayResponse(response []uuid.UUID, w http.Resp
 func encodeTestResponseStringUUIDArrayArrayResponse(response [][]uuid.UUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6771,6 +7209,7 @@ func encodeTestResponseStringUUIDArrayArrayResponse(response [][]uuid.UUID, w ht
 func encodeTestResponseStringUUIDNullableResponse(response NilUUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6785,6 +7224,7 @@ func encodeTestResponseStringUUIDNullableResponse(response NilUUID, w http.Respo
 func encodeTestResponseStringUUIDNullableArrayResponse(response []uuid.UUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -6803,6 +7243,7 @@ func encodeTestResponseStringUUIDNullableArrayResponse(response []uuid.UUID, w h
 func encodeTestResponseStringUUIDNullableArrayArrayResponse(response [][]uuid.UUID, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/examples/ex_tinkoff/oas_handlers_gen.go
+++ b/examples/ex_tinkoff/oas_handlers_gen.go
@@ -106,7 +106,6 @@ func (s *Server) handleMarketBondsGetRequest(args [0]string, w http.ResponseWrit
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -152,7 +151,6 @@ func (s *Server) handleMarketCandlesGetRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -193,7 +191,6 @@ func (s *Server) handleMarketCurrenciesGetRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -234,7 +231,6 @@ func (s *Server) handleMarketEtfsGetRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -280,7 +276,6 @@ func (s *Server) handleMarketOrderbookGetRequest(args [0]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -326,7 +321,6 @@ func (s *Server) handleMarketSearchByFigiGetRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -372,7 +366,6 @@ func (s *Server) handleMarketSearchByTickerGetRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -413,7 +406,6 @@ func (s *Server) handleMarketStocksGetRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -459,7 +451,6 @@ func (s *Server) handleOperationsGetRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -505,7 +496,6 @@ func (s *Server) handleOrdersCancelPostRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -551,7 +541,6 @@ func (s *Server) handleOrdersGetRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -602,7 +591,6 @@ func (s *Server) handleOrdersLimitOrderPostRequest(args [0]string, w http.Respon
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -653,7 +641,6 @@ func (s *Server) handleOrdersMarketOrderPostRequest(args [0]string, w http.Respo
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -699,7 +686,6 @@ func (s *Server) handlePortfolioCurrenciesGetRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -745,7 +731,6 @@ func (s *Server) handlePortfolioGetRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -791,7 +776,6 @@ func (s *Server) handleSandboxClearPostRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -842,7 +826,6 @@ func (s *Server) handleSandboxCurrenciesBalancePostRequest(args [0]string, w htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -893,7 +876,6 @@ func (s *Server) handleSandboxPositionsBalancePostRequest(args [0]string, w http
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -939,7 +921,6 @@ func (s *Server) handleSandboxRegisterPostRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -985,7 +966,6 @@ func (s *Server) handleSandboxRemovePostRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1026,7 +1006,6 @@ func (s *Server) handleUserAccountsGetRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/examples/ex_tinkoff/oas_res_enc_gen.go
+++ b/examples/ex_tinkoff/oas_res_enc_gen.go
@@ -75,6 +75,7 @@ func encodeMarketBondsGetResponse(response MarketBondsGetRes, w http.ResponseWri
 	case *MarketInstrumentListResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeMarketBondsGetResponse(response MarketBondsGetRes, w http.ResponseWri
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -106,6 +108,7 @@ func encodeMarketCandlesGetResponse(response MarketCandlesGetRes, w http.Respons
 	case *CandlesResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -118,6 +121,7 @@ func encodeMarketCandlesGetResponse(response MarketCandlesGetRes, w http.Respons
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -137,6 +141,7 @@ func encodeMarketCurrenciesGetResponse(response MarketCurrenciesGetRes, w http.R
 	case *MarketInstrumentListResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -149,6 +154,7 @@ func encodeMarketCurrenciesGetResponse(response MarketCurrenciesGetRes, w http.R
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -168,6 +174,7 @@ func encodeMarketEtfsGetResponse(response MarketEtfsGetRes, w http.ResponseWrite
 	case *MarketInstrumentListResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -180,6 +187,7 @@ func encodeMarketEtfsGetResponse(response MarketEtfsGetRes, w http.ResponseWrite
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -199,6 +207,7 @@ func encodeMarketOrderbookGetResponse(response MarketOrderbookGetRes, w http.Res
 	case *OrderbookResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -211,6 +220,7 @@ func encodeMarketOrderbookGetResponse(response MarketOrderbookGetRes, w http.Res
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -230,6 +240,7 @@ func encodeMarketSearchByFigiGetResponse(response MarketSearchByFigiGetRes, w ht
 	case *SearchMarketInstrumentResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -242,6 +253,7 @@ func encodeMarketSearchByFigiGetResponse(response MarketSearchByFigiGetRes, w ht
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -261,6 +273,7 @@ func encodeMarketSearchByTickerGetResponse(response MarketSearchByTickerGetRes, 
 	case *MarketInstrumentListResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -273,6 +286,7 @@ func encodeMarketSearchByTickerGetResponse(response MarketSearchByTickerGetRes, 
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -292,6 +306,7 @@ func encodeMarketStocksGetResponse(response MarketStocksGetRes, w http.ResponseW
 	case *MarketInstrumentListResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -304,6 +319,7 @@ func encodeMarketStocksGetResponse(response MarketStocksGetRes, w http.ResponseW
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -323,6 +339,7 @@ func encodeOperationsGetResponse(response OperationsGetRes, w http.ResponseWrite
 	case *OperationsResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -335,6 +352,7 @@ func encodeOperationsGetResponse(response OperationsGetRes, w http.ResponseWrite
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -354,6 +372,7 @@ func encodeOrdersCancelPostResponse(response OrdersCancelPostRes, w http.Respons
 	case *Empty:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -366,6 +385,7 @@ func encodeOrdersCancelPostResponse(response OrdersCancelPostRes, w http.Respons
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -385,6 +405,7 @@ func encodeOrdersGetResponse(response OrdersGetRes, w http.ResponseWriter, span 
 	case *OrdersResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -397,6 +418,7 @@ func encodeOrdersGetResponse(response OrdersGetRes, w http.ResponseWriter, span 
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -416,6 +438,7 @@ func encodeOrdersLimitOrderPostResponse(response OrdersLimitOrderPostRes, w http
 	case *LimitOrderResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -428,6 +451,7 @@ func encodeOrdersLimitOrderPostResponse(response OrdersLimitOrderPostRes, w http
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -447,6 +471,7 @@ func encodeOrdersMarketOrderPostResponse(response OrdersMarketOrderPostRes, w ht
 	case *MarketOrderResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -459,6 +484,7 @@ func encodeOrdersMarketOrderPostResponse(response OrdersMarketOrderPostRes, w ht
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -478,6 +504,7 @@ func encodePortfolioCurrenciesGetResponse(response PortfolioCurrenciesGetRes, w 
 	case *PortfolioCurrenciesResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -490,6 +517,7 @@ func encodePortfolioCurrenciesGetResponse(response PortfolioCurrenciesGetRes, w 
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -509,6 +537,7 @@ func encodePortfolioGetResponse(response PortfolioGetRes, w http.ResponseWriter,
 	case *PortfolioResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -521,6 +550,7 @@ func encodePortfolioGetResponse(response PortfolioGetRes, w http.ResponseWriter,
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -540,6 +570,7 @@ func encodeSandboxClearPostResponse(response SandboxClearPostRes, w http.Respons
 	case *Empty:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -552,6 +583,7 @@ func encodeSandboxClearPostResponse(response SandboxClearPostRes, w http.Respons
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -571,6 +603,7 @@ func encodeSandboxCurrenciesBalancePostResponse(response SandboxCurrenciesBalanc
 	case *Empty:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -583,6 +616,7 @@ func encodeSandboxCurrenciesBalancePostResponse(response SandboxCurrenciesBalanc
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -602,6 +636,7 @@ func encodeSandboxPositionsBalancePostResponse(response SandboxPositionsBalanceP
 	case *Empty:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -614,6 +649,7 @@ func encodeSandboxPositionsBalancePostResponse(response SandboxPositionsBalanceP
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -633,6 +669,7 @@ func encodeSandboxRegisterPostResponse(response SandboxRegisterPostRes, w http.R
 	case *SandboxRegisterResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -645,6 +682,7 @@ func encodeSandboxRegisterPostResponse(response SandboxRegisterPostRes, w http.R
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -664,6 +702,7 @@ func encodeSandboxRemovePostResponse(response SandboxRemovePostRes, w http.Respo
 	case *Empty:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -676,6 +715,7 @@ func encodeSandboxRemovePostResponse(response SandboxRemovePostRes, w http.Respo
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -695,6 +735,7 @@ func encodeUserAccountsGetResponse(response UserAccountsGetRes, w http.ResponseW
 	case *UserAccountsResponse:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -707,6 +748,7 @@ func encodeUserAccountsGetResponse(response UserAccountsGetRes, w http.ResponseW
 	case *Error:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/gen/_template/handlers.tmpl
+++ b/gen/_template/handlers.tmpl
@@ -77,7 +77,6 @@ func (s *Server) handle{{ $op.Name }}Request(args [{{ $op.PathParamsCount }}]str
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/gen/_template/res_enc.tmpl
+++ b/gen/_template/res_enc.tmpl
@@ -59,8 +59,19 @@ w.Header().Set("Content-Type", {{ quote $.ContentType }})
 
 {{- if $.Default }}{{- /* Set status code */}}
 w.WriteHeader(response.StatusCode)
+st := http.StatusText(response.StatusCode)
+if response.StatusCode >= http.StatusBadRequest {
+	span.SetStatus(codes.Error, st)
+} else {
+	span.SetStatus(codes.Ok, st)
+}
 {{- else }}
 w.WriteHeader({{ $.StatusCode }})
+{{- if ge .StatusCode 400 }}
+span.SetStatus(codes.Error, http.StatusText({{ $.StatusCode }}))
+{{- else }}
+span.SetStatus(codes.Ok, http.StatusText({{ $.StatusCode }}))
+{{- end }}
 {{- end }}{{- /* Set status code */}}
 
 {{- if $.NoContent }}{{- /* Encode content */}}

--- a/internal/sample_api/oas_handlers_gen.go
+++ b/internal/sample_api/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleDataGetFormatRequest(args [5]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -154,7 +153,6 @@ func (s *Server) handleDefaultTestRequest(args [0]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -191,7 +189,6 @@ func (s *Server) handleErrorGetRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -233,7 +230,6 @@ func (s *Server) handleFoobarGetRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -275,7 +271,6 @@ func (s *Server) handleFoobarPostRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -310,7 +305,6 @@ func (s *Server) handleFoobarPutRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -352,7 +346,6 @@ func (s *Server) handleGetHeaderRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -389,7 +382,6 @@ func (s *Server) handleNullableDefaultResponseRequest(args [0]string, w http.Res
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -431,7 +423,6 @@ func (s *Server) handleOneofBugRequest(args [0]string, w http.ResponseWriter, r 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -473,7 +464,6 @@ func (s *Server) handlePetCreateRequest(args [0]string, w http.ResponseWriter, r
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -515,7 +505,6 @@ func (s *Server) handlePetFriendsNamesByIDRequest(args [1]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -557,7 +546,6 @@ func (s *Server) handlePetGetRequest(args [0]string, w http.ResponseWriter, r *h
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -599,7 +587,6 @@ func (s *Server) handlePetGetAvatarByIDRequest(args [0]string, w http.ResponseWr
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -641,7 +628,6 @@ func (s *Server) handlePetGetAvatarByNameRequest(args [1]string, w http.Response
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -683,7 +669,6 @@ func (s *Server) handlePetGetByNameRequest(args [1]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -725,7 +710,6 @@ func (s *Server) handlePetNameByIDRequest(args [1]string, w http.ResponseWriter,
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -765,7 +749,6 @@ func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -805,7 +788,6 @@ func (s *Server) handlePetUpdateNamePostRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -852,7 +834,6 @@ func (s *Server) handlePetUploadAvatarByIDRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -887,7 +868,6 @@ func (s *Server) handleRecursiveArrayGetRequest(args [0]string, w http.ResponseW
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -922,7 +902,6 @@ func (s *Server) handleRecursiveMapGetRequest(args [0]string, w http.ResponseWri
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -965,7 +944,6 @@ func (s *Server) handleSecurityTestRequest(args [0]string, w http.ResponseWriter
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1007,7 +985,6 @@ func (s *Server) handleTestFloatValidationRequest(args [0]string, w http.Respons
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -1049,7 +1026,6 @@ func (s *Server) handleTestObjectQueryParameterRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/internal/sample_api/oas_res_enc_gen.go
+++ b/internal/sample_api/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeDataGetFormatResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeDataGetFormatResponse(response string, w http.ResponseWriter, span tr
 func encodeDefaultTestResponse(response int32, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,12 @@ func encodeDefaultTestResponse(response int32, w http.ResponseWriter, span trace
 func encodeErrorGetResponse(response ErrorStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -117,6 +125,7 @@ func encodeFoobarGetResponse(response FoobarGetRes, w http.ResponseWriter, span 
 	case *Pet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -128,6 +137,7 @@ func encodeFoobarGetResponse(response FoobarGetRes, w http.ResponseWriter, span 
 		return nil
 	case *NotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	default:
 		return errors.Errorf("/foobar"+`: unexpected response type: %T`, response)
@@ -139,6 +149,7 @@ func encodeFoobarPostResponse(response FoobarPostRes, w http.ResponseWriter, spa
 	case *Pet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -150,10 +161,17 @@ func encodeFoobarPostResponse(response FoobarPostRes, w http.ResponseWriter, spa
 		return nil
 	case *NotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -170,12 +188,19 @@ func encodeFoobarPostResponse(response FoobarPostRes, w http.ResponseWriter, spa
 
 func encodeFoobarPutResponse(response FoobarPutDefStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	return nil
 }
 
 func encodeGetHeaderResponse(response Hash, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -190,6 +215,12 @@ func encodeGetHeaderResponse(response Hash, w http.ResponseWriter, span trace.Sp
 func encodeNullableDefaultResponseResponse(response NilIntStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -203,12 +234,14 @@ func encodeNullableDefaultResponseResponse(response NilIntStatusCode, w http.Res
 
 func encodeOneofBugResponse(response OneofBugOK, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	return nil
 }
 
 func encodePetCreateResponse(response Pet, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -223,6 +256,7 @@ func encodePetCreateResponse(response Pet, w http.ResponseWriter, span trace.Spa
 func encodePetFriendsNamesByIDResponse(response []string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -243,6 +277,7 @@ func encodePetGetResponse(response PetGetRes, w http.ResponseWriter, span trace.
 	case *Pet:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -255,6 +290,12 @@ func encodePetGetResponse(response PetGetRes, w http.ResponseWriter, span trace.
 	case *PetGetDefStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -274,6 +315,7 @@ func encodePetGetAvatarByIDResponse(response PetGetAvatarByIDRes, w http.Respons
 	case *PetGetAvatarByIDOK:
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		if _, err := io.Copy(w, response); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -281,10 +323,17 @@ func encodePetGetAvatarByIDResponse(response PetGetAvatarByIDRes, w http.Respons
 		return nil
 	case *NotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -304,6 +353,7 @@ func encodePetGetAvatarByNameResponse(response PetGetAvatarByNameRes, w http.Res
 	case *PetGetAvatarByNameOK:
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		if _, err := io.Copy(w, response); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -311,10 +361,17 @@ func encodePetGetAvatarByNameResponse(response PetGetAvatarByNameRes, w http.Res
 		return nil
 	case *NotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -332,6 +389,7 @@ func encodePetGetAvatarByNameResponse(response PetGetAvatarByNameRes, w http.Res
 func encodePetGetByNameResponse(response Pet, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -346,6 +404,7 @@ func encodePetGetByNameResponse(response Pet, w http.ResponseWriter, span trace.
 func encodePetNameByIDResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -359,11 +418,23 @@ func encodePetNameByIDResponse(response string, w http.ResponseWriter, span trac
 
 func encodePetUpdateNameAliasPostResponse(response PetUpdateNameAliasPostDefStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	return nil
 }
 
 func encodePetUpdateNamePostResponse(response PetUpdateNamePostDefStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	return nil
 }
 
@@ -371,13 +442,21 @@ func encodePetUploadAvatarByIDResponse(response PetUploadAvatarByIDRes, w http.R
 	switch response := response.(type) {
 	case *PetUploadAvatarByIDOK:
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		return nil
 	case *NotFound:
 		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
 		return nil
 	case *ErrorStatusCode:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(response.StatusCode)
+		st := http.StatusText(response.StatusCode)
+		if response.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -395,6 +474,7 @@ func encodePetUploadAvatarByIDResponse(response PetUploadAvatarByIDRes, w http.R
 func encodeRecursiveArrayGetResponse(response RecursiveArray, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -409,6 +489,7 @@ func encodeRecursiveArrayGetResponse(response RecursiveArray, w http.ResponseWri
 func encodeRecursiveMapGetResponse(response RecursiveMap, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -423,6 +504,7 @@ func encodeRecursiveMapGetResponse(response RecursiveMap, w http.ResponseWriter,
 func encodeSecurityTestResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -436,12 +518,14 @@ func encodeSecurityTestResponse(response string, w http.ResponseWriter, span tra
 
 func encodeTestFloatValidationResponse(response TestFloatValidationOK, w http.ResponseWriter, span trace.Span) error {
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	return nil
 }
 
 func encodeTestObjectQueryParameterResponse(response TestObjectQueryParameterOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/internal/sample_err/oas_handlers_gen.go
+++ b/internal/sample_err/oas_handlers_gen.go
@@ -116,7 +116,6 @@ func (s *Server) handleDataCreateRequest(args [0]string, w http.ResponseWriter, 
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -162,7 +161,6 @@ func (s *Server) handleDataGetRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/internal/sample_err/oas_res_enc_gen.go
+++ b/internal/sample_err/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeDataCreateResponse(response Data, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeDataCreateResponse(response Data, w http.ResponseWriter, span trace.S
 func encodeDataGetResponse(response Data, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -100,6 +102,12 @@ func encodeDataGetResponse(response Data, w http.ResponseWriter, span trace.Span
 func encodeErrorResponse(response ErrorStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/internal/techempower/oas_handlers_gen.go
+++ b/internal/techempower/oas_handlers_gen.go
@@ -107,7 +107,6 @@ func (s *Server) handleCachingRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -144,7 +143,6 @@ func (s *Server) handleDBRequest(args [0]string, w http.ResponseWriter, r *http.
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -181,7 +179,6 @@ func (s *Server) handleJSONRequest(args [0]string, w http.ResponseWriter, r *htt
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -223,7 +220,6 @@ func (s *Server) handleQueriesRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -265,7 +261,6 @@ func (s *Server) handleUpdatesRequest(args [0]string, w http.ResponseWriter, r *
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/internal/techempower/oas_res_enc_gen.go
+++ b/internal/techempower/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeCachingResponse(response WorldObjects, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -87,6 +88,7 @@ func encodeCachingResponse(response WorldObjects, w http.ResponseWriter, span tr
 func encodeDBResponse(response WorldObject, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -101,6 +103,7 @@ func encodeDBResponse(response WorldObject, w http.ResponseWriter, span trace.Sp
 func encodeJSONResponse(response HelloWorld, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -115,6 +118,7 @@ func encodeJSONResponse(response HelloWorld, w http.ResponseWriter, span trace.S
 func encodeQueriesResponse(response WorldObjects, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -129,6 +133,7 @@ func encodeQueriesResponse(response WorldObjects, w http.ResponseWriter, span tr
 func encodeUpdatesResponse(response WorldObjects, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 

--- a/internal/test_http_responses/oas_handlers_gen.go
+++ b/internal/test_http_responses/oas_handlers_gen.go
@@ -102,7 +102,6 @@ func (s *Server) handleAnyContentTypeBinaryStringSchemaRequest(args [0]string, w
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -139,7 +138,6 @@ func (s *Server) handleAnyContentTypeBinaryStringSchemaDefaultRequest(args [0]st
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -176,7 +174,6 @@ func (s *Server) handleMultipleGenericResponsesRequest(args [0]string, w http.Re
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -213,7 +210,6 @@ func (s *Server) handleOctetStreamBinaryStringSchemaRequest(args [0]string, w ht
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }
@@ -250,7 +246,6 @@ func (s *Server) handleOctetStreamEmptySchemaRequest(args [0]string, w http.Resp
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/internal/test_http_responses/oas_res_enc_gen.go
+++ b/internal/test_http_responses/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeAnyContentTypeBinaryStringSchemaResponse(response AnyContentTypeBinaryStringSchemaOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "*/*")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	if _, err := io.Copy(w, response); err != nil {
 		return errors.Wrap(err, "write")
 	}
@@ -83,6 +84,12 @@ func encodeAnyContentTypeBinaryStringSchemaResponse(response AnyContentTypeBinar
 func encodeAnyContentTypeBinaryStringSchemaDefaultResponse(response AnyContentTypeBinaryStringSchemaDefaultDefStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "*/*")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	if _, err := io.Copy(w, response.Response); err != nil {
 		return errors.Wrap(err, "write")
 	}
@@ -95,6 +102,7 @@ func encodeMultipleGenericResponsesResponse(response MultipleGenericResponsesRes
 	case *NilInt:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -107,6 +115,7 @@ func encodeMultipleGenericResponsesResponse(response MultipleGenericResponsesRes
 	case *NilString:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		span.SetStatus(codes.Ok, http.StatusText(201))
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -124,6 +133,7 @@ func encodeMultipleGenericResponsesResponse(response MultipleGenericResponsesRes
 func encodeOctetStreamBinaryStringSchemaResponse(response OctetStreamBinaryStringSchemaOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	if _, err := io.Copy(w, response); err != nil {
 		return errors.Wrap(err, "write")
 	}
@@ -134,6 +144,7 @@ func encodeOctetStreamBinaryStringSchemaResponse(response OctetStreamBinaryStrin
 func encodeOctetStreamEmptySchemaResponse(response OctetStreamEmptySchemaOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	if _, err := io.Copy(w, response); err != nil {
 		return errors.Wrap(err, "write")
 	}

--- a/internal/test_single_endpoint/oas_handlers_gen.go
+++ b/internal/test_single_endpoint/oas_handlers_gen.go
@@ -111,7 +111,6 @@ func (s *Server) handleProbeLivenessRequest(args [0]string, w http.ResponseWrite
 		s.errors.Add(ctx, 1, otelAttrs...)
 		return
 	}
-	span.SetStatus(codes.Ok, "Ok")
 	elapsedDuration := time.Since(startTime)
 	s.duration.Record(ctx, elapsedDuration.Microseconds(), otelAttrs...)
 }

--- a/internal/test_single_endpoint/oas_res_enc_gen.go
+++ b/internal/test_single_endpoint/oas_res_enc_gen.go
@@ -73,6 +73,7 @@ var (
 func encodeProbeLivenessResponse(response string, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 
@@ -86,6 +87,12 @@ func encodeProbeLivenessResponse(response string, w http.ResponseWriter, span tr
 func encodeErrorResponse(response ErrorStatusCode, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
+	st := http.StatusText(response.StatusCode)
+	if response.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, st)
+	} else {
+		span.SetStatus(codes.Ok, st)
+	}
 	e := jx.GetEncoder()
 	defer jx.PutEncoder(e)
 


### PR DESCRIPTION
If the OAS defines multiple responses, these status codes should be used as span's status, too.