### PR TITLE
feat(json): make Duration encoder allocation-free

### DIFF
--- a/json/std_duration.go
+++ b/json/std_duration.go
@@ -1,0 +1,128 @@
+package json
+
+import "time"
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// formatDuration is port of time.Duration String method to format into byte slice.
+//
+// It returns the offset from the end of passed buf.
+func formatDuration(buf *[32]byte, d time.Duration) (w int) {
+	// Largest time is 2540400h10m10.000000000s
+	w = len(buf)
+
+	u := uint64(d)
+	neg := d < 0
+	if neg {
+		u = -u
+	}
+
+	if u < uint64(time.Second) {
+		// Special case: if duration is smaller than a second,
+		// use smaller units, like 1.2ms
+		var prec int
+		w--
+		buf[w] = 's'
+		w--
+		switch {
+		case u == 0:
+			*buf = [32]byte{}
+			n := copy(buf[len(buf)-len("0s"):], "0s")
+			// Note that formatted text must be in the right part of the buffer.
+			//
+			// So offset is len(buf) - n.
+			return len(buf) - n
+		case u < uint64(time.Microsecond):
+			// print nanoseconds
+			prec = 0
+			buf[w] = 'n'
+		case u < uint64(time.Millisecond):
+			// print microseconds
+			prec = 3
+			// U+00B5 'µ' micro sign == 0xC2 0xB5
+			w-- // Need room for two bytes.
+			copy(buf[w:], "µ")
+		default:
+			// print milliseconds
+			prec = 6
+			buf[w] = 'm'
+		}
+		w, u = fmtFrac(buf[:w], u, prec)
+		w = fmtInt(buf[:w], u)
+	} else {
+		w--
+		buf[w] = 's'
+
+		w, u = fmtFrac(buf[:w], u, 9)
+
+		// u is now integer seconds
+		w = fmtInt(buf[:w], u%60)
+		u /= 60
+
+		// u is now integer minutes
+		if u > 0 {
+			w--
+			buf[w] = 'm'
+			w = fmtInt(buf[:w], u%60)
+			u /= 60
+
+			// u is now integer hours
+			// Stop at hours because days can be different lengths.
+			if u > 0 {
+				w--
+				buf[w] = 'h'
+				w = fmtInt(buf[:w], u)
+			}
+		}
+	}
+
+	if neg {
+		w--
+		buf[w] = '-'
+	}
+
+	return w
+}
+
+// fmtFrac formats the fraction of v/10**prec (e.g., ".12345") into the
+// tail of buf, omitting trailing zeros. It omits the decimal
+// point too when the fraction is 0. It returns the index where the
+// output bytes begin and the value v/10**prec.
+func fmtFrac(buf []byte, v uint64, prec int) (nw int, nv uint64) {
+	// Omit trailing zeros up to and including decimal point.
+	w := len(buf)
+	printFlag := false
+	for i := 0; i < prec; i++ {
+		digit := v % 10
+		printFlag = printFlag || digit != 0
+		if printFlag {
+			w--
+			buf[w] = byte(digit) + '0'
+		}
+		v /= 10
+	}
+	if printFlag {
+		w--
+		buf[w] = '.'
+	}
+	return w, v
+}
+
+// fmtInt formats v into the tail of buf.
+// It returns the index where the output begins.
+func fmtInt(buf []byte, v uint64) int {
+	w := len(buf)
+	if v == 0 {
+		w--
+		buf[w] = '0'
+	} else {
+		for v > 0 {
+			w--
+			buf[w] = byte(v%10) + '0'
+			v /= 10
+		}
+	}
+	return w
+}

--- a/json/time.go
+++ b/json/time.go
@@ -62,5 +62,7 @@ func DecodeDuration(i *jx.Decoder) (v time.Duration, err error) {
 }
 
 func EncodeDuration(s *jx.Encoder, v time.Duration) {
-	s.Str(v.String())
+	var buf [32]byte
+	w := formatDuration(&buf, v)
+	s.ByteStr(buf[w:])
 }

--- a/json/time_test.go
+++ b/json/time_test.go
@@ -52,3 +52,23 @@ func BenchmarkEncodeDateTime(b *testing.B) {
 	}
 }
 
+func BenchmarkEncodeDuration(b *testing.B) {
+	t := time.Nanosecond +
+		time.Microsecond +
+		time.Millisecond +
+		time.Second +
+		time.Minute +
+		time.Hour
+	
+	e := jx.GetEncoder()
+	// Preallocate internal buffer.
+	EncodeDuration(e, t)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		EncodeDuration(e, t)
+	}
+}

--- a/json/time_test.go
+++ b/json/time_test.go
@@ -1,10 +1,12 @@
 package json
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkEncodeDate(b *testing.B) {
@@ -59,7 +61,7 @@ func BenchmarkEncodeDuration(b *testing.B) {
 		time.Second +
 		time.Minute +
 		time.Hour
-	
+
 	e := jx.GetEncoder()
 	// Preallocate internal buffer.
 	EncodeDuration(e, t)
@@ -70,5 +72,43 @@ func BenchmarkEncodeDuration(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		e.Reset()
 		EncodeDuration(e, t)
+	}
+}
+
+func TestEncodeDuration(t *testing.T) {
+	tests := []time.Duration{
+		0,
+		10,
+		time.Nanosecond,
+		time.Microsecond,
+		time.Millisecond,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		time.Nanosecond +
+			time.Microsecond +
+			time.Millisecond +
+			time.Second +
+			time.Minute +
+			time.Hour,
+		// Tests from stdlib.
+		1100 * time.Nanosecond,
+		2200 * time.Microsecond,
+		3300 * time.Millisecond,
+		4*time.Minute + 5*time.Second,
+		4*time.Minute + 5001*time.Millisecond,
+		5*time.Hour + 6*time.Minute + 7001*time.Millisecond,
+		8*time.Minute + 1*time.Nanosecond,
+		1<<63 - 1,
+		-1 << 63,
+	}
+	for _, tt := range tests {
+		tt := tt
+		expected := tt.String()
+		t.Run(expected, func(t *testing.T) {
+			e := jx.GetEncoder()
+			EncodeDuration(e, tt)
+			require.Equal(t, strconv.Quote(tt.String()), e.String())
+		})
 	}
 }


### PR DESCRIPTION
Benchstat result:
```
name              old time/op    new time/op    delta
EncodeDuration-4     106ns ± 7%      69ns ± 2%   -35.36%  (p=0.000 n=15+15)

name              old alloc/op   new alloc/op   delta
EncodeDuration-4     16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=15+15)

name              old allocs/op  new allocs/op  delta
EncodeDuration-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
```
