### PR TITLE
feat(json): reduce string int decoding allocations

### DIFF
--- a/json/int.go
+++ b/json/int.go
@@ -8,15 +8,11 @@ import (
 
 // DecodeStringInt32 decodes string int32 from json.
 func DecodeStringInt32(d *jx.Decoder) (v int32, err error) {
-	s, err := d.Str()
+	s, err := d.StrBytes()
 	if err != nil {
 		return 0, err
 	}
-	val, err := strconv.ParseInt(s, 10, 32)
-	if err != nil {
-		return 0, err
-	}
-	return int32(val), nil
+	return jx.DecodeBytes(s).Int32()
 }
 
 // EncodeStringInt32 encodes string int32 to json.
@@ -38,15 +34,11 @@ func EncodeStringInt32(e *jx.Encoder, v int32) {
 
 // DecodeStringInt64 decodes string int64 from json.
 func DecodeStringInt64(d *jx.Decoder) (v int64, err error) {
-	s, err := d.Str()
+	s, err := d.StrBytes()
 	if err != nil {
 		return 0, err
 	}
-	val, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return int64(val), nil
+	return jx.DecodeBytes(s).Int64()
 }
 
 // EncodeStringInt64 encodes string int64 to json.

--- a/json/int_test.go
+++ b/json/int_test.go
@@ -89,3 +89,45 @@ func TestStringInt64(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkDecodeStringInt32(b *testing.B) {
+	var (
+		d     = jx.GetDecoder()
+		input = []byte(`"1234567890"`)
+		val   int32
+		err   error
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		d.ResetBytes(input)
+		val, err = DecodeStringInt32(d)
+	}
+
+	if val != 1234567890 || err != nil {
+		b.Fatal(val, err)
+	}
+}
+
+func BenchmarkDecodeStringInt64(b *testing.B) {
+	var (
+		d     = jx.GetDecoder()
+		input = []byte(`"1234567890"`)
+		val   int64
+		err   error
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		d.ResetBytes(input)
+		val, err = DecodeStringInt64(d)
+	}
+
+	if val != 1234567890 || err != nil {
+		b.Fatal(val, err)
+	}
+}


### PR DESCRIPTION
Benchstat comparison:
```
name                 old time/op    new time/op    delta
DecodeStringInt32-4    96.3ns ± 2%    55.0ns ± 1%   -42.87%  (p=0.000 n=14+15)
DecodeStringInt64-4    97.1ns ± 2%    52.5ns ± 1%   -45.89%  (p=0.000 n=14+15)

name                 old alloc/op   new alloc/op   delta
DecodeStringInt32-4     16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=15+15)
DecodeStringInt64-4     16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=15+15)

name                 old allocs/op  new allocs/op  delta
DecodeStringInt32-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
DecodeStringInt64-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
```

