### PR TITLE
feat(jsonpointer): improve escaping, reduce allocations

### DIFF
--- a/jsonpointer/jsonpointer.go
+++ b/jsonpointer/jsonpointer.go
@@ -52,6 +52,7 @@ func find(ptr string, buf []byte) ([]byte, error) {
 	if ptr[0] != '/' {
 		return nil, errors.Errorf("invalid pointer %q: pointer must start with '/'", ptr)
 	}
+	// Cut first /.
 	ptr = ptr[1:]
 
 	err := splitFunc(ptr, '/', func(part string) (err error) {
@@ -141,5 +142,9 @@ var (
 )
 
 func unescape(part string) string {
+	// Replacer always creates new string, check that unescape is really necessary.
+	if !strings.Contains(part, "~1") && !strings.Contains(part, "~0") {
+		return part
+	}
 	return unescapeReplacer.Replace(part)
 }

--- a/jsonpointer/jsonpointer_test.go
+++ b/jsonpointer/jsonpointer_test.go
@@ -88,16 +88,28 @@ func TestSpecification(t *testing.T) {
 
 func BenchmarkResolve(b *testing.B) {
 	var specExample = []byte(`{
-  "foo": ["bar", "baz"],
-  "": 0,
-  "a/b": 1,
-  "c%d": 2,
-  "e^f": 3,
-  "g|h": 4,
-  "i\\j": 5,
-  "k\"l": 6,
-  " ": 7,
-  "m~n": 8
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "Error": {
+        "description": "Represents error object",
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
 }`)
 	var (
 		buf []byte
@@ -108,13 +120,13 @@ func BenchmarkResolve(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		buf, err = Resolve("/foo/0", specExample)
+		buf, err = Resolve("#/components/schemas/Error/properties/code/type", specExample)
 	}
 
 	if err != nil {
 		b.Fatal(err)
 	}
-	if string(buf) != `"bar"` {
+	if string(buf) != `"integer"` {
 		b.Fatal("unexpected result", buf)
 	}
 }


### PR DESCRIPTION
```
name       old time/op    new time/op    delta
Resolve-4    4.52µs ± 3%    3.68µs ± 3%   -18.54%  (p=0.000 n=14+14)

name       old alloc/op   new alloc/op   delta
Resolve-4      256B ± 0%        0B       -100.00%  (p=0.000 n=15+15)

name       old allocs/op  new allocs/op  delta
Resolve-4      18.0 ± 0%       0.0       -100.00%  (p=0.000 n=15+15)
```
