### PR TITLE
fix(template): go vet - composite literal uses unkeyed fields

### DIFF
--- a/examples/ex_ent/oas_handlers_gen.go
+++ b/examples/ex_ent/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleCreatePetRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeCreatePetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreatePet",
-			err,
+			Operation: "CreatePet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleCreatePetCategoriesRequest(args [1]string, w http.Respons
 	params, err := decodeCreatePetCategoriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CreatePetCategories",
-			err,
+			Operation: "CreatePetCategories",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -88,8 +88,8 @@ func (s *Server) handleCreatePetCategoriesRequest(args [1]string, w http.Respons
 	request, err := decodeCreatePetCategoriesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreatePetCategories",
-			err,
+			Operation: "CreatePetCategories",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -133,8 +133,8 @@ func (s *Server) handleCreatePetFriendsRequest(args [1]string, w http.ResponseWr
 	params, err := decodeCreatePetFriendsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CreatePetFriends",
-			err,
+			Operation: "CreatePetFriends",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -142,8 +142,8 @@ func (s *Server) handleCreatePetFriendsRequest(args [1]string, w http.ResponseWr
 	request, err := decodeCreatePetFriendsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreatePetFriends",
-			err,
+			Operation: "CreatePetFriends",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -187,8 +187,8 @@ func (s *Server) handleCreatePetOwnerRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeCreatePetOwnerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CreatePetOwner",
-			err,
+			Operation: "CreatePetOwner",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -196,8 +196,8 @@ func (s *Server) handleCreatePetOwnerRequest(args [1]string, w http.ResponseWrit
 	request, err := decodeCreatePetOwnerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreatePetOwner",
-			err,
+			Operation: "CreatePetOwner",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -241,8 +241,8 @@ func (s *Server) handleDeletePetRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeDeletePetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DeletePet",
-			err,
+			Operation: "DeletePet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -286,8 +286,8 @@ func (s *Server) handleDeletePetOwnerRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeDeletePetOwnerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DeletePetOwner",
-			err,
+			Operation: "DeletePetOwner",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -331,8 +331,8 @@ func (s *Server) handleListPetRequest(args [0]string, w http.ResponseWriter, r *
 	params, err := decodeListPetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPet",
-			err,
+			Operation: "ListPet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -376,8 +376,8 @@ func (s *Server) handleListPetCategoriesRequest(args [1]string, w http.ResponseW
 	params, err := decodeListPetCategoriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPetCategories",
-			err,
+			Operation: "ListPetCategories",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -421,8 +421,8 @@ func (s *Server) handleListPetFriendsRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeListPetFriendsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPetFriends",
-			err,
+			Operation: "ListPetFriends",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -466,8 +466,8 @@ func (s *Server) handleReadPetRequest(args [1]string, w http.ResponseWriter, r *
 	params, err := decodeReadPetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPet",
-			err,
+			Operation: "ReadPet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -511,8 +511,8 @@ func (s *Server) handleReadPetOwnerRequest(args [1]string, w http.ResponseWriter
 	params, err := decodeReadPetOwnerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPetOwner",
-			err,
+			Operation: "ReadPetOwner",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -556,8 +556,8 @@ func (s *Server) handleUpdatePetRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeUpdatePetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UpdatePet",
-			err,
+			Operation: "UpdatePet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -565,8 +565,8 @@ func (s *Server) handleUpdatePetRequest(args [1]string, w http.ResponseWriter, r
 	request, err := decodeUpdatePetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UpdatePet",
-			err,
+			Operation: "UpdatePet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_ent/oas_validators_gen.go
+++ b/examples/ex_ent/oas_validators_gen.go
@@ -10,17 +10,17 @@ func (s ListPetCategoriesOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ListPetFriendsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ListPetOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }

--- a/examples/ex_firecracker/oas_client_gen.go
+++ b/examples/ex_firecracker/oas_client_gen.go
@@ -62,7 +62,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, request SnapshotCreateParam
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -127,7 +127,7 @@ func (c *Client) CreateSyncAction(ctx context.Context, request InstanceActionInf
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -804,7 +804,7 @@ func (c *Client) PatchGuestDriveByID(ctx context.Context, request PartialDrive, 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -885,7 +885,7 @@ func (c *Client) PatchGuestNetworkInterfaceByID(ctx context.Context, request Par
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -969,13 +969,13 @@ func (c *Client) PatchMachineConfiguration(ctx context.Context, request OptMachi
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1042,7 +1042,7 @@ func (c *Client) PatchVm(ctx context.Context, request VM) (res PatchVmRes, err e
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1230,7 +1230,7 @@ func (c *Client) PutGuestDriveByID(ctx context.Context, request Drive, params Pu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1311,7 +1311,7 @@ func (c *Client) PutGuestNetworkInterfaceByID(ctx context.Context, request Netwo
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1393,7 +1393,7 @@ func (c *Client) PutGuestVsock(ctx context.Context, request Vsock) (res PutGuest
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1458,7 +1458,7 @@ func (c *Client) PutLogger(ctx context.Context, request Logger) (res PutLoggerRe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1530,13 +1530,13 @@ func (c *Client) PutMachineConfiguration(ctx context.Context, request OptMachine
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_firecracker/oas_handlers_gen.go
+++ b/examples/ex_firecracker/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleCreateSnapshotRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeCreateSnapshotRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateSnapshot",
-			err,
+			Operation: "CreateSnapshot",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleCreateSyncActionRequest(args [0]string, w http.ResponseWr
 	request, err := decodeCreateSyncActionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateSyncAction",
-			err,
+			Operation: "CreateSyncAction",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -304,8 +304,8 @@ func (s *Server) handleLoadSnapshotRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeLoadSnapshotRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"LoadSnapshot",
-			err,
+			Operation: "LoadSnapshot",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -347,8 +347,8 @@ func (s *Server) handleMmdsConfigPutRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeMmdsConfigPutRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MmdsConfigPut",
-			err,
+			Operation: "MmdsConfigPut",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -424,8 +424,8 @@ func (s *Server) handleMmdsPatchRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeMmdsPatchRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MmdsPatch",
-			err,
+			Operation: "MmdsPatch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -467,8 +467,8 @@ func (s *Server) handleMmdsPutRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodeMmdsPutRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MmdsPut",
-			err,
+			Operation: "MmdsPut",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -512,8 +512,8 @@ func (s *Server) handlePatchBalloonRequest(args [0]string, w http.ResponseWriter
 	request, err := decodePatchBalloonRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchBalloon",
-			err,
+			Operation: "PatchBalloon",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -557,8 +557,8 @@ func (s *Server) handlePatchBalloonStatsIntervalRequest(args [0]string, w http.R
 	request, err := decodePatchBalloonStatsIntervalRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchBalloonStatsInterval",
-			err,
+			Operation: "PatchBalloonStatsInterval",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -602,8 +602,8 @@ func (s *Server) handlePatchGuestDriveByIDRequest(args [1]string, w http.Respons
 	params, err := decodePatchGuestDriveByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PatchGuestDriveByID",
-			err,
+			Operation: "PatchGuestDriveByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -611,8 +611,8 @@ func (s *Server) handlePatchGuestDriveByIDRequest(args [1]string, w http.Respons
 	request, err := decodePatchGuestDriveByIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchGuestDriveByID",
-			err,
+			Operation: "PatchGuestDriveByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -656,8 +656,8 @@ func (s *Server) handlePatchGuestNetworkInterfaceByIDRequest(args [1]string, w h
 	params, err := decodePatchGuestNetworkInterfaceByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PatchGuestNetworkInterfaceByID",
-			err,
+			Operation: "PatchGuestNetworkInterfaceByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -665,8 +665,8 @@ func (s *Server) handlePatchGuestNetworkInterfaceByIDRequest(args [1]string, w h
 	request, err := decodePatchGuestNetworkInterfaceByIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchGuestNetworkInterfaceByID",
-			err,
+			Operation: "PatchGuestNetworkInterfaceByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -710,8 +710,8 @@ func (s *Server) handlePatchMachineConfigurationRequest(args [0]string, w http.R
 	request, err := decodePatchMachineConfigurationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchMachineConfiguration",
-			err,
+			Operation: "PatchMachineConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -755,8 +755,8 @@ func (s *Server) handlePatchVmRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodePatchVmRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PatchVm",
-			err,
+			Operation: "PatchVm",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -800,8 +800,8 @@ func (s *Server) handlePutBalloonRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodePutBalloonRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutBalloon",
-			err,
+			Operation: "PutBalloon",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -845,8 +845,8 @@ func (s *Server) handlePutGuestBootSourceRequest(args [0]string, w http.Response
 	request, err := decodePutGuestBootSourceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutGuestBootSource",
-			err,
+			Operation: "PutGuestBootSource",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -890,8 +890,8 @@ func (s *Server) handlePutGuestDriveByIDRequest(args [1]string, w http.ResponseW
 	params, err := decodePutGuestDriveByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PutGuestDriveByID",
-			err,
+			Operation: "PutGuestDriveByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -899,8 +899,8 @@ func (s *Server) handlePutGuestDriveByIDRequest(args [1]string, w http.ResponseW
 	request, err := decodePutGuestDriveByIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutGuestDriveByID",
-			err,
+			Operation: "PutGuestDriveByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -944,8 +944,8 @@ func (s *Server) handlePutGuestNetworkInterfaceByIDRequest(args [1]string, w htt
 	params, err := decodePutGuestNetworkInterfaceByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PutGuestNetworkInterfaceByID",
-			err,
+			Operation: "PutGuestNetworkInterfaceByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -953,8 +953,8 @@ func (s *Server) handlePutGuestNetworkInterfaceByIDRequest(args [1]string, w htt
 	request, err := decodePutGuestNetworkInterfaceByIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutGuestNetworkInterfaceByID",
-			err,
+			Operation: "PutGuestNetworkInterfaceByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -998,8 +998,8 @@ func (s *Server) handlePutGuestVsockRequest(args [0]string, w http.ResponseWrite
 	request, err := decodePutGuestVsockRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutGuestVsock",
-			err,
+			Operation: "PutGuestVsock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1043,8 +1043,8 @@ func (s *Server) handlePutLoggerRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodePutLoggerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutLogger",
-			err,
+			Operation: "PutLogger",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1088,8 +1088,8 @@ func (s *Server) handlePutMachineConfigurationRequest(args [0]string, w http.Res
 	request, err := decodePutMachineConfigurationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutMachineConfiguration",
-			err,
+			Operation: "PutMachineConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1133,8 +1133,8 @@ func (s *Server) handlePutMetricsRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodePutMetricsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PutMetrics",
-			err,
+			Operation: "PutMetrics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_firecracker/oas_req_dec_gen.go
+++ b/examples/ex_firecracker/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeCreateSnapshotRequest(r *http.Request, span trace.Span) (req Snapshot
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateSnapshot request")
 		}
@@ -91,7 +91,7 @@ func decodeCreateSyncActionRequest(r *http.Request, span trace.Span) (req Instan
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateSyncAction request")
 		}
@@ -357,7 +357,7 @@ func decodePatchGuestDriveByIDRequest(r *http.Request, span trace.Span) (req Par
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PatchGuestDriveByID request")
 		}
@@ -401,7 +401,7 @@ func decodePatchGuestNetworkInterfaceByIDRequest(r *http.Request, span trace.Spa
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PatchGuestNetworkInterfaceByID request")
 		}
@@ -448,13 +448,13 @@ func decodePatchMachineConfigurationRequest(r *http.Request, span trace.Span) (r
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PatchMachineConfiguration request")
 		}
@@ -498,7 +498,7 @@ func decodePatchVmRequest(r *http.Request, span trace.Span) (req VM, err error) 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PatchVm request")
 		}
@@ -614,7 +614,7 @@ func decodePutGuestDriveByIDRequest(r *http.Request, span trace.Span) (req Drive
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PutGuestDriveByID request")
 		}
@@ -658,7 +658,7 @@ func decodePutGuestNetworkInterfaceByIDRequest(r *http.Request, span trace.Span)
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PutGuestNetworkInterfaceByID request")
 		}
@@ -702,7 +702,7 @@ func decodePutGuestVsockRequest(r *http.Request, span trace.Span) (req Vsock, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PutGuestVsock request")
 		}
@@ -746,7 +746,7 @@ func decodePutLoggerRequest(r *http.Request, span trace.Span) (req Logger, err e
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PutLogger request")
 		}
@@ -793,13 +793,13 @@ func decodePutMachineConfigurationRequest(r *http.Request, span trace.Span) (req
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PutMachineConfiguration request")
 		}

--- a/examples/ex_firecracker/oas_validators_gen.go
+++ b/examples/ex_firecracker/oas_validators_gen.go
@@ -28,13 +28,13 @@ func (s Drive) Validate() error {
 				if err := s.RateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rate_limiter",
@@ -55,7 +55,7 @@ func (s FullVmConfiguration) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -66,7 +66,7 @@ func (s FullVmConfiguration) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "block_devices",
@@ -79,13 +79,13 @@ func (s FullVmConfiguration) Validate() error {
 				if err := s.Logger.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "logger",
@@ -98,13 +98,13 @@ func (s FullVmConfiguration) Validate() error {
 				if err := s.MachineConfig.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "machine_config",
@@ -118,7 +118,7 @@ func (s FullVmConfiguration) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -129,7 +129,7 @@ func (s FullVmConfiguration) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "net_devices",
@@ -142,13 +142,13 @@ func (s FullVmConfiguration) Validate() error {
 				if err := s.VsockDevice.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vsock_device",
@@ -166,7 +166,7 @@ func (s InstanceActionInfo) Validate() error {
 		if err := s.ActionType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "action_type",
@@ -196,7 +196,7 @@ func (s InstanceInfo) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -228,13 +228,13 @@ func (s Logger) Validate() error {
 				if err := s.Level.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "level",
@@ -268,13 +268,13 @@ func (s MachineConfiguration) Validate() error {
 				if err := s.CPUTemplate.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "cpu_template",
@@ -294,7 +294,7 @@ func (s MachineConfiguration) Validate() error {
 		}).Validate(int64(s.VcpuCount)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcpu_count",
@@ -314,13 +314,13 @@ func (s NetworkInterface) Validate() error {
 				if err := s.RxRateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rx_rate_limiter",
@@ -333,13 +333,13 @@ func (s NetworkInterface) Validate() error {
 				if err := s.TxRateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tx_rate_limiter",
@@ -360,13 +360,13 @@ func (s PartialDrive) Validate() error {
 				if err := s.RateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rate_limiter",
@@ -386,13 +386,13 @@ func (s PartialNetworkInterface) Validate() error {
 				if err := s.RxRateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rx_rate_limiter",
@@ -405,13 +405,13 @@ func (s PartialNetworkInterface) Validate() error {
 				if err := s.TxRateLimiter.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tx_rate_limiter",
@@ -431,13 +431,13 @@ func (s RateLimiter) Validate() error {
 				if err := s.Bandwidth.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "bandwidth",
@@ -450,13 +450,13 @@ func (s RateLimiter) Validate() error {
 				if err := s.Ops.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "ops",
@@ -476,13 +476,13 @@ func (s SnapshotCreateParams) Validate() error {
 				if err := s.SnapshotType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "snapshot_type",
@@ -521,13 +521,13 @@ func (s TokenBucket) Validate() error {
 				}).Validate(int64(s.OneTimeBurst.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "one_time_burst",
@@ -547,7 +547,7 @@ func (s TokenBucket) Validate() error {
 		}).Validate(int64(s.RefillTime)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "refill_time",
@@ -567,7 +567,7 @@ func (s TokenBucket) Validate() error {
 		}).Validate(int64(s.Size)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "size",
@@ -585,7 +585,7 @@ func (s VM) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -622,7 +622,7 @@ func (s Vsock) Validate() error {
 		}).Validate(int64(s.GuestCid)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "guest_cid",

--- a/examples/ex_github/oas_client_gen.go
+++ b/examples/ex_github/oas_client_gen.go
@@ -585,7 +585,7 @@ func (c *Client) ActionsCreateOrUpdateEnvironmentSecret(ctx context.Context, req
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -749,7 +749,7 @@ func (c *Client) ActionsCreateOrUpdateOrgSecret(ctx context.Context, request Act
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -898,7 +898,7 @@ func (c *Client) ActionsCreateOrUpdateRepoSecret(ctx context.Context, request Ac
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1315,7 +1315,7 @@ func (c *Client) ActionsCreateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6474,7 +6474,7 @@ func (c *Client) ActionsReviewPendingDeploymentsForRun(ctx context.Context, requ
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6773,7 +6773,7 @@ func (c *Client) ActionsSetGithubActionsPermissionsOrganization(ctx context.Cont
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6861,7 +6861,7 @@ func (c *Client) ActionsSetGithubActionsPermissionsRepository(ctx context.Contex
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6963,7 +6963,7 @@ func (c *Client) ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Co
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7064,7 +7064,7 @@ func (c *Client) ActionsSetSelectedReposForOrgSecret(ctx context.Context, reques
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7166,7 +7166,7 @@ func (c *Client) ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7252,7 +7252,7 @@ func (c *Client) ActionsSetSelfHostedRunnersInGroupForOrg(ctx context.Context, r
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7353,7 +7353,7 @@ func (c *Client) ActionsUpdateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10214,7 +10214,7 @@ func (c *Client) AppsCreateContentAttachment(ctx context.Context, request AppsCr
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10337,13 +10337,13 @@ func (c *Client) AppsCreateInstallationAccessToken(ctx context.Context, request 
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12161,7 +12161,7 @@ func (c *Client) AppsScopeToken(ctx context.Context, request AppsScopeTokenReq, 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12377,13 +12377,13 @@ func (c *Client) AppsUpdateWebhookConfigForApp(ctx context.Context, request OptA
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15176,7 +15176,7 @@ func (c *Client) CodeScanningUpdateAlert(ctx context.Context, request CodeScanni
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15316,7 +15316,7 @@ func (c *Client) CodeScanningUploadSarif(ctx context.Context, request CodeScanni
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15879,7 +15879,7 @@ func (c *Client) EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise(ctx con
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17881,7 +17881,7 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseGroup(ctx context.Co
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17969,7 +17969,7 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseUser(ctx context.Con
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18314,7 +18314,7 @@ func (c *Client) EnterpriseAdminSetGithubActionsPermissionsEnterprise(ctx contex
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18402,7 +18402,7 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseGroup(ctx 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18507,7 +18507,7 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseUser(ctx c
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18605,7 +18605,7 @@ func (c *Client) EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise(
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18706,7 +18706,7 @@ func (c *Client) EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnte
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18789,7 +18789,7 @@ func (c *Client) EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise(ctx con
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18891,7 +18891,7 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseGroup(ctx context.Co
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19007,7 +19007,7 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseUser(ctx context.Con
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19106,13 +19106,13 @@ func (c *Client) EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise(ctx con
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19268,7 +19268,7 @@ func (c *Client) GistsCreate(ctx context.Context, request GistsCreateReq) (res G
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19333,7 +19333,7 @@ func (c *Client) GistsCreateComment(ctx context.Context, request GistsCreateComm
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20605,7 +20605,7 @@ func (c *Client) GistsUpdateComment(ctx context.Context, request GistsUpdateComm
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21037,7 +21037,7 @@ func (c *Client) GitCreateTag(ctx context.Context, request GitCreateTagReq, para
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21140,7 +21140,7 @@ func (c *Client) GitCreateTree(ctx context.Context, request GitCreateTreeReq, pa
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22395,7 +22395,7 @@ func (c *Client) InteractionsSetRestrictionsForAuthenticatedUser(ctx context.Con
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22465,7 +22465,7 @@ func (c *Client) InteractionsSetRestrictionsForOrg(ctx context.Context, request 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22550,7 +22550,7 @@ func (c *Client) InteractionsSetRestrictionsForRepo(ctx context.Context, request
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23136,7 +23136,7 @@ func (c *Client) IssuesCreateMilestone(ctx context.Context, request IssuesCreate
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25879,13 +25879,13 @@ func (c *Client) IssuesLock(ctx context.Context, request OptNilIssuesLockReq, pa
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26386,13 +26386,13 @@ func (c *Client) IssuesUpdate(ctx context.Context, request OptIssuesUpdateReq, p
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26705,13 +26705,13 @@ func (c *Client) IssuesUpdateMilestone(ctx context.Context, request OptIssuesUpd
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -28523,7 +28523,7 @@ func (c *Client) MigrationsSetLfsPreference(ctx context.Context, request Migrati
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -28620,7 +28620,7 @@ func (c *Client) MigrationsStartForAuthenticatedUser(ctx context.Context, reques
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -28687,7 +28687,7 @@ func (c *Client) MigrationsStartForOrg(ctx context.Context, request MigrationsSt
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -28769,7 +28769,7 @@ func (c *Client) MigrationsStartImport(ctx context.Context, request MigrationsSt
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -29157,13 +29157,13 @@ func (c *Client) OAuthAuthorizationsCreateAuthorization(ctx context.Context, req
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -29523,7 +29523,7 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForApp(ctx context.C
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -29625,7 +29625,7 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -29949,13 +29949,13 @@ func (c *Client) OAuthAuthorizationsUpdateAuthorization(ctx context.Context, req
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -30491,13 +30491,13 @@ func (c *Client) OrgsCreateInvitation(ctx context.Context, request OptOrgsCreate
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -30579,7 +30579,7 @@ func (c *Client) OrgsCreateWebhook(ctx context.Context, request OrgsCreateWebhoo
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -33248,13 +33248,13 @@ func (c *Client) OrgsSetMembershipForUser(ctx context.Context, request OptOrgsSe
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -33498,7 +33498,7 @@ func (c *Client) OrgsUpdateMembershipForAuthenticatedUser(ctx context.Context, r
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -33585,13 +33585,13 @@ func (c *Client) OrgsUpdateWebhook(ctx context.Context, request OptOrgsUpdateWeb
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -33693,13 +33693,13 @@ func (c *Client) OrgsUpdateWebhookConfigForOrg(ctx context.Context, request OptO
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -36252,13 +36252,13 @@ func (c *Client) ProjectsAddCollaborator(ctx context.Context, request OptNilProj
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -37740,7 +37740,7 @@ func (c *Client) ProjectsMoveCard(ctx context.Context, request ProjectsMoveCardR
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -37820,7 +37820,7 @@ func (c *Client) ProjectsMoveColumn(ctx context.Context, request ProjectsMoveCol
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -37981,13 +37981,13 @@ func (c *Client) ProjectsUpdate(ctx context.Context, request OptProjectsUpdateRe
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -38550,13 +38550,13 @@ func (c *Client) PullsCreateReview(ctx context.Context, request OptPullsCreateRe
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -38687,7 +38687,7 @@ func (c *Client) PullsCreateReviewComment(ctx context.Context, request PullsCrea
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -40599,13 +40599,13 @@ func (c *Client) PullsMerge(ctx context.Context, request OptNilPullsMergeReq, pa
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -40715,7 +40715,7 @@ func (c *Client) PullsRemoveRequestedReviewers(ctx context.Context, request Pull
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -40825,7 +40825,7 @@ func (c *Client) PullsSubmitReview(ctx context.Context, request PullsSubmitRevie
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -40961,13 +40961,13 @@ func (c *Client) PullsUpdate(ctx context.Context, request OptPullsUpdateReq, par
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -41454,7 +41454,7 @@ func (c *Client) ReactionsCreateForCommitComment(ctx context.Context, request Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -41567,7 +41567,7 @@ func (c *Client) ReactionsCreateForIssue(ctx context.Context, request ReactionsC
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -41681,7 +41681,7 @@ func (c *Client) ReactionsCreateForIssueComment(ctx context.Context, request Rea
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -41795,7 +41795,7 @@ func (c *Client) ReactionsCreateForPullRequestReviewComment(ctx context.Context,
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -41908,7 +41908,7 @@ func (c *Client) ReactionsCreateForRelease(ctx context.Context, request Reaction
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -42026,7 +42026,7 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentInOrg(ctx context.Contex
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -42161,7 +42161,7 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentLegacy(ctx context.Conte
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -42278,7 +42278,7 @@ func (c *Client) ReactionsCreateForTeamDiscussionInOrg(ctx context.Context, requ
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -42397,7 +42397,7 @@ func (c *Client) ReactionsCreateForTeamDiscussionLegacy(ctx context.Context, req
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -44438,13 +44438,13 @@ func (c *Client) ReposAddAppAccessRestrictions(ctx context.Context, request OptR
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -44577,13 +44577,13 @@ func (c *Client) ReposAddCollaborator(ctx context.Context, request OptReposAddCo
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -44700,13 +44700,13 @@ func (c *Client) ReposAddStatusCheckContexts(ctx context.Context, request OptRep
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -44832,13 +44832,13 @@ func (c *Client) ReposAddTeamAccessRestrictions(ctx context.Context, request Opt
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -44963,13 +44963,13 @@ func (c *Client) ReposAddUserAccessRestrictions(ctx context.Context, request Opt
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -45726,7 +45726,7 @@ func (c *Client) ReposCreateCommitStatus(ctx context.Context, request ReposCreat
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -46070,7 +46070,7 @@ func (c *Client) ReposCreateDeploymentStatus(ctx context.Context, request ReposC
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -46197,7 +46197,7 @@ func (c *Client) ReposCreateDispatchEvent(ctx context.Context, request ReposCrea
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -46458,7 +46458,7 @@ func (c *Client) ReposCreateInOrg(ctx context.Context, request ReposCreateInOrgR
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -46644,8 +46644,8 @@ func (c *Client) ReposCreatePagesSite(ctx context.Context, request NilReposCreat
 		if err := request.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -46942,13 +46942,13 @@ func (c *Client) ReposCreateWebhook(ctx context.Context, request OptNilReposCrea
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -57156,13 +57156,13 @@ func (c *Client) ReposRemoveAppAccessRestrictions(ctx context.Context, request O
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -57367,13 +57367,13 @@ func (c *Client) ReposRemoveStatusCheckContexts(ctx context.Context, request Opt
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -57593,13 +57593,13 @@ func (c *Client) ReposRemoveTeamAccessRestrictions(ctx context.Context, request 
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -57724,13 +57724,13 @@ func (c *Client) ReposRemoveUserAccessRestrictions(ctx context.Context, request 
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -57956,7 +57956,7 @@ func (c *Client) ReposReplaceAllTopics(ctx context.Context, request ReposReplace
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -58245,13 +58245,13 @@ func (c *Client) ReposSetAppAccessRestrictions(ctx context.Context, request OptR
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -58369,13 +58369,13 @@ func (c *Client) ReposSetStatusCheckContexts(ctx context.Context, request OptRep
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -58502,13 +58502,13 @@ func (c *Client) ReposSetTeamAccessRestrictions(ctx context.Context, request Opt
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -58634,13 +58634,13 @@ func (c *Client) ReposSetUserAccessRestrictions(ctx context.Context, request Opt
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -58941,13 +58941,13 @@ func (c *Client) ReposUpdate(ctx context.Context, request OptReposUpdateReq, par
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -59050,7 +59050,7 @@ func (c *Client) ReposUpdateBranchProtection(ctx context.Context, request ReposU
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -59263,13 +59263,13 @@ func (c *Client) ReposUpdateInvitation(ctx context.Context, request OptReposUpda
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -59812,13 +59812,13 @@ func (c *Client) ReposUpdateWebhook(ctx context.Context, request OptReposUpdateW
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -59935,13 +59935,13 @@ func (c *Client) ReposUpdateWebhookConfigForRepo(ctx context.Context, request Op
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -61452,7 +61452,7 @@ func (c *Client) SecretScanningUpdateAlert(ctx context.Context, request SecretSc
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -61682,13 +61682,13 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserInOrg(ctx context.Context, req
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -61825,13 +61825,13 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserLegacy(ctx context.Context, re
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -61933,13 +61933,13 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsInOrg(ctx context.Context, re
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -62058,13 +62058,13 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsLegacy(ctx context.Context, r
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -62173,13 +62173,13 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsInOrg(ctx context.Context, reque
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -62318,13 +62318,13 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsLegacy(ctx context.Context, requ
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -62821,7 +62821,7 @@ func (c *Client) TeamsCreate(ctx context.Context, request TeamsCreateReq, params
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -63406,7 +63406,7 @@ func (c *Client) TeamsCreateOrUpdateIdpGroupConnectionsLegacy(ctx context.Contex
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -67899,13 +67899,13 @@ func (c *Client) TeamsUpdateInOrg(ctx context.Context, request OptTeamsUpdateInO
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -68005,7 +68005,7 @@ func (c *Client) TeamsUpdateLegacy(ctx context.Context, request TeamsUpdateLegac
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -68088,13 +68088,13 @@ func (c *Client) UsersAddEmailForAuthenticated(ctx context.Context, request OptU
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -68467,7 +68467,7 @@ func (c *Client) UsersCreatePublicSSHKeyForAuthenticated(ctx context.Context, re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -68536,13 +68536,13 @@ func (c *Client) UsersDeleteEmailForAuthenticated(ctx context.Context, request O
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -70138,7 +70138,7 @@ func (c *Client) UsersSetPrimaryEmailVisibilityForAuthenticated(ctx context.Cont
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_github/oas_handlers_gen.go
+++ b/examples/ex_github/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleActionsAddRepoAccessToSelfHostedRunnerGroupInOrgRequest(a
 	params, err := decodeActionsAddRepoAccessToSelfHostedRunnerGroupInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsAddRepoAccessToSelfHostedRunnerGroupInOrg",
-			err,
+			Operation: "ActionsAddRepoAccessToSelfHostedRunnerGroupInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleActionsAddSelectedRepoToOrgSecretRequest(args [3]string, 
 	params, err := decodeActionsAddSelectedRepoToOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsAddSelectedRepoToOrgSecret",
-			err,
+			Operation: "ActionsAddSelectedRepoToOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -124,8 +124,8 @@ func (s *Server) handleActionsAddSelfHostedRunnerToGroupForOrgRequest(args [3]st
 	params, err := decodeActionsAddSelfHostedRunnerToGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsAddSelfHostedRunnerToGroupForOrg",
-			err,
+			Operation: "ActionsAddSelfHostedRunnerToGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -169,8 +169,8 @@ func (s *Server) handleActionsApproveWorkflowRunRequest(args [3]string, w http.R
 	params, err := decodeActionsApproveWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsApproveWorkflowRun",
-			err,
+			Operation: "ActionsApproveWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -214,8 +214,8 @@ func (s *Server) handleActionsCancelWorkflowRunRequest(args [3]string, w http.Re
 	params, err := decodeActionsCancelWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCancelWorkflowRun",
-			err,
+			Operation: "ActionsCancelWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -259,8 +259,8 @@ func (s *Server) handleActionsCreateOrUpdateEnvironmentSecretRequest(args [3]str
 	params, err := decodeActionsCreateOrUpdateEnvironmentSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateOrUpdateEnvironmentSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateEnvironmentSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -268,8 +268,8 @@ func (s *Server) handleActionsCreateOrUpdateEnvironmentSecretRequest(args [3]str
 	request, err := decodeActionsCreateOrUpdateEnvironmentSecretRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsCreateOrUpdateEnvironmentSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateEnvironmentSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -313,8 +313,8 @@ func (s *Server) handleActionsCreateOrUpdateOrgSecretRequest(args [2]string, w h
 	params, err := decodeActionsCreateOrUpdateOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateOrUpdateOrgSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -322,8 +322,8 @@ func (s *Server) handleActionsCreateOrUpdateOrgSecretRequest(args [2]string, w h
 	request, err := decodeActionsCreateOrUpdateOrgSecretRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsCreateOrUpdateOrgSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -367,8 +367,8 @@ func (s *Server) handleActionsCreateOrUpdateRepoSecretRequest(args [3]string, w 
 	params, err := decodeActionsCreateOrUpdateRepoSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateOrUpdateRepoSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateRepoSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -376,8 +376,8 @@ func (s *Server) handleActionsCreateOrUpdateRepoSecretRequest(args [3]string, w 
 	request, err := decodeActionsCreateOrUpdateRepoSecretRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsCreateOrUpdateRepoSecret",
-			err,
+			Operation: "ActionsCreateOrUpdateRepoSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -421,8 +421,8 @@ func (s *Server) handleActionsCreateRegistrationTokenForOrgRequest(args [1]strin
 	params, err := decodeActionsCreateRegistrationTokenForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateRegistrationTokenForOrg",
-			err,
+			Operation: "ActionsCreateRegistrationTokenForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -466,8 +466,8 @@ func (s *Server) handleActionsCreateRegistrationTokenForRepoRequest(args [2]stri
 	params, err := decodeActionsCreateRegistrationTokenForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateRegistrationTokenForRepo",
-			err,
+			Operation: "ActionsCreateRegistrationTokenForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -511,8 +511,8 @@ func (s *Server) handleActionsCreateRemoveTokenForOrgRequest(args [1]string, w h
 	params, err := decodeActionsCreateRemoveTokenForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateRemoveTokenForOrg",
-			err,
+			Operation: "ActionsCreateRemoveTokenForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -556,8 +556,8 @@ func (s *Server) handleActionsCreateRemoveTokenForRepoRequest(args [2]string, w 
 	params, err := decodeActionsCreateRemoveTokenForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateRemoveTokenForRepo",
-			err,
+			Operation: "ActionsCreateRemoveTokenForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -601,8 +601,8 @@ func (s *Server) handleActionsCreateSelfHostedRunnerGroupForOrgRequest(args [1]s
 	params, err := decodeActionsCreateSelfHostedRunnerGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsCreateSelfHostedRunnerGroupForOrg",
-			err,
+			Operation: "ActionsCreateSelfHostedRunnerGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -610,8 +610,8 @@ func (s *Server) handleActionsCreateSelfHostedRunnerGroupForOrgRequest(args [1]s
 	request, err := decodeActionsCreateSelfHostedRunnerGroupForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsCreateSelfHostedRunnerGroupForOrg",
-			err,
+			Operation: "ActionsCreateSelfHostedRunnerGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -655,8 +655,8 @@ func (s *Server) handleActionsDeleteArtifactRequest(args [3]string, w http.Respo
 	params, err := decodeActionsDeleteArtifactParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteArtifact",
-			err,
+			Operation: "ActionsDeleteArtifact",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -700,8 +700,8 @@ func (s *Server) handleActionsDeleteEnvironmentSecretRequest(args [3]string, w h
 	params, err := decodeActionsDeleteEnvironmentSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteEnvironmentSecret",
-			err,
+			Operation: "ActionsDeleteEnvironmentSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -745,8 +745,8 @@ func (s *Server) handleActionsDeleteOrgSecretRequest(args [2]string, w http.Resp
 	params, err := decodeActionsDeleteOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteOrgSecret",
-			err,
+			Operation: "ActionsDeleteOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -790,8 +790,8 @@ func (s *Server) handleActionsDeleteRepoSecretRequest(args [3]string, w http.Res
 	params, err := decodeActionsDeleteRepoSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteRepoSecret",
-			err,
+			Operation: "ActionsDeleteRepoSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -835,8 +835,8 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerFromOrgRequest(args [2]strin
 	params, err := decodeActionsDeleteSelfHostedRunnerFromOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteSelfHostedRunnerFromOrg",
-			err,
+			Operation: "ActionsDeleteSelfHostedRunnerFromOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -880,8 +880,8 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerFromRepoRequest(args [3]stri
 	params, err := decodeActionsDeleteSelfHostedRunnerFromRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteSelfHostedRunnerFromRepo",
-			err,
+			Operation: "ActionsDeleteSelfHostedRunnerFromRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -925,8 +925,8 @@ func (s *Server) handleActionsDeleteSelfHostedRunnerGroupFromOrgRequest(args [2]
 	params, err := decodeActionsDeleteSelfHostedRunnerGroupFromOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteSelfHostedRunnerGroupFromOrg",
-			err,
+			Operation: "ActionsDeleteSelfHostedRunnerGroupFromOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -970,8 +970,8 @@ func (s *Server) handleActionsDeleteWorkflowRunRequest(args [3]string, w http.Re
 	params, err := decodeActionsDeleteWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteWorkflowRun",
-			err,
+			Operation: "ActionsDeleteWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1015,8 +1015,8 @@ func (s *Server) handleActionsDeleteWorkflowRunLogsRequest(args [3]string, w htt
 	params, err := decodeActionsDeleteWorkflowRunLogsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDeleteWorkflowRunLogs",
-			err,
+			Operation: "ActionsDeleteWorkflowRunLogs",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1060,8 +1060,8 @@ func (s *Server) handleActionsDisableSelectedRepositoryGithubActionsOrganization
 	params, err := decodeActionsDisableSelectedRepositoryGithubActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDisableSelectedRepositoryGithubActionsOrganization",
-			err,
+			Operation: "ActionsDisableSelectedRepositoryGithubActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1105,8 +1105,8 @@ func (s *Server) handleActionsDownloadArtifactRequest(args [4]string, w http.Res
 	params, err := decodeActionsDownloadArtifactParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDownloadArtifact",
-			err,
+			Operation: "ActionsDownloadArtifact",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1150,8 +1150,8 @@ func (s *Server) handleActionsDownloadJobLogsForWorkflowRunRequest(args [3]strin
 	params, err := decodeActionsDownloadJobLogsForWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDownloadJobLogsForWorkflowRun",
-			err,
+			Operation: "ActionsDownloadJobLogsForWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1195,8 +1195,8 @@ func (s *Server) handleActionsDownloadWorkflowRunLogsRequest(args [3]string, w h
 	params, err := decodeActionsDownloadWorkflowRunLogsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsDownloadWorkflowRunLogs",
-			err,
+			Operation: "ActionsDownloadWorkflowRunLogs",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1240,8 +1240,8 @@ func (s *Server) handleActionsEnableSelectedRepositoryGithubActionsOrganizationR
 	params, err := decodeActionsEnableSelectedRepositoryGithubActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsEnableSelectedRepositoryGithubActionsOrganization",
-			err,
+			Operation: "ActionsEnableSelectedRepositoryGithubActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1285,8 +1285,8 @@ func (s *Server) handleActionsGetAllowedActionsOrganizationRequest(args [1]strin
 	params, err := decodeActionsGetAllowedActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetAllowedActionsOrganization",
-			err,
+			Operation: "ActionsGetAllowedActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1330,8 +1330,8 @@ func (s *Server) handleActionsGetAllowedActionsRepositoryRequest(args [2]string,
 	params, err := decodeActionsGetAllowedActionsRepositoryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetAllowedActionsRepository",
-			err,
+			Operation: "ActionsGetAllowedActionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1375,8 +1375,8 @@ func (s *Server) handleActionsGetArtifactRequest(args [3]string, w http.Response
 	params, err := decodeActionsGetArtifactParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetArtifact",
-			err,
+			Operation: "ActionsGetArtifact",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1420,8 +1420,8 @@ func (s *Server) handleActionsGetEnvironmentPublicKeyRequest(args [2]string, w h
 	params, err := decodeActionsGetEnvironmentPublicKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetEnvironmentPublicKey",
-			err,
+			Operation: "ActionsGetEnvironmentPublicKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1465,8 +1465,8 @@ func (s *Server) handleActionsGetEnvironmentSecretRequest(args [3]string, w http
 	params, err := decodeActionsGetEnvironmentSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetEnvironmentSecret",
-			err,
+			Operation: "ActionsGetEnvironmentSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1510,8 +1510,8 @@ func (s *Server) handleActionsGetGithubActionsPermissionsOrganizationRequest(arg
 	params, err := decodeActionsGetGithubActionsPermissionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetGithubActionsPermissionsOrganization",
-			err,
+			Operation: "ActionsGetGithubActionsPermissionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1555,8 +1555,8 @@ func (s *Server) handleActionsGetGithubActionsPermissionsRepositoryRequest(args 
 	params, err := decodeActionsGetGithubActionsPermissionsRepositoryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetGithubActionsPermissionsRepository",
-			err,
+			Operation: "ActionsGetGithubActionsPermissionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1600,8 +1600,8 @@ func (s *Server) handleActionsGetJobForWorkflowRunRequest(args [3]string, w http
 	params, err := decodeActionsGetJobForWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetJobForWorkflowRun",
-			err,
+			Operation: "ActionsGetJobForWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1645,8 +1645,8 @@ func (s *Server) handleActionsGetOrgPublicKeyRequest(args [1]string, w http.Resp
 	params, err := decodeActionsGetOrgPublicKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetOrgPublicKey",
-			err,
+			Operation: "ActionsGetOrgPublicKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1690,8 +1690,8 @@ func (s *Server) handleActionsGetOrgSecretRequest(args [2]string, w http.Respons
 	params, err := decodeActionsGetOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetOrgSecret",
-			err,
+			Operation: "ActionsGetOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1735,8 +1735,8 @@ func (s *Server) handleActionsGetRepoPublicKeyRequest(args [2]string, w http.Res
 	params, err := decodeActionsGetRepoPublicKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetRepoPublicKey",
-			err,
+			Operation: "ActionsGetRepoPublicKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1780,8 +1780,8 @@ func (s *Server) handleActionsGetRepoSecretRequest(args [3]string, w http.Respon
 	params, err := decodeActionsGetRepoSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetRepoSecret",
-			err,
+			Operation: "ActionsGetRepoSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1825,8 +1825,8 @@ func (s *Server) handleActionsGetReviewsForRunRequest(args [3]string, w http.Res
 	params, err := decodeActionsGetReviewsForRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetReviewsForRun",
-			err,
+			Operation: "ActionsGetReviewsForRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1870,8 +1870,8 @@ func (s *Server) handleActionsGetSelfHostedRunnerForOrgRequest(args [2]string, w
 	params, err := decodeActionsGetSelfHostedRunnerForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetSelfHostedRunnerForOrg",
-			err,
+			Operation: "ActionsGetSelfHostedRunnerForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1915,8 +1915,8 @@ func (s *Server) handleActionsGetSelfHostedRunnerForRepoRequest(args [3]string, 
 	params, err := decodeActionsGetSelfHostedRunnerForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetSelfHostedRunnerForRepo",
-			err,
+			Operation: "ActionsGetSelfHostedRunnerForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1960,8 +1960,8 @@ func (s *Server) handleActionsGetSelfHostedRunnerGroupForOrgRequest(args [2]stri
 	params, err := decodeActionsGetSelfHostedRunnerGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetSelfHostedRunnerGroupForOrg",
-			err,
+			Operation: "ActionsGetSelfHostedRunnerGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2005,8 +2005,8 @@ func (s *Server) handleActionsGetWorkflowRunRequest(args [3]string, w http.Respo
 	params, err := decodeActionsGetWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetWorkflowRun",
-			err,
+			Operation: "ActionsGetWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2050,8 +2050,8 @@ func (s *Server) handleActionsGetWorkflowRunUsageRequest(args [3]string, w http.
 	params, err := decodeActionsGetWorkflowRunUsageParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsGetWorkflowRunUsage",
-			err,
+			Operation: "ActionsGetWorkflowRunUsage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2095,8 +2095,8 @@ func (s *Server) handleActionsListArtifactsForRepoRequest(args [2]string, w http
 	params, err := decodeActionsListArtifactsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListArtifactsForRepo",
-			err,
+			Operation: "ActionsListArtifactsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2140,8 +2140,8 @@ func (s *Server) handleActionsListEnvironmentSecretsRequest(args [2]string, w ht
 	params, err := decodeActionsListEnvironmentSecretsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListEnvironmentSecrets",
-			err,
+			Operation: "ActionsListEnvironmentSecrets",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2185,8 +2185,8 @@ func (s *Server) handleActionsListJobsForWorkflowRunRequest(args [3]string, w ht
 	params, err := decodeActionsListJobsForWorkflowRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListJobsForWorkflowRun",
-			err,
+			Operation: "ActionsListJobsForWorkflowRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2230,8 +2230,8 @@ func (s *Server) handleActionsListOrgSecretsRequest(args [1]string, w http.Respo
 	params, err := decodeActionsListOrgSecretsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListOrgSecrets",
-			err,
+			Operation: "ActionsListOrgSecrets",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2275,8 +2275,8 @@ func (s *Server) handleActionsListRepoAccessToSelfHostedRunnerGroupInOrgRequest(
 	params, err := decodeActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListRepoAccessToSelfHostedRunnerGroupInOrg",
-			err,
+			Operation: "ActionsListRepoAccessToSelfHostedRunnerGroupInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2320,8 +2320,8 @@ func (s *Server) handleActionsListRepoSecretsRequest(args [2]string, w http.Resp
 	params, err := decodeActionsListRepoSecretsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListRepoSecrets",
-			err,
+			Operation: "ActionsListRepoSecrets",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2365,8 +2365,8 @@ func (s *Server) handleActionsListRepoWorkflowsRequest(args [2]string, w http.Re
 	params, err := decodeActionsListRepoWorkflowsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListRepoWorkflows",
-			err,
+			Operation: "ActionsListRepoWorkflows",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2410,8 +2410,8 @@ func (s *Server) handleActionsListRunnerApplicationsForOrgRequest(args [1]string
 	params, err := decodeActionsListRunnerApplicationsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListRunnerApplicationsForOrg",
-			err,
+			Operation: "ActionsListRunnerApplicationsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2455,8 +2455,8 @@ func (s *Server) handleActionsListRunnerApplicationsForRepoRequest(args [2]strin
 	params, err := decodeActionsListRunnerApplicationsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListRunnerApplicationsForRepo",
-			err,
+			Operation: "ActionsListRunnerApplicationsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2500,8 +2500,8 @@ func (s *Server) handleActionsListSelectedReposForOrgSecretRequest(args [2]strin
 	params, err := decodeActionsListSelectedReposForOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelectedReposForOrgSecret",
-			err,
+			Operation: "ActionsListSelectedReposForOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2545,8 +2545,8 @@ func (s *Server) handleActionsListSelectedRepositoriesEnabledGithubActionsOrgani
 	params, err := decodeActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelectedRepositoriesEnabledGithubActionsOrganization",
-			err,
+			Operation: "ActionsListSelectedRepositoriesEnabledGithubActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2590,8 +2590,8 @@ func (s *Server) handleActionsListSelfHostedRunnerGroupsForOrgRequest(args [1]st
 	params, err := decodeActionsListSelfHostedRunnerGroupsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelfHostedRunnerGroupsForOrg",
-			err,
+			Operation: "ActionsListSelfHostedRunnerGroupsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2635,8 +2635,8 @@ func (s *Server) handleActionsListSelfHostedRunnersForOrgRequest(args [1]string,
 	params, err := decodeActionsListSelfHostedRunnersForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelfHostedRunnersForOrg",
-			err,
+			Operation: "ActionsListSelfHostedRunnersForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2680,8 +2680,8 @@ func (s *Server) handleActionsListSelfHostedRunnersForRepoRequest(args [2]string
 	params, err := decodeActionsListSelfHostedRunnersForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelfHostedRunnersForRepo",
-			err,
+			Operation: "ActionsListSelfHostedRunnersForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2725,8 +2725,8 @@ func (s *Server) handleActionsListSelfHostedRunnersInGroupForOrgRequest(args [2]
 	params, err := decodeActionsListSelfHostedRunnersInGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListSelfHostedRunnersInGroupForOrg",
-			err,
+			Operation: "ActionsListSelfHostedRunnersInGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2770,8 +2770,8 @@ func (s *Server) handleActionsListWorkflowRunArtifactsRequest(args [3]string, w 
 	params, err := decodeActionsListWorkflowRunArtifactsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListWorkflowRunArtifacts",
-			err,
+			Operation: "ActionsListWorkflowRunArtifacts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2815,8 +2815,8 @@ func (s *Server) handleActionsListWorkflowRunsForRepoRequest(args [2]string, w h
 	params, err := decodeActionsListWorkflowRunsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsListWorkflowRunsForRepo",
-			err,
+			Operation: "ActionsListWorkflowRunsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2860,8 +2860,8 @@ func (s *Server) handleActionsReRunWorkflowRequest(args [3]string, w http.Respon
 	params, err := decodeActionsReRunWorkflowParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsReRunWorkflow",
-			err,
+			Operation: "ActionsReRunWorkflow",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2905,8 +2905,8 @@ func (s *Server) handleActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgReques
 	params, err := decodeActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg",
-			err,
+			Operation: "ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2950,8 +2950,8 @@ func (s *Server) handleActionsRemoveSelectedRepoFromOrgSecretRequest(args [3]str
 	params, err := decodeActionsRemoveSelectedRepoFromOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsRemoveSelectedRepoFromOrgSecret",
-			err,
+			Operation: "ActionsRemoveSelectedRepoFromOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2995,8 +2995,8 @@ func (s *Server) handleActionsRemoveSelfHostedRunnerFromGroupForOrgRequest(args 
 	params, err := decodeActionsRemoveSelfHostedRunnerFromGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsRemoveSelfHostedRunnerFromGroupForOrg",
-			err,
+			Operation: "ActionsRemoveSelfHostedRunnerFromGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3040,8 +3040,8 @@ func (s *Server) handleActionsRetryWorkflowRequest(args [3]string, w http.Respon
 	params, err := decodeActionsRetryWorkflowParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsRetryWorkflow",
-			err,
+			Operation: "ActionsRetryWorkflow",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3085,8 +3085,8 @@ func (s *Server) handleActionsReviewPendingDeploymentsForRunRequest(args [3]stri
 	params, err := decodeActionsReviewPendingDeploymentsForRunParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsReviewPendingDeploymentsForRun",
-			err,
+			Operation: "ActionsReviewPendingDeploymentsForRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3094,8 +3094,8 @@ func (s *Server) handleActionsReviewPendingDeploymentsForRunRequest(args [3]stri
 	request, err := decodeActionsReviewPendingDeploymentsForRunRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsReviewPendingDeploymentsForRun",
-			err,
+			Operation: "ActionsReviewPendingDeploymentsForRun",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3139,8 +3139,8 @@ func (s *Server) handleActionsSetAllowedActionsOrganizationRequest(args [1]strin
 	params, err := decodeActionsSetAllowedActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetAllowedActionsOrganization",
-			err,
+			Operation: "ActionsSetAllowedActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3148,8 +3148,8 @@ func (s *Server) handleActionsSetAllowedActionsOrganizationRequest(args [1]strin
 	request, err := decodeActionsSetAllowedActionsOrganizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetAllowedActionsOrganization",
-			err,
+			Operation: "ActionsSetAllowedActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3193,8 +3193,8 @@ func (s *Server) handleActionsSetAllowedActionsRepositoryRequest(args [2]string,
 	params, err := decodeActionsSetAllowedActionsRepositoryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetAllowedActionsRepository",
-			err,
+			Operation: "ActionsSetAllowedActionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3202,8 +3202,8 @@ func (s *Server) handleActionsSetAllowedActionsRepositoryRequest(args [2]string,
 	request, err := decodeActionsSetAllowedActionsRepositoryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetAllowedActionsRepository",
-			err,
+			Operation: "ActionsSetAllowedActionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3247,8 +3247,8 @@ func (s *Server) handleActionsSetGithubActionsPermissionsOrganizationRequest(arg
 	params, err := decodeActionsSetGithubActionsPermissionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetGithubActionsPermissionsOrganization",
-			err,
+			Operation: "ActionsSetGithubActionsPermissionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3256,8 +3256,8 @@ func (s *Server) handleActionsSetGithubActionsPermissionsOrganizationRequest(arg
 	request, err := decodeActionsSetGithubActionsPermissionsOrganizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetGithubActionsPermissionsOrganization",
-			err,
+			Operation: "ActionsSetGithubActionsPermissionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3301,8 +3301,8 @@ func (s *Server) handleActionsSetGithubActionsPermissionsRepositoryRequest(args 
 	params, err := decodeActionsSetGithubActionsPermissionsRepositoryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetGithubActionsPermissionsRepository",
-			err,
+			Operation: "ActionsSetGithubActionsPermissionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3310,8 +3310,8 @@ func (s *Server) handleActionsSetGithubActionsPermissionsRepositoryRequest(args 
 	request, err := decodeActionsSetGithubActionsPermissionsRepositoryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetGithubActionsPermissionsRepository",
-			err,
+			Operation: "ActionsSetGithubActionsPermissionsRepository",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3355,8 +3355,8 @@ func (s *Server) handleActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequest(a
 	params, err := decodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg",
-			err,
+			Operation: "ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3364,8 +3364,8 @@ func (s *Server) handleActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequest(a
 	request, err := decodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg",
-			err,
+			Operation: "ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3409,8 +3409,8 @@ func (s *Server) handleActionsSetSelectedReposForOrgSecretRequest(args [2]string
 	params, err := decodeActionsSetSelectedReposForOrgSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetSelectedReposForOrgSecret",
-			err,
+			Operation: "ActionsSetSelectedReposForOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3418,8 +3418,8 @@ func (s *Server) handleActionsSetSelectedReposForOrgSecretRequest(args [2]string
 	request, err := decodeActionsSetSelectedReposForOrgSecretRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetSelectedReposForOrgSecret",
-			err,
+			Operation: "ActionsSetSelectedReposForOrgSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3463,8 +3463,8 @@ func (s *Server) handleActionsSetSelectedRepositoriesEnabledGithubActionsOrganiz
 	params, err := decodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization",
-			err,
+			Operation: "ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3472,8 +3472,8 @@ func (s *Server) handleActionsSetSelectedRepositoriesEnabledGithubActionsOrganiz
 	request, err := decodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization",
-			err,
+			Operation: "ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3517,8 +3517,8 @@ func (s *Server) handleActionsSetSelfHostedRunnersInGroupForOrgRequest(args [2]s
 	params, err := decodeActionsSetSelfHostedRunnersInGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsSetSelfHostedRunnersInGroupForOrg",
-			err,
+			Operation: "ActionsSetSelfHostedRunnersInGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3526,8 +3526,8 @@ func (s *Server) handleActionsSetSelfHostedRunnersInGroupForOrgRequest(args [2]s
 	request, err := decodeActionsSetSelfHostedRunnersInGroupForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsSetSelfHostedRunnersInGroupForOrg",
-			err,
+			Operation: "ActionsSetSelfHostedRunnersInGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3571,8 +3571,8 @@ func (s *Server) handleActionsUpdateSelfHostedRunnerGroupForOrgRequest(args [2]s
 	params, err := decodeActionsUpdateSelfHostedRunnerGroupForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActionsUpdateSelfHostedRunnerGroupForOrg",
-			err,
+			Operation: "ActionsUpdateSelfHostedRunnerGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3580,8 +3580,8 @@ func (s *Server) handleActionsUpdateSelfHostedRunnerGroupForOrgRequest(args [2]s
 	request, err := decodeActionsUpdateSelfHostedRunnerGroupForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActionsUpdateSelfHostedRunnerGroupForOrg",
-			err,
+			Operation: "ActionsUpdateSelfHostedRunnerGroupForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3625,8 +3625,8 @@ func (s *Server) handleActivityCheckRepoIsStarredByAuthenticatedUserRequest(args
 	params, err := decodeActivityCheckRepoIsStarredByAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityCheckRepoIsStarredByAuthenticatedUser",
-			err,
+			Operation: "ActivityCheckRepoIsStarredByAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3670,8 +3670,8 @@ func (s *Server) handleActivityDeleteRepoSubscriptionRequest(args [2]string, w h
 	params, err := decodeActivityDeleteRepoSubscriptionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityDeleteRepoSubscription",
-			err,
+			Operation: "ActivityDeleteRepoSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3715,8 +3715,8 @@ func (s *Server) handleActivityDeleteThreadSubscriptionRequest(args [1]string, w
 	params, err := decodeActivityDeleteThreadSubscriptionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityDeleteThreadSubscription",
-			err,
+			Operation: "ActivityDeleteThreadSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3796,8 +3796,8 @@ func (s *Server) handleActivityGetRepoSubscriptionRequest(args [2]string, w http
 	params, err := decodeActivityGetRepoSubscriptionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityGetRepoSubscription",
-			err,
+			Operation: "ActivityGetRepoSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3841,8 +3841,8 @@ func (s *Server) handleActivityGetThreadRequest(args [1]string, w http.ResponseW
 	params, err := decodeActivityGetThreadParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityGetThread",
-			err,
+			Operation: "ActivityGetThread",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3886,8 +3886,8 @@ func (s *Server) handleActivityGetThreadSubscriptionForAuthenticatedUserRequest(
 	params, err := decodeActivityGetThreadSubscriptionForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityGetThreadSubscriptionForAuthenticatedUser",
-			err,
+			Operation: "ActivityGetThreadSubscriptionForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3931,8 +3931,8 @@ func (s *Server) handleActivityListEventsForAuthenticatedUserRequest(args [1]str
 	params, err := decodeActivityListEventsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListEventsForAuthenticatedUser",
-			err,
+			Operation: "ActivityListEventsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3976,8 +3976,8 @@ func (s *Server) handleActivityListNotificationsForAuthenticatedUserRequest(args
 	params, err := decodeActivityListNotificationsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListNotificationsForAuthenticatedUser",
-			err,
+			Operation: "ActivityListNotificationsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4021,8 +4021,8 @@ func (s *Server) handleActivityListOrgEventsForAuthenticatedUserRequest(args [2]
 	params, err := decodeActivityListOrgEventsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListOrgEventsForAuthenticatedUser",
-			err,
+			Operation: "ActivityListOrgEventsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4066,8 +4066,8 @@ func (s *Server) handleActivityListPublicEventsRequest(args [0]string, w http.Re
 	params, err := decodeActivityListPublicEventsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListPublicEvents",
-			err,
+			Operation: "ActivityListPublicEvents",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4111,8 +4111,8 @@ func (s *Server) handleActivityListPublicEventsForRepoNetworkRequest(args [2]str
 	params, err := decodeActivityListPublicEventsForRepoNetworkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListPublicEventsForRepoNetwork",
-			err,
+			Operation: "ActivityListPublicEventsForRepoNetwork",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4156,8 +4156,8 @@ func (s *Server) handleActivityListPublicEventsForUserRequest(args [1]string, w 
 	params, err := decodeActivityListPublicEventsForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListPublicEventsForUser",
-			err,
+			Operation: "ActivityListPublicEventsForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4201,8 +4201,8 @@ func (s *Server) handleActivityListPublicOrgEventsRequest(args [1]string, w http
 	params, err := decodeActivityListPublicOrgEventsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListPublicOrgEvents",
-			err,
+			Operation: "ActivityListPublicOrgEvents",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4246,8 +4246,8 @@ func (s *Server) handleActivityListReceivedEventsForUserRequest(args [1]string, 
 	params, err := decodeActivityListReceivedEventsForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListReceivedEventsForUser",
-			err,
+			Operation: "ActivityListReceivedEventsForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4291,8 +4291,8 @@ func (s *Server) handleActivityListReceivedPublicEventsForUserRequest(args [1]st
 	params, err := decodeActivityListReceivedPublicEventsForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListReceivedPublicEventsForUser",
-			err,
+			Operation: "ActivityListReceivedPublicEventsForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4336,8 +4336,8 @@ func (s *Server) handleActivityListRepoEventsRequest(args [2]string, w http.Resp
 	params, err := decodeActivityListRepoEventsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListRepoEvents",
-			err,
+			Operation: "ActivityListRepoEvents",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4381,8 +4381,8 @@ func (s *Server) handleActivityListRepoNotificationsForAuthenticatedUserRequest(
 	params, err := decodeActivityListRepoNotificationsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListRepoNotificationsForAuthenticatedUser",
-			err,
+			Operation: "ActivityListRepoNotificationsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4426,8 +4426,8 @@ func (s *Server) handleActivityListReposStarredByAuthenticatedUserRequest(args [
 	params, err := decodeActivityListReposStarredByAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListReposStarredByAuthenticatedUser",
-			err,
+			Operation: "ActivityListReposStarredByAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4471,8 +4471,8 @@ func (s *Server) handleActivityListReposWatchedByUserRequest(args [1]string, w h
 	params, err := decodeActivityListReposWatchedByUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListReposWatchedByUser",
-			err,
+			Operation: "ActivityListReposWatchedByUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4516,8 +4516,8 @@ func (s *Server) handleActivityListWatchedReposForAuthenticatedUserRequest(args 
 	params, err := decodeActivityListWatchedReposForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListWatchedReposForAuthenticatedUser",
-			err,
+			Operation: "ActivityListWatchedReposForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4561,8 +4561,8 @@ func (s *Server) handleActivityListWatchersForRepoRequest(args [2]string, w http
 	params, err := decodeActivityListWatchersForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityListWatchersForRepo",
-			err,
+			Operation: "ActivityListWatchersForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4606,8 +4606,8 @@ func (s *Server) handleActivityMarkNotificationsAsReadRequest(args [0]string, w 
 	request, err := decodeActivityMarkNotificationsAsReadRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActivityMarkNotificationsAsRead",
-			err,
+			Operation: "ActivityMarkNotificationsAsRead",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4651,8 +4651,8 @@ func (s *Server) handleActivityMarkRepoNotificationsAsReadRequest(args [2]string
 	params, err := decodeActivityMarkRepoNotificationsAsReadParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityMarkRepoNotificationsAsRead",
-			err,
+			Operation: "ActivityMarkRepoNotificationsAsRead",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4660,8 +4660,8 @@ func (s *Server) handleActivityMarkRepoNotificationsAsReadRequest(args [2]string
 	request, err := decodeActivityMarkRepoNotificationsAsReadRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActivityMarkRepoNotificationsAsRead",
-			err,
+			Operation: "ActivityMarkRepoNotificationsAsRead",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4705,8 +4705,8 @@ func (s *Server) handleActivityMarkThreadAsReadRequest(args [1]string, w http.Re
 	params, err := decodeActivityMarkThreadAsReadParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityMarkThreadAsRead",
-			err,
+			Operation: "ActivityMarkThreadAsRead",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4750,8 +4750,8 @@ func (s *Server) handleActivitySetRepoSubscriptionRequest(args [2]string, w http
 	params, err := decodeActivitySetRepoSubscriptionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivitySetRepoSubscription",
-			err,
+			Operation: "ActivitySetRepoSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4759,8 +4759,8 @@ func (s *Server) handleActivitySetRepoSubscriptionRequest(args [2]string, w http
 	request, err := decodeActivitySetRepoSubscriptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActivitySetRepoSubscription",
-			err,
+			Operation: "ActivitySetRepoSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4804,8 +4804,8 @@ func (s *Server) handleActivitySetThreadSubscriptionRequest(args [1]string, w ht
 	params, err := decodeActivitySetThreadSubscriptionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivitySetThreadSubscription",
-			err,
+			Operation: "ActivitySetThreadSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4813,8 +4813,8 @@ func (s *Server) handleActivitySetThreadSubscriptionRequest(args [1]string, w ht
 	request, err := decodeActivitySetThreadSubscriptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ActivitySetThreadSubscription",
-			err,
+			Operation: "ActivitySetThreadSubscription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4858,8 +4858,8 @@ func (s *Server) handleActivityStarRepoForAuthenticatedUserRequest(args [2]strin
 	params, err := decodeActivityStarRepoForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityStarRepoForAuthenticatedUser",
-			err,
+			Operation: "ActivityStarRepoForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4903,8 +4903,8 @@ func (s *Server) handleActivityUnstarRepoForAuthenticatedUserRequest(args [2]str
 	params, err := decodeActivityUnstarRepoForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ActivityUnstarRepoForAuthenticatedUser",
-			err,
+			Operation: "ActivityUnstarRepoForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4948,8 +4948,8 @@ func (s *Server) handleAppsAddRepoToInstallationRequest(args [2]string, w http.R
 	params, err := decodeAppsAddRepoToInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsAddRepoToInstallation",
-			err,
+			Operation: "AppsAddRepoToInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4993,8 +4993,8 @@ func (s *Server) handleAppsCheckTokenRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeAppsCheckTokenParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsCheckToken",
-			err,
+			Operation: "AppsCheckToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5002,8 +5002,8 @@ func (s *Server) handleAppsCheckTokenRequest(args [1]string, w http.ResponseWrit
 	request, err := decodeAppsCheckTokenRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsCheckToken",
-			err,
+			Operation: "AppsCheckToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5047,8 +5047,8 @@ func (s *Server) handleAppsCreateContentAttachmentRequest(args [3]string, w http
 	params, err := decodeAppsCreateContentAttachmentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsCreateContentAttachment",
-			err,
+			Operation: "AppsCreateContentAttachment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5056,8 +5056,8 @@ func (s *Server) handleAppsCreateContentAttachmentRequest(args [3]string, w http
 	request, err := decodeAppsCreateContentAttachmentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsCreateContentAttachment",
-			err,
+			Operation: "AppsCreateContentAttachment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5101,8 +5101,8 @@ func (s *Server) handleAppsCreateInstallationAccessTokenRequest(args [1]string, 
 	params, err := decodeAppsCreateInstallationAccessTokenParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsCreateInstallationAccessToken",
-			err,
+			Operation: "AppsCreateInstallationAccessToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5110,8 +5110,8 @@ func (s *Server) handleAppsCreateInstallationAccessTokenRequest(args [1]string, 
 	request, err := decodeAppsCreateInstallationAccessTokenRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsCreateInstallationAccessToken",
-			err,
+			Operation: "AppsCreateInstallationAccessToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5155,8 +5155,8 @@ func (s *Server) handleAppsDeleteAuthorizationRequest(args [1]string, w http.Res
 	params, err := decodeAppsDeleteAuthorizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsDeleteAuthorization",
-			err,
+			Operation: "AppsDeleteAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5164,8 +5164,8 @@ func (s *Server) handleAppsDeleteAuthorizationRequest(args [1]string, w http.Res
 	request, err := decodeAppsDeleteAuthorizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsDeleteAuthorization",
-			err,
+			Operation: "AppsDeleteAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5209,8 +5209,8 @@ func (s *Server) handleAppsDeleteInstallationRequest(args [1]string, w http.Resp
 	params, err := decodeAppsDeleteInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsDeleteInstallation",
-			err,
+			Operation: "AppsDeleteInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5254,8 +5254,8 @@ func (s *Server) handleAppsDeleteTokenRequest(args [1]string, w http.ResponseWri
 	params, err := decodeAppsDeleteTokenParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsDeleteToken",
-			err,
+			Operation: "AppsDeleteToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5263,8 +5263,8 @@ func (s *Server) handleAppsDeleteTokenRequest(args [1]string, w http.ResponseWri
 	request, err := decodeAppsDeleteTokenRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsDeleteToken",
-			err,
+			Operation: "AppsDeleteToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5344,8 +5344,8 @@ func (s *Server) handleAppsGetBySlugRequest(args [1]string, w http.ResponseWrite
 	params, err := decodeAppsGetBySlugParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsGetBySlug",
-			err,
+			Operation: "AppsGetBySlug",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5389,8 +5389,8 @@ func (s *Server) handleAppsGetSubscriptionPlanForAccountRequest(args [1]string, 
 	params, err := decodeAppsGetSubscriptionPlanForAccountParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsGetSubscriptionPlanForAccount",
-			err,
+			Operation: "AppsGetSubscriptionPlanForAccount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5434,8 +5434,8 @@ func (s *Server) handleAppsGetSubscriptionPlanForAccountStubbedRequest(args [1]s
 	params, err := decodeAppsGetSubscriptionPlanForAccountStubbedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsGetSubscriptionPlanForAccountStubbed",
-			err,
+			Operation: "AppsGetSubscriptionPlanForAccountStubbed",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5515,8 +5515,8 @@ func (s *Server) handleAppsGetWebhookDeliveryRequest(args [1]string, w http.Resp
 	params, err := decodeAppsGetWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsGetWebhookDelivery",
-			err,
+			Operation: "AppsGetWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5560,8 +5560,8 @@ func (s *Server) handleAppsListAccountsForPlanRequest(args [1]string, w http.Res
 	params, err := decodeAppsListAccountsForPlanParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListAccountsForPlan",
-			err,
+			Operation: "AppsListAccountsForPlan",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5605,8 +5605,8 @@ func (s *Server) handleAppsListAccountsForPlanStubbedRequest(args [1]string, w h
 	params, err := decodeAppsListAccountsForPlanStubbedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListAccountsForPlanStubbed",
-			err,
+			Operation: "AppsListAccountsForPlanStubbed",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5650,8 +5650,8 @@ func (s *Server) handleAppsListInstallationReposForAuthenticatedUserRequest(args
 	params, err := decodeAppsListInstallationReposForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListInstallationReposForAuthenticatedUser",
-			err,
+			Operation: "AppsListInstallationReposForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5695,8 +5695,8 @@ func (s *Server) handleAppsListPlansRequest(args [0]string, w http.ResponseWrite
 	params, err := decodeAppsListPlansParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListPlans",
-			err,
+			Operation: "AppsListPlans",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5740,8 +5740,8 @@ func (s *Server) handleAppsListPlansStubbedRequest(args [0]string, w http.Respon
 	params, err := decodeAppsListPlansStubbedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListPlansStubbed",
-			err,
+			Operation: "AppsListPlansStubbed",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5785,8 +5785,8 @@ func (s *Server) handleAppsListReposAccessibleToInstallationRequest(args [0]stri
 	params, err := decodeAppsListReposAccessibleToInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListReposAccessibleToInstallation",
-			err,
+			Operation: "AppsListReposAccessibleToInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5830,8 +5830,8 @@ func (s *Server) handleAppsListSubscriptionsForAuthenticatedUserRequest(args [0]
 	params, err := decodeAppsListSubscriptionsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListSubscriptionsForAuthenticatedUser",
-			err,
+			Operation: "AppsListSubscriptionsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5875,8 +5875,8 @@ func (s *Server) handleAppsListSubscriptionsForAuthenticatedUserStubbedRequest(a
 	params, err := decodeAppsListSubscriptionsForAuthenticatedUserStubbedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListSubscriptionsForAuthenticatedUserStubbed",
-			err,
+			Operation: "AppsListSubscriptionsForAuthenticatedUserStubbed",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5920,8 +5920,8 @@ func (s *Server) handleAppsListWebhookDeliveriesRequest(args [0]string, w http.R
 	params, err := decodeAppsListWebhookDeliveriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsListWebhookDeliveries",
-			err,
+			Operation: "AppsListWebhookDeliveries",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5965,8 +5965,8 @@ func (s *Server) handleAppsRedeliverWebhookDeliveryRequest(args [1]string, w htt
 	params, err := decodeAppsRedeliverWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsRedeliverWebhookDelivery",
-			err,
+			Operation: "AppsRedeliverWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6010,8 +6010,8 @@ func (s *Server) handleAppsRemoveRepoFromInstallationRequest(args [2]string, w h
 	params, err := decodeAppsRemoveRepoFromInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsRemoveRepoFromInstallation",
-			err,
+			Operation: "AppsRemoveRepoFromInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6055,8 +6055,8 @@ func (s *Server) handleAppsResetTokenRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeAppsResetTokenParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsResetToken",
-			err,
+			Operation: "AppsResetToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6064,8 +6064,8 @@ func (s *Server) handleAppsResetTokenRequest(args [1]string, w http.ResponseWrit
 	request, err := decodeAppsResetTokenRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsResetToken",
-			err,
+			Operation: "AppsResetToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6145,8 +6145,8 @@ func (s *Server) handleAppsScopeTokenRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeAppsScopeTokenParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsScopeToken",
-			err,
+			Operation: "AppsScopeToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6154,8 +6154,8 @@ func (s *Server) handleAppsScopeTokenRequest(args [1]string, w http.ResponseWrit
 	request, err := decodeAppsScopeTokenRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsScopeToken",
-			err,
+			Operation: "AppsScopeToken",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6199,8 +6199,8 @@ func (s *Server) handleAppsSuspendInstallationRequest(args [1]string, w http.Res
 	params, err := decodeAppsSuspendInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsSuspendInstallation",
-			err,
+			Operation: "AppsSuspendInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6244,8 +6244,8 @@ func (s *Server) handleAppsUnsuspendInstallationRequest(args [1]string, w http.R
 	params, err := decodeAppsUnsuspendInstallationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"AppsUnsuspendInstallation",
-			err,
+			Operation: "AppsUnsuspendInstallation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6289,8 +6289,8 @@ func (s *Server) handleAppsUpdateWebhookConfigForAppRequest(args [0]string, w ht
 	request, err := decodeAppsUpdateWebhookConfigForAppRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AppsUpdateWebhookConfigForApp",
-			err,
+			Operation: "AppsUpdateWebhookConfigForApp",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6334,8 +6334,8 @@ func (s *Server) handleBillingGetGithubActionsBillingGheRequest(args [1]string, 
 	params, err := decodeBillingGetGithubActionsBillingGheParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubActionsBillingGhe",
-			err,
+			Operation: "BillingGetGithubActionsBillingGhe",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6379,8 +6379,8 @@ func (s *Server) handleBillingGetGithubActionsBillingOrgRequest(args [1]string, 
 	params, err := decodeBillingGetGithubActionsBillingOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubActionsBillingOrg",
-			err,
+			Operation: "BillingGetGithubActionsBillingOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6424,8 +6424,8 @@ func (s *Server) handleBillingGetGithubActionsBillingUserRequest(args [1]string,
 	params, err := decodeBillingGetGithubActionsBillingUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubActionsBillingUser",
-			err,
+			Operation: "BillingGetGithubActionsBillingUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6469,8 +6469,8 @@ func (s *Server) handleBillingGetGithubPackagesBillingGheRequest(args [1]string,
 	params, err := decodeBillingGetGithubPackagesBillingGheParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubPackagesBillingGhe",
-			err,
+			Operation: "BillingGetGithubPackagesBillingGhe",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6514,8 +6514,8 @@ func (s *Server) handleBillingGetGithubPackagesBillingOrgRequest(args [1]string,
 	params, err := decodeBillingGetGithubPackagesBillingOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubPackagesBillingOrg",
-			err,
+			Operation: "BillingGetGithubPackagesBillingOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6559,8 +6559,8 @@ func (s *Server) handleBillingGetGithubPackagesBillingUserRequest(args [1]string
 	params, err := decodeBillingGetGithubPackagesBillingUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetGithubPackagesBillingUser",
-			err,
+			Operation: "BillingGetGithubPackagesBillingUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6604,8 +6604,8 @@ func (s *Server) handleBillingGetSharedStorageBillingGheRequest(args [1]string, 
 	params, err := decodeBillingGetSharedStorageBillingGheParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetSharedStorageBillingGhe",
-			err,
+			Operation: "BillingGetSharedStorageBillingGhe",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6649,8 +6649,8 @@ func (s *Server) handleBillingGetSharedStorageBillingOrgRequest(args [1]string, 
 	params, err := decodeBillingGetSharedStorageBillingOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetSharedStorageBillingOrg",
-			err,
+			Operation: "BillingGetSharedStorageBillingOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6694,8 +6694,8 @@ func (s *Server) handleBillingGetSharedStorageBillingUserRequest(args [1]string,
 	params, err := decodeBillingGetSharedStorageBillingUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"BillingGetSharedStorageBillingUser",
-			err,
+			Operation: "BillingGetSharedStorageBillingUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6739,8 +6739,8 @@ func (s *Server) handleChecksCreateSuiteRequest(args [2]string, w http.ResponseW
 	params, err := decodeChecksCreateSuiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksCreateSuite",
-			err,
+			Operation: "ChecksCreateSuite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6748,8 +6748,8 @@ func (s *Server) handleChecksCreateSuiteRequest(args [2]string, w http.ResponseW
 	request, err := decodeChecksCreateSuiteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ChecksCreateSuite",
-			err,
+			Operation: "ChecksCreateSuite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6793,8 +6793,8 @@ func (s *Server) handleChecksGetRequest(args [3]string, w http.ResponseWriter, r
 	params, err := decodeChecksGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksGet",
-			err,
+			Operation: "ChecksGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6838,8 +6838,8 @@ func (s *Server) handleChecksGetSuiteRequest(args [3]string, w http.ResponseWrit
 	params, err := decodeChecksGetSuiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksGetSuite",
-			err,
+			Operation: "ChecksGetSuite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6883,8 +6883,8 @@ func (s *Server) handleChecksListAnnotationsRequest(args [3]string, w http.Respo
 	params, err := decodeChecksListAnnotationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksListAnnotations",
-			err,
+			Operation: "ChecksListAnnotations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6928,8 +6928,8 @@ func (s *Server) handleChecksListForRefRequest(args [3]string, w http.ResponseWr
 	params, err := decodeChecksListForRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksListForRef",
-			err,
+			Operation: "ChecksListForRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6973,8 +6973,8 @@ func (s *Server) handleChecksListForSuiteRequest(args [3]string, w http.Response
 	params, err := decodeChecksListForSuiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksListForSuite",
-			err,
+			Operation: "ChecksListForSuite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7018,8 +7018,8 @@ func (s *Server) handleChecksListSuitesForRefRequest(args [3]string, w http.Resp
 	params, err := decodeChecksListSuitesForRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksListSuitesForRef",
-			err,
+			Operation: "ChecksListSuitesForRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7063,8 +7063,8 @@ func (s *Server) handleChecksRerequestSuiteRequest(args [3]string, w http.Respon
 	params, err := decodeChecksRerequestSuiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksRerequestSuite",
-			err,
+			Operation: "ChecksRerequestSuite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7108,8 +7108,8 @@ func (s *Server) handleChecksSetSuitesPreferencesRequest(args [2]string, w http.
 	params, err := decodeChecksSetSuitesPreferencesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ChecksSetSuitesPreferences",
-			err,
+			Operation: "ChecksSetSuitesPreferences",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7117,8 +7117,8 @@ func (s *Server) handleChecksSetSuitesPreferencesRequest(args [2]string, w http.
 	request, err := decodeChecksSetSuitesPreferencesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ChecksSetSuitesPreferences",
-			err,
+			Operation: "ChecksSetSuitesPreferences",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7162,8 +7162,8 @@ func (s *Server) handleCodeScanningDeleteAnalysisRequest(args [3]string, w http.
 	params, err := decodeCodeScanningDeleteAnalysisParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningDeleteAnalysis",
-			err,
+			Operation: "CodeScanningDeleteAnalysis",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7207,8 +7207,8 @@ func (s *Server) handleCodeScanningGetAlertRequest(args [3]string, w http.Respon
 	params, err := decodeCodeScanningGetAlertParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningGetAlert",
-			err,
+			Operation: "CodeScanningGetAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7252,8 +7252,8 @@ func (s *Server) handleCodeScanningGetAnalysisRequest(args [3]string, w http.Res
 	params, err := decodeCodeScanningGetAnalysisParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningGetAnalysis",
-			err,
+			Operation: "CodeScanningGetAnalysis",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7297,8 +7297,8 @@ func (s *Server) handleCodeScanningGetSarifRequest(args [3]string, w http.Respon
 	params, err := decodeCodeScanningGetSarifParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningGetSarif",
-			err,
+			Operation: "CodeScanningGetSarif",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7342,8 +7342,8 @@ func (s *Server) handleCodeScanningListAlertInstancesRequest(args [3]string, w h
 	params, err := decodeCodeScanningListAlertInstancesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningListAlertInstances",
-			err,
+			Operation: "CodeScanningListAlertInstances",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7387,8 +7387,8 @@ func (s *Server) handleCodeScanningListAlertsForRepoRequest(args [2]string, w ht
 	params, err := decodeCodeScanningListAlertsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningListAlertsForRepo",
-			err,
+			Operation: "CodeScanningListAlertsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7432,8 +7432,8 @@ func (s *Server) handleCodeScanningListRecentAnalysesRequest(args [2]string, w h
 	params, err := decodeCodeScanningListRecentAnalysesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningListRecentAnalyses",
-			err,
+			Operation: "CodeScanningListRecentAnalyses",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7477,8 +7477,8 @@ func (s *Server) handleCodeScanningUpdateAlertRequest(args [3]string, w http.Res
 	params, err := decodeCodeScanningUpdateAlertParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningUpdateAlert",
-			err,
+			Operation: "CodeScanningUpdateAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7486,8 +7486,8 @@ func (s *Server) handleCodeScanningUpdateAlertRequest(args [3]string, w http.Res
 	request, err := decodeCodeScanningUpdateAlertRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CodeScanningUpdateAlert",
-			err,
+			Operation: "CodeScanningUpdateAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7531,8 +7531,8 @@ func (s *Server) handleCodeScanningUploadSarifRequest(args [2]string, w http.Res
 	params, err := decodeCodeScanningUploadSarifParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodeScanningUploadSarif",
-			err,
+			Operation: "CodeScanningUploadSarif",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7540,8 +7540,8 @@ func (s *Server) handleCodeScanningUploadSarifRequest(args [2]string, w http.Res
 	request, err := decodeCodeScanningUploadSarifRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CodeScanningUploadSarif",
-			err,
+			Operation: "CodeScanningUploadSarif",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7621,8 +7621,8 @@ func (s *Server) handleCodesOfConductGetConductCodeRequest(args [1]string, w htt
 	params, err := decodeCodesOfConductGetConductCodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"CodesOfConductGetConductCode",
-			err,
+			Operation: "CodesOfConductGetConductCode",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7702,8 +7702,8 @@ func (s *Server) handleEnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnter
 	params, err := decodeEnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterprise",
-			err,
+			Operation: "EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7747,8 +7747,8 @@ func (s *Server) handleEnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseReq
 	params, err := decodeEnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminAddSelfHostedRunnerToGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminAddSelfHostedRunnerToGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7792,8 +7792,8 @@ func (s *Server) handleEnterpriseAdminCreateRegistrationTokenForEnterpriseReques
 	params, err := decodeEnterpriseAdminCreateRegistrationTokenForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminCreateRegistrationTokenForEnterprise",
-			err,
+			Operation: "EnterpriseAdminCreateRegistrationTokenForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7837,8 +7837,8 @@ func (s *Server) handleEnterpriseAdminCreateRemoveTokenForEnterpriseRequest(args
 	params, err := decodeEnterpriseAdminCreateRemoveTokenForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminCreateRemoveTokenForEnterprise",
-			err,
+			Operation: "EnterpriseAdminCreateRemoveTokenForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7882,8 +7882,8 @@ func (s *Server) handleEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRe
 	params, err := decodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7891,8 +7891,8 @@ func (s *Server) handleEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRe
 	request, err := decodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7936,8 +7936,8 @@ func (s *Server) handleEnterpriseAdminDeleteScimGroupFromEnterpriseRequest(args 
 	params, err := decodeEnterpriseAdminDeleteScimGroupFromEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminDeleteScimGroupFromEnterprise",
-			err,
+			Operation: "EnterpriseAdminDeleteScimGroupFromEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7981,8 +7981,8 @@ func (s *Server) handleEnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseReques
 	params, err := decodeEnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminDeleteSelfHostedRunnerFromEnterprise",
-			err,
+			Operation: "EnterpriseAdminDeleteSelfHostedRunnerFromEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8026,8 +8026,8 @@ func (s *Server) handleEnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseR
 	params, err := decodeEnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterprise",
-			err,
+			Operation: "EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8071,8 +8071,8 @@ func (s *Server) handleEnterpriseAdminDeleteUserFromEnterpriseRequest(args [2]st
 	params, err := decodeEnterpriseAdminDeleteUserFromEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminDeleteUserFromEnterprise",
-			err,
+			Operation: "EnterpriseAdminDeleteUserFromEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8116,8 +8116,8 @@ func (s *Server) handleEnterpriseAdminDisableSelectedOrganizationGithubActionsEn
 	params, err := decodeEnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8161,8 +8161,8 @@ func (s *Server) handleEnterpriseAdminEnableSelectedOrganizationGithubActionsEnt
 	params, err := decodeEnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8206,8 +8206,8 @@ func (s *Server) handleEnterpriseAdminGetAllowedActionsEnterpriseRequest(args [1
 	params, err := decodeEnterpriseAdminGetAllowedActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetAllowedActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminGetAllowedActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8251,8 +8251,8 @@ func (s *Server) handleEnterpriseAdminGetAuditLogRequest(args [1]string, w http.
 	params, err := decodeEnterpriseAdminGetAuditLogParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetAuditLog",
-			err,
+			Operation: "EnterpriseAdminGetAuditLog",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8296,8 +8296,8 @@ func (s *Server) handleEnterpriseAdminGetGithubActionsPermissionsEnterpriseReque
 	params, err := decodeEnterpriseAdminGetGithubActionsPermissionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetGithubActionsPermissionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminGetGithubActionsPermissionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8341,8 +8341,8 @@ func (s *Server) handleEnterpriseAdminGetProvisioningInformationForEnterpriseGro
 	params, err := decodeEnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetProvisioningInformationForEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminGetProvisioningInformationForEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8386,8 +8386,8 @@ func (s *Server) handleEnterpriseAdminGetProvisioningInformationForEnterpriseUse
 	params, err := decodeEnterpriseAdminGetProvisioningInformationForEnterpriseUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetProvisioningInformationForEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminGetProvisioningInformationForEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8431,8 +8431,8 @@ func (s *Server) handleEnterpriseAdminGetSelfHostedRunnerForEnterpriseRequest(ar
 	params, err := decodeEnterpriseAdminGetSelfHostedRunnerForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetSelfHostedRunnerForEnterprise",
-			err,
+			Operation: "EnterpriseAdminGetSelfHostedRunnerForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8476,8 +8476,8 @@ func (s *Server) handleEnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseReque
 	params, err := decodeEnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminGetSelfHostedRunnerGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminGetSelfHostedRunnerGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8521,8 +8521,8 @@ func (s *Server) handleEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnte
 	params, err := decodeEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterprise",
-			err,
+			Operation: "EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8566,8 +8566,8 @@ func (s *Server) handleEnterpriseAdminListProvisionedGroupsEnterpriseRequest(arg
 	params, err := decodeEnterpriseAdminListProvisionedGroupsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListProvisionedGroupsEnterprise",
-			err,
+			Operation: "EnterpriseAdminListProvisionedGroupsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8611,8 +8611,8 @@ func (s *Server) handleEnterpriseAdminListProvisionedIdentitiesEnterpriseRequest
 	params, err := decodeEnterpriseAdminListProvisionedIdentitiesEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListProvisionedIdentitiesEnterprise",
-			err,
+			Operation: "EnterpriseAdminListProvisionedIdentitiesEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8656,8 +8656,8 @@ func (s *Server) handleEnterpriseAdminListRunnerApplicationsForEnterpriseRequest
 	params, err := decodeEnterpriseAdminListRunnerApplicationsForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListRunnerApplicationsForEnterprise",
-			err,
+			Operation: "EnterpriseAdminListRunnerApplicationsForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8701,8 +8701,8 @@ func (s *Server) handleEnterpriseAdminListSelectedOrganizationsEnabledGithubActi
 	params, err := decodeEnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8746,8 +8746,8 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseReq
 	params, err := decodeEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListSelfHostedRunnerGroupsForEnterprise",
-			err,
+			Operation: "EnterpriseAdminListSelfHostedRunnerGroupsForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8791,8 +8791,8 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnersForEnterpriseRequest(
 	params, err := decodeEnterpriseAdminListSelfHostedRunnersForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListSelfHostedRunnersForEnterprise",
-			err,
+			Operation: "EnterpriseAdminListSelfHostedRunnersForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8836,8 +8836,8 @@ func (s *Server) handleEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseR
 	params, err := decodeEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminListSelfHostedRunnersInGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminListSelfHostedRunnersInGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8881,8 +8881,8 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseGroupRequest(a
 	params, err := decodeEnterpriseAdminProvisionAndInviteEnterpriseGroupParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminProvisionAndInviteEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminProvisionAndInviteEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8890,8 +8890,8 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseGroupRequest(a
 	request, err := decodeEnterpriseAdminProvisionAndInviteEnterpriseGroupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminProvisionAndInviteEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminProvisionAndInviteEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8935,8 +8935,8 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseUserRequest(ar
 	params, err := decodeEnterpriseAdminProvisionAndInviteEnterpriseUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminProvisionAndInviteEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminProvisionAndInviteEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8944,8 +8944,8 @@ func (s *Server) handleEnterpriseAdminProvisionAndInviteEnterpriseUserRequest(ar
 	request, err := decodeEnterpriseAdminProvisionAndInviteEnterpriseUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminProvisionAndInviteEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminProvisionAndInviteEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8989,8 +8989,8 @@ func (s *Server) handleEnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEn
 	params, err := decodeEnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterprise",
-			err,
+			Operation: "EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9034,8 +9034,8 @@ func (s *Server) handleEnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpri
 	params, err := decodeEnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9079,8 +9079,8 @@ func (s *Server) handleEnterpriseAdminSetAllowedActionsEnterpriseRequest(args [1
 	params, err := decodeEnterpriseAdminSetAllowedActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetAllowedActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetAllowedActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9088,8 +9088,8 @@ func (s *Server) handleEnterpriseAdminSetAllowedActionsEnterpriseRequest(args [1
 	request, err := decodeEnterpriseAdminSetAllowedActionsEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetAllowedActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetAllowedActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9133,8 +9133,8 @@ func (s *Server) handleEnterpriseAdminSetGithubActionsPermissionsEnterpriseReque
 	params, err := decodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetGithubActionsPermissionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetGithubActionsPermissionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9142,8 +9142,8 @@ func (s *Server) handleEnterpriseAdminSetGithubActionsPermissionsEnterpriseReque
 	request, err := decodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetGithubActionsPermissionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetGithubActionsPermissionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9187,8 +9187,8 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseGrou
 	params, err := decodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetInformationForProvisionedEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminSetInformationForProvisionedEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9196,8 +9196,8 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseGrou
 	request, err := decodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetInformationForProvisionedEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminSetInformationForProvisionedEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9241,8 +9241,8 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseUser
 	params, err := decodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetInformationForProvisionedEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminSetInformationForProvisionedEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9250,8 +9250,8 @@ func (s *Server) handleEnterpriseAdminSetInformationForProvisionedEnterpriseUser
 	request, err := decodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetInformationForProvisionedEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminSetInformationForProvisionedEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9295,8 +9295,8 @@ func (s *Server) handleEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnter
 	params, err := decodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9304,8 +9304,8 @@ func (s *Server) handleEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnter
 	request, err := decodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9349,8 +9349,8 @@ func (s *Server) handleEnterpriseAdminSetSelectedOrganizationsEnabledGithubActio
 	params, err := decodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9358,8 +9358,8 @@ func (s *Server) handleEnterpriseAdminSetSelectedOrganizationsEnabledGithubActio
 	request, err := decodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9403,8 +9403,8 @@ func (s *Server) handleEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRe
 	params, err := decodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9412,8 +9412,8 @@ func (s *Server) handleEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRe
 	request, err := decodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9457,8 +9457,8 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseGroupRequest(a
 	params, err := decodeEnterpriseAdminUpdateAttributeForEnterpriseGroupParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminUpdateAttributeForEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminUpdateAttributeForEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9466,8 +9466,8 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseGroupRequest(a
 	request, err := decodeEnterpriseAdminUpdateAttributeForEnterpriseGroupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminUpdateAttributeForEnterpriseGroup",
-			err,
+			Operation: "EnterpriseAdminUpdateAttributeForEnterpriseGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9511,8 +9511,8 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseUserRequest(ar
 	params, err := decodeEnterpriseAdminUpdateAttributeForEnterpriseUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminUpdateAttributeForEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminUpdateAttributeForEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9520,8 +9520,8 @@ func (s *Server) handleEnterpriseAdminUpdateAttributeForEnterpriseUserRequest(ar
 	request, err := decodeEnterpriseAdminUpdateAttributeForEnterpriseUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminUpdateAttributeForEnterpriseUser",
-			err,
+			Operation: "EnterpriseAdminUpdateAttributeForEnterpriseUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9565,8 +9565,8 @@ func (s *Server) handleEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRe
 	params, err := decodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9574,8 +9574,8 @@ func (s *Server) handleEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRe
 	request, err := decodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise",
-			err,
+			Operation: "EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9619,8 +9619,8 @@ func (s *Server) handleGistsCheckIsStarredRequest(args [1]string, w http.Respons
 	params, err := decodeGistsCheckIsStarredParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsCheckIsStarred",
-			err,
+			Operation: "GistsCheckIsStarred",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9664,8 +9664,8 @@ func (s *Server) handleGistsCreateRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeGistsCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GistsCreate",
-			err,
+			Operation: "GistsCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9709,8 +9709,8 @@ func (s *Server) handleGistsCreateCommentRequest(args [1]string, w http.Response
 	params, err := decodeGistsCreateCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsCreateComment",
-			err,
+			Operation: "GistsCreateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9718,8 +9718,8 @@ func (s *Server) handleGistsCreateCommentRequest(args [1]string, w http.Response
 	request, err := decodeGistsCreateCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GistsCreateComment",
-			err,
+			Operation: "GistsCreateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9763,8 +9763,8 @@ func (s *Server) handleGistsDeleteRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeGistsDeleteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsDelete",
-			err,
+			Operation: "GistsDelete",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9808,8 +9808,8 @@ func (s *Server) handleGistsDeleteCommentRequest(args [2]string, w http.Response
 	params, err := decodeGistsDeleteCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsDeleteComment",
-			err,
+			Operation: "GistsDeleteComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9853,8 +9853,8 @@ func (s *Server) handleGistsForkRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeGistsForkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsFork",
-			err,
+			Operation: "GistsFork",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9898,8 +9898,8 @@ func (s *Server) handleGistsGetRequest(args [1]string, w http.ResponseWriter, r 
 	params, err := decodeGistsGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsGet",
-			err,
+			Operation: "GistsGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9943,8 +9943,8 @@ func (s *Server) handleGistsGetCommentRequest(args [2]string, w http.ResponseWri
 	params, err := decodeGistsGetCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsGetComment",
-			err,
+			Operation: "GistsGetComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9988,8 +9988,8 @@ func (s *Server) handleGistsGetRevisionRequest(args [2]string, w http.ResponseWr
 	params, err := decodeGistsGetRevisionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsGetRevision",
-			err,
+			Operation: "GistsGetRevision",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10033,8 +10033,8 @@ func (s *Server) handleGistsListRequest(args [0]string, w http.ResponseWriter, r
 	params, err := decodeGistsListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsList",
-			err,
+			Operation: "GistsList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10078,8 +10078,8 @@ func (s *Server) handleGistsListCommentsRequest(args [1]string, w http.ResponseW
 	params, err := decodeGistsListCommentsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListComments",
-			err,
+			Operation: "GistsListComments",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10123,8 +10123,8 @@ func (s *Server) handleGistsListCommitsRequest(args [1]string, w http.ResponseWr
 	params, err := decodeGistsListCommitsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListCommits",
-			err,
+			Operation: "GistsListCommits",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10168,8 +10168,8 @@ func (s *Server) handleGistsListForUserRequest(args [1]string, w http.ResponseWr
 	params, err := decodeGistsListForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListForUser",
-			err,
+			Operation: "GistsListForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10213,8 +10213,8 @@ func (s *Server) handleGistsListForksRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeGistsListForksParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListForks",
-			err,
+			Operation: "GistsListForks",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10258,8 +10258,8 @@ func (s *Server) handleGistsListPublicRequest(args [0]string, w http.ResponseWri
 	params, err := decodeGistsListPublicParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListPublic",
-			err,
+			Operation: "GistsListPublic",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10303,8 +10303,8 @@ func (s *Server) handleGistsListStarredRequest(args [0]string, w http.ResponseWr
 	params, err := decodeGistsListStarredParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsListStarred",
-			err,
+			Operation: "GistsListStarred",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10348,8 +10348,8 @@ func (s *Server) handleGistsStarRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeGistsStarParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsStar",
-			err,
+			Operation: "GistsStar",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10393,8 +10393,8 @@ func (s *Server) handleGistsUnstarRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeGistsUnstarParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsUnstar",
-			err,
+			Operation: "GistsUnstar",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10438,8 +10438,8 @@ func (s *Server) handleGistsUpdateCommentRequest(args [2]string, w http.Response
 	params, err := decodeGistsUpdateCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GistsUpdateComment",
-			err,
+			Operation: "GistsUpdateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10447,8 +10447,8 @@ func (s *Server) handleGistsUpdateCommentRequest(args [2]string, w http.Response
 	request, err := decodeGistsUpdateCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GistsUpdateComment",
-			err,
+			Operation: "GistsUpdateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10492,8 +10492,8 @@ func (s *Server) handleGitCreateBlobRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeGitCreateBlobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitCreateBlob",
-			err,
+			Operation: "GitCreateBlob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10501,8 +10501,8 @@ func (s *Server) handleGitCreateBlobRequest(args [2]string, w http.ResponseWrite
 	request, err := decodeGitCreateBlobRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitCreateBlob",
-			err,
+			Operation: "GitCreateBlob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10546,8 +10546,8 @@ func (s *Server) handleGitCreateCommitRequest(args [2]string, w http.ResponseWri
 	params, err := decodeGitCreateCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitCreateCommit",
-			err,
+			Operation: "GitCreateCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10555,8 +10555,8 @@ func (s *Server) handleGitCreateCommitRequest(args [2]string, w http.ResponseWri
 	request, err := decodeGitCreateCommitRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitCreateCommit",
-			err,
+			Operation: "GitCreateCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10600,8 +10600,8 @@ func (s *Server) handleGitCreateRefRequest(args [2]string, w http.ResponseWriter
 	params, err := decodeGitCreateRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitCreateRef",
-			err,
+			Operation: "GitCreateRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10609,8 +10609,8 @@ func (s *Server) handleGitCreateRefRequest(args [2]string, w http.ResponseWriter
 	request, err := decodeGitCreateRefRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitCreateRef",
-			err,
+			Operation: "GitCreateRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10654,8 +10654,8 @@ func (s *Server) handleGitCreateTagRequest(args [2]string, w http.ResponseWriter
 	params, err := decodeGitCreateTagParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitCreateTag",
-			err,
+			Operation: "GitCreateTag",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10663,8 +10663,8 @@ func (s *Server) handleGitCreateTagRequest(args [2]string, w http.ResponseWriter
 	request, err := decodeGitCreateTagRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitCreateTag",
-			err,
+			Operation: "GitCreateTag",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10708,8 +10708,8 @@ func (s *Server) handleGitCreateTreeRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeGitCreateTreeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitCreateTree",
-			err,
+			Operation: "GitCreateTree",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10717,8 +10717,8 @@ func (s *Server) handleGitCreateTreeRequest(args [2]string, w http.ResponseWrite
 	request, err := decodeGitCreateTreeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitCreateTree",
-			err,
+			Operation: "GitCreateTree",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10762,8 +10762,8 @@ func (s *Server) handleGitDeleteRefRequest(args [3]string, w http.ResponseWriter
 	params, err := decodeGitDeleteRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitDeleteRef",
-			err,
+			Operation: "GitDeleteRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10807,8 +10807,8 @@ func (s *Server) handleGitGetBlobRequest(args [3]string, w http.ResponseWriter, 
 	params, err := decodeGitGetBlobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitGetBlob",
-			err,
+			Operation: "GitGetBlob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10852,8 +10852,8 @@ func (s *Server) handleGitGetCommitRequest(args [3]string, w http.ResponseWriter
 	params, err := decodeGitGetCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitGetCommit",
-			err,
+			Operation: "GitGetCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10897,8 +10897,8 @@ func (s *Server) handleGitGetRefRequest(args [3]string, w http.ResponseWriter, r
 	params, err := decodeGitGetRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitGetRef",
-			err,
+			Operation: "GitGetRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10942,8 +10942,8 @@ func (s *Server) handleGitGetTagRequest(args [3]string, w http.ResponseWriter, r
 	params, err := decodeGitGetTagParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitGetTag",
-			err,
+			Operation: "GitGetTag",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10987,8 +10987,8 @@ func (s *Server) handleGitGetTreeRequest(args [3]string, w http.ResponseWriter, 
 	params, err := decodeGitGetTreeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitGetTree",
-			err,
+			Operation: "GitGetTree",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11032,8 +11032,8 @@ func (s *Server) handleGitListMatchingRefsRequest(args [3]string, w http.Respons
 	params, err := decodeGitListMatchingRefsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitListMatchingRefs",
-			err,
+			Operation: "GitListMatchingRefs",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11077,8 +11077,8 @@ func (s *Server) handleGitUpdateRefRequest(args [3]string, w http.ResponseWriter
 	params, err := decodeGitUpdateRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitUpdateRef",
-			err,
+			Operation: "GitUpdateRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11086,8 +11086,8 @@ func (s *Server) handleGitUpdateRefRequest(args [3]string, w http.ResponseWriter
 	request, err := decodeGitUpdateRefRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GitUpdateRef",
-			err,
+			Operation: "GitUpdateRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11167,8 +11167,8 @@ func (s *Server) handleGitignoreGetTemplateRequest(args [1]string, w http.Respon
 	params, err := decodeGitignoreGetTemplateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GitignoreGetTemplate",
-			err,
+			Operation: "GitignoreGetTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11248,8 +11248,8 @@ func (s *Server) handleInteractionsRemoveRestrictionsForOrgRequest(args [1]strin
 	params, err := decodeInteractionsRemoveRestrictionsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"InteractionsRemoveRestrictionsForOrg",
-			err,
+			Operation: "InteractionsRemoveRestrictionsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11293,8 +11293,8 @@ func (s *Server) handleInteractionsRemoveRestrictionsForRepoRequest(args [2]stri
 	params, err := decodeInteractionsRemoveRestrictionsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"InteractionsRemoveRestrictionsForRepo",
-			err,
+			Operation: "InteractionsRemoveRestrictionsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11338,8 +11338,8 @@ func (s *Server) handleInteractionsSetRestrictionsForAuthenticatedUserRequest(ar
 	request, err := decodeInteractionsSetRestrictionsForAuthenticatedUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"InteractionsSetRestrictionsForAuthenticatedUser",
-			err,
+			Operation: "InteractionsSetRestrictionsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11383,8 +11383,8 @@ func (s *Server) handleInteractionsSetRestrictionsForOrgRequest(args [1]string, 
 	params, err := decodeInteractionsSetRestrictionsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"InteractionsSetRestrictionsForOrg",
-			err,
+			Operation: "InteractionsSetRestrictionsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11392,8 +11392,8 @@ func (s *Server) handleInteractionsSetRestrictionsForOrgRequest(args [1]string, 
 	request, err := decodeInteractionsSetRestrictionsForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"InteractionsSetRestrictionsForOrg",
-			err,
+			Operation: "InteractionsSetRestrictionsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11437,8 +11437,8 @@ func (s *Server) handleInteractionsSetRestrictionsForRepoRequest(args [2]string,
 	params, err := decodeInteractionsSetRestrictionsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"InteractionsSetRestrictionsForRepo",
-			err,
+			Operation: "InteractionsSetRestrictionsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11446,8 +11446,8 @@ func (s *Server) handleInteractionsSetRestrictionsForRepoRequest(args [2]string,
 	request, err := decodeInteractionsSetRestrictionsForRepoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"InteractionsSetRestrictionsForRepo",
-			err,
+			Operation: "InteractionsSetRestrictionsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11491,8 +11491,8 @@ func (s *Server) handleIssuesAddAssigneesRequest(args [3]string, w http.Response
 	params, err := decodeIssuesAddAssigneesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesAddAssignees",
-			err,
+			Operation: "IssuesAddAssignees",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11500,8 +11500,8 @@ func (s *Server) handleIssuesAddAssigneesRequest(args [3]string, w http.Response
 	request, err := decodeIssuesAddAssigneesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesAddAssignees",
-			err,
+			Operation: "IssuesAddAssignees",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11545,8 +11545,8 @@ func (s *Server) handleIssuesCheckUserCanBeAssignedRequest(args [3]string, w htt
 	params, err := decodeIssuesCheckUserCanBeAssignedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesCheckUserCanBeAssigned",
-			err,
+			Operation: "IssuesCheckUserCanBeAssigned",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11590,8 +11590,8 @@ func (s *Server) handleIssuesCreateRequest(args [2]string, w http.ResponseWriter
 	params, err := decodeIssuesCreateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesCreate",
-			err,
+			Operation: "IssuesCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11599,8 +11599,8 @@ func (s *Server) handleIssuesCreateRequest(args [2]string, w http.ResponseWriter
 	request, err := decodeIssuesCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesCreate",
-			err,
+			Operation: "IssuesCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11644,8 +11644,8 @@ func (s *Server) handleIssuesCreateCommentRequest(args [3]string, w http.Respons
 	params, err := decodeIssuesCreateCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesCreateComment",
-			err,
+			Operation: "IssuesCreateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11653,8 +11653,8 @@ func (s *Server) handleIssuesCreateCommentRequest(args [3]string, w http.Respons
 	request, err := decodeIssuesCreateCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesCreateComment",
-			err,
+			Operation: "IssuesCreateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11698,8 +11698,8 @@ func (s *Server) handleIssuesCreateLabelRequest(args [2]string, w http.ResponseW
 	params, err := decodeIssuesCreateLabelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesCreateLabel",
-			err,
+			Operation: "IssuesCreateLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11707,8 +11707,8 @@ func (s *Server) handleIssuesCreateLabelRequest(args [2]string, w http.ResponseW
 	request, err := decodeIssuesCreateLabelRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesCreateLabel",
-			err,
+			Operation: "IssuesCreateLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11752,8 +11752,8 @@ func (s *Server) handleIssuesCreateMilestoneRequest(args [2]string, w http.Respo
 	params, err := decodeIssuesCreateMilestoneParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesCreateMilestone",
-			err,
+			Operation: "IssuesCreateMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11761,8 +11761,8 @@ func (s *Server) handleIssuesCreateMilestoneRequest(args [2]string, w http.Respo
 	request, err := decodeIssuesCreateMilestoneRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesCreateMilestone",
-			err,
+			Operation: "IssuesCreateMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11806,8 +11806,8 @@ func (s *Server) handleIssuesDeleteCommentRequest(args [3]string, w http.Respons
 	params, err := decodeIssuesDeleteCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesDeleteComment",
-			err,
+			Operation: "IssuesDeleteComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11851,8 +11851,8 @@ func (s *Server) handleIssuesDeleteLabelRequest(args [3]string, w http.ResponseW
 	params, err := decodeIssuesDeleteLabelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesDeleteLabel",
-			err,
+			Operation: "IssuesDeleteLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11896,8 +11896,8 @@ func (s *Server) handleIssuesDeleteMilestoneRequest(args [3]string, w http.Respo
 	params, err := decodeIssuesDeleteMilestoneParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesDeleteMilestone",
-			err,
+			Operation: "IssuesDeleteMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11941,8 +11941,8 @@ func (s *Server) handleIssuesGetRequest(args [3]string, w http.ResponseWriter, r
 	params, err := decodeIssuesGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesGet",
-			err,
+			Operation: "IssuesGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11986,8 +11986,8 @@ func (s *Server) handleIssuesGetCommentRequest(args [3]string, w http.ResponseWr
 	params, err := decodeIssuesGetCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesGetComment",
-			err,
+			Operation: "IssuesGetComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12031,8 +12031,8 @@ func (s *Server) handleIssuesGetEventRequest(args [3]string, w http.ResponseWrit
 	params, err := decodeIssuesGetEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesGetEvent",
-			err,
+			Operation: "IssuesGetEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12076,8 +12076,8 @@ func (s *Server) handleIssuesGetLabelRequest(args [3]string, w http.ResponseWrit
 	params, err := decodeIssuesGetLabelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesGetLabel",
-			err,
+			Operation: "IssuesGetLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12121,8 +12121,8 @@ func (s *Server) handleIssuesGetMilestoneRequest(args [3]string, w http.Response
 	params, err := decodeIssuesGetMilestoneParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesGetMilestone",
-			err,
+			Operation: "IssuesGetMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12166,8 +12166,8 @@ func (s *Server) handleIssuesListRequest(args [0]string, w http.ResponseWriter, 
 	params, err := decodeIssuesListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesList",
-			err,
+			Operation: "IssuesList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12211,8 +12211,8 @@ func (s *Server) handleIssuesListAssigneesRequest(args [2]string, w http.Respons
 	params, err := decodeIssuesListAssigneesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListAssignees",
-			err,
+			Operation: "IssuesListAssignees",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12256,8 +12256,8 @@ func (s *Server) handleIssuesListCommentsRequest(args [3]string, w http.Response
 	params, err := decodeIssuesListCommentsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListComments",
-			err,
+			Operation: "IssuesListComments",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12301,8 +12301,8 @@ func (s *Server) handleIssuesListCommentsForRepoRequest(args [2]string, w http.R
 	params, err := decodeIssuesListCommentsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListCommentsForRepo",
-			err,
+			Operation: "IssuesListCommentsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12346,8 +12346,8 @@ func (s *Server) handleIssuesListEventsForRepoRequest(args [2]string, w http.Res
 	params, err := decodeIssuesListEventsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListEventsForRepo",
-			err,
+			Operation: "IssuesListEventsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12391,8 +12391,8 @@ func (s *Server) handleIssuesListForAuthenticatedUserRequest(args [0]string, w h
 	params, err := decodeIssuesListForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListForAuthenticatedUser",
-			err,
+			Operation: "IssuesListForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12436,8 +12436,8 @@ func (s *Server) handleIssuesListForOrgRequest(args [1]string, w http.ResponseWr
 	params, err := decodeIssuesListForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListForOrg",
-			err,
+			Operation: "IssuesListForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12481,8 +12481,8 @@ func (s *Server) handleIssuesListForRepoRequest(args [2]string, w http.ResponseW
 	params, err := decodeIssuesListForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListForRepo",
-			err,
+			Operation: "IssuesListForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12526,8 +12526,8 @@ func (s *Server) handleIssuesListLabelsForMilestoneRequest(args [3]string, w htt
 	params, err := decodeIssuesListLabelsForMilestoneParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListLabelsForMilestone",
-			err,
+			Operation: "IssuesListLabelsForMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12571,8 +12571,8 @@ func (s *Server) handleIssuesListLabelsForRepoRequest(args [2]string, w http.Res
 	params, err := decodeIssuesListLabelsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListLabelsForRepo",
-			err,
+			Operation: "IssuesListLabelsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12616,8 +12616,8 @@ func (s *Server) handleIssuesListLabelsOnIssueRequest(args [3]string, w http.Res
 	params, err := decodeIssuesListLabelsOnIssueParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListLabelsOnIssue",
-			err,
+			Operation: "IssuesListLabelsOnIssue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12661,8 +12661,8 @@ func (s *Server) handleIssuesListMilestonesRequest(args [2]string, w http.Respon
 	params, err := decodeIssuesListMilestonesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesListMilestones",
-			err,
+			Operation: "IssuesListMilestones",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12706,8 +12706,8 @@ func (s *Server) handleIssuesLockRequest(args [3]string, w http.ResponseWriter, 
 	params, err := decodeIssuesLockParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesLock",
-			err,
+			Operation: "IssuesLock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12715,8 +12715,8 @@ func (s *Server) handleIssuesLockRequest(args [3]string, w http.ResponseWriter, 
 	request, err := decodeIssuesLockRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesLock",
-			err,
+			Operation: "IssuesLock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12760,8 +12760,8 @@ func (s *Server) handleIssuesRemoveAllLabelsRequest(args [3]string, w http.Respo
 	params, err := decodeIssuesRemoveAllLabelsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesRemoveAllLabels",
-			err,
+			Operation: "IssuesRemoveAllLabels",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12805,8 +12805,8 @@ func (s *Server) handleIssuesRemoveAssigneesRequest(args [3]string, w http.Respo
 	params, err := decodeIssuesRemoveAssigneesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesRemoveAssignees",
-			err,
+			Operation: "IssuesRemoveAssignees",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12814,8 +12814,8 @@ func (s *Server) handleIssuesRemoveAssigneesRequest(args [3]string, w http.Respo
 	request, err := decodeIssuesRemoveAssigneesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesRemoveAssignees",
-			err,
+			Operation: "IssuesRemoveAssignees",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12859,8 +12859,8 @@ func (s *Server) handleIssuesRemoveLabelRequest(args [4]string, w http.ResponseW
 	params, err := decodeIssuesRemoveLabelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesRemoveLabel",
-			err,
+			Operation: "IssuesRemoveLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12904,8 +12904,8 @@ func (s *Server) handleIssuesUnlockRequest(args [3]string, w http.ResponseWriter
 	params, err := decodeIssuesUnlockParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesUnlock",
-			err,
+			Operation: "IssuesUnlock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12949,8 +12949,8 @@ func (s *Server) handleIssuesUpdateRequest(args [3]string, w http.ResponseWriter
 	params, err := decodeIssuesUpdateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesUpdate",
-			err,
+			Operation: "IssuesUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12958,8 +12958,8 @@ func (s *Server) handleIssuesUpdateRequest(args [3]string, w http.ResponseWriter
 	request, err := decodeIssuesUpdateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesUpdate",
-			err,
+			Operation: "IssuesUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13003,8 +13003,8 @@ func (s *Server) handleIssuesUpdateCommentRequest(args [3]string, w http.Respons
 	params, err := decodeIssuesUpdateCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesUpdateComment",
-			err,
+			Operation: "IssuesUpdateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13012,8 +13012,8 @@ func (s *Server) handleIssuesUpdateCommentRequest(args [3]string, w http.Respons
 	request, err := decodeIssuesUpdateCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesUpdateComment",
-			err,
+			Operation: "IssuesUpdateComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13057,8 +13057,8 @@ func (s *Server) handleIssuesUpdateLabelRequest(args [3]string, w http.ResponseW
 	params, err := decodeIssuesUpdateLabelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesUpdateLabel",
-			err,
+			Operation: "IssuesUpdateLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13066,8 +13066,8 @@ func (s *Server) handleIssuesUpdateLabelRequest(args [3]string, w http.ResponseW
 	request, err := decodeIssuesUpdateLabelRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesUpdateLabel",
-			err,
+			Operation: "IssuesUpdateLabel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13111,8 +13111,8 @@ func (s *Server) handleIssuesUpdateMilestoneRequest(args [3]string, w http.Respo
 	params, err := decodeIssuesUpdateMilestoneParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"IssuesUpdateMilestone",
-			err,
+			Operation: "IssuesUpdateMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13120,8 +13120,8 @@ func (s *Server) handleIssuesUpdateMilestoneRequest(args [3]string, w http.Respo
 	request, err := decodeIssuesUpdateMilestoneRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"IssuesUpdateMilestone",
-			err,
+			Operation: "IssuesUpdateMilestone",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13165,8 +13165,8 @@ func (s *Server) handleLicensesGetRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeLicensesGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"LicensesGet",
-			err,
+			Operation: "LicensesGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13210,8 +13210,8 @@ func (s *Server) handleLicensesGetAllCommonlyUsedRequest(args [0]string, w http.
 	params, err := decodeLicensesGetAllCommonlyUsedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"LicensesGetAllCommonlyUsed",
-			err,
+			Operation: "LicensesGetAllCommonlyUsed",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13255,8 +13255,8 @@ func (s *Server) handleLicensesGetForRepoRequest(args [2]string, w http.Response
 	params, err := decodeLicensesGetForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"LicensesGetForRepo",
-			err,
+			Operation: "LicensesGetForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13372,8 +13372,8 @@ func (s *Server) handleMigrationsCancelImportRequest(args [2]string, w http.Resp
 	params, err := decodeMigrationsCancelImportParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsCancelImport",
-			err,
+			Operation: "MigrationsCancelImport",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13417,8 +13417,8 @@ func (s *Server) handleMigrationsDeleteArchiveForAuthenticatedUserRequest(args [
 	params, err := decodeMigrationsDeleteArchiveForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsDeleteArchiveForAuthenticatedUser",
-			err,
+			Operation: "MigrationsDeleteArchiveForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13462,8 +13462,8 @@ func (s *Server) handleMigrationsDeleteArchiveForOrgRequest(args [2]string, w ht
 	params, err := decodeMigrationsDeleteArchiveForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsDeleteArchiveForOrg",
-			err,
+			Operation: "MigrationsDeleteArchiveForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13507,8 +13507,8 @@ func (s *Server) handleMigrationsDownloadArchiveForOrgRequest(args [2]string, w 
 	params, err := decodeMigrationsDownloadArchiveForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsDownloadArchiveForOrg",
-			err,
+			Operation: "MigrationsDownloadArchiveForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13552,8 +13552,8 @@ func (s *Server) handleMigrationsGetArchiveForAuthenticatedUserRequest(args [1]s
 	params, err := decodeMigrationsGetArchiveForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetArchiveForAuthenticatedUser",
-			err,
+			Operation: "MigrationsGetArchiveForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13597,8 +13597,8 @@ func (s *Server) handleMigrationsGetCommitAuthorsRequest(args [2]string, w http.
 	params, err := decodeMigrationsGetCommitAuthorsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetCommitAuthors",
-			err,
+			Operation: "MigrationsGetCommitAuthors",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13642,8 +13642,8 @@ func (s *Server) handleMigrationsGetImportStatusRequest(args [2]string, w http.R
 	params, err := decodeMigrationsGetImportStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetImportStatus",
-			err,
+			Operation: "MigrationsGetImportStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13687,8 +13687,8 @@ func (s *Server) handleMigrationsGetLargeFilesRequest(args [2]string, w http.Res
 	params, err := decodeMigrationsGetLargeFilesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetLargeFiles",
-			err,
+			Operation: "MigrationsGetLargeFiles",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13732,8 +13732,8 @@ func (s *Server) handleMigrationsGetStatusForAuthenticatedUserRequest(args [1]st
 	params, err := decodeMigrationsGetStatusForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetStatusForAuthenticatedUser",
-			err,
+			Operation: "MigrationsGetStatusForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13777,8 +13777,8 @@ func (s *Server) handleMigrationsGetStatusForOrgRequest(args [2]string, w http.R
 	params, err := decodeMigrationsGetStatusForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsGetStatusForOrg",
-			err,
+			Operation: "MigrationsGetStatusForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13822,8 +13822,8 @@ func (s *Server) handleMigrationsListForAuthenticatedUserRequest(args [0]string,
 	params, err := decodeMigrationsListForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsListForAuthenticatedUser",
-			err,
+			Operation: "MigrationsListForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13867,8 +13867,8 @@ func (s *Server) handleMigrationsListForOrgRequest(args [1]string, w http.Respon
 	params, err := decodeMigrationsListForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsListForOrg",
-			err,
+			Operation: "MigrationsListForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13912,8 +13912,8 @@ func (s *Server) handleMigrationsListReposForOrgRequest(args [2]string, w http.R
 	params, err := decodeMigrationsListReposForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsListReposForOrg",
-			err,
+			Operation: "MigrationsListReposForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13957,8 +13957,8 @@ func (s *Server) handleMigrationsListReposForUserRequest(args [1]string, w http.
 	params, err := decodeMigrationsListReposForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsListReposForUser",
-			err,
+			Operation: "MigrationsListReposForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14002,8 +14002,8 @@ func (s *Server) handleMigrationsMapCommitAuthorRequest(args [3]string, w http.R
 	params, err := decodeMigrationsMapCommitAuthorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsMapCommitAuthor",
-			err,
+			Operation: "MigrationsMapCommitAuthor",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14011,8 +14011,8 @@ func (s *Server) handleMigrationsMapCommitAuthorRequest(args [3]string, w http.R
 	request, err := decodeMigrationsMapCommitAuthorRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsMapCommitAuthor",
-			err,
+			Operation: "MigrationsMapCommitAuthor",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14056,8 +14056,8 @@ func (s *Server) handleMigrationsSetLfsPreferenceRequest(args [2]string, w http.
 	params, err := decodeMigrationsSetLfsPreferenceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsSetLfsPreference",
-			err,
+			Operation: "MigrationsSetLfsPreference",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14065,8 +14065,8 @@ func (s *Server) handleMigrationsSetLfsPreferenceRequest(args [2]string, w http.
 	request, err := decodeMigrationsSetLfsPreferenceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsSetLfsPreference",
-			err,
+			Operation: "MigrationsSetLfsPreference",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14110,8 +14110,8 @@ func (s *Server) handleMigrationsStartForAuthenticatedUserRequest(args [0]string
 	request, err := decodeMigrationsStartForAuthenticatedUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsStartForAuthenticatedUser",
-			err,
+			Operation: "MigrationsStartForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14155,8 +14155,8 @@ func (s *Server) handleMigrationsStartForOrgRequest(args [1]string, w http.Respo
 	params, err := decodeMigrationsStartForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsStartForOrg",
-			err,
+			Operation: "MigrationsStartForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14164,8 +14164,8 @@ func (s *Server) handleMigrationsStartForOrgRequest(args [1]string, w http.Respo
 	request, err := decodeMigrationsStartForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsStartForOrg",
-			err,
+			Operation: "MigrationsStartForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14209,8 +14209,8 @@ func (s *Server) handleMigrationsStartImportRequest(args [2]string, w http.Respo
 	params, err := decodeMigrationsStartImportParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsStartImport",
-			err,
+			Operation: "MigrationsStartImport",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14218,8 +14218,8 @@ func (s *Server) handleMigrationsStartImportRequest(args [2]string, w http.Respo
 	request, err := decodeMigrationsStartImportRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsStartImport",
-			err,
+			Operation: "MigrationsStartImport",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14263,8 +14263,8 @@ func (s *Server) handleMigrationsUnlockRepoForAuthenticatedUserRequest(args [2]s
 	params, err := decodeMigrationsUnlockRepoForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsUnlockRepoForAuthenticatedUser",
-			err,
+			Operation: "MigrationsUnlockRepoForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14308,8 +14308,8 @@ func (s *Server) handleMigrationsUnlockRepoForOrgRequest(args [3]string, w http.
 	params, err := decodeMigrationsUnlockRepoForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsUnlockRepoForOrg",
-			err,
+			Operation: "MigrationsUnlockRepoForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14353,8 +14353,8 @@ func (s *Server) handleMigrationsUpdateImportRequest(args [2]string, w http.Resp
 	params, err := decodeMigrationsUpdateImportParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MigrationsUpdateImport",
-			err,
+			Operation: "MigrationsUpdateImport",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14362,8 +14362,8 @@ func (s *Server) handleMigrationsUpdateImportRequest(args [2]string, w http.Resp
 	request, err := decodeMigrationsUpdateImportRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"MigrationsUpdateImport",
-			err,
+			Operation: "MigrationsUpdateImport",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14407,8 +14407,8 @@ func (s *Server) handleOAuthAuthorizationsCreateAuthorizationRequest(args [0]str
 	request, err := decodeOAuthAuthorizationsCreateAuthorizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OAuthAuthorizationsCreateAuthorization",
-			err,
+			Operation: "OAuthAuthorizationsCreateAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14452,8 +14452,8 @@ func (s *Server) handleOAuthAuthorizationsDeleteAuthorizationRequest(args [1]str
 	params, err := decodeOAuthAuthorizationsDeleteAuthorizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsDeleteAuthorization",
-			err,
+			Operation: "OAuthAuthorizationsDeleteAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14497,8 +14497,8 @@ func (s *Server) handleOAuthAuthorizationsDeleteGrantRequest(args [1]string, w h
 	params, err := decodeOAuthAuthorizationsDeleteGrantParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsDeleteGrant",
-			err,
+			Operation: "OAuthAuthorizationsDeleteGrant",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14542,8 +14542,8 @@ func (s *Server) handleOAuthAuthorizationsGetAuthorizationRequest(args [1]string
 	params, err := decodeOAuthAuthorizationsGetAuthorizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsGetAuthorization",
-			err,
+			Operation: "OAuthAuthorizationsGetAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14587,8 +14587,8 @@ func (s *Server) handleOAuthAuthorizationsGetGrantRequest(args [1]string, w http
 	params, err := decodeOAuthAuthorizationsGetGrantParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsGetGrant",
-			err,
+			Operation: "OAuthAuthorizationsGetGrant",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14632,8 +14632,8 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppRequest(
 	params, err := decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsGetOrCreateAuthorizationForApp",
-			err,
+			Operation: "OAuthAuthorizationsGetOrCreateAuthorizationForApp",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14641,8 +14641,8 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppRequest(
 	request, err := decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OAuthAuthorizationsGetOrCreateAuthorizationForApp",
-			err,
+			Operation: "OAuthAuthorizationsGetOrCreateAuthorizationForApp",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14686,8 +14686,8 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFinge
 	params, err := decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint",
-			err,
+			Operation: "OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14695,8 +14695,8 @@ func (s *Server) handleOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFinge
 	request, err := decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint",
-			err,
+			Operation: "OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14740,8 +14740,8 @@ func (s *Server) handleOAuthAuthorizationsListAuthorizationsRequest(args [0]stri
 	params, err := decodeOAuthAuthorizationsListAuthorizationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsListAuthorizations",
-			err,
+			Operation: "OAuthAuthorizationsListAuthorizations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14785,8 +14785,8 @@ func (s *Server) handleOAuthAuthorizationsListGrantsRequest(args [0]string, w ht
 	params, err := decodeOAuthAuthorizationsListGrantsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsListGrants",
-			err,
+			Operation: "OAuthAuthorizationsListGrants",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14830,8 +14830,8 @@ func (s *Server) handleOAuthAuthorizationsUpdateAuthorizationRequest(args [1]str
 	params, err := decodeOAuthAuthorizationsUpdateAuthorizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OAuthAuthorizationsUpdateAuthorization",
-			err,
+			Operation: "OAuthAuthorizationsUpdateAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14839,8 +14839,8 @@ func (s *Server) handleOAuthAuthorizationsUpdateAuthorizationRequest(args [1]str
 	request, err := decodeOAuthAuthorizationsUpdateAuthorizationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OAuthAuthorizationsUpdateAuthorization",
-			err,
+			Operation: "OAuthAuthorizationsUpdateAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14884,8 +14884,8 @@ func (s *Server) handleOrgsBlockUserRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeOrgsBlockUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsBlockUser",
-			err,
+			Operation: "OrgsBlockUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14929,8 +14929,8 @@ func (s *Server) handleOrgsCancelInvitationRequest(args [2]string, w http.Respon
 	params, err := decodeOrgsCancelInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCancelInvitation",
-			err,
+			Operation: "OrgsCancelInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14974,8 +14974,8 @@ func (s *Server) handleOrgsCheckBlockedUserRequest(args [2]string, w http.Respon
 	params, err := decodeOrgsCheckBlockedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCheckBlockedUser",
-			err,
+			Operation: "OrgsCheckBlockedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15019,8 +15019,8 @@ func (s *Server) handleOrgsCheckMembershipForUserRequest(args [2]string, w http.
 	params, err := decodeOrgsCheckMembershipForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCheckMembershipForUser",
-			err,
+			Operation: "OrgsCheckMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15064,8 +15064,8 @@ func (s *Server) handleOrgsCheckPublicMembershipForUserRequest(args [2]string, w
 	params, err := decodeOrgsCheckPublicMembershipForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCheckPublicMembershipForUser",
-			err,
+			Operation: "OrgsCheckPublicMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15109,8 +15109,8 @@ func (s *Server) handleOrgsConvertMemberToOutsideCollaboratorRequest(args [2]str
 	params, err := decodeOrgsConvertMemberToOutsideCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsConvertMemberToOutsideCollaborator",
-			err,
+			Operation: "OrgsConvertMemberToOutsideCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15154,8 +15154,8 @@ func (s *Server) handleOrgsCreateInvitationRequest(args [1]string, w http.Respon
 	params, err := decodeOrgsCreateInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCreateInvitation",
-			err,
+			Operation: "OrgsCreateInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15163,8 +15163,8 @@ func (s *Server) handleOrgsCreateInvitationRequest(args [1]string, w http.Respon
 	request, err := decodeOrgsCreateInvitationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsCreateInvitation",
-			err,
+			Operation: "OrgsCreateInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15208,8 +15208,8 @@ func (s *Server) handleOrgsCreateWebhookRequest(args [1]string, w http.ResponseW
 	params, err := decodeOrgsCreateWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsCreateWebhook",
-			err,
+			Operation: "OrgsCreateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15217,8 +15217,8 @@ func (s *Server) handleOrgsCreateWebhookRequest(args [1]string, w http.ResponseW
 	request, err := decodeOrgsCreateWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsCreateWebhook",
-			err,
+			Operation: "OrgsCreateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15262,8 +15262,8 @@ func (s *Server) handleOrgsDeleteWebhookRequest(args [2]string, w http.ResponseW
 	params, err := decodeOrgsDeleteWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsDeleteWebhook",
-			err,
+			Operation: "OrgsDeleteWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15307,8 +15307,8 @@ func (s *Server) handleOrgsGetRequest(args [1]string, w http.ResponseWriter, r *
 	params, err := decodeOrgsGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGet",
-			err,
+			Operation: "OrgsGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15352,8 +15352,8 @@ func (s *Server) handleOrgsGetAuditLogRequest(args [1]string, w http.ResponseWri
 	params, err := decodeOrgsGetAuditLogParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetAuditLog",
-			err,
+			Operation: "OrgsGetAuditLog",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15397,8 +15397,8 @@ func (s *Server) handleOrgsGetMembershipForAuthenticatedUserRequest(args [1]stri
 	params, err := decodeOrgsGetMembershipForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetMembershipForAuthenticatedUser",
-			err,
+			Operation: "OrgsGetMembershipForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15442,8 +15442,8 @@ func (s *Server) handleOrgsGetMembershipForUserRequest(args [2]string, w http.Re
 	params, err := decodeOrgsGetMembershipForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetMembershipForUser",
-			err,
+			Operation: "OrgsGetMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15487,8 +15487,8 @@ func (s *Server) handleOrgsGetWebhookRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeOrgsGetWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetWebhook",
-			err,
+			Operation: "OrgsGetWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15532,8 +15532,8 @@ func (s *Server) handleOrgsGetWebhookConfigForOrgRequest(args [2]string, w http.
 	params, err := decodeOrgsGetWebhookConfigForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetWebhookConfigForOrg",
-			err,
+			Operation: "OrgsGetWebhookConfigForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15577,8 +15577,8 @@ func (s *Server) handleOrgsGetWebhookDeliveryRequest(args [3]string, w http.Resp
 	params, err := decodeOrgsGetWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsGetWebhookDelivery",
-			err,
+			Operation: "OrgsGetWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15622,8 +15622,8 @@ func (s *Server) handleOrgsListRequest(args [0]string, w http.ResponseWriter, r 
 	params, err := decodeOrgsListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsList",
-			err,
+			Operation: "OrgsList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15667,8 +15667,8 @@ func (s *Server) handleOrgsListBlockedUsersRequest(args [1]string, w http.Respon
 	params, err := decodeOrgsListBlockedUsersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListBlockedUsers",
-			err,
+			Operation: "OrgsListBlockedUsers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15712,8 +15712,8 @@ func (s *Server) handleOrgsListFailedInvitationsRequest(args [1]string, w http.R
 	params, err := decodeOrgsListFailedInvitationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListFailedInvitations",
-			err,
+			Operation: "OrgsListFailedInvitations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15757,8 +15757,8 @@ func (s *Server) handleOrgsListForAuthenticatedUserRequest(args [0]string, w htt
 	params, err := decodeOrgsListForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListForAuthenticatedUser",
-			err,
+			Operation: "OrgsListForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15802,8 +15802,8 @@ func (s *Server) handleOrgsListForUserRequest(args [1]string, w http.ResponseWri
 	params, err := decodeOrgsListForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListForUser",
-			err,
+			Operation: "OrgsListForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15847,8 +15847,8 @@ func (s *Server) handleOrgsListInvitationTeamsRequest(args [2]string, w http.Res
 	params, err := decodeOrgsListInvitationTeamsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListInvitationTeams",
-			err,
+			Operation: "OrgsListInvitationTeams",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15892,8 +15892,8 @@ func (s *Server) handleOrgsListMembersRequest(args [1]string, w http.ResponseWri
 	params, err := decodeOrgsListMembersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListMembers",
-			err,
+			Operation: "OrgsListMembers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15937,8 +15937,8 @@ func (s *Server) handleOrgsListMembershipsForAuthenticatedUserRequest(args [0]st
 	params, err := decodeOrgsListMembershipsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListMembershipsForAuthenticatedUser",
-			err,
+			Operation: "OrgsListMembershipsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15982,8 +15982,8 @@ func (s *Server) handleOrgsListOutsideCollaboratorsRequest(args [1]string, w htt
 	params, err := decodeOrgsListOutsideCollaboratorsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListOutsideCollaborators",
-			err,
+			Operation: "OrgsListOutsideCollaborators",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16027,8 +16027,8 @@ func (s *Server) handleOrgsListPendingInvitationsRequest(args [1]string, w http.
 	params, err := decodeOrgsListPendingInvitationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListPendingInvitations",
-			err,
+			Operation: "OrgsListPendingInvitations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16072,8 +16072,8 @@ func (s *Server) handleOrgsListPublicMembersRequest(args [1]string, w http.Respo
 	params, err := decodeOrgsListPublicMembersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListPublicMembers",
-			err,
+			Operation: "OrgsListPublicMembers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16117,8 +16117,8 @@ func (s *Server) handleOrgsListSamlSSOAuthorizationsRequest(args [1]string, w ht
 	params, err := decodeOrgsListSamlSSOAuthorizationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListSamlSSOAuthorizations",
-			err,
+			Operation: "OrgsListSamlSSOAuthorizations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16162,8 +16162,8 @@ func (s *Server) handleOrgsListWebhookDeliveriesRequest(args [2]string, w http.R
 	params, err := decodeOrgsListWebhookDeliveriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListWebhookDeliveries",
-			err,
+			Operation: "OrgsListWebhookDeliveries",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16207,8 +16207,8 @@ func (s *Server) handleOrgsListWebhooksRequest(args [1]string, w http.ResponseWr
 	params, err := decodeOrgsListWebhooksParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsListWebhooks",
-			err,
+			Operation: "OrgsListWebhooks",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16252,8 +16252,8 @@ func (s *Server) handleOrgsPingWebhookRequest(args [2]string, w http.ResponseWri
 	params, err := decodeOrgsPingWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsPingWebhook",
-			err,
+			Operation: "OrgsPingWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16297,8 +16297,8 @@ func (s *Server) handleOrgsRedeliverWebhookDeliveryRequest(args [3]string, w htt
 	params, err := decodeOrgsRedeliverWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRedeliverWebhookDelivery",
-			err,
+			Operation: "OrgsRedeliverWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16342,8 +16342,8 @@ func (s *Server) handleOrgsRemoveMemberRequest(args [2]string, w http.ResponseWr
 	params, err := decodeOrgsRemoveMemberParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRemoveMember",
-			err,
+			Operation: "OrgsRemoveMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16387,8 +16387,8 @@ func (s *Server) handleOrgsRemoveMembershipForUserRequest(args [2]string, w http
 	params, err := decodeOrgsRemoveMembershipForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRemoveMembershipForUser",
-			err,
+			Operation: "OrgsRemoveMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16432,8 +16432,8 @@ func (s *Server) handleOrgsRemoveOutsideCollaboratorRequest(args [2]string, w ht
 	params, err := decodeOrgsRemoveOutsideCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRemoveOutsideCollaborator",
-			err,
+			Operation: "OrgsRemoveOutsideCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16477,8 +16477,8 @@ func (s *Server) handleOrgsRemovePublicMembershipForAuthenticatedUserRequest(arg
 	params, err := decodeOrgsRemovePublicMembershipForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRemovePublicMembershipForAuthenticatedUser",
-			err,
+			Operation: "OrgsRemovePublicMembershipForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16522,8 +16522,8 @@ func (s *Server) handleOrgsRemoveSamlSSOAuthorizationRequest(args [2]string, w h
 	params, err := decodeOrgsRemoveSamlSSOAuthorizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsRemoveSamlSSOAuthorization",
-			err,
+			Operation: "OrgsRemoveSamlSSOAuthorization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16567,8 +16567,8 @@ func (s *Server) handleOrgsSetMembershipForUserRequest(args [2]string, w http.Re
 	params, err := decodeOrgsSetMembershipForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsSetMembershipForUser",
-			err,
+			Operation: "OrgsSetMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16576,8 +16576,8 @@ func (s *Server) handleOrgsSetMembershipForUserRequest(args [2]string, w http.Re
 	request, err := decodeOrgsSetMembershipForUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsSetMembershipForUser",
-			err,
+			Operation: "OrgsSetMembershipForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16621,8 +16621,8 @@ func (s *Server) handleOrgsSetPublicMembershipForAuthenticatedUserRequest(args [
 	params, err := decodeOrgsSetPublicMembershipForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsSetPublicMembershipForAuthenticatedUser",
-			err,
+			Operation: "OrgsSetPublicMembershipForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16666,8 +16666,8 @@ func (s *Server) handleOrgsUnblockUserRequest(args [2]string, w http.ResponseWri
 	params, err := decodeOrgsUnblockUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsUnblockUser",
-			err,
+			Operation: "OrgsUnblockUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16711,8 +16711,8 @@ func (s *Server) handleOrgsUpdateMembershipForAuthenticatedUserRequest(args [1]s
 	params, err := decodeOrgsUpdateMembershipForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsUpdateMembershipForAuthenticatedUser",
-			err,
+			Operation: "OrgsUpdateMembershipForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16720,8 +16720,8 @@ func (s *Server) handleOrgsUpdateMembershipForAuthenticatedUserRequest(args [1]s
 	request, err := decodeOrgsUpdateMembershipForAuthenticatedUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsUpdateMembershipForAuthenticatedUser",
-			err,
+			Operation: "OrgsUpdateMembershipForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16765,8 +16765,8 @@ func (s *Server) handleOrgsUpdateWebhookRequest(args [2]string, w http.ResponseW
 	params, err := decodeOrgsUpdateWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsUpdateWebhook",
-			err,
+			Operation: "OrgsUpdateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16774,8 +16774,8 @@ func (s *Server) handleOrgsUpdateWebhookRequest(args [2]string, w http.ResponseW
 	request, err := decodeOrgsUpdateWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsUpdateWebhook",
-			err,
+			Operation: "OrgsUpdateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16819,8 +16819,8 @@ func (s *Server) handleOrgsUpdateWebhookConfigForOrgRequest(args [2]string, w ht
 	params, err := decodeOrgsUpdateWebhookConfigForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrgsUpdateWebhookConfigForOrg",
-			err,
+			Operation: "OrgsUpdateWebhookConfigForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16828,8 +16828,8 @@ func (s *Server) handleOrgsUpdateWebhookConfigForOrgRequest(args [2]string, w ht
 	request, err := decodeOrgsUpdateWebhookConfigForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrgsUpdateWebhookConfigForOrg",
-			err,
+			Operation: "OrgsUpdateWebhookConfigForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16873,8 +16873,8 @@ func (s *Server) handlePackagesDeletePackageForAuthenticatedUserRequest(args [2]
 	params, err := decodePackagesDeletePackageForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageForAuthenticatedUser",
-			err,
+			Operation: "PackagesDeletePackageForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16918,8 +16918,8 @@ func (s *Server) handlePackagesDeletePackageForOrgRequest(args [3]string, w http
 	params, err := decodePackagesDeletePackageForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageForOrg",
-			err,
+			Operation: "PackagesDeletePackageForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16963,8 +16963,8 @@ func (s *Server) handlePackagesDeletePackageForUserRequest(args [3]string, w htt
 	params, err := decodePackagesDeletePackageForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageForUser",
-			err,
+			Operation: "PackagesDeletePackageForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17008,8 +17008,8 @@ func (s *Server) handlePackagesDeletePackageVersionForAuthenticatedUserRequest(a
 	params, err := decodePackagesDeletePackageVersionForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageVersionForAuthenticatedUser",
-			err,
+			Operation: "PackagesDeletePackageVersionForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17053,8 +17053,8 @@ func (s *Server) handlePackagesDeletePackageVersionForOrgRequest(args [4]string,
 	params, err := decodePackagesDeletePackageVersionForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageVersionForOrg",
-			err,
+			Operation: "PackagesDeletePackageVersionForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17098,8 +17098,8 @@ func (s *Server) handlePackagesDeletePackageVersionForUserRequest(args [4]string
 	params, err := decodePackagesDeletePackageVersionForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesDeletePackageVersionForUser",
-			err,
+			Operation: "PackagesDeletePackageVersionForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17143,8 +17143,8 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByAuthenticat
 	params, err := decodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser",
-			err,
+			Operation: "PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17188,8 +17188,8 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByOrgRequest(
 	params, err := decodePackagesGetAllPackageVersionsForPackageOwnedByOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetAllPackageVersionsForPackageOwnedByOrg",
-			err,
+			Operation: "PackagesGetAllPackageVersionsForPackageOwnedByOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17233,8 +17233,8 @@ func (s *Server) handlePackagesGetAllPackageVersionsForPackageOwnedByUserRequest
 	params, err := decodePackagesGetAllPackageVersionsForPackageOwnedByUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetAllPackageVersionsForPackageOwnedByUser",
-			err,
+			Operation: "PackagesGetAllPackageVersionsForPackageOwnedByUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17278,8 +17278,8 @@ func (s *Server) handlePackagesGetPackageForAuthenticatedUserRequest(args [2]str
 	params, err := decodePackagesGetPackageForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageForAuthenticatedUser",
-			err,
+			Operation: "PackagesGetPackageForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17323,8 +17323,8 @@ func (s *Server) handlePackagesGetPackageForOrganizationRequest(args [3]string, 
 	params, err := decodePackagesGetPackageForOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageForOrganization",
-			err,
+			Operation: "PackagesGetPackageForOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17368,8 +17368,8 @@ func (s *Server) handlePackagesGetPackageForUserRequest(args [3]string, w http.R
 	params, err := decodePackagesGetPackageForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageForUser",
-			err,
+			Operation: "PackagesGetPackageForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17413,8 +17413,8 @@ func (s *Server) handlePackagesGetPackageVersionForAuthenticatedUserRequest(args
 	params, err := decodePackagesGetPackageVersionForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageVersionForAuthenticatedUser",
-			err,
+			Operation: "PackagesGetPackageVersionForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17458,8 +17458,8 @@ func (s *Server) handlePackagesGetPackageVersionForOrganizationRequest(args [4]s
 	params, err := decodePackagesGetPackageVersionForOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageVersionForOrganization",
-			err,
+			Operation: "PackagesGetPackageVersionForOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17503,8 +17503,8 @@ func (s *Server) handlePackagesGetPackageVersionForUserRequest(args [4]string, w
 	params, err := decodePackagesGetPackageVersionForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesGetPackageVersionForUser",
-			err,
+			Operation: "PackagesGetPackageVersionForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17548,8 +17548,8 @@ func (s *Server) handlePackagesListPackagesForAuthenticatedUserRequest(args [0]s
 	params, err := decodePackagesListPackagesForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesListPackagesForAuthenticatedUser",
-			err,
+			Operation: "PackagesListPackagesForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17593,8 +17593,8 @@ func (s *Server) handlePackagesListPackagesForOrganizationRequest(args [1]string
 	params, err := decodePackagesListPackagesForOrganizationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesListPackagesForOrganization",
-			err,
+			Operation: "PackagesListPackagesForOrganization",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17638,8 +17638,8 @@ func (s *Server) handlePackagesListPackagesForUserRequest(args [1]string, w http
 	params, err := decodePackagesListPackagesForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesListPackagesForUser",
-			err,
+			Operation: "PackagesListPackagesForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17683,8 +17683,8 @@ func (s *Server) handlePackagesRestorePackageForAuthenticatedUserRequest(args [2
 	params, err := decodePackagesRestorePackageForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageForAuthenticatedUser",
-			err,
+			Operation: "PackagesRestorePackageForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17728,8 +17728,8 @@ func (s *Server) handlePackagesRestorePackageForOrgRequest(args [3]string, w htt
 	params, err := decodePackagesRestorePackageForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageForOrg",
-			err,
+			Operation: "PackagesRestorePackageForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17773,8 +17773,8 @@ func (s *Server) handlePackagesRestorePackageForUserRequest(args [3]string, w ht
 	params, err := decodePackagesRestorePackageForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageForUser",
-			err,
+			Operation: "PackagesRestorePackageForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17818,8 +17818,8 @@ func (s *Server) handlePackagesRestorePackageVersionForAuthenticatedUserRequest(
 	params, err := decodePackagesRestorePackageVersionForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageVersionForAuthenticatedUser",
-			err,
+			Operation: "PackagesRestorePackageVersionForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17863,8 +17863,8 @@ func (s *Server) handlePackagesRestorePackageVersionForOrgRequest(args [4]string
 	params, err := decodePackagesRestorePackageVersionForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageVersionForOrg",
-			err,
+			Operation: "PackagesRestorePackageVersionForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17908,8 +17908,8 @@ func (s *Server) handlePackagesRestorePackageVersionForUserRequest(args [4]strin
 	params, err := decodePackagesRestorePackageVersionForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PackagesRestorePackageVersionForUser",
-			err,
+			Operation: "PackagesRestorePackageVersionForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17953,8 +17953,8 @@ func (s *Server) handleProjectsAddCollaboratorRequest(args [2]string, w http.Res
 	params, err := decodeProjectsAddCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsAddCollaborator",
-			err,
+			Operation: "ProjectsAddCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17962,8 +17962,8 @@ func (s *Server) handleProjectsAddCollaboratorRequest(args [2]string, w http.Res
 	request, err := decodeProjectsAddCollaboratorRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsAddCollaborator",
-			err,
+			Operation: "ProjectsAddCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18007,8 +18007,8 @@ func (s *Server) handleProjectsCreateColumnRequest(args [1]string, w http.Respon
 	params, err := decodeProjectsCreateColumnParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsCreateColumn",
-			err,
+			Operation: "ProjectsCreateColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18016,8 +18016,8 @@ func (s *Server) handleProjectsCreateColumnRequest(args [1]string, w http.Respon
 	request, err := decodeProjectsCreateColumnRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsCreateColumn",
-			err,
+			Operation: "ProjectsCreateColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18061,8 +18061,8 @@ func (s *Server) handleProjectsCreateForAuthenticatedUserRequest(args [0]string,
 	request, err := decodeProjectsCreateForAuthenticatedUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsCreateForAuthenticatedUser",
-			err,
+			Operation: "ProjectsCreateForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18106,8 +18106,8 @@ func (s *Server) handleProjectsCreateForOrgRequest(args [1]string, w http.Respon
 	params, err := decodeProjectsCreateForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsCreateForOrg",
-			err,
+			Operation: "ProjectsCreateForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18115,8 +18115,8 @@ func (s *Server) handleProjectsCreateForOrgRequest(args [1]string, w http.Respon
 	request, err := decodeProjectsCreateForOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsCreateForOrg",
-			err,
+			Operation: "ProjectsCreateForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18160,8 +18160,8 @@ func (s *Server) handleProjectsCreateForRepoRequest(args [2]string, w http.Respo
 	params, err := decodeProjectsCreateForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsCreateForRepo",
-			err,
+			Operation: "ProjectsCreateForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18169,8 +18169,8 @@ func (s *Server) handleProjectsCreateForRepoRequest(args [2]string, w http.Respo
 	request, err := decodeProjectsCreateForRepoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsCreateForRepo",
-			err,
+			Operation: "ProjectsCreateForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18214,8 +18214,8 @@ func (s *Server) handleProjectsDeleteRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeProjectsDeleteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsDelete",
-			err,
+			Operation: "ProjectsDelete",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18259,8 +18259,8 @@ func (s *Server) handleProjectsDeleteCardRequest(args [1]string, w http.Response
 	params, err := decodeProjectsDeleteCardParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsDeleteCard",
-			err,
+			Operation: "ProjectsDeleteCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18304,8 +18304,8 @@ func (s *Server) handleProjectsDeleteColumnRequest(args [1]string, w http.Respon
 	params, err := decodeProjectsDeleteColumnParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsDeleteColumn",
-			err,
+			Operation: "ProjectsDeleteColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18349,8 +18349,8 @@ func (s *Server) handleProjectsGetRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeProjectsGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsGet",
-			err,
+			Operation: "ProjectsGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18394,8 +18394,8 @@ func (s *Server) handleProjectsGetCardRequest(args [1]string, w http.ResponseWri
 	params, err := decodeProjectsGetCardParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsGetCard",
-			err,
+			Operation: "ProjectsGetCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18439,8 +18439,8 @@ func (s *Server) handleProjectsGetColumnRequest(args [1]string, w http.ResponseW
 	params, err := decodeProjectsGetColumnParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsGetColumn",
-			err,
+			Operation: "ProjectsGetColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18484,8 +18484,8 @@ func (s *Server) handleProjectsGetPermissionForUserRequest(args [2]string, w htt
 	params, err := decodeProjectsGetPermissionForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsGetPermissionForUser",
-			err,
+			Operation: "ProjectsGetPermissionForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18529,8 +18529,8 @@ func (s *Server) handleProjectsListCardsRequest(args [1]string, w http.ResponseW
 	params, err := decodeProjectsListCardsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListCards",
-			err,
+			Operation: "ProjectsListCards",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18574,8 +18574,8 @@ func (s *Server) handleProjectsListCollaboratorsRequest(args [1]string, w http.R
 	params, err := decodeProjectsListCollaboratorsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListCollaborators",
-			err,
+			Operation: "ProjectsListCollaborators",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18619,8 +18619,8 @@ func (s *Server) handleProjectsListColumnsRequest(args [1]string, w http.Respons
 	params, err := decodeProjectsListColumnsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListColumns",
-			err,
+			Operation: "ProjectsListColumns",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18664,8 +18664,8 @@ func (s *Server) handleProjectsListForOrgRequest(args [1]string, w http.Response
 	params, err := decodeProjectsListForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListForOrg",
-			err,
+			Operation: "ProjectsListForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18709,8 +18709,8 @@ func (s *Server) handleProjectsListForRepoRequest(args [2]string, w http.Respons
 	params, err := decodeProjectsListForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListForRepo",
-			err,
+			Operation: "ProjectsListForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18754,8 +18754,8 @@ func (s *Server) handleProjectsListForUserRequest(args [1]string, w http.Respons
 	params, err := decodeProjectsListForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsListForUser",
-			err,
+			Operation: "ProjectsListForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18799,8 +18799,8 @@ func (s *Server) handleProjectsMoveCardRequest(args [1]string, w http.ResponseWr
 	params, err := decodeProjectsMoveCardParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsMoveCard",
-			err,
+			Operation: "ProjectsMoveCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18808,8 +18808,8 @@ func (s *Server) handleProjectsMoveCardRequest(args [1]string, w http.ResponseWr
 	request, err := decodeProjectsMoveCardRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsMoveCard",
-			err,
+			Operation: "ProjectsMoveCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18853,8 +18853,8 @@ func (s *Server) handleProjectsMoveColumnRequest(args [1]string, w http.Response
 	params, err := decodeProjectsMoveColumnParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsMoveColumn",
-			err,
+			Operation: "ProjectsMoveColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18862,8 +18862,8 @@ func (s *Server) handleProjectsMoveColumnRequest(args [1]string, w http.Response
 	request, err := decodeProjectsMoveColumnRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsMoveColumn",
-			err,
+			Operation: "ProjectsMoveColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18907,8 +18907,8 @@ func (s *Server) handleProjectsRemoveCollaboratorRequest(args [2]string, w http.
 	params, err := decodeProjectsRemoveCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsRemoveCollaborator",
-			err,
+			Operation: "ProjectsRemoveCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18952,8 +18952,8 @@ func (s *Server) handleProjectsUpdateRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeProjectsUpdateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsUpdate",
-			err,
+			Operation: "ProjectsUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18961,8 +18961,8 @@ func (s *Server) handleProjectsUpdateRequest(args [1]string, w http.ResponseWrit
 	request, err := decodeProjectsUpdateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsUpdate",
-			err,
+			Operation: "ProjectsUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19006,8 +19006,8 @@ func (s *Server) handleProjectsUpdateCardRequest(args [1]string, w http.Response
 	params, err := decodeProjectsUpdateCardParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsUpdateCard",
-			err,
+			Operation: "ProjectsUpdateCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19015,8 +19015,8 @@ func (s *Server) handleProjectsUpdateCardRequest(args [1]string, w http.Response
 	request, err := decodeProjectsUpdateCardRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsUpdateCard",
-			err,
+			Operation: "ProjectsUpdateCard",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19060,8 +19060,8 @@ func (s *Server) handleProjectsUpdateColumnRequest(args [1]string, w http.Respon
 	params, err := decodeProjectsUpdateColumnParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ProjectsUpdateColumn",
-			err,
+			Operation: "ProjectsUpdateColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19069,8 +19069,8 @@ func (s *Server) handleProjectsUpdateColumnRequest(args [1]string, w http.Respon
 	request, err := decodeProjectsUpdateColumnRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ProjectsUpdateColumn",
-			err,
+			Operation: "ProjectsUpdateColumn",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19114,8 +19114,8 @@ func (s *Server) handlePullsCheckIfMergedRequest(args [3]string, w http.Response
 	params, err := decodePullsCheckIfMergedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsCheckIfMerged",
-			err,
+			Operation: "PullsCheckIfMerged",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19159,8 +19159,8 @@ func (s *Server) handlePullsCreateRequest(args [2]string, w http.ResponseWriter,
 	params, err := decodePullsCreateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsCreate",
-			err,
+			Operation: "PullsCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19168,8 +19168,8 @@ func (s *Server) handlePullsCreateRequest(args [2]string, w http.ResponseWriter,
 	request, err := decodePullsCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsCreate",
-			err,
+			Operation: "PullsCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19213,8 +19213,8 @@ func (s *Server) handlePullsCreateReplyForReviewCommentRequest(args [4]string, w
 	params, err := decodePullsCreateReplyForReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsCreateReplyForReviewComment",
-			err,
+			Operation: "PullsCreateReplyForReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19222,8 +19222,8 @@ func (s *Server) handlePullsCreateReplyForReviewCommentRequest(args [4]string, w
 	request, err := decodePullsCreateReplyForReviewCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsCreateReplyForReviewComment",
-			err,
+			Operation: "PullsCreateReplyForReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19267,8 +19267,8 @@ func (s *Server) handlePullsCreateReviewRequest(args [3]string, w http.ResponseW
 	params, err := decodePullsCreateReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsCreateReview",
-			err,
+			Operation: "PullsCreateReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19276,8 +19276,8 @@ func (s *Server) handlePullsCreateReviewRequest(args [3]string, w http.ResponseW
 	request, err := decodePullsCreateReviewRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsCreateReview",
-			err,
+			Operation: "PullsCreateReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19321,8 +19321,8 @@ func (s *Server) handlePullsCreateReviewCommentRequest(args [3]string, w http.Re
 	params, err := decodePullsCreateReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsCreateReviewComment",
-			err,
+			Operation: "PullsCreateReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19330,8 +19330,8 @@ func (s *Server) handlePullsCreateReviewCommentRequest(args [3]string, w http.Re
 	request, err := decodePullsCreateReviewCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsCreateReviewComment",
-			err,
+			Operation: "PullsCreateReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19375,8 +19375,8 @@ func (s *Server) handlePullsDeletePendingReviewRequest(args [4]string, w http.Re
 	params, err := decodePullsDeletePendingReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsDeletePendingReview",
-			err,
+			Operation: "PullsDeletePendingReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19420,8 +19420,8 @@ func (s *Server) handlePullsDeleteReviewCommentRequest(args [3]string, w http.Re
 	params, err := decodePullsDeleteReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsDeleteReviewComment",
-			err,
+			Operation: "PullsDeleteReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19465,8 +19465,8 @@ func (s *Server) handlePullsDismissReviewRequest(args [4]string, w http.Response
 	params, err := decodePullsDismissReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsDismissReview",
-			err,
+			Operation: "PullsDismissReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19474,8 +19474,8 @@ func (s *Server) handlePullsDismissReviewRequest(args [4]string, w http.Response
 	request, err := decodePullsDismissReviewRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsDismissReview",
-			err,
+			Operation: "PullsDismissReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19519,8 +19519,8 @@ func (s *Server) handlePullsGetRequest(args [3]string, w http.ResponseWriter, r 
 	params, err := decodePullsGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsGet",
-			err,
+			Operation: "PullsGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19564,8 +19564,8 @@ func (s *Server) handlePullsGetReviewRequest(args [4]string, w http.ResponseWrit
 	params, err := decodePullsGetReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsGetReview",
-			err,
+			Operation: "PullsGetReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19609,8 +19609,8 @@ func (s *Server) handlePullsGetReviewCommentRequest(args [3]string, w http.Respo
 	params, err := decodePullsGetReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsGetReviewComment",
-			err,
+			Operation: "PullsGetReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19654,8 +19654,8 @@ func (s *Server) handlePullsListRequest(args [2]string, w http.ResponseWriter, r
 	params, err := decodePullsListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsList",
-			err,
+			Operation: "PullsList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19699,8 +19699,8 @@ func (s *Server) handlePullsListCommentsForReviewRequest(args [4]string, w http.
 	params, err := decodePullsListCommentsForReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListCommentsForReview",
-			err,
+			Operation: "PullsListCommentsForReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19744,8 +19744,8 @@ func (s *Server) handlePullsListCommitsRequest(args [3]string, w http.ResponseWr
 	params, err := decodePullsListCommitsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListCommits",
-			err,
+			Operation: "PullsListCommits",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19789,8 +19789,8 @@ func (s *Server) handlePullsListFilesRequest(args [3]string, w http.ResponseWrit
 	params, err := decodePullsListFilesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListFiles",
-			err,
+			Operation: "PullsListFiles",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19834,8 +19834,8 @@ func (s *Server) handlePullsListRequestedReviewersRequest(args [3]string, w http
 	params, err := decodePullsListRequestedReviewersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListRequestedReviewers",
-			err,
+			Operation: "PullsListRequestedReviewers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19879,8 +19879,8 @@ func (s *Server) handlePullsListReviewCommentsRequest(args [3]string, w http.Res
 	params, err := decodePullsListReviewCommentsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListReviewComments",
-			err,
+			Operation: "PullsListReviewComments",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19924,8 +19924,8 @@ func (s *Server) handlePullsListReviewCommentsForRepoRequest(args [2]string, w h
 	params, err := decodePullsListReviewCommentsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListReviewCommentsForRepo",
-			err,
+			Operation: "PullsListReviewCommentsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19969,8 +19969,8 @@ func (s *Server) handlePullsListReviewsRequest(args [3]string, w http.ResponseWr
 	params, err := decodePullsListReviewsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsListReviews",
-			err,
+			Operation: "PullsListReviews",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20014,8 +20014,8 @@ func (s *Server) handlePullsMergeRequest(args [3]string, w http.ResponseWriter, 
 	params, err := decodePullsMergeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsMerge",
-			err,
+			Operation: "PullsMerge",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20023,8 +20023,8 @@ func (s *Server) handlePullsMergeRequest(args [3]string, w http.ResponseWriter, 
 	request, err := decodePullsMergeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsMerge",
-			err,
+			Operation: "PullsMerge",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20068,8 +20068,8 @@ func (s *Server) handlePullsRemoveRequestedReviewersRequest(args [3]string, w ht
 	params, err := decodePullsRemoveRequestedReviewersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsRemoveRequestedReviewers",
-			err,
+			Operation: "PullsRemoveRequestedReviewers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20077,8 +20077,8 @@ func (s *Server) handlePullsRemoveRequestedReviewersRequest(args [3]string, w ht
 	request, err := decodePullsRemoveRequestedReviewersRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsRemoveRequestedReviewers",
-			err,
+			Operation: "PullsRemoveRequestedReviewers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20122,8 +20122,8 @@ func (s *Server) handlePullsSubmitReviewRequest(args [4]string, w http.ResponseW
 	params, err := decodePullsSubmitReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsSubmitReview",
-			err,
+			Operation: "PullsSubmitReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20131,8 +20131,8 @@ func (s *Server) handlePullsSubmitReviewRequest(args [4]string, w http.ResponseW
 	request, err := decodePullsSubmitReviewRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsSubmitReview",
-			err,
+			Operation: "PullsSubmitReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20176,8 +20176,8 @@ func (s *Server) handlePullsUpdateRequest(args [3]string, w http.ResponseWriter,
 	params, err := decodePullsUpdateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsUpdate",
-			err,
+			Operation: "PullsUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20185,8 +20185,8 @@ func (s *Server) handlePullsUpdateRequest(args [3]string, w http.ResponseWriter,
 	request, err := decodePullsUpdateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsUpdate",
-			err,
+			Operation: "PullsUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20230,8 +20230,8 @@ func (s *Server) handlePullsUpdateBranchRequest(args [3]string, w http.ResponseW
 	params, err := decodePullsUpdateBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsUpdateBranch",
-			err,
+			Operation: "PullsUpdateBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20239,8 +20239,8 @@ func (s *Server) handlePullsUpdateBranchRequest(args [3]string, w http.ResponseW
 	request, err := decodePullsUpdateBranchRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsUpdateBranch",
-			err,
+			Operation: "PullsUpdateBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20284,8 +20284,8 @@ func (s *Server) handlePullsUpdateReviewRequest(args [4]string, w http.ResponseW
 	params, err := decodePullsUpdateReviewParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsUpdateReview",
-			err,
+			Operation: "PullsUpdateReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20293,8 +20293,8 @@ func (s *Server) handlePullsUpdateReviewRequest(args [4]string, w http.ResponseW
 	request, err := decodePullsUpdateReviewRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsUpdateReview",
-			err,
+			Operation: "PullsUpdateReview",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20338,8 +20338,8 @@ func (s *Server) handlePullsUpdateReviewCommentRequest(args [3]string, w http.Re
 	params, err := decodePullsUpdateReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PullsUpdateReviewComment",
-			err,
+			Operation: "PullsUpdateReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20347,8 +20347,8 @@ func (s *Server) handlePullsUpdateReviewCommentRequest(args [3]string, w http.Re
 	request, err := decodePullsUpdateReviewCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PullsUpdateReviewComment",
-			err,
+			Operation: "PullsUpdateReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20428,8 +20428,8 @@ func (s *Server) handleReactionsCreateForCommitCommentRequest(args [3]string, w 
 	params, err := decodeReactionsCreateForCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForCommitComment",
-			err,
+			Operation: "ReactionsCreateForCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20437,8 +20437,8 @@ func (s *Server) handleReactionsCreateForCommitCommentRequest(args [3]string, w 
 	request, err := decodeReactionsCreateForCommitCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForCommitComment",
-			err,
+			Operation: "ReactionsCreateForCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20482,8 +20482,8 @@ func (s *Server) handleReactionsCreateForIssueRequest(args [3]string, w http.Res
 	params, err := decodeReactionsCreateForIssueParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForIssue",
-			err,
+			Operation: "ReactionsCreateForIssue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20491,8 +20491,8 @@ func (s *Server) handleReactionsCreateForIssueRequest(args [3]string, w http.Res
 	request, err := decodeReactionsCreateForIssueRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForIssue",
-			err,
+			Operation: "ReactionsCreateForIssue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20536,8 +20536,8 @@ func (s *Server) handleReactionsCreateForIssueCommentRequest(args [3]string, w h
 	params, err := decodeReactionsCreateForIssueCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForIssueComment",
-			err,
+			Operation: "ReactionsCreateForIssueComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20545,8 +20545,8 @@ func (s *Server) handleReactionsCreateForIssueCommentRequest(args [3]string, w h
 	request, err := decodeReactionsCreateForIssueCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForIssueComment",
-			err,
+			Operation: "ReactionsCreateForIssueComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20590,8 +20590,8 @@ func (s *Server) handleReactionsCreateForPullRequestReviewCommentRequest(args [3
 	params, err := decodeReactionsCreateForPullRequestReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForPullRequestReviewComment",
-			err,
+			Operation: "ReactionsCreateForPullRequestReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20599,8 +20599,8 @@ func (s *Server) handleReactionsCreateForPullRequestReviewCommentRequest(args [3
 	request, err := decodeReactionsCreateForPullRequestReviewCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForPullRequestReviewComment",
-			err,
+			Operation: "ReactionsCreateForPullRequestReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20644,8 +20644,8 @@ func (s *Server) handleReactionsCreateForReleaseRequest(args [3]string, w http.R
 	params, err := decodeReactionsCreateForReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForRelease",
-			err,
+			Operation: "ReactionsCreateForRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20653,8 +20653,8 @@ func (s *Server) handleReactionsCreateForReleaseRequest(args [3]string, w http.R
 	request, err := decodeReactionsCreateForReleaseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForRelease",
-			err,
+			Operation: "ReactionsCreateForRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20698,8 +20698,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentInOrgRequest(args 
 	params, err := decodeReactionsCreateForTeamDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForTeamDiscussionCommentInOrg",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20707,8 +20707,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentInOrgRequest(args 
 	request, err := decodeReactionsCreateForTeamDiscussionCommentInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForTeamDiscussionCommentInOrg",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20752,8 +20752,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentLegacyRequest(args
 	params, err := decodeReactionsCreateForTeamDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForTeamDiscussionCommentLegacy",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20761,8 +20761,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionCommentLegacyRequest(args
 	request, err := decodeReactionsCreateForTeamDiscussionCommentLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForTeamDiscussionCommentLegacy",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20806,8 +20806,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionInOrgRequest(args [3]stri
 	params, err := decodeReactionsCreateForTeamDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForTeamDiscussionInOrg",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20815,8 +20815,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionInOrgRequest(args [3]stri
 	request, err := decodeReactionsCreateForTeamDiscussionInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForTeamDiscussionInOrg",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20860,8 +20860,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionLegacyRequest(args [2]str
 	params, err := decodeReactionsCreateForTeamDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsCreateForTeamDiscussionLegacy",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20869,8 +20869,8 @@ func (s *Server) handleReactionsCreateForTeamDiscussionLegacyRequest(args [2]str
 	request, err := decodeReactionsCreateForTeamDiscussionLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReactionsCreateForTeamDiscussionLegacy",
-			err,
+			Operation: "ReactionsCreateForTeamDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20914,8 +20914,8 @@ func (s *Server) handleReactionsDeleteForCommitCommentRequest(args [4]string, w 
 	params, err := decodeReactionsDeleteForCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForCommitComment",
-			err,
+			Operation: "ReactionsDeleteForCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20959,8 +20959,8 @@ func (s *Server) handleReactionsDeleteForIssueRequest(args [4]string, w http.Res
 	params, err := decodeReactionsDeleteForIssueParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForIssue",
-			err,
+			Operation: "ReactionsDeleteForIssue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21004,8 +21004,8 @@ func (s *Server) handleReactionsDeleteForIssueCommentRequest(args [4]string, w h
 	params, err := decodeReactionsDeleteForIssueCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForIssueComment",
-			err,
+			Operation: "ReactionsDeleteForIssueComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21049,8 +21049,8 @@ func (s *Server) handleReactionsDeleteForPullRequestCommentRequest(args [4]strin
 	params, err := decodeReactionsDeleteForPullRequestCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForPullRequestComment",
-			err,
+			Operation: "ReactionsDeleteForPullRequestComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21094,8 +21094,8 @@ func (s *Server) handleReactionsDeleteForTeamDiscussionRequest(args [4]string, w
 	params, err := decodeReactionsDeleteForTeamDiscussionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForTeamDiscussion",
-			err,
+			Operation: "ReactionsDeleteForTeamDiscussion",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21139,8 +21139,8 @@ func (s *Server) handleReactionsDeleteForTeamDiscussionCommentRequest(args [5]st
 	params, err := decodeReactionsDeleteForTeamDiscussionCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteForTeamDiscussionComment",
-			err,
+			Operation: "ReactionsDeleteForTeamDiscussionComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21184,8 +21184,8 @@ func (s *Server) handleReactionsDeleteLegacyRequest(args [1]string, w http.Respo
 	params, err := decodeReactionsDeleteLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsDeleteLegacy",
-			err,
+			Operation: "ReactionsDeleteLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21229,8 +21229,8 @@ func (s *Server) handleReactionsListForCommitCommentRequest(args [3]string, w ht
 	params, err := decodeReactionsListForCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForCommitComment",
-			err,
+			Operation: "ReactionsListForCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21274,8 +21274,8 @@ func (s *Server) handleReactionsListForIssueRequest(args [3]string, w http.Respo
 	params, err := decodeReactionsListForIssueParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForIssue",
-			err,
+			Operation: "ReactionsListForIssue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21319,8 +21319,8 @@ func (s *Server) handleReactionsListForIssueCommentRequest(args [3]string, w htt
 	params, err := decodeReactionsListForIssueCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForIssueComment",
-			err,
+			Operation: "ReactionsListForIssueComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21364,8 +21364,8 @@ func (s *Server) handleReactionsListForPullRequestReviewCommentRequest(args [3]s
 	params, err := decodeReactionsListForPullRequestReviewCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForPullRequestReviewComment",
-			err,
+			Operation: "ReactionsListForPullRequestReviewComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21409,8 +21409,8 @@ func (s *Server) handleReactionsListForTeamDiscussionCommentInOrgRequest(args [4
 	params, err := decodeReactionsListForTeamDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForTeamDiscussionCommentInOrg",
-			err,
+			Operation: "ReactionsListForTeamDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21454,8 +21454,8 @@ func (s *Server) handleReactionsListForTeamDiscussionCommentLegacyRequest(args [
 	params, err := decodeReactionsListForTeamDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForTeamDiscussionCommentLegacy",
-			err,
+			Operation: "ReactionsListForTeamDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21499,8 +21499,8 @@ func (s *Server) handleReactionsListForTeamDiscussionInOrgRequest(args [3]string
 	params, err := decodeReactionsListForTeamDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForTeamDiscussionInOrg",
-			err,
+			Operation: "ReactionsListForTeamDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21544,8 +21544,8 @@ func (s *Server) handleReactionsListForTeamDiscussionLegacyRequest(args [2]strin
 	params, err := decodeReactionsListForTeamDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReactionsListForTeamDiscussionLegacy",
-			err,
+			Operation: "ReactionsListForTeamDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21589,8 +21589,8 @@ func (s *Server) handleReposAcceptInvitationRequest(args [1]string, w http.Respo
 	params, err := decodeReposAcceptInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAcceptInvitation",
-			err,
+			Operation: "ReposAcceptInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21634,8 +21634,8 @@ func (s *Server) handleReposAddAppAccessRestrictionsRequest(args [3]string, w ht
 	params, err := decodeReposAddAppAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAddAppAccessRestrictions",
-			err,
+			Operation: "ReposAddAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21643,8 +21643,8 @@ func (s *Server) handleReposAddAppAccessRestrictionsRequest(args [3]string, w ht
 	request, err := decodeReposAddAppAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposAddAppAccessRestrictions",
-			err,
+			Operation: "ReposAddAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21688,8 +21688,8 @@ func (s *Server) handleReposAddCollaboratorRequest(args [3]string, w http.Respon
 	params, err := decodeReposAddCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAddCollaborator",
-			err,
+			Operation: "ReposAddCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21697,8 +21697,8 @@ func (s *Server) handleReposAddCollaboratorRequest(args [3]string, w http.Respon
 	request, err := decodeReposAddCollaboratorRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposAddCollaborator",
-			err,
+			Operation: "ReposAddCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21742,8 +21742,8 @@ func (s *Server) handleReposAddStatusCheckContextsRequest(args [3]string, w http
 	params, err := decodeReposAddStatusCheckContextsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAddStatusCheckContexts",
-			err,
+			Operation: "ReposAddStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21751,8 +21751,8 @@ func (s *Server) handleReposAddStatusCheckContextsRequest(args [3]string, w http
 	request, err := decodeReposAddStatusCheckContextsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposAddStatusCheckContexts",
-			err,
+			Operation: "ReposAddStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21796,8 +21796,8 @@ func (s *Server) handleReposAddTeamAccessRestrictionsRequest(args [3]string, w h
 	params, err := decodeReposAddTeamAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAddTeamAccessRestrictions",
-			err,
+			Operation: "ReposAddTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21805,8 +21805,8 @@ func (s *Server) handleReposAddTeamAccessRestrictionsRequest(args [3]string, w h
 	request, err := decodeReposAddTeamAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposAddTeamAccessRestrictions",
-			err,
+			Operation: "ReposAddTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21850,8 +21850,8 @@ func (s *Server) handleReposAddUserAccessRestrictionsRequest(args [3]string, w h
 	params, err := decodeReposAddUserAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposAddUserAccessRestrictions",
-			err,
+			Operation: "ReposAddUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21859,8 +21859,8 @@ func (s *Server) handleReposAddUserAccessRestrictionsRequest(args [3]string, w h
 	request, err := decodeReposAddUserAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposAddUserAccessRestrictions",
-			err,
+			Operation: "ReposAddUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21904,8 +21904,8 @@ func (s *Server) handleReposCheckCollaboratorRequest(args [3]string, w http.Resp
 	params, err := decodeReposCheckCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCheckCollaborator",
-			err,
+			Operation: "ReposCheckCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21949,8 +21949,8 @@ func (s *Server) handleReposCheckVulnerabilityAlertsRequest(args [2]string, w ht
 	params, err := decodeReposCheckVulnerabilityAlertsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCheckVulnerabilityAlerts",
-			err,
+			Operation: "ReposCheckVulnerabilityAlerts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21994,8 +21994,8 @@ func (s *Server) handleReposCompareCommitsRequest(args [3]string, w http.Respons
 	params, err := decodeReposCompareCommitsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCompareCommits",
-			err,
+			Operation: "ReposCompareCommits",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22039,8 +22039,8 @@ func (s *Server) handleReposCreateAutolinkRequest(args [2]string, w http.Respons
 	params, err := decodeReposCreateAutolinkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateAutolink",
-			err,
+			Operation: "ReposCreateAutolink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22048,8 +22048,8 @@ func (s *Server) handleReposCreateAutolinkRequest(args [2]string, w http.Respons
 	request, err := decodeReposCreateAutolinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateAutolink",
-			err,
+			Operation: "ReposCreateAutolink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22093,8 +22093,8 @@ func (s *Server) handleReposCreateCommitCommentRequest(args [3]string, w http.Re
 	params, err := decodeReposCreateCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateCommitComment",
-			err,
+			Operation: "ReposCreateCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22102,8 +22102,8 @@ func (s *Server) handleReposCreateCommitCommentRequest(args [3]string, w http.Re
 	request, err := decodeReposCreateCommitCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateCommitComment",
-			err,
+			Operation: "ReposCreateCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22147,8 +22147,8 @@ func (s *Server) handleReposCreateCommitSignatureProtectionRequest(args [3]strin
 	params, err := decodeReposCreateCommitSignatureProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateCommitSignatureProtection",
-			err,
+			Operation: "ReposCreateCommitSignatureProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22192,8 +22192,8 @@ func (s *Server) handleReposCreateCommitStatusRequest(args [3]string, w http.Res
 	params, err := decodeReposCreateCommitStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateCommitStatus",
-			err,
+			Operation: "ReposCreateCommitStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22201,8 +22201,8 @@ func (s *Server) handleReposCreateCommitStatusRequest(args [3]string, w http.Res
 	request, err := decodeReposCreateCommitStatusRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateCommitStatus",
-			err,
+			Operation: "ReposCreateCommitStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22246,8 +22246,8 @@ func (s *Server) handleReposCreateDeployKeyRequest(args [2]string, w http.Respon
 	params, err := decodeReposCreateDeployKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateDeployKey",
-			err,
+			Operation: "ReposCreateDeployKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22255,8 +22255,8 @@ func (s *Server) handleReposCreateDeployKeyRequest(args [2]string, w http.Respon
 	request, err := decodeReposCreateDeployKeyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateDeployKey",
-			err,
+			Operation: "ReposCreateDeployKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22300,8 +22300,8 @@ func (s *Server) handleReposCreateDeploymentRequest(args [2]string, w http.Respo
 	params, err := decodeReposCreateDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateDeployment",
-			err,
+			Operation: "ReposCreateDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22309,8 +22309,8 @@ func (s *Server) handleReposCreateDeploymentRequest(args [2]string, w http.Respo
 	request, err := decodeReposCreateDeploymentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateDeployment",
-			err,
+			Operation: "ReposCreateDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22354,8 +22354,8 @@ func (s *Server) handleReposCreateDeploymentStatusRequest(args [3]string, w http
 	params, err := decodeReposCreateDeploymentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateDeploymentStatus",
-			err,
+			Operation: "ReposCreateDeploymentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22363,8 +22363,8 @@ func (s *Server) handleReposCreateDeploymentStatusRequest(args [3]string, w http
 	request, err := decodeReposCreateDeploymentStatusRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateDeploymentStatus",
-			err,
+			Operation: "ReposCreateDeploymentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22408,8 +22408,8 @@ func (s *Server) handleReposCreateDispatchEventRequest(args [2]string, w http.Re
 	params, err := decodeReposCreateDispatchEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateDispatchEvent",
-			err,
+			Operation: "ReposCreateDispatchEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22417,8 +22417,8 @@ func (s *Server) handleReposCreateDispatchEventRequest(args [2]string, w http.Re
 	request, err := decodeReposCreateDispatchEventRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateDispatchEvent",
-			err,
+			Operation: "ReposCreateDispatchEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22462,8 +22462,8 @@ func (s *Server) handleReposCreateForAuthenticatedUserRequest(args [0]string, w 
 	request, err := decodeReposCreateForAuthenticatedUserRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateForAuthenticatedUser",
-			err,
+			Operation: "ReposCreateForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22507,8 +22507,8 @@ func (s *Server) handleReposCreateForkRequest(args [2]string, w http.ResponseWri
 	params, err := decodeReposCreateForkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateFork",
-			err,
+			Operation: "ReposCreateFork",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22516,8 +22516,8 @@ func (s *Server) handleReposCreateForkRequest(args [2]string, w http.ResponseWri
 	request, err := decodeReposCreateForkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateFork",
-			err,
+			Operation: "ReposCreateFork",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22561,8 +22561,8 @@ func (s *Server) handleReposCreateInOrgRequest(args [1]string, w http.ResponseWr
 	params, err := decodeReposCreateInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateInOrg",
-			err,
+			Operation: "ReposCreateInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22570,8 +22570,8 @@ func (s *Server) handleReposCreateInOrgRequest(args [1]string, w http.ResponseWr
 	request, err := decodeReposCreateInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateInOrg",
-			err,
+			Operation: "ReposCreateInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22615,8 +22615,8 @@ func (s *Server) handleReposCreateOrUpdateFileContentsRequest(args [3]string, w 
 	params, err := decodeReposCreateOrUpdateFileContentsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateOrUpdateFileContents",
-			err,
+			Operation: "ReposCreateOrUpdateFileContents",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22624,8 +22624,8 @@ func (s *Server) handleReposCreateOrUpdateFileContentsRequest(args [3]string, w 
 	request, err := decodeReposCreateOrUpdateFileContentsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateOrUpdateFileContents",
-			err,
+			Operation: "ReposCreateOrUpdateFileContents",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22669,8 +22669,8 @@ func (s *Server) handleReposCreatePagesSiteRequest(args [2]string, w http.Respon
 	params, err := decodeReposCreatePagesSiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreatePagesSite",
-			err,
+			Operation: "ReposCreatePagesSite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22678,8 +22678,8 @@ func (s *Server) handleReposCreatePagesSiteRequest(args [2]string, w http.Respon
 	request, err := decodeReposCreatePagesSiteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreatePagesSite",
-			err,
+			Operation: "ReposCreatePagesSite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22723,8 +22723,8 @@ func (s *Server) handleReposCreateReleaseRequest(args [2]string, w http.Response
 	params, err := decodeReposCreateReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateRelease",
-			err,
+			Operation: "ReposCreateRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22732,8 +22732,8 @@ func (s *Server) handleReposCreateReleaseRequest(args [2]string, w http.Response
 	request, err := decodeReposCreateReleaseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateRelease",
-			err,
+			Operation: "ReposCreateRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22777,8 +22777,8 @@ func (s *Server) handleReposCreateUsingTemplateRequest(args [2]string, w http.Re
 	params, err := decodeReposCreateUsingTemplateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateUsingTemplate",
-			err,
+			Operation: "ReposCreateUsingTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22786,8 +22786,8 @@ func (s *Server) handleReposCreateUsingTemplateRequest(args [2]string, w http.Re
 	request, err := decodeReposCreateUsingTemplateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateUsingTemplate",
-			err,
+			Operation: "ReposCreateUsingTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22831,8 +22831,8 @@ func (s *Server) handleReposCreateWebhookRequest(args [2]string, w http.Response
 	params, err := decodeReposCreateWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposCreateWebhook",
-			err,
+			Operation: "ReposCreateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22840,8 +22840,8 @@ func (s *Server) handleReposCreateWebhookRequest(args [2]string, w http.Response
 	request, err := decodeReposCreateWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposCreateWebhook",
-			err,
+			Operation: "ReposCreateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22885,8 +22885,8 @@ func (s *Server) handleReposDeclineInvitationRequest(args [1]string, w http.Resp
 	params, err := decodeReposDeclineInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeclineInvitation",
-			err,
+			Operation: "ReposDeclineInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22930,8 +22930,8 @@ func (s *Server) handleReposDeleteRequest(args [2]string, w http.ResponseWriter,
 	params, err := decodeReposDeleteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDelete",
-			err,
+			Operation: "ReposDelete",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22975,8 +22975,8 @@ func (s *Server) handleReposDeleteAccessRestrictionsRequest(args [3]string, w ht
 	params, err := decodeReposDeleteAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteAccessRestrictions",
-			err,
+			Operation: "ReposDeleteAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23020,8 +23020,8 @@ func (s *Server) handleReposDeleteAdminBranchProtectionRequest(args [3]string, w
 	params, err := decodeReposDeleteAdminBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteAdminBranchProtection",
-			err,
+			Operation: "ReposDeleteAdminBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23065,8 +23065,8 @@ func (s *Server) handleReposDeleteAnEnvironmentRequest(args [3]string, w http.Re
 	params, err := decodeReposDeleteAnEnvironmentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteAnEnvironment",
-			err,
+			Operation: "ReposDeleteAnEnvironment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23110,8 +23110,8 @@ func (s *Server) handleReposDeleteAutolinkRequest(args [3]string, w http.Respons
 	params, err := decodeReposDeleteAutolinkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteAutolink",
-			err,
+			Operation: "ReposDeleteAutolink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23155,8 +23155,8 @@ func (s *Server) handleReposDeleteBranchProtectionRequest(args [3]string, w http
 	params, err := decodeReposDeleteBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteBranchProtection",
-			err,
+			Operation: "ReposDeleteBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23200,8 +23200,8 @@ func (s *Server) handleReposDeleteCommitCommentRequest(args [3]string, w http.Re
 	params, err := decodeReposDeleteCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteCommitComment",
-			err,
+			Operation: "ReposDeleteCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23245,8 +23245,8 @@ func (s *Server) handleReposDeleteCommitSignatureProtectionRequest(args [3]strin
 	params, err := decodeReposDeleteCommitSignatureProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteCommitSignatureProtection",
-			err,
+			Operation: "ReposDeleteCommitSignatureProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23290,8 +23290,8 @@ func (s *Server) handleReposDeleteDeployKeyRequest(args [3]string, w http.Respon
 	params, err := decodeReposDeleteDeployKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteDeployKey",
-			err,
+			Operation: "ReposDeleteDeployKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23335,8 +23335,8 @@ func (s *Server) handleReposDeleteDeploymentRequest(args [3]string, w http.Respo
 	params, err := decodeReposDeleteDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteDeployment",
-			err,
+			Operation: "ReposDeleteDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23380,8 +23380,8 @@ func (s *Server) handleReposDeleteFileRequest(args [3]string, w http.ResponseWri
 	params, err := decodeReposDeleteFileParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteFile",
-			err,
+			Operation: "ReposDeleteFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23389,8 +23389,8 @@ func (s *Server) handleReposDeleteFileRequest(args [3]string, w http.ResponseWri
 	request, err := decodeReposDeleteFileRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposDeleteFile",
-			err,
+			Operation: "ReposDeleteFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23434,8 +23434,8 @@ func (s *Server) handleReposDeleteInvitationRequest(args [3]string, w http.Respo
 	params, err := decodeReposDeleteInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteInvitation",
-			err,
+			Operation: "ReposDeleteInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23479,8 +23479,8 @@ func (s *Server) handleReposDeletePagesSiteRequest(args [2]string, w http.Respon
 	params, err := decodeReposDeletePagesSiteParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeletePagesSite",
-			err,
+			Operation: "ReposDeletePagesSite",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23524,8 +23524,8 @@ func (s *Server) handleReposDeletePullRequestReviewProtectionRequest(args [3]str
 	params, err := decodeReposDeletePullRequestReviewProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeletePullRequestReviewProtection",
-			err,
+			Operation: "ReposDeletePullRequestReviewProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23569,8 +23569,8 @@ func (s *Server) handleReposDeleteReleaseRequest(args [3]string, w http.Response
 	params, err := decodeReposDeleteReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteRelease",
-			err,
+			Operation: "ReposDeleteRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23614,8 +23614,8 @@ func (s *Server) handleReposDeleteReleaseAssetRequest(args [3]string, w http.Res
 	params, err := decodeReposDeleteReleaseAssetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteReleaseAsset",
-			err,
+			Operation: "ReposDeleteReleaseAsset",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23659,8 +23659,8 @@ func (s *Server) handleReposDeleteWebhookRequest(args [3]string, w http.Response
 	params, err := decodeReposDeleteWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDeleteWebhook",
-			err,
+			Operation: "ReposDeleteWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23704,8 +23704,8 @@ func (s *Server) handleReposDisableAutomatedSecurityFixesRequest(args [2]string,
 	params, err := decodeReposDisableAutomatedSecurityFixesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDisableAutomatedSecurityFixes",
-			err,
+			Operation: "ReposDisableAutomatedSecurityFixes",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23749,8 +23749,8 @@ func (s *Server) handleReposDisableLfsForRepoRequest(args [2]string, w http.Resp
 	params, err := decodeReposDisableLfsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDisableLfsForRepo",
-			err,
+			Operation: "ReposDisableLfsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23794,8 +23794,8 @@ func (s *Server) handleReposDisableVulnerabilityAlertsRequest(args [2]string, w 
 	params, err := decodeReposDisableVulnerabilityAlertsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDisableVulnerabilityAlerts",
-			err,
+			Operation: "ReposDisableVulnerabilityAlerts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23839,8 +23839,8 @@ func (s *Server) handleReposDownloadTarballArchiveRequest(args [3]string, w http
 	params, err := decodeReposDownloadTarballArchiveParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDownloadTarballArchive",
-			err,
+			Operation: "ReposDownloadTarballArchive",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23884,8 +23884,8 @@ func (s *Server) handleReposDownloadZipballArchiveRequest(args [3]string, w http
 	params, err := decodeReposDownloadZipballArchiveParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposDownloadZipballArchive",
-			err,
+			Operation: "ReposDownloadZipballArchive",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23929,8 +23929,8 @@ func (s *Server) handleReposEnableAutomatedSecurityFixesRequest(args [2]string, 
 	params, err := decodeReposEnableAutomatedSecurityFixesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposEnableAutomatedSecurityFixes",
-			err,
+			Operation: "ReposEnableAutomatedSecurityFixes",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23974,8 +23974,8 @@ func (s *Server) handleReposEnableLfsForRepoRequest(args [2]string, w http.Respo
 	params, err := decodeReposEnableLfsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposEnableLfsForRepo",
-			err,
+			Operation: "ReposEnableLfsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24019,8 +24019,8 @@ func (s *Server) handleReposEnableVulnerabilityAlertsRequest(args [2]string, w h
 	params, err := decodeReposEnableVulnerabilityAlertsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposEnableVulnerabilityAlerts",
-			err,
+			Operation: "ReposEnableVulnerabilityAlerts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24064,8 +24064,8 @@ func (s *Server) handleReposGetRequest(args [2]string, w http.ResponseWriter, r 
 	params, err := decodeReposGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGet",
-			err,
+			Operation: "ReposGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24109,8 +24109,8 @@ func (s *Server) handleReposGetAccessRestrictionsRequest(args [3]string, w http.
 	params, err := decodeReposGetAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAccessRestrictions",
-			err,
+			Operation: "ReposGetAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24154,8 +24154,8 @@ func (s *Server) handleReposGetAdminBranchProtectionRequest(args [3]string, w ht
 	params, err := decodeReposGetAdminBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAdminBranchProtection",
-			err,
+			Operation: "ReposGetAdminBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24199,8 +24199,8 @@ func (s *Server) handleReposGetAllStatusCheckContextsRequest(args [3]string, w h
 	params, err := decodeReposGetAllStatusCheckContextsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAllStatusCheckContexts",
-			err,
+			Operation: "ReposGetAllStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24244,8 +24244,8 @@ func (s *Server) handleReposGetAllTopicsRequest(args [2]string, w http.ResponseW
 	params, err := decodeReposGetAllTopicsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAllTopics",
-			err,
+			Operation: "ReposGetAllTopics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24289,8 +24289,8 @@ func (s *Server) handleReposGetAppsWithAccessToProtectedBranchRequest(args [3]st
 	params, err := decodeReposGetAppsWithAccessToProtectedBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAppsWithAccessToProtectedBranch",
-			err,
+			Operation: "ReposGetAppsWithAccessToProtectedBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24334,8 +24334,8 @@ func (s *Server) handleReposGetAutolinkRequest(args [3]string, w http.ResponseWr
 	params, err := decodeReposGetAutolinkParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetAutolink",
-			err,
+			Operation: "ReposGetAutolink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24379,8 +24379,8 @@ func (s *Server) handleReposGetBranchRequest(args [3]string, w http.ResponseWrit
 	params, err := decodeReposGetBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetBranch",
-			err,
+			Operation: "ReposGetBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24424,8 +24424,8 @@ func (s *Server) handleReposGetBranchProtectionRequest(args [3]string, w http.Re
 	params, err := decodeReposGetBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetBranchProtection",
-			err,
+			Operation: "ReposGetBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24469,8 +24469,8 @@ func (s *Server) handleReposGetClonesRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeReposGetClonesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetClones",
-			err,
+			Operation: "ReposGetClones",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24514,8 +24514,8 @@ func (s *Server) handleReposGetCodeFrequencyStatsRequest(args [2]string, w http.
 	params, err := decodeReposGetCodeFrequencyStatsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCodeFrequencyStats",
-			err,
+			Operation: "ReposGetCodeFrequencyStats",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24559,8 +24559,8 @@ func (s *Server) handleReposGetCollaboratorPermissionLevelRequest(args [3]string
 	params, err := decodeReposGetCollaboratorPermissionLevelParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCollaboratorPermissionLevel",
-			err,
+			Operation: "ReposGetCollaboratorPermissionLevel",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24604,8 +24604,8 @@ func (s *Server) handleReposGetCombinedStatusForRefRequest(args [3]string, w htt
 	params, err := decodeReposGetCombinedStatusForRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCombinedStatusForRef",
-			err,
+			Operation: "ReposGetCombinedStatusForRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24649,8 +24649,8 @@ func (s *Server) handleReposGetCommitRequest(args [3]string, w http.ResponseWrit
 	params, err := decodeReposGetCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCommit",
-			err,
+			Operation: "ReposGetCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24694,8 +24694,8 @@ func (s *Server) handleReposGetCommitActivityStatsRequest(args [2]string, w http
 	params, err := decodeReposGetCommitActivityStatsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCommitActivityStats",
-			err,
+			Operation: "ReposGetCommitActivityStats",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24739,8 +24739,8 @@ func (s *Server) handleReposGetCommitCommentRequest(args [3]string, w http.Respo
 	params, err := decodeReposGetCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCommitComment",
-			err,
+			Operation: "ReposGetCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24784,8 +24784,8 @@ func (s *Server) handleReposGetCommitSignatureProtectionRequest(args [3]string, 
 	params, err := decodeReposGetCommitSignatureProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCommitSignatureProtection",
-			err,
+			Operation: "ReposGetCommitSignatureProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24829,8 +24829,8 @@ func (s *Server) handleReposGetCommunityProfileMetricsRequest(args [2]string, w 
 	params, err := decodeReposGetCommunityProfileMetricsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetCommunityProfileMetrics",
-			err,
+			Operation: "ReposGetCommunityProfileMetrics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24874,8 +24874,8 @@ func (s *Server) handleReposGetContributorsStatsRequest(args [2]string, w http.R
 	params, err := decodeReposGetContributorsStatsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetContributorsStats",
-			err,
+			Operation: "ReposGetContributorsStats",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24919,8 +24919,8 @@ func (s *Server) handleReposGetDeployKeyRequest(args [3]string, w http.ResponseW
 	params, err := decodeReposGetDeployKeyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetDeployKey",
-			err,
+			Operation: "ReposGetDeployKey",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24964,8 +24964,8 @@ func (s *Server) handleReposGetDeploymentRequest(args [3]string, w http.Response
 	params, err := decodeReposGetDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetDeployment",
-			err,
+			Operation: "ReposGetDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25009,8 +25009,8 @@ func (s *Server) handleReposGetDeploymentStatusRequest(args [4]string, w http.Re
 	params, err := decodeReposGetDeploymentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetDeploymentStatus",
-			err,
+			Operation: "ReposGetDeploymentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25054,8 +25054,8 @@ func (s *Server) handleReposGetLatestPagesBuildRequest(args [2]string, w http.Re
 	params, err := decodeReposGetLatestPagesBuildParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetLatestPagesBuild",
-			err,
+			Operation: "ReposGetLatestPagesBuild",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25099,8 +25099,8 @@ func (s *Server) handleReposGetLatestReleaseRequest(args [2]string, w http.Respo
 	params, err := decodeReposGetLatestReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetLatestRelease",
-			err,
+			Operation: "ReposGetLatestRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25144,8 +25144,8 @@ func (s *Server) handleReposGetPagesRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeReposGetPagesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetPages",
-			err,
+			Operation: "ReposGetPages",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25189,8 +25189,8 @@ func (s *Server) handleReposGetPagesBuildRequest(args [3]string, w http.Response
 	params, err := decodeReposGetPagesBuildParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetPagesBuild",
-			err,
+			Operation: "ReposGetPagesBuild",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25234,8 +25234,8 @@ func (s *Server) handleReposGetPagesHealthCheckRequest(args [2]string, w http.Re
 	params, err := decodeReposGetPagesHealthCheckParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetPagesHealthCheck",
-			err,
+			Operation: "ReposGetPagesHealthCheck",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25279,8 +25279,8 @@ func (s *Server) handleReposGetParticipationStatsRequest(args [2]string, w http.
 	params, err := decodeReposGetParticipationStatsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetParticipationStats",
-			err,
+			Operation: "ReposGetParticipationStats",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25324,8 +25324,8 @@ func (s *Server) handleReposGetPullRequestReviewProtectionRequest(args [3]string
 	params, err := decodeReposGetPullRequestReviewProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetPullRequestReviewProtection",
-			err,
+			Operation: "ReposGetPullRequestReviewProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25369,8 +25369,8 @@ func (s *Server) handleReposGetPunchCardStatsRequest(args [2]string, w http.Resp
 	params, err := decodeReposGetPunchCardStatsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetPunchCardStats",
-			err,
+			Operation: "ReposGetPunchCardStats",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25414,8 +25414,8 @@ func (s *Server) handleReposGetReadmeRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeReposGetReadmeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetReadme",
-			err,
+			Operation: "ReposGetReadme",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25459,8 +25459,8 @@ func (s *Server) handleReposGetReadmeInDirectoryRequest(args [3]string, w http.R
 	params, err := decodeReposGetReadmeInDirectoryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetReadmeInDirectory",
-			err,
+			Operation: "ReposGetReadmeInDirectory",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25504,8 +25504,8 @@ func (s *Server) handleReposGetReleaseRequest(args [3]string, w http.ResponseWri
 	params, err := decodeReposGetReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetRelease",
-			err,
+			Operation: "ReposGetRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25549,8 +25549,8 @@ func (s *Server) handleReposGetReleaseAssetRequest(args [3]string, w http.Respon
 	params, err := decodeReposGetReleaseAssetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetReleaseAsset",
-			err,
+			Operation: "ReposGetReleaseAsset",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25594,8 +25594,8 @@ func (s *Server) handleReposGetReleaseByTagRequest(args [3]string, w http.Respon
 	params, err := decodeReposGetReleaseByTagParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetReleaseByTag",
-			err,
+			Operation: "ReposGetReleaseByTag",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25639,8 +25639,8 @@ func (s *Server) handleReposGetStatusChecksProtectionRequest(args [3]string, w h
 	params, err := decodeReposGetStatusChecksProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetStatusChecksProtection",
-			err,
+			Operation: "ReposGetStatusChecksProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25684,8 +25684,8 @@ func (s *Server) handleReposGetTeamsWithAccessToProtectedBranchRequest(args [3]s
 	params, err := decodeReposGetTeamsWithAccessToProtectedBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetTeamsWithAccessToProtectedBranch",
-			err,
+			Operation: "ReposGetTeamsWithAccessToProtectedBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25729,8 +25729,8 @@ func (s *Server) handleReposGetTopPathsRequest(args [2]string, w http.ResponseWr
 	params, err := decodeReposGetTopPathsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetTopPaths",
-			err,
+			Operation: "ReposGetTopPaths",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25774,8 +25774,8 @@ func (s *Server) handleReposGetTopReferrersRequest(args [2]string, w http.Respon
 	params, err := decodeReposGetTopReferrersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetTopReferrers",
-			err,
+			Operation: "ReposGetTopReferrers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25819,8 +25819,8 @@ func (s *Server) handleReposGetUsersWithAccessToProtectedBranchRequest(args [3]s
 	params, err := decodeReposGetUsersWithAccessToProtectedBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetUsersWithAccessToProtectedBranch",
-			err,
+			Operation: "ReposGetUsersWithAccessToProtectedBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25864,8 +25864,8 @@ func (s *Server) handleReposGetViewsRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeReposGetViewsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetViews",
-			err,
+			Operation: "ReposGetViews",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25909,8 +25909,8 @@ func (s *Server) handleReposGetWebhookRequest(args [3]string, w http.ResponseWri
 	params, err := decodeReposGetWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetWebhook",
-			err,
+			Operation: "ReposGetWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25954,8 +25954,8 @@ func (s *Server) handleReposGetWebhookConfigForRepoRequest(args [3]string, w htt
 	params, err := decodeReposGetWebhookConfigForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetWebhookConfigForRepo",
-			err,
+			Operation: "ReposGetWebhookConfigForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25999,8 +25999,8 @@ func (s *Server) handleReposGetWebhookDeliveryRequest(args [4]string, w http.Res
 	params, err := decodeReposGetWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposGetWebhookDelivery",
-			err,
+			Operation: "ReposGetWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26044,8 +26044,8 @@ func (s *Server) handleReposListAutolinksRequest(args [2]string, w http.Response
 	params, err := decodeReposListAutolinksParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListAutolinks",
-			err,
+			Operation: "ReposListAutolinks",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26089,8 +26089,8 @@ func (s *Server) handleReposListBranchesRequest(args [2]string, w http.ResponseW
 	params, err := decodeReposListBranchesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListBranches",
-			err,
+			Operation: "ReposListBranches",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26134,8 +26134,8 @@ func (s *Server) handleReposListBranchesForHeadCommitRequest(args [3]string, w h
 	params, err := decodeReposListBranchesForHeadCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListBranchesForHeadCommit",
-			err,
+			Operation: "ReposListBranchesForHeadCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26179,8 +26179,8 @@ func (s *Server) handleReposListCollaboratorsRequest(args [2]string, w http.Resp
 	params, err := decodeReposListCollaboratorsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListCollaborators",
-			err,
+			Operation: "ReposListCollaborators",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26224,8 +26224,8 @@ func (s *Server) handleReposListCommentsForCommitRequest(args [3]string, w http.
 	params, err := decodeReposListCommentsForCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListCommentsForCommit",
-			err,
+			Operation: "ReposListCommentsForCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26269,8 +26269,8 @@ func (s *Server) handleReposListCommitCommentsForRepoRequest(args [2]string, w h
 	params, err := decodeReposListCommitCommentsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListCommitCommentsForRepo",
-			err,
+			Operation: "ReposListCommitCommentsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26314,8 +26314,8 @@ func (s *Server) handleReposListCommitStatusesForRefRequest(args [3]string, w ht
 	params, err := decodeReposListCommitStatusesForRefParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListCommitStatusesForRef",
-			err,
+			Operation: "ReposListCommitStatusesForRef",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26359,8 +26359,8 @@ func (s *Server) handleReposListCommitsRequest(args [2]string, w http.ResponseWr
 	params, err := decodeReposListCommitsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListCommits",
-			err,
+			Operation: "ReposListCommits",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26404,8 +26404,8 @@ func (s *Server) handleReposListContributorsRequest(args [2]string, w http.Respo
 	params, err := decodeReposListContributorsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListContributors",
-			err,
+			Operation: "ReposListContributors",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26449,8 +26449,8 @@ func (s *Server) handleReposListDeployKeysRequest(args [2]string, w http.Respons
 	params, err := decodeReposListDeployKeysParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListDeployKeys",
-			err,
+			Operation: "ReposListDeployKeys",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26494,8 +26494,8 @@ func (s *Server) handleReposListDeploymentStatusesRequest(args [3]string, w http
 	params, err := decodeReposListDeploymentStatusesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListDeploymentStatuses",
-			err,
+			Operation: "ReposListDeploymentStatuses",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26539,8 +26539,8 @@ func (s *Server) handleReposListDeploymentsRequest(args [2]string, w http.Respon
 	params, err := decodeReposListDeploymentsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListDeployments",
-			err,
+			Operation: "ReposListDeployments",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26584,8 +26584,8 @@ func (s *Server) handleReposListForAuthenticatedUserRequest(args [0]string, w ht
 	params, err := decodeReposListForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListForAuthenticatedUser",
-			err,
+			Operation: "ReposListForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26629,8 +26629,8 @@ func (s *Server) handleReposListForOrgRequest(args [1]string, w http.ResponseWri
 	params, err := decodeReposListForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListForOrg",
-			err,
+			Operation: "ReposListForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26674,8 +26674,8 @@ func (s *Server) handleReposListForUserRequest(args [1]string, w http.ResponseWr
 	params, err := decodeReposListForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListForUser",
-			err,
+			Operation: "ReposListForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26719,8 +26719,8 @@ func (s *Server) handleReposListForksRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeReposListForksParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListForks",
-			err,
+			Operation: "ReposListForks",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26764,8 +26764,8 @@ func (s *Server) handleReposListInvitationsRequest(args [2]string, w http.Respon
 	params, err := decodeReposListInvitationsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListInvitations",
-			err,
+			Operation: "ReposListInvitations",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26809,8 +26809,8 @@ func (s *Server) handleReposListInvitationsForAuthenticatedUserRequest(args [0]s
 	params, err := decodeReposListInvitationsForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListInvitationsForAuthenticatedUser",
-			err,
+			Operation: "ReposListInvitationsForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26854,8 +26854,8 @@ func (s *Server) handleReposListLanguagesRequest(args [2]string, w http.Response
 	params, err := decodeReposListLanguagesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListLanguages",
-			err,
+			Operation: "ReposListLanguages",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26899,8 +26899,8 @@ func (s *Server) handleReposListPagesBuildsRequest(args [2]string, w http.Respon
 	params, err := decodeReposListPagesBuildsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListPagesBuilds",
-			err,
+			Operation: "ReposListPagesBuilds",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26944,8 +26944,8 @@ func (s *Server) handleReposListPublicRequest(args [0]string, w http.ResponseWri
 	params, err := decodeReposListPublicParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListPublic",
-			err,
+			Operation: "ReposListPublic",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26989,8 +26989,8 @@ func (s *Server) handleReposListPullRequestsAssociatedWithCommitRequest(args [3]
 	params, err := decodeReposListPullRequestsAssociatedWithCommitParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListPullRequestsAssociatedWithCommit",
-			err,
+			Operation: "ReposListPullRequestsAssociatedWithCommit",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27034,8 +27034,8 @@ func (s *Server) handleReposListReleaseAssetsRequest(args [3]string, w http.Resp
 	params, err := decodeReposListReleaseAssetsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListReleaseAssets",
-			err,
+			Operation: "ReposListReleaseAssets",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27079,8 +27079,8 @@ func (s *Server) handleReposListReleasesRequest(args [2]string, w http.ResponseW
 	params, err := decodeReposListReleasesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListReleases",
-			err,
+			Operation: "ReposListReleases",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27124,8 +27124,8 @@ func (s *Server) handleReposListTagsRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeReposListTagsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListTags",
-			err,
+			Operation: "ReposListTags",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27169,8 +27169,8 @@ func (s *Server) handleReposListTeamsRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeReposListTeamsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListTeams",
-			err,
+			Operation: "ReposListTeams",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27214,8 +27214,8 @@ func (s *Server) handleReposListWebhookDeliveriesRequest(args [3]string, w http.
 	params, err := decodeReposListWebhookDeliveriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListWebhookDeliveries",
-			err,
+			Operation: "ReposListWebhookDeliveries",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27259,8 +27259,8 @@ func (s *Server) handleReposListWebhooksRequest(args [2]string, w http.ResponseW
 	params, err := decodeReposListWebhooksParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposListWebhooks",
-			err,
+			Operation: "ReposListWebhooks",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27304,8 +27304,8 @@ func (s *Server) handleReposMergeRequest(args [2]string, w http.ResponseWriter, 
 	params, err := decodeReposMergeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposMerge",
-			err,
+			Operation: "ReposMerge",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27313,8 +27313,8 @@ func (s *Server) handleReposMergeRequest(args [2]string, w http.ResponseWriter, 
 	request, err := decodeReposMergeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposMerge",
-			err,
+			Operation: "ReposMerge",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27358,8 +27358,8 @@ func (s *Server) handleReposMergeUpstreamRequest(args [2]string, w http.Response
 	params, err := decodeReposMergeUpstreamParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposMergeUpstream",
-			err,
+			Operation: "ReposMergeUpstream",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27367,8 +27367,8 @@ func (s *Server) handleReposMergeUpstreamRequest(args [2]string, w http.Response
 	request, err := decodeReposMergeUpstreamRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposMergeUpstream",
-			err,
+			Operation: "ReposMergeUpstream",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27412,8 +27412,8 @@ func (s *Server) handleReposPingWebhookRequest(args [3]string, w http.ResponseWr
 	params, err := decodeReposPingWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposPingWebhook",
-			err,
+			Operation: "ReposPingWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27457,8 +27457,8 @@ func (s *Server) handleReposRedeliverWebhookDeliveryRequest(args [4]string, w ht
 	params, err := decodeReposRedeliverWebhookDeliveryParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRedeliverWebhookDelivery",
-			err,
+			Operation: "ReposRedeliverWebhookDelivery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27502,8 +27502,8 @@ func (s *Server) handleReposRemoveAppAccessRestrictionsRequest(args [3]string, w
 	params, err := decodeReposRemoveAppAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveAppAccessRestrictions",
-			err,
+			Operation: "ReposRemoveAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27511,8 +27511,8 @@ func (s *Server) handleReposRemoveAppAccessRestrictionsRequest(args [3]string, w
 	request, err := decodeReposRemoveAppAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposRemoveAppAccessRestrictions",
-			err,
+			Operation: "ReposRemoveAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27556,8 +27556,8 @@ func (s *Server) handleReposRemoveCollaboratorRequest(args [3]string, w http.Res
 	params, err := decodeReposRemoveCollaboratorParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveCollaborator",
-			err,
+			Operation: "ReposRemoveCollaborator",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27601,8 +27601,8 @@ func (s *Server) handleReposRemoveStatusCheckContextsRequest(args [3]string, w h
 	params, err := decodeReposRemoveStatusCheckContextsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveStatusCheckContexts",
-			err,
+			Operation: "ReposRemoveStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27610,8 +27610,8 @@ func (s *Server) handleReposRemoveStatusCheckContextsRequest(args [3]string, w h
 	request, err := decodeReposRemoveStatusCheckContextsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposRemoveStatusCheckContexts",
-			err,
+			Operation: "ReposRemoveStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27655,8 +27655,8 @@ func (s *Server) handleReposRemoveStatusCheckProtectionRequest(args [3]string, w
 	params, err := decodeReposRemoveStatusCheckProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveStatusCheckProtection",
-			err,
+			Operation: "ReposRemoveStatusCheckProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27700,8 +27700,8 @@ func (s *Server) handleReposRemoveTeamAccessRestrictionsRequest(args [3]string, 
 	params, err := decodeReposRemoveTeamAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveTeamAccessRestrictions",
-			err,
+			Operation: "ReposRemoveTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27709,8 +27709,8 @@ func (s *Server) handleReposRemoveTeamAccessRestrictionsRequest(args [3]string, 
 	request, err := decodeReposRemoveTeamAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposRemoveTeamAccessRestrictions",
-			err,
+			Operation: "ReposRemoveTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27754,8 +27754,8 @@ func (s *Server) handleReposRemoveUserAccessRestrictionsRequest(args [3]string, 
 	params, err := decodeReposRemoveUserAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRemoveUserAccessRestrictions",
-			err,
+			Operation: "ReposRemoveUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27763,8 +27763,8 @@ func (s *Server) handleReposRemoveUserAccessRestrictionsRequest(args [3]string, 
 	request, err := decodeReposRemoveUserAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposRemoveUserAccessRestrictions",
-			err,
+			Operation: "ReposRemoveUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27808,8 +27808,8 @@ func (s *Server) handleReposRenameBranchRequest(args [3]string, w http.ResponseW
 	params, err := decodeReposRenameBranchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRenameBranch",
-			err,
+			Operation: "ReposRenameBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27817,8 +27817,8 @@ func (s *Server) handleReposRenameBranchRequest(args [3]string, w http.ResponseW
 	request, err := decodeReposRenameBranchRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposRenameBranch",
-			err,
+			Operation: "ReposRenameBranch",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27862,8 +27862,8 @@ func (s *Server) handleReposReplaceAllTopicsRequest(args [2]string, w http.Respo
 	params, err := decodeReposReplaceAllTopicsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposReplaceAllTopics",
-			err,
+			Operation: "ReposReplaceAllTopics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27871,8 +27871,8 @@ func (s *Server) handleReposReplaceAllTopicsRequest(args [2]string, w http.Respo
 	request, err := decodeReposReplaceAllTopicsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposReplaceAllTopics",
-			err,
+			Operation: "ReposReplaceAllTopics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27916,8 +27916,8 @@ func (s *Server) handleReposRequestPagesBuildRequest(args [2]string, w http.Resp
 	params, err := decodeReposRequestPagesBuildParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposRequestPagesBuild",
-			err,
+			Operation: "ReposRequestPagesBuild",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -27961,8 +27961,8 @@ func (s *Server) handleReposSetAdminBranchProtectionRequest(args [3]string, w ht
 	params, err := decodeReposSetAdminBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposSetAdminBranchProtection",
-			err,
+			Operation: "ReposSetAdminBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28006,8 +28006,8 @@ func (s *Server) handleReposSetAppAccessRestrictionsRequest(args [3]string, w ht
 	params, err := decodeReposSetAppAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposSetAppAccessRestrictions",
-			err,
+			Operation: "ReposSetAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28015,8 +28015,8 @@ func (s *Server) handleReposSetAppAccessRestrictionsRequest(args [3]string, w ht
 	request, err := decodeReposSetAppAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposSetAppAccessRestrictions",
-			err,
+			Operation: "ReposSetAppAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28060,8 +28060,8 @@ func (s *Server) handleReposSetStatusCheckContextsRequest(args [3]string, w http
 	params, err := decodeReposSetStatusCheckContextsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposSetStatusCheckContexts",
-			err,
+			Operation: "ReposSetStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28069,8 +28069,8 @@ func (s *Server) handleReposSetStatusCheckContextsRequest(args [3]string, w http
 	request, err := decodeReposSetStatusCheckContextsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposSetStatusCheckContexts",
-			err,
+			Operation: "ReposSetStatusCheckContexts",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28114,8 +28114,8 @@ func (s *Server) handleReposSetTeamAccessRestrictionsRequest(args [3]string, w h
 	params, err := decodeReposSetTeamAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposSetTeamAccessRestrictions",
-			err,
+			Operation: "ReposSetTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28123,8 +28123,8 @@ func (s *Server) handleReposSetTeamAccessRestrictionsRequest(args [3]string, w h
 	request, err := decodeReposSetTeamAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposSetTeamAccessRestrictions",
-			err,
+			Operation: "ReposSetTeamAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28168,8 +28168,8 @@ func (s *Server) handleReposSetUserAccessRestrictionsRequest(args [3]string, w h
 	params, err := decodeReposSetUserAccessRestrictionsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposSetUserAccessRestrictions",
-			err,
+			Operation: "ReposSetUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28177,8 +28177,8 @@ func (s *Server) handleReposSetUserAccessRestrictionsRequest(args [3]string, w h
 	request, err := decodeReposSetUserAccessRestrictionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposSetUserAccessRestrictions",
-			err,
+			Operation: "ReposSetUserAccessRestrictions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28222,8 +28222,8 @@ func (s *Server) handleReposTestPushWebhookRequest(args [3]string, w http.Respon
 	params, err := decodeReposTestPushWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposTestPushWebhook",
-			err,
+			Operation: "ReposTestPushWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28267,8 +28267,8 @@ func (s *Server) handleReposTransferRequest(args [2]string, w http.ResponseWrite
 	params, err := decodeReposTransferParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposTransfer",
-			err,
+			Operation: "ReposTransfer",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28276,8 +28276,8 @@ func (s *Server) handleReposTransferRequest(args [2]string, w http.ResponseWrite
 	request, err := decodeReposTransferRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposTransfer",
-			err,
+			Operation: "ReposTransfer",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28321,8 +28321,8 @@ func (s *Server) handleReposUpdateRequest(args [2]string, w http.ResponseWriter,
 	params, err := decodeReposUpdateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdate",
-			err,
+			Operation: "ReposUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28330,8 +28330,8 @@ func (s *Server) handleReposUpdateRequest(args [2]string, w http.ResponseWriter,
 	request, err := decodeReposUpdateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdate",
-			err,
+			Operation: "ReposUpdate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28375,8 +28375,8 @@ func (s *Server) handleReposUpdateBranchProtectionRequest(args [3]string, w http
 	params, err := decodeReposUpdateBranchProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateBranchProtection",
-			err,
+			Operation: "ReposUpdateBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28384,8 +28384,8 @@ func (s *Server) handleReposUpdateBranchProtectionRequest(args [3]string, w http
 	request, err := decodeReposUpdateBranchProtectionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateBranchProtection",
-			err,
+			Operation: "ReposUpdateBranchProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28429,8 +28429,8 @@ func (s *Server) handleReposUpdateCommitCommentRequest(args [3]string, w http.Re
 	params, err := decodeReposUpdateCommitCommentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateCommitComment",
-			err,
+			Operation: "ReposUpdateCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28438,8 +28438,8 @@ func (s *Server) handleReposUpdateCommitCommentRequest(args [3]string, w http.Re
 	request, err := decodeReposUpdateCommitCommentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateCommitComment",
-			err,
+			Operation: "ReposUpdateCommitComment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28483,8 +28483,8 @@ func (s *Server) handleReposUpdateInvitationRequest(args [3]string, w http.Respo
 	params, err := decodeReposUpdateInvitationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateInvitation",
-			err,
+			Operation: "ReposUpdateInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28492,8 +28492,8 @@ func (s *Server) handleReposUpdateInvitationRequest(args [3]string, w http.Respo
 	request, err := decodeReposUpdateInvitationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateInvitation",
-			err,
+			Operation: "ReposUpdateInvitation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28537,8 +28537,8 @@ func (s *Server) handleReposUpdatePullRequestReviewProtectionRequest(args [3]str
 	params, err := decodeReposUpdatePullRequestReviewProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdatePullRequestReviewProtection",
-			err,
+			Operation: "ReposUpdatePullRequestReviewProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28546,8 +28546,8 @@ func (s *Server) handleReposUpdatePullRequestReviewProtectionRequest(args [3]str
 	request, err := decodeReposUpdatePullRequestReviewProtectionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdatePullRequestReviewProtection",
-			err,
+			Operation: "ReposUpdatePullRequestReviewProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28591,8 +28591,8 @@ func (s *Server) handleReposUpdateReleaseRequest(args [3]string, w http.Response
 	params, err := decodeReposUpdateReleaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateRelease",
-			err,
+			Operation: "ReposUpdateRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28600,8 +28600,8 @@ func (s *Server) handleReposUpdateReleaseRequest(args [3]string, w http.Response
 	request, err := decodeReposUpdateReleaseRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateRelease",
-			err,
+			Operation: "ReposUpdateRelease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28645,8 +28645,8 @@ func (s *Server) handleReposUpdateReleaseAssetRequest(args [3]string, w http.Res
 	params, err := decodeReposUpdateReleaseAssetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateReleaseAsset",
-			err,
+			Operation: "ReposUpdateReleaseAsset",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28654,8 +28654,8 @@ func (s *Server) handleReposUpdateReleaseAssetRequest(args [3]string, w http.Res
 	request, err := decodeReposUpdateReleaseAssetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateReleaseAsset",
-			err,
+			Operation: "ReposUpdateReleaseAsset",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28699,8 +28699,8 @@ func (s *Server) handleReposUpdateStatusCheckProtectionRequest(args [3]string, w
 	params, err := decodeReposUpdateStatusCheckProtectionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateStatusCheckProtection",
-			err,
+			Operation: "ReposUpdateStatusCheckProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28708,8 +28708,8 @@ func (s *Server) handleReposUpdateStatusCheckProtectionRequest(args [3]string, w
 	request, err := decodeReposUpdateStatusCheckProtectionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateStatusCheckProtection",
-			err,
+			Operation: "ReposUpdateStatusCheckProtection",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28753,8 +28753,8 @@ func (s *Server) handleReposUpdateWebhookRequest(args [3]string, w http.Response
 	params, err := decodeReposUpdateWebhookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateWebhook",
-			err,
+			Operation: "ReposUpdateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28762,8 +28762,8 @@ func (s *Server) handleReposUpdateWebhookRequest(args [3]string, w http.Response
 	request, err := decodeReposUpdateWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateWebhook",
-			err,
+			Operation: "ReposUpdateWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28807,8 +28807,8 @@ func (s *Server) handleReposUpdateWebhookConfigForRepoRequest(args [3]string, w 
 	params, err := decodeReposUpdateWebhookConfigForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReposUpdateWebhookConfigForRepo",
-			err,
+			Operation: "ReposUpdateWebhookConfigForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28816,8 +28816,8 @@ func (s *Server) handleReposUpdateWebhookConfigForRepoRequest(args [3]string, w 
 	request, err := decodeReposUpdateWebhookConfigForRepoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ReposUpdateWebhookConfigForRepo",
-			err,
+			Operation: "ReposUpdateWebhookConfigForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28861,8 +28861,8 @@ func (s *Server) handleScimDeleteUserFromOrgRequest(args [2]string, w http.Respo
 	params, err := decodeScimDeleteUserFromOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ScimDeleteUserFromOrg",
-			err,
+			Operation: "ScimDeleteUserFromOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28906,8 +28906,8 @@ func (s *Server) handleSearchCodeRequest(args [0]string, w http.ResponseWriter, 
 	params, err := decodeSearchCodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchCode",
-			err,
+			Operation: "SearchCode",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28951,8 +28951,8 @@ func (s *Server) handleSearchCommitsRequest(args [0]string, w http.ResponseWrite
 	params, err := decodeSearchCommitsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchCommits",
-			err,
+			Operation: "SearchCommits",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -28996,8 +28996,8 @@ func (s *Server) handleSearchIssuesAndPullRequestsRequest(args [0]string, w http
 	params, err := decodeSearchIssuesAndPullRequestsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchIssuesAndPullRequests",
-			err,
+			Operation: "SearchIssuesAndPullRequests",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29041,8 +29041,8 @@ func (s *Server) handleSearchLabelsRequest(args [0]string, w http.ResponseWriter
 	params, err := decodeSearchLabelsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchLabels",
-			err,
+			Operation: "SearchLabels",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29086,8 +29086,8 @@ func (s *Server) handleSearchReposRequest(args [0]string, w http.ResponseWriter,
 	params, err := decodeSearchReposParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchRepos",
-			err,
+			Operation: "SearchRepos",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29131,8 +29131,8 @@ func (s *Server) handleSearchTopicsRequest(args [0]string, w http.ResponseWriter
 	params, err := decodeSearchTopicsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchTopics",
-			err,
+			Operation: "SearchTopics",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29176,8 +29176,8 @@ func (s *Server) handleSearchUsersRequest(args [0]string, w http.ResponseWriter,
 	params, err := decodeSearchUsersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchUsers",
-			err,
+			Operation: "SearchUsers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29221,8 +29221,8 @@ func (s *Server) handleSecretScanningGetAlertRequest(args [3]string, w http.Resp
 	params, err := decodeSecretScanningGetAlertParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SecretScanningGetAlert",
-			err,
+			Operation: "SecretScanningGetAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29266,8 +29266,8 @@ func (s *Server) handleSecretScanningListAlertsForOrgRequest(args [1]string, w h
 	params, err := decodeSecretScanningListAlertsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SecretScanningListAlertsForOrg",
-			err,
+			Operation: "SecretScanningListAlertsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29311,8 +29311,8 @@ func (s *Server) handleSecretScanningListAlertsForRepoRequest(args [2]string, w 
 	params, err := decodeSecretScanningListAlertsForRepoParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SecretScanningListAlertsForRepo",
-			err,
+			Operation: "SecretScanningListAlertsForRepo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29356,8 +29356,8 @@ func (s *Server) handleSecretScanningUpdateAlertRequest(args [3]string, w http.R
 	params, err := decodeSecretScanningUpdateAlertParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SecretScanningUpdateAlert",
-			err,
+			Operation: "SecretScanningUpdateAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29365,8 +29365,8 @@ func (s *Server) handleSecretScanningUpdateAlertRequest(args [3]string, w http.R
 	request, err := decodeSecretScanningUpdateAlertRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SecretScanningUpdateAlert",
-			err,
+			Operation: "SecretScanningUpdateAlert",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29410,8 +29410,8 @@ func (s *Server) handleTeamsAddMemberLegacyRequest(args [2]string, w http.Respon
 	params, err := decodeTeamsAddMemberLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddMemberLegacy",
-			err,
+			Operation: "TeamsAddMemberLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29455,8 +29455,8 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserInOrgRequest(args [3]str
 	params, err := decodeTeamsAddOrUpdateMembershipForUserInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateMembershipForUserInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateMembershipForUserInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29464,8 +29464,8 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserInOrgRequest(args [3]str
 	request, err := decodeTeamsAddOrUpdateMembershipForUserInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateMembershipForUserInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateMembershipForUserInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29509,8 +29509,8 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserLegacyRequest(args [2]st
 	params, err := decodeTeamsAddOrUpdateMembershipForUserLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateMembershipForUserLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateMembershipForUserLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29518,8 +29518,8 @@ func (s *Server) handleTeamsAddOrUpdateMembershipForUserLegacyRequest(args [2]st
 	request, err := decodeTeamsAddOrUpdateMembershipForUserLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateMembershipForUserLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateMembershipForUserLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29563,8 +29563,8 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsInOrgRequest(args [3]st
 	params, err := decodeTeamsAddOrUpdateProjectPermissionsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateProjectPermissionsInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateProjectPermissionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29572,8 +29572,8 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsInOrgRequest(args [3]st
 	request, err := decodeTeamsAddOrUpdateProjectPermissionsInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateProjectPermissionsInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateProjectPermissionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29617,8 +29617,8 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsLegacyRequest(args [2]s
 	params, err := decodeTeamsAddOrUpdateProjectPermissionsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateProjectPermissionsLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateProjectPermissionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29626,8 +29626,8 @@ func (s *Server) handleTeamsAddOrUpdateProjectPermissionsLegacyRequest(args [2]s
 	request, err := decodeTeamsAddOrUpdateProjectPermissionsLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateProjectPermissionsLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateProjectPermissionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29671,8 +29671,8 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsInOrgRequest(args [4]strin
 	params, err := decodeTeamsAddOrUpdateRepoPermissionsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateRepoPermissionsInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateRepoPermissionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29680,8 +29680,8 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsInOrgRequest(args [4]strin
 	request, err := decodeTeamsAddOrUpdateRepoPermissionsInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateRepoPermissionsInOrg",
-			err,
+			Operation: "TeamsAddOrUpdateRepoPermissionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29725,8 +29725,8 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsLegacyRequest(args [3]stri
 	params, err := decodeTeamsAddOrUpdateRepoPermissionsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsAddOrUpdateRepoPermissionsLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateRepoPermissionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29734,8 +29734,8 @@ func (s *Server) handleTeamsAddOrUpdateRepoPermissionsLegacyRequest(args [3]stri
 	request, err := decodeTeamsAddOrUpdateRepoPermissionsLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsAddOrUpdateRepoPermissionsLegacy",
-			err,
+			Operation: "TeamsAddOrUpdateRepoPermissionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29779,8 +29779,8 @@ func (s *Server) handleTeamsCheckPermissionsForProjectInOrgRequest(args [3]strin
 	params, err := decodeTeamsCheckPermissionsForProjectInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCheckPermissionsForProjectInOrg",
-			err,
+			Operation: "TeamsCheckPermissionsForProjectInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29824,8 +29824,8 @@ func (s *Server) handleTeamsCheckPermissionsForProjectLegacyRequest(args [2]stri
 	params, err := decodeTeamsCheckPermissionsForProjectLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCheckPermissionsForProjectLegacy",
-			err,
+			Operation: "TeamsCheckPermissionsForProjectLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29869,8 +29869,8 @@ func (s *Server) handleTeamsCheckPermissionsForRepoInOrgRequest(args [4]string, 
 	params, err := decodeTeamsCheckPermissionsForRepoInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCheckPermissionsForRepoInOrg",
-			err,
+			Operation: "TeamsCheckPermissionsForRepoInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29914,8 +29914,8 @@ func (s *Server) handleTeamsCheckPermissionsForRepoLegacyRequest(args [3]string,
 	params, err := decodeTeamsCheckPermissionsForRepoLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCheckPermissionsForRepoLegacy",
-			err,
+			Operation: "TeamsCheckPermissionsForRepoLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29959,8 +29959,8 @@ func (s *Server) handleTeamsCreateRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeTeamsCreateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreate",
-			err,
+			Operation: "TeamsCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -29968,8 +29968,8 @@ func (s *Server) handleTeamsCreateRequest(args [1]string, w http.ResponseWriter,
 	request, err := decodeTeamsCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreate",
-			err,
+			Operation: "TeamsCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30013,8 +30013,8 @@ func (s *Server) handleTeamsCreateDiscussionCommentInOrgRequest(args [3]string, 
 	params, err := decodeTeamsCreateDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsCreateDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30022,8 +30022,8 @@ func (s *Server) handleTeamsCreateDiscussionCommentInOrgRequest(args [3]string, 
 	request, err := decodeTeamsCreateDiscussionCommentInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsCreateDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30067,8 +30067,8 @@ func (s *Server) handleTeamsCreateDiscussionCommentLegacyRequest(args [2]string,
 	params, err := decodeTeamsCreateDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsCreateDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30076,8 +30076,8 @@ func (s *Server) handleTeamsCreateDiscussionCommentLegacyRequest(args [2]string,
 	request, err := decodeTeamsCreateDiscussionCommentLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsCreateDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30121,8 +30121,8 @@ func (s *Server) handleTeamsCreateDiscussionInOrgRequest(args [2]string, w http.
 	params, err := decodeTeamsCreateDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateDiscussionInOrg",
-			err,
+			Operation: "TeamsCreateDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30130,8 +30130,8 @@ func (s *Server) handleTeamsCreateDiscussionInOrgRequest(args [2]string, w http.
 	request, err := decodeTeamsCreateDiscussionInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateDiscussionInOrg",
-			err,
+			Operation: "TeamsCreateDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30175,8 +30175,8 @@ func (s *Server) handleTeamsCreateDiscussionLegacyRequest(args [1]string, w http
 	params, err := decodeTeamsCreateDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateDiscussionLegacy",
-			err,
+			Operation: "TeamsCreateDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30184,8 +30184,8 @@ func (s *Server) handleTeamsCreateDiscussionLegacyRequest(args [1]string, w http
 	request, err := decodeTeamsCreateDiscussionLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateDiscussionLegacy",
-			err,
+			Operation: "TeamsCreateDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30229,8 +30229,8 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequest(args [
 	params, err := decodeTeamsCreateOrUpdateIdpGroupConnectionsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateOrUpdateIdpGroupConnectionsInOrg",
-			err,
+			Operation: "TeamsCreateOrUpdateIdpGroupConnectionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30238,8 +30238,8 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequest(args [
 	request, err := decodeTeamsCreateOrUpdateIdpGroupConnectionsInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateOrUpdateIdpGroupConnectionsInOrg",
-			err,
+			Operation: "TeamsCreateOrUpdateIdpGroupConnectionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30283,8 +30283,8 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequest(args 
 	params, err := decodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsCreateOrUpdateIdpGroupConnectionsLegacy",
-			err,
+			Operation: "TeamsCreateOrUpdateIdpGroupConnectionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30292,8 +30292,8 @@ func (s *Server) handleTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequest(args 
 	request, err := decodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsCreateOrUpdateIdpGroupConnectionsLegacy",
-			err,
+			Operation: "TeamsCreateOrUpdateIdpGroupConnectionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30337,8 +30337,8 @@ func (s *Server) handleTeamsDeleteDiscussionCommentInOrgRequest(args [4]string, 
 	params, err := decodeTeamsDeleteDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsDeleteDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30382,8 +30382,8 @@ func (s *Server) handleTeamsDeleteDiscussionCommentLegacyRequest(args [3]string,
 	params, err := decodeTeamsDeleteDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsDeleteDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30427,8 +30427,8 @@ func (s *Server) handleTeamsDeleteDiscussionInOrgRequest(args [3]string, w http.
 	params, err := decodeTeamsDeleteDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteDiscussionInOrg",
-			err,
+			Operation: "TeamsDeleteDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30472,8 +30472,8 @@ func (s *Server) handleTeamsDeleteDiscussionLegacyRequest(args [2]string, w http
 	params, err := decodeTeamsDeleteDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteDiscussionLegacy",
-			err,
+			Operation: "TeamsDeleteDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30517,8 +30517,8 @@ func (s *Server) handleTeamsDeleteInOrgRequest(args [2]string, w http.ResponseWr
 	params, err := decodeTeamsDeleteInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteInOrg",
-			err,
+			Operation: "TeamsDeleteInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30562,8 +30562,8 @@ func (s *Server) handleTeamsDeleteLegacyRequest(args [1]string, w http.ResponseW
 	params, err := decodeTeamsDeleteLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsDeleteLegacy",
-			err,
+			Operation: "TeamsDeleteLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30607,8 +30607,8 @@ func (s *Server) handleTeamsGetByNameRequest(args [2]string, w http.ResponseWrit
 	params, err := decodeTeamsGetByNameParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetByName",
-			err,
+			Operation: "TeamsGetByName",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30652,8 +30652,8 @@ func (s *Server) handleTeamsGetDiscussionCommentInOrgRequest(args [4]string, w h
 	params, err := decodeTeamsGetDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsGetDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30697,8 +30697,8 @@ func (s *Server) handleTeamsGetDiscussionCommentLegacyRequest(args [3]string, w 
 	params, err := decodeTeamsGetDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsGetDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30742,8 +30742,8 @@ func (s *Server) handleTeamsGetDiscussionInOrgRequest(args [3]string, w http.Res
 	params, err := decodeTeamsGetDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetDiscussionInOrg",
-			err,
+			Operation: "TeamsGetDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30787,8 +30787,8 @@ func (s *Server) handleTeamsGetDiscussionLegacyRequest(args [2]string, w http.Re
 	params, err := decodeTeamsGetDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetDiscussionLegacy",
-			err,
+			Operation: "TeamsGetDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30832,8 +30832,8 @@ func (s *Server) handleTeamsGetLegacyRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeTeamsGetLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetLegacy",
-			err,
+			Operation: "TeamsGetLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30877,8 +30877,8 @@ func (s *Server) handleTeamsGetMemberLegacyRequest(args [2]string, w http.Respon
 	params, err := decodeTeamsGetMemberLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetMemberLegacy",
-			err,
+			Operation: "TeamsGetMemberLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30922,8 +30922,8 @@ func (s *Server) handleTeamsGetMembershipForUserInOrgRequest(args [3]string, w h
 	params, err := decodeTeamsGetMembershipForUserInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetMembershipForUserInOrg",
-			err,
+			Operation: "TeamsGetMembershipForUserInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -30967,8 +30967,8 @@ func (s *Server) handleTeamsGetMembershipForUserLegacyRequest(args [2]string, w 
 	params, err := decodeTeamsGetMembershipForUserLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsGetMembershipForUserLegacy",
-			err,
+			Operation: "TeamsGetMembershipForUserLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31012,8 +31012,8 @@ func (s *Server) handleTeamsListRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeTeamsListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsList",
-			err,
+			Operation: "TeamsList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31057,8 +31057,8 @@ func (s *Server) handleTeamsListChildInOrgRequest(args [2]string, w http.Respons
 	params, err := decodeTeamsListChildInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListChildInOrg",
-			err,
+			Operation: "TeamsListChildInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31102,8 +31102,8 @@ func (s *Server) handleTeamsListChildLegacyRequest(args [1]string, w http.Respon
 	params, err := decodeTeamsListChildLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListChildLegacy",
-			err,
+			Operation: "TeamsListChildLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31147,8 +31147,8 @@ func (s *Server) handleTeamsListDiscussionCommentsInOrgRequest(args [3]string, w
 	params, err := decodeTeamsListDiscussionCommentsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListDiscussionCommentsInOrg",
-			err,
+			Operation: "TeamsListDiscussionCommentsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31192,8 +31192,8 @@ func (s *Server) handleTeamsListDiscussionCommentsLegacyRequest(args [2]string, 
 	params, err := decodeTeamsListDiscussionCommentsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListDiscussionCommentsLegacy",
-			err,
+			Operation: "TeamsListDiscussionCommentsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31237,8 +31237,8 @@ func (s *Server) handleTeamsListDiscussionsInOrgRequest(args [2]string, w http.R
 	params, err := decodeTeamsListDiscussionsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListDiscussionsInOrg",
-			err,
+			Operation: "TeamsListDiscussionsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31282,8 +31282,8 @@ func (s *Server) handleTeamsListDiscussionsLegacyRequest(args [1]string, w http.
 	params, err := decodeTeamsListDiscussionsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListDiscussionsLegacy",
-			err,
+			Operation: "TeamsListDiscussionsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31327,8 +31327,8 @@ func (s *Server) handleTeamsListForAuthenticatedUserRequest(args [0]string, w ht
 	params, err := decodeTeamsListForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListForAuthenticatedUser",
-			err,
+			Operation: "TeamsListForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31372,8 +31372,8 @@ func (s *Server) handleTeamsListIdpGroupsForLegacyRequest(args [1]string, w http
 	params, err := decodeTeamsListIdpGroupsForLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListIdpGroupsForLegacy",
-			err,
+			Operation: "TeamsListIdpGroupsForLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31417,8 +31417,8 @@ func (s *Server) handleTeamsListIdpGroupsForOrgRequest(args [1]string, w http.Re
 	params, err := decodeTeamsListIdpGroupsForOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListIdpGroupsForOrg",
-			err,
+			Operation: "TeamsListIdpGroupsForOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31462,8 +31462,8 @@ func (s *Server) handleTeamsListIdpGroupsInOrgRequest(args [2]string, w http.Res
 	params, err := decodeTeamsListIdpGroupsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListIdpGroupsInOrg",
-			err,
+			Operation: "TeamsListIdpGroupsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31507,8 +31507,8 @@ func (s *Server) handleTeamsListMembersInOrgRequest(args [2]string, w http.Respo
 	params, err := decodeTeamsListMembersInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListMembersInOrg",
-			err,
+			Operation: "TeamsListMembersInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31552,8 +31552,8 @@ func (s *Server) handleTeamsListMembersLegacyRequest(args [1]string, w http.Resp
 	params, err := decodeTeamsListMembersLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListMembersLegacy",
-			err,
+			Operation: "TeamsListMembersLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31597,8 +31597,8 @@ func (s *Server) handleTeamsListPendingInvitationsInOrgRequest(args [2]string, w
 	params, err := decodeTeamsListPendingInvitationsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListPendingInvitationsInOrg",
-			err,
+			Operation: "TeamsListPendingInvitationsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31642,8 +31642,8 @@ func (s *Server) handleTeamsListPendingInvitationsLegacyRequest(args [1]string, 
 	params, err := decodeTeamsListPendingInvitationsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListPendingInvitationsLegacy",
-			err,
+			Operation: "TeamsListPendingInvitationsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31687,8 +31687,8 @@ func (s *Server) handleTeamsListProjectsInOrgRequest(args [2]string, w http.Resp
 	params, err := decodeTeamsListProjectsInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListProjectsInOrg",
-			err,
+			Operation: "TeamsListProjectsInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31732,8 +31732,8 @@ func (s *Server) handleTeamsListProjectsLegacyRequest(args [1]string, w http.Res
 	params, err := decodeTeamsListProjectsLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListProjectsLegacy",
-			err,
+			Operation: "TeamsListProjectsLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31777,8 +31777,8 @@ func (s *Server) handleTeamsListReposInOrgRequest(args [2]string, w http.Respons
 	params, err := decodeTeamsListReposInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListReposInOrg",
-			err,
+			Operation: "TeamsListReposInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31822,8 +31822,8 @@ func (s *Server) handleTeamsListReposLegacyRequest(args [1]string, w http.Respon
 	params, err := decodeTeamsListReposLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsListReposLegacy",
-			err,
+			Operation: "TeamsListReposLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31867,8 +31867,8 @@ func (s *Server) handleTeamsRemoveMemberLegacyRequest(args [2]string, w http.Res
 	params, err := decodeTeamsRemoveMemberLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveMemberLegacy",
-			err,
+			Operation: "TeamsRemoveMemberLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31912,8 +31912,8 @@ func (s *Server) handleTeamsRemoveMembershipForUserInOrgRequest(args [3]string, 
 	params, err := decodeTeamsRemoveMembershipForUserInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveMembershipForUserInOrg",
-			err,
+			Operation: "TeamsRemoveMembershipForUserInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -31957,8 +31957,8 @@ func (s *Server) handleTeamsRemoveMembershipForUserLegacyRequest(args [2]string,
 	params, err := decodeTeamsRemoveMembershipForUserLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveMembershipForUserLegacy",
-			err,
+			Operation: "TeamsRemoveMembershipForUserLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32002,8 +32002,8 @@ func (s *Server) handleTeamsRemoveProjectInOrgRequest(args [3]string, w http.Res
 	params, err := decodeTeamsRemoveProjectInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveProjectInOrg",
-			err,
+			Operation: "TeamsRemoveProjectInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32047,8 +32047,8 @@ func (s *Server) handleTeamsRemoveProjectLegacyRequest(args [2]string, w http.Re
 	params, err := decodeTeamsRemoveProjectLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveProjectLegacy",
-			err,
+			Operation: "TeamsRemoveProjectLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32092,8 +32092,8 @@ func (s *Server) handleTeamsRemoveRepoInOrgRequest(args [4]string, w http.Respon
 	params, err := decodeTeamsRemoveRepoInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveRepoInOrg",
-			err,
+			Operation: "TeamsRemoveRepoInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32137,8 +32137,8 @@ func (s *Server) handleTeamsRemoveRepoLegacyRequest(args [3]string, w http.Respo
 	params, err := decodeTeamsRemoveRepoLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsRemoveRepoLegacy",
-			err,
+			Operation: "TeamsRemoveRepoLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32182,8 +32182,8 @@ func (s *Server) handleTeamsUpdateDiscussionCommentInOrgRequest(args [4]string, 
 	params, err := decodeTeamsUpdateDiscussionCommentInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsUpdateDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32191,8 +32191,8 @@ func (s *Server) handleTeamsUpdateDiscussionCommentInOrgRequest(args [4]string, 
 	request, err := decodeTeamsUpdateDiscussionCommentInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateDiscussionCommentInOrg",
-			err,
+			Operation: "TeamsUpdateDiscussionCommentInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32236,8 +32236,8 @@ func (s *Server) handleTeamsUpdateDiscussionCommentLegacyRequest(args [3]string,
 	params, err := decodeTeamsUpdateDiscussionCommentLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsUpdateDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32245,8 +32245,8 @@ func (s *Server) handleTeamsUpdateDiscussionCommentLegacyRequest(args [3]string,
 	request, err := decodeTeamsUpdateDiscussionCommentLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateDiscussionCommentLegacy",
-			err,
+			Operation: "TeamsUpdateDiscussionCommentLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32290,8 +32290,8 @@ func (s *Server) handleTeamsUpdateDiscussionInOrgRequest(args [3]string, w http.
 	params, err := decodeTeamsUpdateDiscussionInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateDiscussionInOrg",
-			err,
+			Operation: "TeamsUpdateDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32299,8 +32299,8 @@ func (s *Server) handleTeamsUpdateDiscussionInOrgRequest(args [3]string, w http.
 	request, err := decodeTeamsUpdateDiscussionInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateDiscussionInOrg",
-			err,
+			Operation: "TeamsUpdateDiscussionInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32344,8 +32344,8 @@ func (s *Server) handleTeamsUpdateDiscussionLegacyRequest(args [2]string, w http
 	params, err := decodeTeamsUpdateDiscussionLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateDiscussionLegacy",
-			err,
+			Operation: "TeamsUpdateDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32353,8 +32353,8 @@ func (s *Server) handleTeamsUpdateDiscussionLegacyRequest(args [2]string, w http
 	request, err := decodeTeamsUpdateDiscussionLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateDiscussionLegacy",
-			err,
+			Operation: "TeamsUpdateDiscussionLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32398,8 +32398,8 @@ func (s *Server) handleTeamsUpdateInOrgRequest(args [2]string, w http.ResponseWr
 	params, err := decodeTeamsUpdateInOrgParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateInOrg",
-			err,
+			Operation: "TeamsUpdateInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32407,8 +32407,8 @@ func (s *Server) handleTeamsUpdateInOrgRequest(args [2]string, w http.ResponseWr
 	request, err := decodeTeamsUpdateInOrgRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateInOrg",
-			err,
+			Operation: "TeamsUpdateInOrg",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32452,8 +32452,8 @@ func (s *Server) handleTeamsUpdateLegacyRequest(args [1]string, w http.ResponseW
 	params, err := decodeTeamsUpdateLegacyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TeamsUpdateLegacy",
-			err,
+			Operation: "TeamsUpdateLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32461,8 +32461,8 @@ func (s *Server) handleTeamsUpdateLegacyRequest(args [1]string, w http.ResponseW
 	request, err := decodeTeamsUpdateLegacyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TeamsUpdateLegacy",
-			err,
+			Operation: "TeamsUpdateLegacy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32506,8 +32506,8 @@ func (s *Server) handleUsersAddEmailForAuthenticatedRequest(args [0]string, w ht
 	request, err := decodeUsersAddEmailForAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersAddEmailForAuthenticated",
-			err,
+			Operation: "UsersAddEmailForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32551,8 +32551,8 @@ func (s *Server) handleUsersBlockRequest(args [1]string, w http.ResponseWriter, 
 	params, err := decodeUsersBlockParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersBlock",
-			err,
+			Operation: "UsersBlock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32596,8 +32596,8 @@ func (s *Server) handleUsersCheckBlockedRequest(args [1]string, w http.ResponseW
 	params, err := decodeUsersCheckBlockedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersCheckBlocked",
-			err,
+			Operation: "UsersCheckBlocked",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32641,8 +32641,8 @@ func (s *Server) handleUsersCheckFollowingForUserRequest(args [2]string, w http.
 	params, err := decodeUsersCheckFollowingForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersCheckFollowingForUser",
-			err,
+			Operation: "UsersCheckFollowingForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32686,8 +32686,8 @@ func (s *Server) handleUsersCheckPersonIsFollowedByAuthenticatedRequest(args [1]
 	params, err := decodeUsersCheckPersonIsFollowedByAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersCheckPersonIsFollowedByAuthenticated",
-			err,
+			Operation: "UsersCheckPersonIsFollowedByAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32731,8 +32731,8 @@ func (s *Server) handleUsersCreateGpgKeyForAuthenticatedRequest(args [0]string, 
 	request, err := decodeUsersCreateGpgKeyForAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersCreateGpgKeyForAuthenticated",
-			err,
+			Operation: "UsersCreateGpgKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32776,8 +32776,8 @@ func (s *Server) handleUsersCreatePublicSSHKeyForAuthenticatedRequest(args [0]st
 	request, err := decodeUsersCreatePublicSSHKeyForAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersCreatePublicSSHKeyForAuthenticated",
-			err,
+			Operation: "UsersCreatePublicSSHKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32821,8 +32821,8 @@ func (s *Server) handleUsersDeleteEmailForAuthenticatedRequest(args [0]string, w
 	request, err := decodeUsersDeleteEmailForAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersDeleteEmailForAuthenticated",
-			err,
+			Operation: "UsersDeleteEmailForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32866,8 +32866,8 @@ func (s *Server) handleUsersDeleteGpgKeyForAuthenticatedRequest(args [1]string, 
 	params, err := decodeUsersDeleteGpgKeyForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersDeleteGpgKeyForAuthenticated",
-			err,
+			Operation: "UsersDeleteGpgKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32911,8 +32911,8 @@ func (s *Server) handleUsersDeletePublicSSHKeyForAuthenticatedRequest(args [1]st
 	params, err := decodeUsersDeletePublicSSHKeyForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersDeletePublicSSHKeyForAuthenticated",
-			err,
+			Operation: "UsersDeletePublicSSHKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -32956,8 +32956,8 @@ func (s *Server) handleUsersFollowRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeUsersFollowParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersFollow",
-			err,
+			Operation: "UsersFollow",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33037,8 +33037,8 @@ func (s *Server) handleUsersGetByUsernameRequest(args [1]string, w http.Response
 	params, err := decodeUsersGetByUsernameParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersGetByUsername",
-			err,
+			Operation: "UsersGetByUsername",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33082,8 +33082,8 @@ func (s *Server) handleUsersGetContextForUserRequest(args [1]string, w http.Resp
 	params, err := decodeUsersGetContextForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersGetContextForUser",
-			err,
+			Operation: "UsersGetContextForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33127,8 +33127,8 @@ func (s *Server) handleUsersGetGpgKeyForAuthenticatedRequest(args [1]string, w h
 	params, err := decodeUsersGetGpgKeyForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersGetGpgKeyForAuthenticated",
-			err,
+			Operation: "UsersGetGpgKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33172,8 +33172,8 @@ func (s *Server) handleUsersGetPublicSSHKeyForAuthenticatedRequest(args [1]strin
 	params, err := decodeUsersGetPublicSSHKeyForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersGetPublicSSHKeyForAuthenticated",
-			err,
+			Operation: "UsersGetPublicSSHKeyForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33217,8 +33217,8 @@ func (s *Server) handleUsersListRequest(args [0]string, w http.ResponseWriter, r
 	params, err := decodeUsersListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersList",
-			err,
+			Operation: "UsersList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33298,8 +33298,8 @@ func (s *Server) handleUsersListEmailsForAuthenticatedRequest(args [0]string, w 
 	params, err := decodeUsersListEmailsForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListEmailsForAuthenticated",
-			err,
+			Operation: "UsersListEmailsForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33343,8 +33343,8 @@ func (s *Server) handleUsersListFollowedByAuthenticatedRequest(args [0]string, w
 	params, err := decodeUsersListFollowedByAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListFollowedByAuthenticated",
-			err,
+			Operation: "UsersListFollowedByAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33388,8 +33388,8 @@ func (s *Server) handleUsersListFollowersForAuthenticatedUserRequest(args [0]str
 	params, err := decodeUsersListFollowersForAuthenticatedUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListFollowersForAuthenticatedUser",
-			err,
+			Operation: "UsersListFollowersForAuthenticatedUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33433,8 +33433,8 @@ func (s *Server) handleUsersListFollowersForUserRequest(args [1]string, w http.R
 	params, err := decodeUsersListFollowersForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListFollowersForUser",
-			err,
+			Operation: "UsersListFollowersForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33478,8 +33478,8 @@ func (s *Server) handleUsersListFollowingForUserRequest(args [1]string, w http.R
 	params, err := decodeUsersListFollowingForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListFollowingForUser",
-			err,
+			Operation: "UsersListFollowingForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33523,8 +33523,8 @@ func (s *Server) handleUsersListGpgKeysForAuthenticatedRequest(args [0]string, w
 	params, err := decodeUsersListGpgKeysForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListGpgKeysForAuthenticated",
-			err,
+			Operation: "UsersListGpgKeysForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33568,8 +33568,8 @@ func (s *Server) handleUsersListGpgKeysForUserRequest(args [1]string, w http.Res
 	params, err := decodeUsersListGpgKeysForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListGpgKeysForUser",
-			err,
+			Operation: "UsersListGpgKeysForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33613,8 +33613,8 @@ func (s *Server) handleUsersListPublicEmailsForAuthenticatedRequest(args [0]stri
 	params, err := decodeUsersListPublicEmailsForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListPublicEmailsForAuthenticated",
-			err,
+			Operation: "UsersListPublicEmailsForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33658,8 +33658,8 @@ func (s *Server) handleUsersListPublicKeysForUserRequest(args [1]string, w http.
 	params, err := decodeUsersListPublicKeysForUserParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListPublicKeysForUser",
-			err,
+			Operation: "UsersListPublicKeysForUser",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33703,8 +33703,8 @@ func (s *Server) handleUsersListPublicSSHKeysForAuthenticatedRequest(args [0]str
 	params, err := decodeUsersListPublicSSHKeysForAuthenticatedParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersListPublicSSHKeysForAuthenticated",
-			err,
+			Operation: "UsersListPublicSSHKeysForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33748,8 +33748,8 @@ func (s *Server) handleUsersSetPrimaryEmailVisibilityForAuthenticatedRequest(arg
 	request, err := decodeUsersSetPrimaryEmailVisibilityForAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersSetPrimaryEmailVisibilityForAuthenticated",
-			err,
+			Operation: "UsersSetPrimaryEmailVisibilityForAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33793,8 +33793,8 @@ func (s *Server) handleUsersUnblockRequest(args [1]string, w http.ResponseWriter
 	params, err := decodeUsersUnblockParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersUnblock",
-			err,
+			Operation: "UsersUnblock",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33838,8 +33838,8 @@ func (s *Server) handleUsersUnfollowRequest(args [1]string, w http.ResponseWrite
 	params, err := decodeUsersUnfollowParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"UsersUnfollow",
-			err,
+			Operation: "UsersUnfollow",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -33883,8 +33883,8 @@ func (s *Server) handleUsersUpdateAuthenticatedRequest(args [0]string, w http.Re
 	request, err := decodeUsersUpdateAuthenticatedRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UsersUpdateAuthenticated",
-			err,
+			Operation: "UsersUpdateAuthenticated",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_github/oas_param_dec_gen.go
+++ b/examples/ex_github/oas_param_dec_gen.go
@@ -4155,13 +4155,13 @@ func decodeActionsListJobsForWorkflowRunParams(args [3]string, r *http.Request) 
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -6149,13 +6149,13 @@ func decodeActionsListWorkflowRunsForRepoParams(args [2]string, r *http.Request)
 						if err := params.Status.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: status: invalid")
 			}
@@ -9477,13 +9477,13 @@ func decodeActivityListReposStarredByAuthenticatedUserParams(args [0]string, r *
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -9534,13 +9534,13 @@ func decodeActivityListReposStarredByAuthenticatedUserParams(args [0]string, r *
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -10938,13 +10938,13 @@ func decodeAppsListAccountsForPlanParams(args [1]string, r *http.Request) (AppsL
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -10989,13 +10989,13 @@ func decodeAppsListAccountsForPlanParams(args [1]string, r *http.Request) (AppsL
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -11167,13 +11167,13 @@ func decodeAppsListAccountsForPlanStubbedParams(args [1]string, r *http.Request)
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -11218,13 +11218,13 @@ func decodeAppsListAccountsForPlanStubbedParams(args [1]string, r *http.Request)
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -13195,13 +13195,13 @@ func decodeChecksListForRefParams(args [3]string, r *http.Request) (ChecksListFo
 						if err := params.Status.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: status: invalid")
 			}
@@ -13252,13 +13252,13 @@ func decodeChecksListForRefParams(args [3]string, r *http.Request) (ChecksListFo
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -13556,13 +13556,13 @@ func decodeChecksListForSuiteParams(args [3]string, r *http.Request) (ChecksList
 						if err := params.Status.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: status: invalid")
 			}
@@ -13613,13 +13613,13 @@ func decodeChecksListForSuiteParams(args [3]string, r *http.Request) (ChecksList
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -15121,13 +15121,13 @@ func decodeCodeScanningListAlertsForRepoParams(args [2]string, r *http.Request) 
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -16546,13 +16546,13 @@ func decodeEnterpriseAdminGetAuditLogParams(args [1]string, r *http.Request) (En
 						if err := params.Include.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: include: invalid")
 			}
@@ -16667,13 +16667,13 @@ func decodeEnterpriseAdminGetAuditLogParams(args [1]string, r *http.Request) (En
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -23324,13 +23324,13 @@ func decodeIssuesListParams(args [0]string, r *http.Request) (IssuesListParams, 
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -23381,13 +23381,13 @@ func decodeIssuesListParams(args [0]string, r *http.Request) (IssuesListParams, 
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -23473,13 +23473,13 @@ func decodeIssuesListParams(args [0]string, r *http.Request) (IssuesListParams, 
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -23530,13 +23530,13 @@ func decodeIssuesListParams(args [0]string, r *http.Request) (IssuesListParams, 
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -24284,13 +24284,13 @@ func decodeIssuesListCommentsForRepoParams(args [2]string, r *http.Request) (Iss
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -24335,13 +24335,13 @@ func decodeIssuesListCommentsForRepoParams(args [2]string, r *http.Request) (Iss
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -24669,13 +24669,13 @@ func decodeIssuesListForAuthenticatedUserParams(args [0]string, r *http.Request)
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -24726,13 +24726,13 @@ func decodeIssuesListForAuthenticatedUserParams(args [0]string, r *http.Request)
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -24818,13 +24818,13 @@ func decodeIssuesListForAuthenticatedUserParams(args [0]string, r *http.Request)
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -24875,13 +24875,13 @@ func decodeIssuesListForAuthenticatedUserParams(args [0]string, r *http.Request)
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -25088,13 +25088,13 @@ func decodeIssuesListForOrgParams(args [1]string, r *http.Request) (IssuesListFo
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -25145,13 +25145,13 @@ func decodeIssuesListForOrgParams(args [1]string, r *http.Request) (IssuesListFo
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -25237,13 +25237,13 @@ func decodeIssuesListForOrgParams(args [1]string, r *http.Request) (IssuesListFo
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -25294,13 +25294,13 @@ func decodeIssuesListForOrgParams(args [1]string, r *http.Request) (IssuesListFo
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -25573,13 +25573,13 @@ func decodeIssuesListForRepoParams(args [2]string, r *http.Request) (IssuesListF
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -25770,13 +25770,13 @@ func decodeIssuesListForRepoParams(args [2]string, r *http.Request) (IssuesListF
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -25827,13 +25827,13 @@ func decodeIssuesListForRepoParams(args [2]string, r *http.Request) (IssuesListF
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -26589,13 +26589,13 @@ func decodeIssuesListMilestonesParams(args [2]string, r *http.Request) (IssuesLi
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -26646,13 +26646,13 @@ func decodeIssuesListMilestonesParams(args [2]string, r *http.Request) (IssuesLi
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -26703,13 +26703,13 @@ func decodeIssuesListMilestonesParams(args [2]string, r *http.Request) (IssuesLi
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -28674,7 +28674,7 @@ func decodeMigrationsGetStatusForOrgParams(args [2]string, r *http.Request) (Mig
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -28685,7 +28685,7 @@ func decodeMigrationsGetStatusForOrgParams(args [2]string, r *http.Request) (Mig
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: exclude: invalid")
 			}
@@ -28944,7 +28944,7 @@ func decodeMigrationsListForOrgParams(args [1]string, r *http.Request) (Migratio
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -28955,7 +28955,7 @@ func decodeMigrationsListForOrgParams(args [1]string, r *http.Request) (Migratio
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: exclude: invalid")
 			}
@@ -31005,13 +31005,13 @@ func decodeOrgsGetAuditLogParams(args [1]string, r *http.Request) (OrgsGetAuditL
 						if err := params.Include.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: include: invalid")
 			}
@@ -31126,13 +31126,13 @@ func decodeOrgsGetAuditLogParams(args [1]string, r *http.Request) (OrgsGetAuditL
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -32255,13 +32255,13 @@ func decodeOrgsListMembersParams(args [1]string, r *http.Request) (OrgsListMembe
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -32312,13 +32312,13 @@ func decodeOrgsListMembersParams(args [1]string, r *http.Request) (OrgsListMembe
 						if err := params.Role.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: role: invalid")
 			}
@@ -32453,13 +32453,13 @@ func decodeOrgsListMembershipsForAuthenticatedUserParams(args [0]string, r *http
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -32631,13 +32631,13 @@ func decodeOrgsListOutsideCollaboratorsParams(args [1]string, r *http.Request) (
 						if err := params.Filter.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: filter: invalid")
 			}
@@ -34997,13 +34997,13 @@ func decodePackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -35237,13 +35237,13 @@ func decodePackagesGetAllPackageVersionsForPackageOwnedByOrgParams(args [3]strin
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -36018,7 +36018,7 @@ func decodePackagesListPackagesForAuthenticatedUserParams(args [0]string, r *htt
 				if err := params.PackageType.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: package_type: invalid")
 			}
@@ -36065,13 +36065,13 @@ func decodePackagesListPackagesForAuthenticatedUserParams(args [0]string, r *htt
 						if err := params.Visibility.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: visibility: invalid")
 			}
@@ -36115,7 +36115,7 @@ func decodePackagesListPackagesForOrganizationParams(args [1]string, r *http.Req
 				if err := params.PackageType.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: package_type: invalid")
 			}
@@ -36193,13 +36193,13 @@ func decodePackagesListPackagesForOrganizationParams(args [1]string, r *http.Req
 						if err := params.Visibility.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: visibility: invalid")
 			}
@@ -36243,7 +36243,7 @@ func decodePackagesListPackagesForUserParams(args [1]string, r *http.Request) (P
 				if err := params.PackageType.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: package_type: invalid")
 			}
@@ -36290,13 +36290,13 @@ func decodePackagesListPackagesForUserParams(args [1]string, r *http.Request) (P
 						if err := params.Visibility.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: visibility: invalid")
 			}
@@ -37667,13 +37667,13 @@ func decodeProjectsListCardsParams(args [1]string, r *http.Request) (ProjectsLis
 						if err := params.ArchivedState.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: archived_state: invalid")
 			}
@@ -37845,13 +37845,13 @@ func decodeProjectsListCollaboratorsParams(args [1]string, r *http.Request) (Pro
 						if err := params.Affiliation.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: affiliation: invalid")
 			}
@@ -38144,13 +38144,13 @@ func decodeProjectsListForOrgParams(args [1]string, r *http.Request) (ProjectsLi
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -38353,13 +38353,13 @@ func decodeProjectsListForRepoParams(args [2]string, r *http.Request) (ProjectsL
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -38531,13 +38531,13 @@ func decodeProjectsListForUserParams(args [1]string, r *http.Request) (ProjectsL
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -40192,13 +40192,13 @@ func decodePullsListParams(args [2]string, r *http.Request) (PullsListParams, er
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -40319,13 +40319,13 @@ func decodePullsListParams(args [2]string, r *http.Request) (PullsListParams, er
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -40370,13 +40370,13 @@ func decodePullsListParams(args [2]string, r *http.Request) (PullsListParams, er
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -41373,13 +41373,13 @@ func decodePullsListReviewCommentsParams(args [3]string, r *http.Request) (Pulls
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -41424,13 +41424,13 @@ func decodePullsListReviewCommentsParams(args [3]string, r *http.Request) (Pulls
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -41662,13 +41662,13 @@ func decodePullsListReviewCommentsForRepoParams(args [2]string, r *http.Request)
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -41713,13 +41713,13 @@ func decodePullsListReviewCommentsForRepoParams(args [2]string, r *http.Request)
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -44682,13 +44682,13 @@ func decodeReactionsListForCommitCommentParams(args [3]string, r *http.Request) 
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -44916,13 +44916,13 @@ func decodeReactionsListForIssueParams(args [3]string, r *http.Request) (Reactio
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -45150,13 +45150,13 @@ func decodeReactionsListForIssueCommentParams(args [3]string, r *http.Request) (
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -45384,13 +45384,13 @@ func decodeReactionsListForPullRequestReviewCommentParams(args [3]string, r *htt
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -45649,13 +45649,13 @@ func decodeReactionsListForTeamDiscussionCommentInOrgParams(args [4]string, r *h
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -45883,13 +45883,13 @@ func decodeReactionsListForTeamDiscussionCommentLegacyParams(args [3]string, r *
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -46117,13 +46117,13 @@ func decodeReactionsListForTeamDiscussionInOrgParams(args [3]string, r *http.Req
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -46320,13 +46320,13 @@ func decodeReactionsListForTeamDiscussionLegacyParams(args [2]string, r *http.Re
 						if err := params.Content.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: content: invalid")
 			}
@@ -51789,13 +51789,13 @@ func decodeReposGetClonesParams(args [2]string, r *http.Request) (ReposGetClones
 						if err := params.Per.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: per: invalid")
 			}
@@ -54782,13 +54782,13 @@ func decodeReposGetViewsParams(args [2]string, r *http.Request) (ReposGetViewsPa
 						if err := params.Per.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: per: invalid")
 			}
@@ -55638,13 +55638,13 @@ func decodeReposListCollaboratorsParams(args [2]string, r *http.Request) (ReposL
 						if err := params.Affiliation.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: affiliation: invalid")
 			}
@@ -57468,13 +57468,13 @@ func decodeReposListForAuthenticatedUserParams(args [0]string, r *http.Request) 
 						if err := params.Visibility.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: visibility: invalid")
 			}
@@ -57566,13 +57566,13 @@ func decodeReposListForAuthenticatedUserParams(args [0]string, r *http.Request) 
 						if err := params.Type.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: type: invalid")
 			}
@@ -57623,13 +57623,13 @@ func decodeReposListForAuthenticatedUserParams(args [0]string, r *http.Request) 
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -57674,13 +57674,13 @@ func decodeReposListForAuthenticatedUserParams(args [0]string, r *http.Request) 
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -57916,13 +57916,13 @@ func decodeReposListForOrgParams(args [1]string, r *http.Request) (ReposListForO
 						if err := params.Type.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: type: invalid")
 			}
@@ -57973,13 +57973,13 @@ func decodeReposListForOrgParams(args [1]string, r *http.Request) (ReposListForO
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -58024,13 +58024,13 @@ func decodeReposListForOrgParams(args [1]string, r *http.Request) (ReposListForO
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -58202,13 +58202,13 @@ func decodeReposListForUserParams(args [1]string, r *http.Request) (ReposListFor
 						if err := params.Type.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: type: invalid")
 			}
@@ -58259,13 +58259,13 @@ func decodeReposListForUserParams(args [1]string, r *http.Request) (ReposListFor
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -58310,13 +58310,13 @@ func decodeReposListForUserParams(args [1]string, r *http.Request) (ReposListFor
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -58519,13 +58519,13 @@ func decodeReposListForksParams(args [2]string, r *http.Request) (ReposListForks
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -63261,13 +63261,13 @@ func decodeSearchCodeParams(args [0]string, r *http.Request) (SearchCodeParams, 
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -63318,13 +63318,13 @@ func decodeSearchCodeParams(args [0]string, r *http.Request) (SearchCodeParams, 
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -63489,13 +63489,13 @@ func decodeSearchCommitsParams(args [0]string, r *http.Request) (SearchCommitsPa
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -63546,13 +63546,13 @@ func decodeSearchCommitsParams(args [0]string, r *http.Request) (SearchCommitsPa
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -63717,13 +63717,13 @@ func decodeSearchIssuesAndPullRequestsParams(args [0]string, r *http.Request) (S
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -63774,13 +63774,13 @@ func decodeSearchIssuesAndPullRequestsParams(args [0]string, r *http.Request) (S
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -63975,13 +63975,13 @@ func decodeSearchLabelsParams(args [0]string, r *http.Request) (SearchLabelsPara
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -64032,13 +64032,13 @@ func decodeSearchLabelsParams(args [0]string, r *http.Request) (SearchLabelsPara
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -64203,13 +64203,13 @@ func decodeSearchReposParams(args [0]string, r *http.Request) (SearchReposParams
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -64260,13 +64260,13 @@ func decodeSearchReposParams(args [0]string, r *http.Request) (SearchReposParams
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -64551,13 +64551,13 @@ func decodeSearchUsersParams(args [0]string, r *http.Request) (SearchUsersParams
 						if err := params.Sort.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: sort: invalid")
 			}
@@ -64608,13 +64608,13 @@ func decodeSearchUsersParams(args [0]string, r *http.Request) (SearchUsersParams
 						if err := params.Order.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: order: invalid")
 			}
@@ -64887,13 +64887,13 @@ func decodeSecretScanningListAlertsForOrgParams(args [1]string, r *http.Request)
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -65125,13 +65125,13 @@ func decodeSecretScanningListAlertsForRepoParams(args [2]string, r *http.Request
 						if err := params.State.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: state: invalid")
 			}
@@ -68612,13 +68612,13 @@ func decodeTeamsListDiscussionCommentsInOrgParams(args [3]string, r *http.Reques
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -68821,13 +68821,13 @@ func decodeTeamsListDiscussionCommentsLegacyParams(args [2]string, r *http.Reque
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -69030,13 +69030,13 @@ func decodeTeamsListDiscussionsInOrgParams(args [2]string, r *http.Request) (Tea
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -69243,13 +69243,13 @@ func decodeTeamsListDiscussionsLegacyParams(args [1]string, r *http.Request) (Te
 						if err := params.Direction.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: direction: invalid")
 			}
@@ -69764,13 +69764,13 @@ func decodeTeamsListMembersInOrgParams(args [2]string, r *http.Request) (TeamsLi
 						if err := params.Role.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: role: invalid")
 			}
@@ -69942,13 +69942,13 @@ func decodeTeamsListMembersLegacyParams(args [1]string, r *http.Request) (TeamsL
 						if err := params.Role.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: role: invalid")
 			}
@@ -72413,13 +72413,13 @@ func decodeUsersGetContextForUserParams(args [1]string, r *http.Request) (UsersG
 						if err := params.SubjectType.Value.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						return err
 					}
 				}
-				return nil
-				return nil
+				return nil // return 2
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: subject_type: invalid")
 			}

--- a/examples/ex_github/oas_req_dec_gen.go
+++ b/examples/ex_github/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeActionsCreateOrUpdateEnvironmentSecretRequest(r *http.Request, span t
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsCreateOrUpdateEnvironmentSecret request")
 		}
@@ -91,7 +91,7 @@ func decodeActionsCreateOrUpdateOrgSecretRequest(r *http.Request, span trace.Spa
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsCreateOrUpdateOrgSecret request")
 		}
@@ -135,7 +135,7 @@ func decodeActionsCreateOrUpdateRepoSecretRequest(r *http.Request, span trace.Sp
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsCreateOrUpdateRepoSecret request")
 		}
@@ -179,7 +179,7 @@ func decodeActionsCreateSelfHostedRunnerGroupForOrgRequest(r *http.Request, span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsCreateSelfHostedRunnerGroupForOrg request")
 		}
@@ -223,7 +223,7 @@ func decodeActionsReviewPendingDeploymentsForRunRequest(r *http.Request, span tr
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsReviewPendingDeploymentsForRun request")
 		}
@@ -341,7 +341,7 @@ func decodeActionsSetGithubActionsPermissionsOrganizationRequest(r *http.Request
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetGithubActionsPermissionsOrganization request")
 		}
@@ -385,7 +385,7 @@ func decodeActionsSetGithubActionsPermissionsRepositoryRequest(r *http.Request, 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetGithubActionsPermissionsRepository request")
 		}
@@ -429,7 +429,7 @@ func decodeActionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequest(r *http.Reque
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg request")
 		}
@@ -473,7 +473,7 @@ func decodeActionsSetSelectedReposForOrgSecretRequest(r *http.Request, span trac
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetSelectedReposForOrgSecret request")
 		}
@@ -517,7 +517,7 @@ func decodeActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationRequest
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization request")
 		}
@@ -561,7 +561,7 @@ func decodeActionsSetSelfHostedRunnersInGroupForOrgRequest(r *http.Request, span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsSetSelfHostedRunnersInGroupForOrg request")
 		}
@@ -605,7 +605,7 @@ func decodeActionsUpdateSelfHostedRunnerGroupForOrgRequest(r *http.Request, span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ActionsUpdateSelfHostedRunnerGroupForOrg request")
 		}
@@ -833,7 +833,7 @@ func decodeAppsCreateContentAttachmentRequest(r *http.Request, span trace.Span) 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AppsCreateContentAttachment request")
 		}
@@ -880,13 +880,13 @@ func decodeAppsCreateInstallationAccessTokenRequest(r *http.Request, span trace.
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AppsCreateInstallationAccessToken request")
 		}
@@ -1038,7 +1038,7 @@ func decodeAppsScopeTokenRequest(r *http.Request, span trace.Span) (req AppsScop
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AppsScopeToken request")
 		}
@@ -1085,13 +1085,13 @@ func decodeAppsUpdateWebhookConfigForAppRequest(r *http.Request, span trace.Span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AppsUpdateWebhookConfigForApp request")
 		}
@@ -1207,7 +1207,7 @@ func decodeCodeScanningUpdateAlertRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CodeScanningUpdateAlert request")
 		}
@@ -1251,7 +1251,7 @@ func decodeCodeScanningUploadSarifRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CodeScanningUploadSarif request")
 		}
@@ -1295,7 +1295,7 @@ func decodeEnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseRequest(r *htt
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise request")
 		}
@@ -1339,7 +1339,7 @@ func decodeEnterpriseAdminProvisionAndInviteEnterpriseGroupRequest(r *http.Reque
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminProvisionAndInviteEnterpriseGroup request")
 		}
@@ -1383,7 +1383,7 @@ func decodeEnterpriseAdminProvisionAndInviteEnterpriseUserRequest(r *http.Reques
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminProvisionAndInviteEnterpriseUser request")
 		}
@@ -1463,7 +1463,7 @@ func decodeEnterpriseAdminSetGithubActionsPermissionsEnterpriseRequest(r *http.R
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetGithubActionsPermissionsEnterprise request")
 		}
@@ -1507,7 +1507,7 @@ func decodeEnterpriseAdminSetInformationForProvisionedEnterpriseGroupRequest(r *
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetInformationForProvisionedEnterpriseGroup request")
 		}
@@ -1551,7 +1551,7 @@ func decodeEnterpriseAdminSetInformationForProvisionedEnterpriseUserRequest(r *h
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetInformationForProvisionedEnterpriseUser request")
 		}
@@ -1595,7 +1595,7 @@ func decodeEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseRequest
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise request")
 		}
@@ -1639,7 +1639,7 @@ func decodeEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise request")
 		}
@@ -1683,7 +1683,7 @@ func decodeEnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseRequest(r *htt
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise request")
 		}
@@ -1727,7 +1727,7 @@ func decodeEnterpriseAdminUpdateAttributeForEnterpriseGroupRequest(r *http.Reque
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminUpdateAttributeForEnterpriseGroup request")
 		}
@@ -1771,7 +1771,7 @@ func decodeEnterpriseAdminUpdateAttributeForEnterpriseUserRequest(r *http.Reques
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminUpdateAttributeForEnterpriseUser request")
 		}
@@ -1818,13 +1818,13 @@ func decodeEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseRequest(r *htt
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise request")
 		}
@@ -1868,7 +1868,7 @@ func decodeGistsCreateRequest(r *http.Request, span trace.Span) (req GistsCreate
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GistsCreate request")
 		}
@@ -1912,7 +1912,7 @@ func decodeGistsCreateCommentRequest(r *http.Request, span trace.Span) (req Gist
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GistsCreateComment request")
 		}
@@ -1956,7 +1956,7 @@ func decodeGistsUpdateCommentRequest(r *http.Request, span trace.Span) (req Gist
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GistsUpdateComment request")
 		}
@@ -2108,7 +2108,7 @@ func decodeGitCreateTagRequest(r *http.Request, span trace.Span) (req GitCreateT
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GitCreateTag request")
 		}
@@ -2152,7 +2152,7 @@ func decodeGitCreateTreeRequest(r *http.Request, span trace.Span) (req GitCreate
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GitCreateTree request")
 		}
@@ -2232,7 +2232,7 @@ func decodeInteractionsSetRestrictionsForAuthenticatedUserRequest(r *http.Reques
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate InteractionsSetRestrictionsForAuthenticatedUser request")
 		}
@@ -2276,7 +2276,7 @@ func decodeInteractionsSetRestrictionsForOrgRequest(r *http.Request, span trace.
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate InteractionsSetRestrictionsForOrg request")
 		}
@@ -2320,7 +2320,7 @@ func decodeInteractionsSetRestrictionsForRepoRequest(r *http.Request, span trace
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate InteractionsSetRestrictionsForRepo request")
 		}
@@ -2509,7 +2509,7 @@ func decodeIssuesCreateMilestoneRequest(r *http.Request, span trace.Span) (req I
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate IssuesCreateMilestone request")
 		}
@@ -2556,13 +2556,13 @@ func decodeIssuesLockRequest(r *http.Request, span trace.Span) (req OptNilIssues
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate IssuesLock request")
 		}
@@ -2646,13 +2646,13 @@ func decodeIssuesUpdateRequest(r *http.Request, span trace.Span) (req OptIssuesU
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate IssuesUpdate request")
 		}
@@ -2772,13 +2772,13 @@ func decodeIssuesUpdateMilestoneRequest(r *http.Request, span trace.Span) (req O
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate IssuesUpdateMilestone request")
 		}
@@ -2859,7 +2859,7 @@ func decodeMigrationsSetLfsPreferenceRequest(r *http.Request, span trace.Span) (
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate MigrationsSetLfsPreference request")
 		}
@@ -2903,7 +2903,7 @@ func decodeMigrationsStartForAuthenticatedUserRequest(r *http.Request, span trac
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate MigrationsStartForAuthenticatedUser request")
 		}
@@ -2947,7 +2947,7 @@ func decodeMigrationsStartForOrgRequest(r *http.Request, span trace.Span) (req M
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate MigrationsStartForOrg request")
 		}
@@ -2991,7 +2991,7 @@ func decodeMigrationsStartImportRequest(r *http.Request, span trace.Span) (req M
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate MigrationsStartImport request")
 		}
@@ -3075,13 +3075,13 @@ func decodeOAuthAuthorizationsCreateAuthorizationRequest(r *http.Request, span t
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OAuthAuthorizationsCreateAuthorization request")
 		}
@@ -3125,7 +3125,7 @@ func decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppRequest(r *http.Requ
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OAuthAuthorizationsGetOrCreateAuthorizationForApp request")
 		}
@@ -3169,7 +3169,7 @@ func decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReques
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint request")
 		}
@@ -3216,13 +3216,13 @@ func decodeOAuthAuthorizationsUpdateAuthorizationRequest(r *http.Request, span t
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OAuthAuthorizationsUpdateAuthorization request")
 		}
@@ -3269,13 +3269,13 @@ func decodeOrgsCreateInvitationRequest(r *http.Request, span trace.Span) (req Op
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsCreateInvitation request")
 		}
@@ -3319,7 +3319,7 @@ func decodeOrgsCreateWebhookRequest(r *http.Request, span trace.Span) (req OrgsC
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsCreateWebhook request")
 		}
@@ -3366,13 +3366,13 @@ func decodeOrgsSetMembershipForUserRequest(r *http.Request, span trace.Span) (re
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsSetMembershipForUser request")
 		}
@@ -3416,7 +3416,7 @@ func decodeOrgsUpdateMembershipForAuthenticatedUserRequest(r *http.Request, span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsUpdateMembershipForAuthenticatedUser request")
 		}
@@ -3463,13 +3463,13 @@ func decodeOrgsUpdateWebhookRequest(r *http.Request, span trace.Span) (req OptOr
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsUpdateWebhook request")
 		}
@@ -3516,13 +3516,13 @@ func decodeOrgsUpdateWebhookConfigForOrgRequest(r *http.Request, span trace.Span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrgsUpdateWebhookConfigForOrg request")
 		}
@@ -3569,13 +3569,13 @@ func decodeProjectsAddCollaboratorRequest(r *http.Request, span trace.Span) (req
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ProjectsAddCollaborator request")
 		}
@@ -3763,7 +3763,7 @@ func decodeProjectsMoveCardRequest(r *http.Request, span trace.Span) (req Projec
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ProjectsMoveCard request")
 		}
@@ -3807,7 +3807,7 @@ func decodeProjectsMoveColumnRequest(r *http.Request, span trace.Span) (req Proj
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ProjectsMoveColumn request")
 		}
@@ -3854,13 +3854,13 @@ func decodeProjectsUpdateRequest(r *http.Request, span trace.Span) (req OptProje
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ProjectsUpdate request")
 		}
@@ -4052,13 +4052,13 @@ func decodePullsCreateReviewRequest(r *http.Request, span trace.Span) (req OptPu
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsCreateReview request")
 		}
@@ -4102,7 +4102,7 @@ func decodePullsCreateReviewCommentRequest(r *http.Request, span trace.Span) (re
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsCreateReviewComment request")
 		}
@@ -4185,13 +4185,13 @@ func decodePullsMergeRequest(r *http.Request, span trace.Span) (req OptNilPullsM
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsMerge request")
 		}
@@ -4235,7 +4235,7 @@ func decodePullsRemoveRequestedReviewersRequest(r *http.Request, span trace.Span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsRemoveRequestedReviewers request")
 		}
@@ -4279,7 +4279,7 @@ func decodePullsSubmitReviewRequest(r *http.Request, span trace.Span) (req Pulls
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsSubmitReview request")
 		}
@@ -4326,13 +4326,13 @@ func decodePullsUpdateRequest(r *http.Request, span trace.Span) (req OptPullsUpd
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PullsUpdate request")
 		}
@@ -4485,7 +4485,7 @@ func decodeReactionsCreateForCommitCommentRequest(r *http.Request, span trace.Sp
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForCommitComment request")
 		}
@@ -4529,7 +4529,7 @@ func decodeReactionsCreateForIssueRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForIssue request")
 		}
@@ -4573,7 +4573,7 @@ func decodeReactionsCreateForIssueCommentRequest(r *http.Request, span trace.Spa
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForIssueComment request")
 		}
@@ -4617,7 +4617,7 @@ func decodeReactionsCreateForPullRequestReviewCommentRequest(r *http.Request, sp
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForPullRequestReviewComment request")
 		}
@@ -4661,7 +4661,7 @@ func decodeReactionsCreateForReleaseRequest(r *http.Request, span trace.Span) (r
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForRelease request")
 		}
@@ -4705,7 +4705,7 @@ func decodeReactionsCreateForTeamDiscussionCommentInOrgRequest(r *http.Request, 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForTeamDiscussionCommentInOrg request")
 		}
@@ -4749,7 +4749,7 @@ func decodeReactionsCreateForTeamDiscussionCommentLegacyRequest(r *http.Request,
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForTeamDiscussionCommentLegacy request")
 		}
@@ -4793,7 +4793,7 @@ func decodeReactionsCreateForTeamDiscussionInOrgRequest(r *http.Request, span tr
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForTeamDiscussionInOrg request")
 		}
@@ -4837,7 +4837,7 @@ func decodeReactionsCreateForTeamDiscussionLegacyRequest(r *http.Request, span t
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReactionsCreateForTeamDiscussionLegacy request")
 		}
@@ -4884,13 +4884,13 @@ func decodeReposAddAppAccessRestrictionsRequest(r *http.Request, span trace.Span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposAddAppAccessRestrictions request")
 		}
@@ -4937,13 +4937,13 @@ func decodeReposAddCollaboratorRequest(r *http.Request, span trace.Span) (req Op
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposAddCollaborator request")
 		}
@@ -4990,13 +4990,13 @@ func decodeReposAddStatusCheckContextsRequest(r *http.Request, span trace.Span) 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposAddStatusCheckContexts request")
 		}
@@ -5043,13 +5043,13 @@ func decodeReposAddTeamAccessRestrictionsRequest(r *http.Request, span trace.Spa
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposAddTeamAccessRestrictions request")
 		}
@@ -5096,13 +5096,13 @@ func decodeReposAddUserAccessRestrictionsRequest(r *http.Request, span trace.Spa
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposAddUserAccessRestrictions request")
 		}
@@ -5218,7 +5218,7 @@ func decodeReposCreateCommitStatusRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreateCommitStatus request")
 		}
@@ -5334,7 +5334,7 @@ func decodeReposCreateDeploymentStatusRequest(r *http.Request, span trace.Span) 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreateDeploymentStatus request")
 		}
@@ -5378,7 +5378,7 @@ func decodeReposCreateDispatchEventRequest(r *http.Request, span trace.Span) (re
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreateDispatchEvent request")
 		}
@@ -5495,7 +5495,7 @@ func decodeReposCreateInOrgRequest(r *http.Request, span trace.Span) (req ReposC
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreateInOrg request")
 		}
@@ -5575,8 +5575,8 @@ func decodeReposCreatePagesSiteRequest(r *http.Request, span trace.Span) (req Ni
 			if err := request.Value.Validate(); err != nil {
 				return err
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreatePagesSite request")
 		}
@@ -5695,13 +5695,13 @@ func decodeReposCreateWebhookRequest(r *http.Request, span trace.Span) (req OptN
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposCreateWebhook request")
 		}
@@ -5856,13 +5856,13 @@ func decodeReposRemoveAppAccessRestrictionsRequest(r *http.Request, span trace.S
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposRemoveAppAccessRestrictions request")
 		}
@@ -5909,13 +5909,13 @@ func decodeReposRemoveStatusCheckContextsRequest(r *http.Request, span trace.Spa
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposRemoveStatusCheckContexts request")
 		}
@@ -5962,13 +5962,13 @@ func decodeReposRemoveTeamAccessRestrictionsRequest(r *http.Request, span trace.
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposRemoveTeamAccessRestrictions request")
 		}
@@ -6015,13 +6015,13 @@ func decodeReposRemoveUserAccessRestrictionsRequest(r *http.Request, span trace.
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposRemoveUserAccessRestrictions request")
 		}
@@ -6102,7 +6102,7 @@ func decodeReposReplaceAllTopicsRequest(r *http.Request, span trace.Span) (req R
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposReplaceAllTopics request")
 		}
@@ -6149,13 +6149,13 @@ func decodeReposSetAppAccessRestrictionsRequest(r *http.Request, span trace.Span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposSetAppAccessRestrictions request")
 		}
@@ -6202,13 +6202,13 @@ func decodeReposSetStatusCheckContextsRequest(r *http.Request, span trace.Span) 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposSetStatusCheckContexts request")
 		}
@@ -6255,13 +6255,13 @@ func decodeReposSetTeamAccessRestrictionsRequest(r *http.Request, span trace.Spa
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposSetTeamAccessRestrictions request")
 		}
@@ -6308,13 +6308,13 @@ func decodeReposSetUserAccessRestrictionsRequest(r *http.Request, span trace.Spa
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposSetUserAccessRestrictions request")
 		}
@@ -6397,13 +6397,13 @@ func decodeReposUpdateRequest(r *http.Request, span trace.Span) (req OptReposUpd
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposUpdate request")
 		}
@@ -6447,7 +6447,7 @@ func decodeReposUpdateBranchProtectionRequest(r *http.Request, span trace.Span) 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposUpdateBranchProtection request")
 		}
@@ -6530,13 +6530,13 @@ func decodeReposUpdateInvitationRequest(r *http.Request, span trace.Span) (req O
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposUpdateInvitation request")
 		}
@@ -6731,13 +6731,13 @@ func decodeReposUpdateWebhookRequest(r *http.Request, span trace.Span) (req OptR
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposUpdateWebhook request")
 		}
@@ -6784,13 +6784,13 @@ func decodeReposUpdateWebhookConfigForRepoRequest(r *http.Request, span trace.Sp
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate ReposUpdateWebhookConfigForRepo request")
 		}
@@ -6834,7 +6834,7 @@ func decodeSecretScanningUpdateAlertRequest(r *http.Request, span trace.Span) (r
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SecretScanningUpdateAlert request")
 		}
@@ -6881,13 +6881,13 @@ func decodeTeamsAddOrUpdateMembershipForUserInOrgRequest(r *http.Request, span t
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateMembershipForUserInOrg request")
 		}
@@ -6934,13 +6934,13 @@ func decodeTeamsAddOrUpdateMembershipForUserLegacyRequest(r *http.Request, span 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateMembershipForUserLegacy request")
 		}
@@ -6987,13 +6987,13 @@ func decodeTeamsAddOrUpdateProjectPermissionsInOrgRequest(r *http.Request, span 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateProjectPermissionsInOrg request")
 		}
@@ -7040,13 +7040,13 @@ func decodeTeamsAddOrUpdateProjectPermissionsLegacyRequest(r *http.Request, span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateProjectPermissionsLegacy request")
 		}
@@ -7093,13 +7093,13 @@ func decodeTeamsAddOrUpdateRepoPermissionsInOrgRequest(r *http.Request, span tra
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateRepoPermissionsInOrg request")
 		}
@@ -7146,13 +7146,13 @@ func decodeTeamsAddOrUpdateRepoPermissionsLegacyRequest(r *http.Request, span tr
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsAddOrUpdateRepoPermissionsLegacy request")
 		}
@@ -7196,7 +7196,7 @@ func decodeTeamsCreateRequest(r *http.Request, span trace.Span) (req TeamsCreate
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsCreate request")
 		}
@@ -7420,7 +7420,7 @@ func decodeTeamsCreateOrUpdateIdpGroupConnectionsLegacyRequest(r *http.Request, 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsCreateOrUpdateIdpGroupConnectionsLegacy request")
 		}
@@ -7613,13 +7613,13 @@ func decodeTeamsUpdateInOrgRequest(r *http.Request, span trace.Span) (req OptTea
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsUpdateInOrg request")
 		}
@@ -7663,7 +7663,7 @@ func decodeTeamsUpdateLegacyRequest(r *http.Request, span trace.Span) (req Teams
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TeamsUpdateLegacy request")
 		}
@@ -7710,13 +7710,13 @@ func decodeUsersAddEmailForAuthenticatedRequest(r *http.Request, span trace.Span
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate UsersAddEmailForAuthenticated request")
 		}
@@ -7796,7 +7796,7 @@ func decodeUsersCreatePublicSSHKeyForAuthenticatedRequest(r *http.Request, span 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate UsersCreatePublicSSHKeyForAuthenticated request")
 		}
@@ -7843,13 +7843,13 @@ func decodeUsersDeleteEmailForAuthenticatedRequest(r *http.Request, span trace.S
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate UsersDeleteEmailForAuthenticated request")
 		}
@@ -7893,7 +7893,7 @@ func decodeUsersSetPrimaryEmailVisibilityForAuthenticatedRequest(r *http.Request
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate UsersSetPrimaryEmailVisibilityForAuthenticated request")
 		}

--- a/examples/ex_github/oas_validators_gen.go
+++ b/examples/ex_github/oas_validators_gen.go
@@ -24,7 +24,7 @@ func (s ActionsCreateOrUpdateEnvironmentSecretReq) Validate() error {
 		}).Validate(string(s.EncryptedValue)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "encrypted_value",
@@ -52,13 +52,13 @@ func (s ActionsCreateOrUpdateOrgSecretReq) Validate() error {
 				}).Validate(string(s.EncryptedValue.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "encrypted_value",
@@ -69,7 +69,7 @@ func (s ActionsCreateOrUpdateOrgSecretReq) Validate() error {
 		if err := s.Visibility.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -109,13 +109,13 @@ func (s ActionsCreateOrUpdateRepoSecretReq) Validate() error {
 				}).Validate(string(s.EncryptedValue.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "encrypted_value",
@@ -135,13 +135,13 @@ func (s ActionsCreateSelfHostedRunnerGroupForOrgReq) Validate() error {
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -171,7 +171,7 @@ func (s ActionsEnterprisePermissions) Validate() error {
 		if err := s.EnabledOrganizations.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enabled_organizations",
@@ -184,13 +184,13 @@ func (s ActionsEnterprisePermissions) Validate() error {
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -208,7 +208,7 @@ func (s ActionsListArtifactsForRepoOK) Validate() error {
 		if s.Artifacts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "artifacts",
@@ -226,7 +226,7 @@ func (s ActionsListEnvironmentSecretsOK) Validate() error {
 		if s.Secrets == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secrets",
@@ -260,7 +260,7 @@ func (s ActionsListJobsForWorkflowRunOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -271,7 +271,7 @@ func (s ActionsListJobsForWorkflowRunOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "jobs",
@@ -295,7 +295,7 @@ func (s ActionsListOrgSecretsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -306,7 +306,7 @@ func (s ActionsListOrgSecretsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secrets",
@@ -324,7 +324,7 @@ func (s ActionsListRepoAccessToSelfHostedRunnerGroupInOrgOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -335,7 +335,7 @@ func (s ActionsListRepoAccessToSelfHostedRunnerGroupInOrgOK) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -353,7 +353,7 @@ func (s ActionsListRepoSecretsOK) Validate() error {
 		if s.Secrets == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secrets",
@@ -377,7 +377,7 @@ func (s ActionsListRepoWorkflowsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -388,7 +388,7 @@ func (s ActionsListRepoWorkflowsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "workflows",
@@ -406,7 +406,7 @@ func (s ActionsListSelectedReposForOrgSecretOK) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -424,7 +424,7 @@ func (s ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationOK) Valid
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -435,7 +435,7 @@ func (s ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationOK) Valid
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -453,7 +453,7 @@ func (s ActionsListSelfHostedRunnerGroupsForOrgOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -470,7 +470,7 @@ func (s ActionsListSelfHostedRunnerGroupsForOrgOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -481,7 +481,7 @@ func (s ActionsListSelfHostedRunnerGroupsForOrgOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runner_groups",
@@ -505,7 +505,7 @@ func (s ActionsListSelfHostedRunnersForOrgOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -516,7 +516,7 @@ func (s ActionsListSelfHostedRunnersForOrgOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -540,7 +540,7 @@ func (s ActionsListSelfHostedRunnersForRepoOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -551,7 +551,7 @@ func (s ActionsListSelfHostedRunnersForRepoOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -569,7 +569,7 @@ func (s ActionsListSelfHostedRunnersInGroupForOrgOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -586,7 +586,7 @@ func (s ActionsListSelfHostedRunnersInGroupForOrgOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -597,7 +597,7 @@ func (s ActionsListSelfHostedRunnersInGroupForOrgOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -615,7 +615,7 @@ func (s ActionsListWorkflowRunArtifactsOK) Validate() error {
 		if s.Artifacts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "artifacts",
@@ -633,7 +633,7 @@ func (s ActionsListWorkflowRunsForRepoOK) Validate() error {
 		if s.WorkflowRuns == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "workflow_runs",
@@ -683,7 +683,7 @@ func (s ActionsOrganizationPermissions) Validate() error {
 		if err := s.EnabledRepositories.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enabled_repositories",
@@ -696,13 +696,13 @@ func (s ActionsOrganizationPermissions) Validate() error {
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -722,13 +722,13 @@ func (s ActionsRepositoryPermissions) Validate() error {
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -746,7 +746,7 @@ func (s ActionsReviewPendingDeploymentsForRunReq) Validate() error {
 		if s.EnvironmentIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "environment_ids",
@@ -757,7 +757,7 @@ func (s ActionsReviewPendingDeploymentsForRunReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -785,7 +785,7 @@ func (s ActionsSetGithubActionsPermissionsOrganizationReq) Validate() error {
 		if err := s.EnabledRepositories.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enabled_repositories",
@@ -798,13 +798,13 @@ func (s ActionsSetGithubActionsPermissionsOrganizationReq) Validate() error {
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -824,13 +824,13 @@ func (s ActionsSetGithubActionsPermissionsRepositoryReq) Validate() error {
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -848,7 +848,7 @@ func (s ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgReq) Validate() error {
 		if s.SelectedRepositoryIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "selected_repository_ids",
@@ -866,7 +866,7 @@ func (s ActionsSetSelectedReposForOrgSecretReq) Validate() error {
 		if s.SelectedRepositoryIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "selected_repository_ids",
@@ -884,7 +884,7 @@ func (s ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationReq) Valid
 		if s.SelectedRepositoryIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "selected_repository_ids",
@@ -902,7 +902,7 @@ func (s ActionsSetSelfHostedRunnersInGroupForOrgReq) Validate() error {
 		if s.Runners == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -922,13 +922,13 @@ func (s ActionsUpdateSelfHostedRunnerGroupForOrgReq) Validate() error {
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -956,7 +956,7 @@ func (s ActivityListNotificationsForAuthenticatedUserOKApplicationJSON) Validate
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ActivityListPublicEventsForRepoNetworkOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -968,7 +968,7 @@ func (s ActivityListPublicEventsForRepoNetworkOKApplicationJSON) Validate() erro
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -979,7 +979,7 @@ func (s ActivityListPublicEventsForRepoNetworkOKApplicationJSON) Validate() erro
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ActivityListPublicEventsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -991,7 +991,7 @@ func (s ActivityListPublicEventsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -1002,7 +1002,7 @@ func (s ActivityListPublicEventsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ActivityListReposStarredByAuthenticatedUserDirection) Validate() error {
 	switch s {
@@ -1018,7 +1018,7 @@ func (s ActivityListReposStarredByAuthenticatedUserOKApplicationJSON) Validate()
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ActivityListReposStarredByAuthenticatedUserSort) Validate() error {
 	switch s {
@@ -1034,7 +1034,7 @@ func (s ActivityListWatchedReposForAuthenticatedUserOKApplicationJSON) Validate(
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s AllowedActions) Validate() error {
 	switch s {
@@ -1056,13 +1056,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Actions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "actions",
@@ -1075,13 +1075,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Administration.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "administration",
@@ -1094,13 +1094,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Checks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "checks",
@@ -1113,13 +1113,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.ContentReferences.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content_references",
@@ -1132,13 +1132,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Contents.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contents",
@@ -1151,13 +1151,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Deployments.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "deployments",
@@ -1170,13 +1170,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Environments.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "environments",
@@ -1189,13 +1189,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Issues.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "issues",
@@ -1208,13 +1208,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Metadata.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "metadata",
@@ -1227,13 +1227,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Packages.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "packages",
@@ -1246,13 +1246,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Pages.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pages",
@@ -1265,13 +1265,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.PullRequests.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pull_requests",
@@ -1284,13 +1284,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.RepositoryHooks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repository_hooks",
@@ -1303,13 +1303,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.RepositoryProjects.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repository_projects",
@@ -1322,13 +1322,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.SecretScanningAlerts.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secret_scanning_alerts",
@@ -1341,13 +1341,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Secrets.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secrets",
@@ -1360,13 +1360,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.SecurityEvents.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "security_events",
@@ -1379,13 +1379,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.SingleFile.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "single_file",
@@ -1398,13 +1398,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Statuses.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "statuses",
@@ -1417,13 +1417,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.VulnerabilityAlerts.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vulnerability_alerts",
@@ -1436,13 +1436,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Workflows.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "workflows",
@@ -1455,13 +1455,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.Members.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "members",
@@ -1474,13 +1474,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationAdministration.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_administration",
@@ -1493,13 +1493,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationHooks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_hooks",
@@ -1512,13 +1512,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationPlan.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_plan",
@@ -1531,13 +1531,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationProjects.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_projects",
@@ -1550,13 +1550,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationPackages.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_packages",
@@ -1569,13 +1569,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationSecrets.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_secrets",
@@ -1588,13 +1588,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationSelfHostedRunners.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_self_hosted_runners",
@@ -1607,13 +1607,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.OrganizationUserBlocking.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_user_blocking",
@@ -1626,13 +1626,13 @@ func (s AppPermissions) Validate() error {
 				if err := s.TeamDiscussions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "team_discussions",
@@ -1958,7 +1958,7 @@ func (s ApplicationGrant) Validate() error {
 		if s.Scopes == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scopes",
@@ -1984,7 +1984,7 @@ func (s AppsCreateContentAttachmentReq) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -2003,7 +2003,7 @@ func (s AppsCreateContentAttachmentReq) Validate() error {
 		}).Validate(string(s.Body)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "body",
@@ -2023,13 +2023,13 @@ func (s AppsCreateInstallationAccessTokenReq) Validate() error {
 				if err := s.Permissions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -2061,7 +2061,7 @@ func (s AppsListAccountsForPlanOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2072,7 +2072,7 @@ func (s AppsListAccountsForPlanOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListAccountsForPlanSort) Validate() error {
 	switch s {
@@ -2104,7 +2104,7 @@ func (s AppsListAccountsForPlanStubbedOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2115,7 +2115,7 @@ func (s AppsListAccountsForPlanStubbedOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListAccountsForPlanStubbedSort) Validate() error {
 	switch s {
@@ -2133,7 +2133,7 @@ func (s AppsListInstallationReposForAuthenticatedUserOK) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -2155,7 +2155,7 @@ func (s AppsListPlansOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2166,7 +2166,7 @@ func (s AppsListPlansOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListPlansStubbedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -2178,7 +2178,7 @@ func (s AppsListPlansStubbedOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2189,7 +2189,7 @@ func (s AppsListPlansStubbedOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListReposAccessibleToInstallationOK) Validate() error {
 	var failures []validate.FieldError
@@ -2197,7 +2197,7 @@ func (s AppsListReposAccessibleToInstallationOK) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -2219,7 +2219,7 @@ func (s AppsListSubscriptionsForAuthenticatedUserOKApplicationJSON) Validate() e
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2230,7 +2230,7 @@ func (s AppsListSubscriptionsForAuthenticatedUserOKApplicationJSON) Validate() e
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListSubscriptionsForAuthenticatedUserStubbedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -2242,7 +2242,7 @@ func (s AppsListSubscriptionsForAuthenticatedUserStubbedOKApplicationJSON) Valid
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2253,7 +2253,7 @@ func (s AppsListSubscriptionsForAuthenticatedUserStubbedOKApplicationJSON) Valid
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -2265,7 +2265,7 @@ func (s AppsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -2276,7 +2276,7 @@ func (s AppsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s AppsScopeTokenReq) Validate() error {
 	var failures []validate.FieldError
@@ -2286,13 +2286,13 @@ func (s AppsScopeTokenReq) Validate() error {
 				if err := s.Permissions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -2312,13 +2312,13 @@ func (s AppsUpdateWebhookConfigForAppReq) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -2338,13 +2338,13 @@ func (s AuthenticationToken) Validate() error {
 				if err := s.RepositorySelection.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repository_selection",
@@ -2396,13 +2396,13 @@ func (s Authorization) Validate() error {
 				if err := s.Installation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "installation",
@@ -2420,7 +2420,7 @@ func (s AutoMerge) Validate() error {
 		if err := s.MergeMethod.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "merge_method",
@@ -2452,13 +2452,13 @@ func (s BranchProtection) Validate() error {
 				if err := s.RequiredStatusChecks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_status_checks",
@@ -2471,13 +2471,13 @@ func (s BranchProtection) Validate() error {
 				if err := s.RequiredPullRequestReviews.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_pull_request_reviews",
@@ -2490,13 +2490,13 @@ func (s BranchProtection) Validate() error {
 				if err := s.Restrictions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "restrictions",
@@ -2514,7 +2514,7 @@ func (s BranchProtectionRequiredStatusChecks) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -2532,7 +2532,7 @@ func (s BranchRestrictionPolicy) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -2543,7 +2543,7 @@ func (s BranchRestrictionPolicy) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -2554,7 +2554,7 @@ func (s BranchRestrictionPolicy) Validate() error {
 		if s.Apps == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apps",
@@ -2572,7 +2572,7 @@ func (s BranchWithProtection) Validate() error {
 		if err := s.Commit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commit",
@@ -2583,7 +2583,7 @@ func (s BranchWithProtection) Validate() error {
 		if err := s.Protection.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "protection",
@@ -2601,7 +2601,7 @@ func (s CheckRun) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -2612,8 +2612,8 @@ func (s CheckRun) Validate() error {
 		if err := s.Conclusion.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conclusion",
@@ -2624,8 +2624,8 @@ func (s CheckRun) Validate() error {
 		if err := s.App.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "app",
@@ -2636,7 +2636,7 @@ func (s CheckRun) Validate() error {
 		if s.PullRequests == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pull_requests",
@@ -2649,13 +2649,13 @@ func (s CheckRun) Validate() error {
 				if err := s.Deployment.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "deployment",
@@ -2705,8 +2705,8 @@ func (s CheckSuite) Validate() error {
 		if err := s.Status.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -2717,8 +2717,8 @@ func (s CheckSuite) Validate() error {
 		if err := s.Conclusion.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conclusion",
@@ -2729,8 +2729,8 @@ func (s CheckSuite) Validate() error {
 		if err := s.App.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "app",
@@ -2778,13 +2778,13 @@ func (s ChecksCreateSuiteApplicationJSONCreated) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ChecksCreateSuiteApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ChecksListForRefFilter) Validate() error {
 	switch s {
@@ -2808,7 +2808,7 @@ func (s ChecksListForRefOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2819,7 +2819,7 @@ func (s ChecksListForRefOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "check_runs",
@@ -2865,7 +2865,7 @@ func (s ChecksListForSuiteOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2876,7 +2876,7 @@ func (s ChecksListForSuiteOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "check_runs",
@@ -2912,7 +2912,7 @@ func (s ChecksListSuitesForRefOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2923,7 +2923,7 @@ func (s ChecksListSuitesForRefOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "check_suites",
@@ -2941,7 +2941,7 @@ func (s CloneTraffic) Validate() error {
 		if s.Clones == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "clones",
@@ -2957,7 +2957,7 @@ func (s CodeFrequencyStat) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s CodeScanningAlert) Validate() error {
 	var failures []validate.FieldError
@@ -2965,7 +2965,7 @@ func (s CodeScanningAlert) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -2976,8 +2976,8 @@ func (s CodeScanningAlert) Validate() error {
 		if err := s.DismissedReason.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "dismissed_reason",
@@ -2988,7 +2988,7 @@ func (s CodeScanningAlert) Validate() error {
 		if err := s.Rule.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rule",
@@ -2999,7 +2999,7 @@ func (s CodeScanningAlert) Validate() error {
 		if err := s.MostRecentInstance.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "most_recent_instance",
@@ -3045,13 +3045,13 @@ func (s CodeScanningAlertInstance) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -3065,7 +3065,7 @@ func (s CodeScanningAlertInstance) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3076,7 +3076,7 @@ func (s CodeScanningAlertInstance) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "classifications",
@@ -3094,7 +3094,7 @@ func (s CodeScanningAlertItems) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -3105,8 +3105,8 @@ func (s CodeScanningAlertItems) Validate() error {
 		if err := s.DismissedReason.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "dismissed_reason",
@@ -3117,7 +3117,7 @@ func (s CodeScanningAlertItems) Validate() error {
 		if err := s.Rule.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rule",
@@ -3128,7 +3128,7 @@ func (s CodeScanningAlertItems) Validate() error {
 		if err := s.MostRecentInstance.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "most_recent_instance",
@@ -3148,13 +3148,13 @@ func (s CodeScanningAlertRule) Validate() error {
 				if err := s.Severity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "severity",
@@ -3167,13 +3167,13 @@ func (s CodeScanningAlertRule) Validate() error {
 				if err := s.SecuritySeverityLevel.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "security_severity_level",
@@ -3186,13 +3186,13 @@ func (s CodeScanningAlertRule) Validate() error {
 				if s.Tags.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tags",
@@ -3240,13 +3240,13 @@ func (s CodeScanningAlertRuleSummary) Validate() error {
 				if err := s.Severity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "severity",
@@ -3302,7 +3302,7 @@ func (s CodeScanningAnalysis) Validate() error {
 		if err := s.CommitSha.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commit_sha",
@@ -3326,7 +3326,7 @@ func (s CodeScanningAnalysisCommitSha) Validate() error {
 	}).Validate(string(s)); err != nil {
 		return errors.Wrap(err, "string")
 	}
-	return nil
+	return nil // return 1
 }
 func (s CodeScanningListAlertInstancesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -3338,7 +3338,7 @@ func (s CodeScanningListAlertInstancesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -3349,7 +3349,7 @@ func (s CodeScanningListAlertInstancesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s CodeScanningListAlertsForRepoOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -3361,7 +3361,7 @@ func (s CodeScanningListAlertsForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -3372,7 +3372,7 @@ func (s CodeScanningListAlertsForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s CodeScanningListRecentAnalysesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -3384,7 +3384,7 @@ func (s CodeScanningListRecentAnalysesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -3395,7 +3395,7 @@ func (s CodeScanningListRecentAnalysesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s CodeScanningSarifsStatus) Validate() error {
 	var failures []validate.FieldError
@@ -3405,13 +3405,13 @@ func (s CodeScanningSarifsStatus) Validate() error {
 				if err := s.ProcessingStatus.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "processing_status",
@@ -3439,7 +3439,7 @@ func (s CodeScanningUpdateAlertReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -3452,13 +3452,13 @@ func (s CodeScanningUpdateAlertReq) Validate() error {
 				if err := s.DismissedReason.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "dismissed_reason",
@@ -3476,7 +3476,7 @@ func (s CodeScanningUploadSarifReq) Validate() error {
 		if err := s.CommitSha.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commit_sha",
@@ -3494,7 +3494,7 @@ func (s CodeSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -3509,11 +3509,11 @@ func (s CodeSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -3529,7 +3529,7 @@ func (s CodesOfConductGetAllCodesOfConductOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s CombinedCommitStatus) Validate() error {
 	var failures []validate.FieldError
@@ -3537,7 +3537,7 @@ func (s CombinedCommitStatus) Validate() error {
 		if s.Statuses == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "statuses",
@@ -3555,7 +3555,7 @@ func (s Commit) Validate() error {
 		if s.Parents == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parents",
@@ -3573,7 +3573,7 @@ func (s CommitActivity) Validate() error {
 		if s.Days == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "days",
@@ -3591,7 +3591,7 @@ func (s CommitComment) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -3609,7 +3609,7 @@ func (s CommitComparison) Validate() error {
 		if err := s.BaseCommit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "base_commit",
@@ -3620,7 +3620,7 @@ func (s CommitComparison) Validate() error {
 		if err := s.MergeBaseCommit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "merge_base_commit",
@@ -3631,7 +3631,7 @@ func (s CommitComparison) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -3648,7 +3648,7 @@ func (s CommitComparison) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3659,7 +3659,7 @@ func (s CommitComparison) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commits",
@@ -3673,7 +3673,7 @@ func (s CommitComparison) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3684,7 +3684,7 @@ func (s CommitComparison) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "files",
@@ -3716,7 +3716,7 @@ func (s CommitSearchResultItem) Validate() error {
 		if s.Parents == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parents",
@@ -3727,7 +3727,7 @@ func (s CommitSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -3742,11 +3742,11 @@ func (s CommitSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -3772,7 +3772,7 @@ func (s ContentReferenceAttachment) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -3791,7 +3791,7 @@ func (s ContentReferenceAttachment) Validate() error {
 		}).Validate(string(s.Body)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "body",
@@ -3809,7 +3809,7 @@ func (s ContributorActivity) Validate() error {
 		if s.Weeks == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "weeks",
@@ -3829,13 +3829,13 @@ func (s Deployment) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -3855,13 +3855,13 @@ func (s DeploymentSimple) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -3879,7 +3879,7 @@ func (s DeploymentStatus) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -3898,7 +3898,7 @@ func (s DeploymentStatus) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -3911,13 +3911,13 @@ func (s DeploymentStatus) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -3955,7 +3955,7 @@ func (s DiffEntry) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -4001,7 +4001,7 @@ func (s Email) Validate() error {
 		}).Validate(string(s.Email)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -4045,13 +4045,13 @@ func (s EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseReq) Validate() e
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -4101,7 +4101,7 @@ func (s EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseOK) Valid
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -4112,7 +4112,7 @@ func (s EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseOK) Valid
 		if s.Organizations == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organizations",
@@ -4130,7 +4130,7 @@ func (s EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseOK
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -4141,7 +4141,7 @@ func (s EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseOK
 		if s.Organizations == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organizations",
@@ -4159,7 +4159,7 @@ func (s EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseOK) Validate() err
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -4176,7 +4176,7 @@ func (s EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseOK) Validate() err
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4187,7 +4187,7 @@ func (s EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseOK) Validate() err
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runner_groups",
@@ -4207,13 +4207,13 @@ func (s EnterpriseAdminListSelfHostedRunnersForEnterpriseOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.TotalCount.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -4227,7 +4227,7 @@ func (s EnterpriseAdminListSelfHostedRunnersForEnterpriseOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4238,7 +4238,7 @@ func (s EnterpriseAdminListSelfHostedRunnersForEnterpriseOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -4256,7 +4256,7 @@ func (s EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseOK) Validate() e
 		if err := (validate.Float{}).Validate(float64(s.TotalCount)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "total_count",
@@ -4273,7 +4273,7 @@ func (s EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseOK) Validate() e
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4284,7 +4284,7 @@ func (s EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseOK) Validate() e
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -4302,7 +4302,7 @@ func (s EnterpriseAdminProvisionAndInviteEnterpriseGroupReq) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4320,7 +4320,7 @@ func (s EnterpriseAdminProvisionAndInviteEnterpriseUserReq) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4331,7 +4331,7 @@ func (s EnterpriseAdminProvisionAndInviteEnterpriseUserReq) Validate() error {
 		if s.Emails == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "emails",
@@ -4349,7 +4349,7 @@ func (s EnterpriseAdminSetGithubActionsPermissionsEnterpriseReq) Validate() erro
 		if err := s.EnabledOrganizations.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enabled_organizations",
@@ -4362,13 +4362,13 @@ func (s EnterpriseAdminSetGithubActionsPermissionsEnterpriseReq) Validate() erro
 				if err := s.AllowedActions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowed_actions",
@@ -4386,7 +4386,7 @@ func (s EnterpriseAdminSetInformationForProvisionedEnterpriseGroupReq) Validate(
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4404,7 +4404,7 @@ func (s EnterpriseAdminSetInformationForProvisionedEnterpriseUserReq) Validate()
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4415,7 +4415,7 @@ func (s EnterpriseAdminSetInformationForProvisionedEnterpriseUserReq) Validate()
 		if s.Emails == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "emails",
@@ -4433,7 +4433,7 @@ func (s EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseReq) Valid
 		if s.SelectedOrganizationIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "selected_organization_ids",
@@ -4451,7 +4451,7 @@ func (s EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseReq
 		if s.SelectedOrganizationIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "selected_organization_ids",
@@ -4469,7 +4469,7 @@ func (s EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseReq) Validate() e
 		if s.Runners == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runners",
@@ -4487,7 +4487,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReq) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4512,7 +4512,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReq) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4523,7 +4523,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Operations",
@@ -4541,7 +4541,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReqOperationsItem) Valid
 		if err := s.Op.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "op",
@@ -4554,13 +4554,13 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReqOperationsItem) Valid
 				if err := s.Value.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "value",
@@ -4600,7 +4600,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseGroupReqOperationsItemValue) 
 		if s.AnyArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -4612,7 +4612,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseUserReq) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -4623,7 +4623,7 @@ func (s EnterpriseAdminUpdateAttributeForEnterpriseUserReq) Validate() error {
 		if s.Operations == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Operations",
@@ -4643,13 +4643,13 @@ func (s EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseReq) Validate() e
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -4677,7 +4677,7 @@ func (s EnvironmentApprovals) Validate() error {
 		if s.Environments == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "environments",
@@ -4688,7 +4688,7 @@ func (s EnvironmentApprovals) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -4716,7 +4716,7 @@ func (s Event) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -4736,13 +4736,13 @@ func (s EventPayload) Validate() error {
 				if err := s.Issue.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "issue",
@@ -4755,13 +4755,13 @@ func (s EventPayload) Validate() error {
 				if err := s.Comment.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "comment",
@@ -4781,13 +4781,13 @@ func (s FullRepository) Validate() error {
 				if err := s.SecurityAndAnalysis.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "security_and_analysis",
@@ -4807,13 +4807,13 @@ func (s FullRepositorySecurityAndAnalysis) Validate() error {
 				if err := s.AdvancedSecurity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "advanced_security",
@@ -4826,13 +4826,13 @@ func (s FullRepositorySecurityAndAnalysis) Validate() error {
 				if err := s.SecretScanning.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "secret_scanning",
@@ -4852,13 +4852,13 @@ func (s FullRepositorySecurityAndAnalysisAdvancedSecurity) Validate() error {
 				if err := s.Status.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -4888,13 +4888,13 @@ func (s FullRepositorySecurityAndAnalysisSecretScanning) Validate() error {
 				if err := s.Status.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -4930,7 +4930,7 @@ func (s GistComment) Validate() error {
 		}).Validate(string(s.Body)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "body",
@@ -4941,7 +4941,7 @@ func (s GistComment) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -4967,7 +4967,7 @@ func (s GistSimple) Validate() error {
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4978,13 +4978,13 @@ func (s GistSimple) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "forks",
@@ -4997,13 +4997,13 @@ func (s GistSimple) Validate() error {
 				if s.History.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "history",
@@ -5023,13 +5023,13 @@ func (s GistSimpleForksItem) Validate() error {
 				if err := s.User.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "user",
@@ -5055,7 +5055,7 @@ func (s GistsCreateCommentReq) Validate() error {
 		}).Validate(string(s.Body)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "body",
@@ -5075,13 +5075,13 @@ func (s GistsCreateReq) Validate() error {
 				if err := s.Public.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "public",
@@ -5101,7 +5101,7 @@ func (s GistsCreateReqPublic) Validate() error {
 		if err := s.GistsCreateReqPublic1.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -5127,7 +5127,7 @@ func (s GistsListCommentsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -5138,19 +5138,19 @@ func (s GistsListCommentsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListCommitsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListForUserOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListForksOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -5162,7 +5162,7 @@ func (s GistsListForksOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -5173,25 +5173,25 @@ func (s GistsListForksOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListPublicOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsListStarredOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GistsUpdateCommentReq) Validate() error {
 	var failures []validate.FieldError
@@ -5207,7 +5207,7 @@ func (s GistsUpdateCommentReq) Validate() error {
 		}).Validate(string(s.Body)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "body",
@@ -5225,7 +5225,7 @@ func (s GitCommit) Validate() error {
 		if s.Parents == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parents",
@@ -5243,7 +5243,7 @@ func (s GitCreateTagReq) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -5279,7 +5279,7 @@ func (s GitCreateTreeReq) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5290,7 +5290,7 @@ func (s GitCreateTreeReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tree",
@@ -5310,13 +5310,13 @@ func (s GitCreateTreeReqTreeItem) Validate() error {
 				if err := s.Mode.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mode",
@@ -5329,13 +5329,13 @@ func (s GitCreateTreeReqTreeItem) Validate() error {
 				if err := s.Type.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -5381,7 +5381,7 @@ func (s GitRef) Validate() error {
 		if err := s.Object.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "object",
@@ -5407,7 +5407,7 @@ func (s GitRefObject) Validate() error {
 		}).Validate(string(s.Sha)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sha",
@@ -5425,7 +5425,7 @@ func (s GitTree) Validate() error {
 		if s.Tree == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tree",
@@ -5441,7 +5441,7 @@ func (s GitignoreGetAllTemplatesOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s GpgKey) Validate() error {
 	var failures []validate.FieldError
@@ -5449,7 +5449,7 @@ func (s GpgKey) Validate() error {
 		if s.Emails == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "emails",
@@ -5460,7 +5460,7 @@ func (s GpgKey) Validate() error {
 		if s.Subkeys == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "subkeys",
@@ -5478,7 +5478,7 @@ func (s Hook) Validate() error {
 		if s.Events == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "events",
@@ -5489,7 +5489,7 @@ func (s Hook) Validate() error {
 		if err := s.Config.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "config",
@@ -5509,13 +5509,13 @@ func (s HookConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -5533,7 +5533,7 @@ func (s HookDelivery) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Duration)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5551,7 +5551,7 @@ func (s HookDeliveryItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Duration)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5569,7 +5569,7 @@ func (s Hovercard) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -5587,7 +5587,7 @@ func (s Import) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -5645,13 +5645,13 @@ func (s InstallationToken) Validate() error {
 				if err := s.Permissions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -5664,13 +5664,13 @@ func (s InstallationToken) Validate() error {
 				if err := s.RepositorySelection.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repository_selection",
@@ -5698,7 +5698,7 @@ func (s Integration) Validate() error {
 		if s.Events == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "events",
@@ -5744,7 +5744,7 @@ func (s InteractionLimit) Validate() error {
 		if err := s.Limit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -5757,13 +5757,13 @@ func (s InteractionLimit) Validate() error {
 				if err := s.Expiry.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "expiry",
@@ -5781,7 +5781,7 @@ func (s InteractionLimitResponse) Validate() error {
 		if err := s.Limit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -5799,7 +5799,7 @@ func (s Issue) Validate() error {
 		if s.Labels == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -5812,13 +5812,13 @@ func (s Issue) Validate() error {
 				if s.Assignees.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assignees",
@@ -5829,8 +5829,8 @@ func (s Issue) Validate() error {
 		if err := s.Milestone.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "milestone",
@@ -5843,13 +5843,13 @@ func (s Issue) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -5860,7 +5860,7 @@ func (s Issue) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -5878,7 +5878,7 @@ func (s IssueComment) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -5891,13 +5891,13 @@ func (s IssueComment) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -5917,13 +5917,13 @@ func (s IssueEvent) Validate() error {
 				if err := s.Issue.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "issue",
@@ -5936,13 +5936,13 @@ func (s IssueEvent) Validate() error {
 				if err := s.AuthorAssociation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -5955,13 +5955,13 @@ func (s IssueEvent) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -5981,13 +5981,13 @@ func (s IssueSearchResultItem) Validate() error {
 				if s.Assignees.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assignees",
@@ -5998,7 +5998,7 @@ func (s IssueSearchResultItem) Validate() error {
 		if s.Labels == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -6009,8 +6009,8 @@ func (s IssueSearchResultItem) Validate() error {
 		if err := s.Milestone.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "milestone",
@@ -6025,11 +6025,11 @@ func (s IssueSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -6040,7 +6040,7 @@ func (s IssueSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -6051,7 +6051,7 @@ func (s IssueSearchResultItem) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -6064,13 +6064,13 @@ func (s IssueSearchResultItem) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -6088,7 +6088,7 @@ func (s IssueSimple) Validate() error {
 		if s.Labels == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -6101,13 +6101,13 @@ func (s IssueSimple) Validate() error {
 				if s.Assignees.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assignees",
@@ -6118,8 +6118,8 @@ func (s IssueSimple) Validate() error {
 		if err := s.Milestone.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "milestone",
@@ -6130,7 +6130,7 @@ func (s IssueSimple) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -6143,13 +6143,13 @@ func (s IssueSimple) Validate() error {
 				if err := s.PerformedViaGithubApp.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "performed_via_github_app",
@@ -6169,13 +6169,13 @@ func (s IssuesCreateMilestoneReq) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -6201,7 +6201,7 @@ func (s IssuesListAssigneesOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListCommentsForRepoDirection) Validate() error {
 	switch s {
@@ -6223,7 +6223,7 @@ func (s IssuesListCommentsForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6234,7 +6234,7 @@ func (s IssuesListCommentsForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListCommentsForRepoSort) Validate() error {
 	switch s {
@@ -6256,7 +6256,7 @@ func (s IssuesListCommentsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6267,7 +6267,7 @@ func (s IssuesListCommentsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListDirection) Validate() error {
 	switch s {
@@ -6289,7 +6289,7 @@ func (s IssuesListEventsForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6300,7 +6300,7 @@ func (s IssuesListEventsForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListFilter) Validate() error {
 	switch s {
@@ -6358,7 +6358,7 @@ func (s IssuesListForAuthenticatedUserOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6369,7 +6369,7 @@ func (s IssuesListForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListForAuthenticatedUserSort) Validate() error {
 	switch s {
@@ -6433,7 +6433,7 @@ func (s IssuesListForOrgOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6444,7 +6444,7 @@ func (s IssuesListForOrgOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListForOrgSort) Validate() error {
 	switch s {
@@ -6490,7 +6490,7 @@ func (s IssuesListForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6501,7 +6501,7 @@ func (s IssuesListForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListForRepoSort) Validate() error {
 	switch s {
@@ -6531,13 +6531,13 @@ func (s IssuesListLabelsForRepoOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListLabelsOnIssueOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListMilestonesDirection) Validate() error {
 	switch s {
@@ -6559,7 +6559,7 @@ func (s IssuesListMilestonesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6570,7 +6570,7 @@ func (s IssuesListMilestonesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListMilestonesSort) Validate() error {
 	switch s {
@@ -6604,7 +6604,7 @@ func (s IssuesListOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -6615,7 +6615,7 @@ func (s IssuesListOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesListSort) Validate() error {
 	switch s {
@@ -6649,13 +6649,13 @@ func (s IssuesLockReq) Validate() error {
 				if err := s.LockReason.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "lock_reason",
@@ -6685,7 +6685,7 @@ func (s IssuesRemoveLabelOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s IssuesUpdateMilestoneReq) Validate() error {
 	var failures []validate.FieldError
@@ -6695,13 +6695,13 @@ func (s IssuesUpdateMilestoneReq) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -6731,13 +6731,13 @@ func (s IssuesUpdateReq) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -6765,7 +6765,7 @@ func (s Job) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -6779,7 +6779,7 @@ func (s Job) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6790,7 +6790,7 @@ func (s Job) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "steps",
@@ -6820,7 +6820,7 @@ func (s JobStepsItem) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -6850,7 +6850,7 @@ func (s LabelSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -6865,11 +6865,11 @@ func (s LabelSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -6887,7 +6887,7 @@ func (s License) Validate() error {
 		if s.Permissions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -6898,7 +6898,7 @@ func (s License) Validate() error {
 		if s.Conditions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conditions",
@@ -6909,7 +6909,7 @@ func (s License) Validate() error {
 		if s.Limitations == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limitations",
@@ -6925,7 +6925,7 @@ func (s LicensesGetAllCommonlyUsedOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s MarketplaceAccount) Validate() error {
 	var failures []validate.FieldError
@@ -6943,13 +6943,13 @@ func (s MarketplaceAccount) Validate() error {
 				}).Validate(string(s.Email.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -6970,13 +6970,13 @@ func (s MarketplaceAccount) Validate() error {
 				}).Validate(string(s.OrganizationBillingEmail.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_billing_email",
@@ -6994,7 +6994,7 @@ func (s MarketplaceListingPlan) Validate() error {
 		if s.Bullets == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "bullets",
@@ -7014,13 +7014,13 @@ func (s MarketplacePurchase) Validate() error {
 				if err := s.MarketplacePendingChange.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "marketplace_pending_change",
@@ -7031,7 +7031,7 @@ func (s MarketplacePurchase) Validate() error {
 		if err := s.MarketplacePurchase.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "marketplace_purchase",
@@ -7051,13 +7051,13 @@ func (s MarketplacePurchaseMarketplacePendingChange) Validate() error {
 				if err := s.Plan.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "plan",
@@ -7077,13 +7077,13 @@ func (s MarketplacePurchaseMarketplacePurchase) Validate() error {
 				if err := s.Plan.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "plan",
@@ -7103,13 +7103,13 @@ func (s MergedUpstream) Validate() error {
 				if err := s.MergeType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "merge_type",
@@ -7139,7 +7139,7 @@ func (s Migration) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -7155,7 +7155,7 @@ func (s MigrationsGetCommitAuthorsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s MigrationsGetStatusForOrgExcludeItem) Validate() error {
 	switch s {
@@ -7175,7 +7175,7 @@ func (s MigrationsListForAuthenticatedUserOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -7186,7 +7186,7 @@ func (s MigrationsListForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s MigrationsListForOrgExcludeItem) Validate() error {
 	switch s {
@@ -7200,13 +7200,13 @@ func (s MigrationsListReposForOrgOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s MigrationsListReposForUserOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s MigrationsSetLfsPreferenceReq) Validate() error {
 	var failures []validate.FieldError
@@ -7214,7 +7214,7 @@ func (s MigrationsSetLfsPreferenceReq) Validate() error {
 		if err := s.UseLfs.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "use_lfs",
@@ -7245,7 +7245,7 @@ func (s MigrationsStartForAuthenticatedUserReq) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7256,7 +7256,7 @@ func (s MigrationsStartForAuthenticatedUserReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "exclude",
@@ -7267,7 +7267,7 @@ func (s MigrationsStartForAuthenticatedUserReq) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -7293,7 +7293,7 @@ func (s MigrationsStartForOrgReq) Validate() error {
 		if s.Repositories == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repositories",
@@ -7307,7 +7307,7 @@ func (s MigrationsStartForOrgReq) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7318,7 +7318,7 @@ func (s MigrationsStartForOrgReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "exclude",
@@ -7346,13 +7346,13 @@ func (s MigrationsStartImportReq) Validate() error {
 				if err := s.Vcs.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcs",
@@ -7384,7 +7384,7 @@ func (s Milestone) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -7413,7 +7413,7 @@ func (s NullableIntegration) Validate() error {
 		if s.Events == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "events",
@@ -7431,7 +7431,7 @@ func (s NullableMilestone) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -7459,7 +7459,7 @@ func (s NullableScopedInstallation) Validate() error {
 		if err := s.Permissions.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -7470,7 +7470,7 @@ func (s NullableScopedInstallation) Validate() error {
 		if err := s.RepositorySelection.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "repository_selection",
@@ -7500,13 +7500,13 @@ func (s OAuthAuthorizationsCreateAuthorizationReq) Validate() error {
 				if s.Scopes.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scopes",
@@ -7527,13 +7527,13 @@ func (s OAuthAuthorizationsCreateAuthorizationReq) Validate() error {
 				}).Validate(string(s.ClientID.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "client_id",
@@ -7554,13 +7554,13 @@ func (s OAuthAuthorizationsCreateAuthorizationReq) Validate() error {
 				}).Validate(string(s.ClientSecret.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "client_secret",
@@ -7576,13 +7576,13 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintApplicati
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq) Validate() error {
 	var failures []validate.FieldError
@@ -7598,7 +7598,7 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq) Vali
 		}).Validate(string(s.ClientSecret)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "client_secret",
@@ -7611,13 +7611,13 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq) Vali
 				if s.Scopes.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scopes",
@@ -7633,13 +7633,13 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONCreated)
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppReq) Validate() error {
 	var failures []validate.FieldError
@@ -7655,7 +7655,7 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppReq) Validate() error {
 		}).Validate(string(s.ClientSecret)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "client_secret",
@@ -7668,13 +7668,13 @@ func (s OAuthAuthorizationsGetOrCreateAuthorizationForAppReq) Validate() error {
 				if s.Scopes.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scopes",
@@ -7696,7 +7696,7 @@ func (s OAuthAuthorizationsListAuthorizationsOKApplicationJSON) Validate() error
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -7707,7 +7707,7 @@ func (s OAuthAuthorizationsListAuthorizationsOKApplicationJSON) Validate() error
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsListGrantsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -7719,7 +7719,7 @@ func (s OAuthAuthorizationsListGrantsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -7730,7 +7730,7 @@ func (s OAuthAuthorizationsListGrantsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s OAuthAuthorizationsUpdateAuthorizationReq) Validate() error {
 	var failures []validate.FieldError
@@ -7740,13 +7740,13 @@ func (s OAuthAuthorizationsUpdateAuthorizationReq) Validate() error {
 				if s.Scopes.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scopes",
@@ -7765,7 +7765,7 @@ func (s OrgHook) Validate() error {
 		if s.Events == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "events",
@@ -7783,7 +7783,7 @@ func (s OrgMembership) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -7794,7 +7794,7 @@ func (s OrgMembership) Validate() error {
 		if err := s.Role.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -7834,7 +7834,7 @@ func (s OrganizationActionsSecret) Validate() error {
 		if err := s.Visibility.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -7874,13 +7874,13 @@ func (s OrganizationFull) Validate() error {
 				}).Validate(string(s.Email.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -7901,13 +7901,13 @@ func (s OrganizationFull) Validate() error {
 				}).Validate(string(s.BillingEmail.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "billing_email",
@@ -7927,13 +7927,13 @@ func (s OrganizationSecretScanningAlert) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -7946,13 +7946,13 @@ func (s OrganizationSecretScanningAlert) Validate() error {
 				if err := s.Resolution.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resolution",
@@ -7972,13 +7972,13 @@ func (s OrgsCreateInvitationReq) Validate() error {
 				if err := s.Role.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -8008,7 +8008,7 @@ func (s OrgsCreateWebhookReq) Validate() error {
 		if err := s.Config.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "config",
@@ -8028,13 +8028,13 @@ func (s OrgsCreateWebhookReqConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -8072,25 +8072,25 @@ func (s OrgsListBlockedUsersOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListFailedInvitationsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListInvitationTeamsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListMembersFilter) Validate() error {
 	switch s {
@@ -8106,7 +8106,7 @@ func (s OrgsListMembersOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListMembersRole) Validate() error {
 	switch s {
@@ -8130,7 +8130,7 @@ func (s OrgsListMembershipsForAuthenticatedUserOKApplicationJSON) Validate() err
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8141,7 +8141,7 @@ func (s OrgsListMembershipsForAuthenticatedUserOKApplicationJSON) Validate() err
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListMembershipsForAuthenticatedUserState) Validate() error {
 	switch s {
@@ -8157,7 +8157,7 @@ func (s OrgsListOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListOutsideCollaboratorsFilter) Validate() error {
 	switch s {
@@ -8173,7 +8173,7 @@ func (s OrgsListPendingInvitationsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -8185,7 +8185,7 @@ func (s OrgsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8196,7 +8196,7 @@ func (s OrgsListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsListWebhooksOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -8208,7 +8208,7 @@ func (s OrgsListWebhooksOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8219,7 +8219,7 @@ func (s OrgsListWebhooksOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s OrgsSetMembershipForUserReq) Validate() error {
 	var failures []validate.FieldError
@@ -8229,13 +8229,13 @@ func (s OrgsSetMembershipForUserReq) Validate() error {
 				if err := s.Role.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -8263,7 +8263,7 @@ func (s OrgsUpdateMembershipForAuthenticatedUserReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -8291,13 +8291,13 @@ func (s OrgsUpdateWebhookConfigForOrgReq) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -8317,13 +8317,13 @@ func (s OrgsUpdateWebhookReq) Validate() error {
 				if err := s.Config.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "config",
@@ -8343,13 +8343,13 @@ func (s OrgsUpdateWebhookReqConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -8367,7 +8367,7 @@ func (s Package) Validate() error {
 		if err := s.PackageType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "package_type",
@@ -8378,7 +8378,7 @@ func (s Package) Validate() error {
 		if err := s.Visibility.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -8416,13 +8416,13 @@ func (s PackageVersion) Validate() error {
 				if err := s.Metadata.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "metadata",
@@ -8440,7 +8440,7 @@ func (s PackageVersionMetadata) Validate() error {
 		if err := s.PackageType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "package_type",
@@ -8453,13 +8453,13 @@ func (s PackageVersionMetadata) Validate() error {
 				if err := s.Container.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "container",
@@ -8477,7 +8477,7 @@ func (s PackageVersionMetadataContainer) Validate() error {
 		if s.Tags == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tags",
@@ -8635,7 +8635,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserOKApplica
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8646,7 +8646,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserOKApplica
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserPackageType) Validate() error {
 	switch s {
@@ -8686,7 +8686,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByOrgOKApplicationJSON) Vali
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8697,7 +8697,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByOrgOKApplicationJSON) Vali
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PackagesGetAllPackageVersionsForPackageOwnedByOrgPackageType) Validate() error {
 	switch s {
@@ -8737,7 +8737,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByUserOKApplicationJSON) Val
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8748,7 +8748,7 @@ func (s PackagesGetAllPackageVersionsForPackageOwnedByUserOKApplicationJSON) Val
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PackagesGetAllPackageVersionsForPackageOwnedByUserPackageType) Validate() error {
 	switch s {
@@ -8916,7 +8916,7 @@ func (s PackagesListPackagesForOrganizationOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8927,7 +8927,7 @@ func (s PackagesListPackagesForOrganizationOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PackagesListPackagesForOrganizationPackageType) Validate() error {
 	switch s {
@@ -8969,7 +8969,7 @@ func (s PackagesListPackagesForUserOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -8980,7 +8980,7 @@ func (s PackagesListPackagesForUserOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PackagesListPackagesForUserPackageType) Validate() error {
 	switch s {
@@ -9126,8 +9126,8 @@ func (s Page) Validate() error {
 		if err := s.Status.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -9140,13 +9140,13 @@ func (s Page) Validate() error {
 				if err := s.ProtectedDomainState.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "protected_domain_state",
@@ -9159,13 +9159,13 @@ func (s Page) Validate() error {
 				if err := s.HTTPSCertificate.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "https_certificate",
@@ -9207,7 +9207,7 @@ func (s PagesHTTPSCertificate) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -9218,7 +9218,7 @@ func (s PagesHTTPSCertificate) Validate() error {
 		if s.Domains == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "domains",
@@ -9266,7 +9266,7 @@ func (s ParticipationStats) Validate() error {
 		if s.All == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "all",
@@ -9277,7 +9277,7 @@ func (s ParticipationStats) Validate() error {
 		if s.Owner == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "owner",
@@ -9303,8 +9303,8 @@ func (s PrivateUser) Validate() error {
 		}).Validate(string(s.Email.Value)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -9324,13 +9324,13 @@ func (s Project) Validate() error {
 				if err := s.OrganizationPermission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_permission",
@@ -9364,13 +9364,13 @@ func (s ProjectsAddCollaboratorReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -9410,7 +9410,7 @@ func (s ProjectsListCardsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListCollaboratorsAffiliation) Validate() error {
 	switch s {
@@ -9428,13 +9428,13 @@ func (s ProjectsListCollaboratorsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListColumnsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListForOrgOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -9446,7 +9446,7 @@ func (s ProjectsListForOrgOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -9457,7 +9457,7 @@ func (s ProjectsListForOrgOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListForOrgState) Validate() error {
 	switch s {
@@ -9481,7 +9481,7 @@ func (s ProjectsListForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -9492,7 +9492,7 @@ func (s ProjectsListForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListForRepoState) Validate() error {
 	switch s {
@@ -9516,7 +9516,7 @@ func (s ProjectsListForUserOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -9527,7 +9527,7 @@ func (s ProjectsListForUserOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ProjectsListForUserState) Validate() error {
 	switch s {
@@ -9555,7 +9555,7 @@ func (s ProjectsMoveCardReq) Validate() error {
 		}).Validate(string(s.Position)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "position",
@@ -9581,7 +9581,7 @@ func (s ProjectsMoveColumnReq) Validate() error {
 		}).Validate(string(s.Position)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "position",
@@ -9601,13 +9601,13 @@ func (s ProjectsUpdateReq) Validate() error {
 				if err := s.OrganizationPermission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization_permission",
@@ -9641,13 +9641,13 @@ func (s ProtectedBranch) Validate() error {
 				if err := s.RequiredStatusChecks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_status_checks",
@@ -9660,13 +9660,13 @@ func (s ProtectedBranch) Validate() error {
 				if err := s.RequiredPullRequestReviews.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_pull_request_reviews",
@@ -9679,13 +9679,13 @@ func (s ProtectedBranch) Validate() error {
 				if err := s.Restrictions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "restrictions",
@@ -9714,13 +9714,13 @@ func (s ProtectedBranchPullRequestReview) Validate() error {
 				}).Validate(int64(s.RequiredApprovingReviewCount.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_approving_review_count",
@@ -9740,13 +9740,13 @@ func (s ProtectedBranchRequiredPullRequestReviews) Validate() error {
 				if err := s.DismissalRestrictions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "dismissal_restrictions",
@@ -9764,7 +9764,7 @@ func (s ProtectedBranchRequiredPullRequestReviewsDismissalRestrictions) Validate
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -9775,7 +9775,7 @@ func (s ProtectedBranchRequiredPullRequestReviewsDismissalRestrictions) Validate
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -9801,8 +9801,8 @@ func (s PublicUser) Validate() error {
 		}).Validate(string(s.Email.Value)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -9820,7 +9820,7 @@ func (s PullRequest) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -9831,7 +9831,7 @@ func (s PullRequest) Validate() error {
 		if s.Labels == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -9842,8 +9842,8 @@ func (s PullRequest) Validate() error {
 		if err := s.Milestone.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "milestone",
@@ -9856,13 +9856,13 @@ func (s PullRequest) Validate() error {
 				if s.Assignees.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assignees",
@@ -9875,13 +9875,13 @@ func (s PullRequest) Validate() error {
 				if s.RequestedReviewers.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requested_reviewers",
@@ -9894,13 +9894,13 @@ func (s PullRequest) Validate() error {
 				if s.RequestedTeams.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requested_teams",
@@ -9911,7 +9911,7 @@ func (s PullRequest) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -9922,8 +9922,8 @@ func (s PullRequest) Validate() error {
 		if err := s.AutoMerge.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "auto_merge",
@@ -9941,7 +9941,7 @@ func (s PullRequestReview) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -9959,7 +9959,7 @@ func (s PullRequestReviewComment) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -9972,13 +9972,13 @@ func (s PullRequestReviewComment) Validate() error {
 				if err := s.StartSide.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "start_side",
@@ -9991,13 +9991,13 @@ func (s PullRequestReviewComment) Validate() error {
 				if err := s.Side.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "side",
@@ -10035,7 +10035,7 @@ func (s PullRequestReviewRequest) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -10046,7 +10046,7 @@ func (s PullRequestReviewRequest) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -10064,7 +10064,7 @@ func (s PullRequestSimple) Validate() error {
 		if s.Labels == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -10075,8 +10075,8 @@ func (s PullRequestSimple) Validate() error {
 		if err := s.Milestone.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "milestone",
@@ -10089,13 +10089,13 @@ func (s PullRequestSimple) Validate() error {
 				if s.Assignees.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assignees",
@@ -10108,13 +10108,13 @@ func (s PullRequestSimple) Validate() error {
 				if s.RequestedReviewers.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requested_reviewers",
@@ -10127,13 +10127,13 @@ func (s PullRequestSimple) Validate() error {
 				if s.RequestedTeams.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requested_teams",
@@ -10144,7 +10144,7 @@ func (s PullRequestSimple) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -10155,8 +10155,8 @@ func (s PullRequestSimple) Validate() error {
 		if err := s.AutoMerge.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "auto_merge",
@@ -10186,13 +10186,13 @@ func (s PullsCreateReviewCommentReq) Validate() error {
 				if err := s.Side.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "side",
@@ -10205,13 +10205,13 @@ func (s PullsCreateReviewCommentReq) Validate() error {
 				if err := s.StartSide.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "start_side",
@@ -10253,13 +10253,13 @@ func (s PullsCreateReviewReq) Validate() error {
 				if err := s.Event.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "event",
@@ -10293,7 +10293,7 @@ func (s PullsListCommentsForReviewOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -10304,7 +10304,7 @@ func (s PullsListCommentsForReviewOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PullsListDirection) Validate() error {
 	switch s {
@@ -10326,7 +10326,7 @@ func (s PullsListFilesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -10337,7 +10337,7 @@ func (s PullsListFilesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PullsListOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -10349,7 +10349,7 @@ func (s PullsListOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -10360,7 +10360,7 @@ func (s PullsListOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s PullsListReviewCommentsDirection) Validate() error {
 	switch s {
@@ -10438,13 +10438,13 @@ func (s PullsMergeReq) Validate() error {
 				if err := s.MergeMethod.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "merge_method",
@@ -10474,7 +10474,7 @@ func (s PullsRemoveRequestedReviewersReq) Validate() error {
 		if s.Reviewers == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reviewers",
@@ -10492,7 +10492,7 @@ func (s PullsSubmitReviewReq) Validate() error {
 		if err := s.Event.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "event",
@@ -10524,13 +10524,13 @@ func (s PullsUpdateReq) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -10558,7 +10558,7 @@ func (s Reaction) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10596,13 +10596,13 @@ func (s ReactionsCreateForCommitCommentApplicationJSONCreated) Validate() error 
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForCommitCommentApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForCommitCommentReq) Validate() error {
 	var failures []validate.FieldError
@@ -10610,7 +10610,7 @@ func (s ReactionsCreateForCommitCommentReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10648,25 +10648,25 @@ func (s ReactionsCreateForIssueApplicationJSONCreated) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForIssueApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForIssueCommentApplicationJSONCreated) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForIssueCommentApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForIssueCommentReq) Validate() error {
 	var failures []validate.FieldError
@@ -10674,7 +10674,7 @@ func (s ReactionsCreateForIssueCommentReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10714,7 +10714,7 @@ func (s ReactionsCreateForIssueReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10752,13 +10752,13 @@ func (s ReactionsCreateForPullRequestReviewCommentApplicationJSONCreated) Valida
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForPullRequestReviewCommentApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForPullRequestReviewCommentReq) Validate() error {
 	var failures []validate.FieldError
@@ -10766,7 +10766,7 @@ func (s ReactionsCreateForPullRequestReviewCommentReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10804,13 +10804,13 @@ func (s ReactionsCreateForReleaseApplicationJSONCreated) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForReleaseApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForReleaseReq) Validate() error {
 	var failures []validate.FieldError
@@ -10818,7 +10818,7 @@ func (s ReactionsCreateForReleaseReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10852,13 +10852,13 @@ func (s ReactionsCreateForTeamDiscussionCommentInOrgApplicationJSONCreated) Vali
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForTeamDiscussionCommentInOrgApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForTeamDiscussionCommentInOrgReq) Validate() error {
 	var failures []validate.FieldError
@@ -10866,7 +10866,7 @@ func (s ReactionsCreateForTeamDiscussionCommentInOrgReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10906,7 +10906,7 @@ func (s ReactionsCreateForTeamDiscussionCommentLegacyReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10944,13 +10944,13 @@ func (s ReactionsCreateForTeamDiscussionInOrgApplicationJSONCreated) Validate() 
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForTeamDiscussionInOrgApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsCreateForTeamDiscussionInOrgReq) Validate() error {
 	var failures []validate.FieldError
@@ -10958,7 +10958,7 @@ func (s ReactionsCreateForTeamDiscussionInOrgReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -10998,7 +10998,7 @@ func (s ReactionsCreateForTeamDiscussionLegacyReq) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -11064,7 +11064,7 @@ func (s ReactionsListForCommitCommentOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11075,7 +11075,7 @@ func (s ReactionsListForCommitCommentOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsListForIssueCommentContent) Validate() error {
 	switch s {
@@ -11109,7 +11109,7 @@ func (s ReactionsListForIssueCommentOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11120,7 +11120,7 @@ func (s ReactionsListForIssueCommentOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsListForIssueContent) Validate() error {
 	switch s {
@@ -11154,7 +11154,7 @@ func (s ReactionsListForIssueOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11165,7 +11165,7 @@ func (s ReactionsListForIssueOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsListForPullRequestReviewCommentContent) Validate() error {
 	switch s {
@@ -11199,7 +11199,7 @@ func (s ReactionsListForPullRequestReviewCommentOKApplicationJSON) Validate() er
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11210,7 +11210,7 @@ func (s ReactionsListForPullRequestReviewCommentOKApplicationJSON) Validate() er
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReactionsListForTeamDiscussionCommentInOrgContent) Validate() error {
 	switch s {
@@ -11312,7 +11312,7 @@ func (s Release) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11323,7 +11323,7 @@ func (s Release) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "assets",
@@ -11341,7 +11341,7 @@ func (s ReleaseAsset) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -11369,7 +11369,7 @@ func (s RepoSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -11384,11 +11384,11 @@ func (s RepoSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -11410,7 +11410,7 @@ func (s ReposAddAppAccessRestrictionsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11421,7 +11421,7 @@ func (s ReposAddAppAccessRestrictionsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposAddAppAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -11429,12 +11429,12 @@ func (s ReposAddAppAccessRestrictionsReq) Validate() error {
 		if err := s.ReposAddAppAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposAddAppAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -11446,7 +11446,7 @@ func (s ReposAddAppAccessRestrictionsReq0) Validate() error {
 		if s.Apps == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apps",
@@ -11466,13 +11466,13 @@ func (s ReposAddCollaboratorReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -11504,7 +11504,7 @@ func (s ReposAddStatusCheckContextsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposAddStatusCheckContextsReq) Validate() error {
 	switch s.Type {
@@ -11512,12 +11512,12 @@ func (s ReposAddStatusCheckContextsReq) Validate() error {
 		if err := s.ReposAddStatusCheckContextsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposAddStatusCheckContextsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -11529,7 +11529,7 @@ func (s ReposAddStatusCheckContextsReq0) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -11545,7 +11545,7 @@ func (s ReposAddTeamAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposAddTeamAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -11553,12 +11553,12 @@ func (s ReposAddTeamAccessRestrictionsReq) Validate() error {
 		if err := s.ReposAddTeamAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposAddTeamAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -11570,7 +11570,7 @@ func (s ReposAddTeamAccessRestrictionsReq0) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -11586,7 +11586,7 @@ func (s ReposAddUserAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposAddUserAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -11594,12 +11594,12 @@ func (s ReposAddUserAccessRestrictionsReq) Validate() error {
 		if err := s.ReposAddUserAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposAddUserAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -11611,7 +11611,7 @@ func (s ReposAddUserAccessRestrictionsReq0) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -11629,7 +11629,7 @@ func (s ReposCreateCommitStatusReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -11661,7 +11661,7 @@ func (s ReposCreateDeploymentStatusReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -11674,13 +11674,13 @@ func (s ReposCreateDeploymentStatusReq) Validate() error {
 				if err := s.Environment.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "environment",
@@ -11738,7 +11738,7 @@ func (s ReposCreateDispatchEventReq) Validate() error {
 		}).Validate(string(s.EventType)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "event_type",
@@ -11751,13 +11751,13 @@ func (s ReposCreateDispatchEventReq) Validate() error {
 				if err := s.ClientPayload.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "client_payload",
@@ -11785,13 +11785,13 @@ func (s ReposCreateInOrgReq) Validate() error {
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -11823,7 +11823,7 @@ func (s ReposCreatePagesSiteReq) Validate() error {
 		if err := s.Source.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "source",
@@ -11843,13 +11843,13 @@ func (s ReposCreatePagesSiteReqSource) Validate() error {
 				if err := s.Path.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "path",
@@ -11879,13 +11879,13 @@ func (s ReposCreateWebhookReq) Validate() error {
 				if err := s.Config.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "config",
@@ -11905,13 +11905,13 @@ func (s ReposCreateWebhookReqConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -11927,7 +11927,7 @@ func (s ReposGetAllStatusCheckContextsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetAppsWithAccessToProtectedBranchOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -11939,7 +11939,7 @@ func (s ReposGetAppsWithAccessToProtectedBranchOKApplicationJSON) Validate() err
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11950,7 +11950,7 @@ func (s ReposGetAppsWithAccessToProtectedBranchOKApplicationJSON) Validate() err
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetClonesPer) Validate() error {
 	switch s {
@@ -11974,7 +11974,7 @@ func (s ReposGetCodeFrequencyStatsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -11985,7 +11985,7 @@ func (s ReposGetCodeFrequencyStatsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetCommitActivityStatsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -11997,7 +11997,7 @@ func (s ReposGetCommitActivityStatsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12008,7 +12008,7 @@ func (s ReposGetCommitActivityStatsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetContributorsStatsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12020,7 +12020,7 @@ func (s ReposGetContributorsStatsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12031,7 +12031,7 @@ func (s ReposGetContributorsStatsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetPunchCardStatsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12043,7 +12043,7 @@ func (s ReposGetPunchCardStatsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12054,31 +12054,31 @@ func (s ReposGetPunchCardStatsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetTeamsWithAccessToProtectedBranchOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetTopPathsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetTopReferrersOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetUsersWithAccessToProtectedBranchOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposGetViewsPer) Validate() error {
 	switch s {
@@ -12096,7 +12096,7 @@ func (s ReposListBranchesForHeadCommitOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListBranchesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12108,7 +12108,7 @@ func (s ReposListBranchesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12119,7 +12119,7 @@ func (s ReposListBranchesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListCollaboratorsAffiliation) Validate() error {
 	switch s {
@@ -12137,13 +12137,13 @@ func (s ReposListCollaboratorsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListCommitStatusesForRefOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListCommitsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12155,7 +12155,7 @@ func (s ReposListCommitsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12166,13 +12166,13 @@ func (s ReposListCommitsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListContributorsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListDeploymentStatusesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12184,7 +12184,7 @@ func (s ReposListDeploymentStatusesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12195,7 +12195,7 @@ func (s ReposListDeploymentStatusesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListForAuthenticatedUserDirection) Validate() error {
 	switch s {
@@ -12211,7 +12211,7 @@ func (s ReposListForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListForAuthenticatedUserSort) Validate() error {
 	switch s {
@@ -12339,7 +12339,7 @@ func (s ReposListForksOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListForksSort) Validate() error {
 	switch s {
@@ -12365,7 +12365,7 @@ func (s ReposListInvitationsForAuthenticatedUserOKApplicationJSON) Validate() er
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12376,13 +12376,13 @@ func (s ReposListInvitationsForAuthenticatedUserOKApplicationJSON) Validate() er
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListPublicOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListReleasesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12394,7 +12394,7 @@ func (s ReposListReleasesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12405,7 +12405,7 @@ func (s ReposListReleasesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12417,7 +12417,7 @@ func (s ReposListWebhookDeliveriesOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12428,7 +12428,7 @@ func (s ReposListWebhookDeliveriesOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposListWebhooksOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12440,7 +12440,7 @@ func (s ReposListWebhooksOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12451,7 +12451,7 @@ func (s ReposListWebhooksOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposRemoveAppAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -12463,7 +12463,7 @@ func (s ReposRemoveAppAccessRestrictionsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12474,7 +12474,7 @@ func (s ReposRemoveAppAccessRestrictionsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposRemoveAppAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12482,12 +12482,12 @@ func (s ReposRemoveAppAccessRestrictionsReq) Validate() error {
 		if err := s.ReposRemoveAppAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposRemoveAppAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12499,7 +12499,7 @@ func (s ReposRemoveAppAccessRestrictionsReq0) Validate() error {
 		if s.Apps == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apps",
@@ -12515,7 +12515,7 @@ func (s ReposRemoveStatusCheckContextsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposRemoveStatusCheckContextsReq) Validate() error {
 	switch s.Type {
@@ -12523,12 +12523,12 @@ func (s ReposRemoveStatusCheckContextsReq) Validate() error {
 		if err := s.ReposRemoveStatusCheckContextsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposRemoveStatusCheckContextsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12540,7 +12540,7 @@ func (s ReposRemoveStatusCheckContextsReq0) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -12556,7 +12556,7 @@ func (s ReposRemoveTeamAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposRemoveTeamAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12564,12 +12564,12 @@ func (s ReposRemoveTeamAccessRestrictionsReq) Validate() error {
 		if err := s.ReposRemoveTeamAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposRemoveTeamAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12581,7 +12581,7 @@ func (s ReposRemoveTeamAccessRestrictionsReq0) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -12597,7 +12597,7 @@ func (s ReposRemoveUserAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposRemoveUserAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12605,12 +12605,12 @@ func (s ReposRemoveUserAccessRestrictionsReq) Validate() error {
 		if err := s.ReposRemoveUserAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposRemoveUserAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12622,7 +12622,7 @@ func (s ReposRemoveUserAccessRestrictionsReq0) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -12640,7 +12640,7 @@ func (s ReposReplaceAllTopicsReq) Validate() error {
 		if s.Names == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "names",
@@ -12662,7 +12662,7 @@ func (s ReposSetAppAccessRestrictionsOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -12673,7 +12673,7 @@ func (s ReposSetAppAccessRestrictionsOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposSetAppAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12681,12 +12681,12 @@ func (s ReposSetAppAccessRestrictionsReq) Validate() error {
 		if err := s.ReposSetAppAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposSetAppAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12698,7 +12698,7 @@ func (s ReposSetAppAccessRestrictionsReq0) Validate() error {
 		if s.Apps == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apps",
@@ -12714,7 +12714,7 @@ func (s ReposSetStatusCheckContextsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposSetStatusCheckContextsReq) Validate() error {
 	switch s.Type {
@@ -12722,12 +12722,12 @@ func (s ReposSetStatusCheckContextsReq) Validate() error {
 		if err := s.ReposSetStatusCheckContextsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposSetStatusCheckContextsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12739,7 +12739,7 @@ func (s ReposSetStatusCheckContextsReq0) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -12755,7 +12755,7 @@ func (s ReposSetTeamAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposSetTeamAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12763,12 +12763,12 @@ func (s ReposSetTeamAccessRestrictionsReq) Validate() error {
 		if err := s.ReposSetTeamAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposSetTeamAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12780,7 +12780,7 @@ func (s ReposSetTeamAccessRestrictionsReq0) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -12796,7 +12796,7 @@ func (s ReposSetUserAccessRestrictionsOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s ReposSetUserAccessRestrictionsReq) Validate() error {
 	switch s.Type {
@@ -12804,12 +12804,12 @@ func (s ReposSetUserAccessRestrictionsReq) Validate() error {
 		if err := s.ReposSetUserAccessRestrictionsReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayReposSetUserAccessRestrictionsReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -12821,7 +12821,7 @@ func (s ReposSetUserAccessRestrictionsReq0) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -12839,8 +12839,8 @@ func (s ReposUpdateBranchProtectionReq) Validate() error {
 		if err := s.RequiredStatusChecks.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_status_checks",
@@ -12851,8 +12851,8 @@ func (s ReposUpdateBranchProtectionReq) Validate() error {
 		if err := s.Restrictions.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "restrictions",
@@ -12870,7 +12870,7 @@ func (s ReposUpdateBranchProtectionReqRequiredStatusChecks) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -12888,7 +12888,7 @@ func (s ReposUpdateBranchProtectionReqRestrictions) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -12899,7 +12899,7 @@ func (s ReposUpdateBranchProtectionReqRestrictions) Validate() error {
 		if s.Teams == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "teams",
@@ -12919,13 +12919,13 @@ func (s ReposUpdateInvitationReq) Validate() error {
 				if err := s.Permissions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -12961,13 +12961,13 @@ func (s ReposUpdateReq) Validate() error {
 				if err := s.Visibility.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -13001,13 +13001,13 @@ func (s ReposUpdateWebhookConfigForRepoReq) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -13027,13 +13027,13 @@ func (s ReposUpdateWebhookReq) Validate() error {
 				if err := s.Config.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "config",
@@ -13053,13 +13053,13 @@ func (s ReposUpdateWebhookReqConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -13077,7 +13077,7 @@ func (s RepositoryInvitation) Validate() error {
 		if err := s.Permissions.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permissions",
@@ -13111,7 +13111,7 @@ func (s ReviewComment) Validate() error {
 		if err := s.AuthorAssociation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "author_association",
@@ -13124,13 +13124,13 @@ func (s ReviewComment) Validate() error {
 				if err := s.Side.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "side",
@@ -13143,13 +13143,13 @@ func (s ReviewComment) Validate() error {
 				if err := s.StartSide.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "start_side",
@@ -13193,7 +13193,7 @@ func (s Runner) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13204,7 +13204,7 @@ func (s Runner) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "labels",
@@ -13222,7 +13222,7 @@ func (s RunnerGroupsEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.ID)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -13240,7 +13240,7 @@ func (s RunnerGroupsOrg) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.ID)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -13260,13 +13260,13 @@ func (s RunnerLabelsItem) Validate() error {
 				if err := s.Type.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -13294,7 +13294,7 @@ func (s ScimEnterpriseGroup) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13312,7 +13312,7 @@ func (s ScimEnterpriseUser) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13330,7 +13330,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13341,7 +13341,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.TotalResults)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "totalResults",
@@ -13352,7 +13352,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.ItemsPerPage)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "itemsPerPage",
@@ -13363,7 +13363,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.StartIndex)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "startIndex",
@@ -13380,7 +13380,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13391,7 +13391,7 @@ func (s ScimGroupListEnterprise) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Resources",
@@ -13409,7 +13409,7 @@ func (s ScimGroupListEnterpriseResourcesItem) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13427,7 +13427,7 @@ func (s ScimUserListEnterprise) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13438,7 +13438,7 @@ func (s ScimUserListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.TotalResults)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "totalResults",
@@ -13449,7 +13449,7 @@ func (s ScimUserListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.ItemsPerPage)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "itemsPerPage",
@@ -13460,7 +13460,7 @@ func (s ScimUserListEnterprise) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.StartIndex)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "startIndex",
@@ -13477,7 +13477,7 @@ func (s ScimUserListEnterprise) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13488,7 +13488,7 @@ func (s ScimUserListEnterprise) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Resources",
@@ -13506,7 +13506,7 @@ func (s ScimUserListEnterpriseResourcesItem) Validate() error {
 		if s.Schemas == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -13530,7 +13530,7 @@ func (s SearchCodeOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13541,7 +13541,7 @@ func (s SearchCodeOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13583,7 +13583,7 @@ func (s SearchCommitsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13594,7 +13594,7 @@ func (s SearchCommitsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13638,7 +13638,7 @@ func (s SearchIssuesAndPullRequestsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13649,7 +13649,7 @@ func (s SearchIssuesAndPullRequestsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13711,7 +13711,7 @@ func (s SearchLabelsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13722,7 +13722,7 @@ func (s SearchLabelsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13766,7 +13766,7 @@ func (s SearchReposOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13777,7 +13777,7 @@ func (s SearchReposOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13817,7 +13817,7 @@ func (s SearchResultTextMatches) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s SearchTopicsOK) Validate() error {
 	var failures []validate.FieldError
@@ -13831,7 +13831,7 @@ func (s SearchTopicsOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13842,7 +13842,7 @@ func (s SearchTopicsOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13866,7 +13866,7 @@ func (s SearchUsersOK) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13877,7 +13877,7 @@ func (s SearchUsersOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -13919,13 +13919,13 @@ func (s SecretScanningAlert) Validate() error {
 				if err := s.State.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -13938,13 +13938,13 @@ func (s SecretScanningAlert) Validate() error {
 				if err := s.Resolution.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resolution",
@@ -13990,7 +13990,7 @@ func (s SecretScanningListAlertsForOrgOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -14001,7 +14001,7 @@ func (s SecretScanningListAlertsForOrgOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s SecretScanningListAlertsForOrgState) Validate() error {
 	switch s {
@@ -14023,7 +14023,7 @@ func (s SecretScanningListAlertsForRepoOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -14034,7 +14034,7 @@ func (s SecretScanningListAlertsForRepoOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s SecretScanningListAlertsForRepoState) Validate() error {
 	switch s {
@@ -14052,7 +14052,7 @@ func (s SecretScanningUpdateAlertReq) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -14065,13 +14065,13 @@ func (s SecretScanningUpdateAlertReq) Validate() error {
 				if err := s.Resolution.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resolution",
@@ -14091,13 +14091,13 @@ func (s ShortBranch) Validate() error {
 				if err := s.Protection.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "protection",
@@ -14115,7 +14115,7 @@ func (s StatusCheckPolicy) Validate() error {
 		if s.Contexts == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "contexts",
@@ -14135,13 +14135,13 @@ func (s TeamFull) Validate() error {
 				if err := s.Privacy.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "privacy",
@@ -14152,7 +14152,7 @@ func (s TeamFull) Validate() error {
 		if err := s.Organization.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "organization",
@@ -14180,7 +14180,7 @@ func (s TeamMembership) Validate() error {
 		if err := s.Role.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -14191,7 +14191,7 @@ func (s TeamMembership) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",
@@ -14231,13 +14231,13 @@ func (s TeamsAddOrUpdateMembershipForUserInOrgReq) Validate() error {
 				if err := s.Role.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -14267,13 +14267,13 @@ func (s TeamsAddOrUpdateMembershipForUserLegacyReq) Validate() error {
 				if err := s.Role.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "role",
@@ -14303,13 +14303,13 @@ func (s TeamsAddOrUpdateProjectPermissionsInOrgReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14341,13 +14341,13 @@ func (s TeamsAddOrUpdateProjectPermissionsLegacyReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14379,13 +14379,13 @@ func (s TeamsAddOrUpdateRepoPermissionsInOrgReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14421,13 +14421,13 @@ func (s TeamsAddOrUpdateRepoPermissionsLegacyReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14457,7 +14457,7 @@ func (s TeamsCreateOrUpdateIdpGroupConnectionsLegacyReq) Validate() error {
 		if s.Groups == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "groups",
@@ -14477,13 +14477,13 @@ func (s TeamsCreateReq) Validate() error {
 				if err := s.Privacy.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "privacy",
@@ -14496,13 +14496,13 @@ func (s TeamsCreateReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14540,7 +14540,7 @@ func (s TeamsListChildLegacyOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsListDiscussionCommentsInOrgDirection) Validate() error {
 	switch s {
@@ -14592,7 +14592,7 @@ func (s TeamsListForAuthenticatedUserOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -14603,7 +14603,7 @@ func (s TeamsListForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsListMembersInOrgRole) Validate() error {
 	switch s {
@@ -14621,7 +14621,7 @@ func (s TeamsListMembersLegacyOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsListMembersLegacyRole) Validate() error {
 	switch s {
@@ -14639,19 +14639,19 @@ func (s TeamsListOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsListProjectsLegacyOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsListReposLegacyOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsUpdateInOrgReq) Validate() error {
 	var failures []validate.FieldError
@@ -14661,13 +14661,13 @@ func (s TeamsUpdateInOrgReq) Validate() error {
 				if err := s.Privacy.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "privacy",
@@ -14680,13 +14680,13 @@ func (s TeamsUpdateInOrgReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14724,13 +14724,13 @@ func (s TeamsUpdateLegacyApplicationJSONCreated) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsUpdateLegacyApplicationJSONOK) Validate() error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	return nil
+	return nil // return 1
 }
 func (s TeamsUpdateLegacyReq) Validate() error {
 	var failures []validate.FieldError
@@ -14740,13 +14740,13 @@ func (s TeamsUpdateLegacyReq) Validate() error {
 				if err := s.Privacy.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "privacy",
@@ -14759,13 +14759,13 @@ func (s TeamsUpdateLegacyReq) Validate() error {
 				if err := s.Permission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "permission",
@@ -14805,7 +14805,7 @@ func (s Topic) Validate() error {
 		if s.Names == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "names",
@@ -14823,7 +14823,7 @@ func (s TopicSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -14838,11 +14838,11 @@ func (s TopicSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -14855,13 +14855,13 @@ func (s TopicSearchResultItem) Validate() error {
 				if s.Related.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "related",
@@ -14874,13 +14874,13 @@ func (s TopicSearchResultItem) Validate() error {
 				if s.Aliases.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "aliases",
@@ -14898,7 +14898,7 @@ func (s UserMarketplacePurchase) Validate() error {
 		if err := s.Account.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "account",
@@ -14909,7 +14909,7 @@ func (s UserMarketplacePurchase) Validate() error {
 		if err := s.Plan.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "plan",
@@ -14927,7 +14927,7 @@ func (s UserSearchResultItem) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Score)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "score",
@@ -14948,13 +14948,13 @@ func (s UserSearchResultItem) Validate() error {
 				}).Validate(string(s.Email.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -14969,11 +14969,11 @@ func (s UserSearchResultItem) Validate() error {
 			if err := s.TextMatches.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_matches",
@@ -14995,7 +14995,7 @@ func (s UsersAddEmailForAuthenticatedCreatedApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -15006,7 +15006,7 @@ func (s UsersAddEmailForAuthenticatedCreatedApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersAddEmailForAuthenticatedReq) Validate() error {
 	switch s.Type {
@@ -15014,12 +15014,12 @@ func (s UsersAddEmailForAuthenticatedReq) Validate() error {
 		if err := s.UsersAddEmailForAuthenticatedReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayUsersAddEmailForAuthenticatedReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	case StringUsersAddEmailForAuthenticatedReq:
 		return nil // no validation needed
 	default:
@@ -15033,7 +15033,7 @@ func (s UsersAddEmailForAuthenticatedReq0) Validate() error {
 		if s.Emails == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "emails",
@@ -15059,7 +15059,7 @@ func (s UsersCreatePublicSSHKeyForAuthenticatedReq) Validate() error {
 		}).Validate(string(s.Key)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "key",
@@ -15077,12 +15077,12 @@ func (s UsersDeleteEmailForAuthenticatedReq) Validate() error {
 		if err := s.UsersDeleteEmailForAuthenticatedReq0.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case StringArrayUsersDeleteEmailForAuthenticatedReq:
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	case StringUsersDeleteEmailForAuthenticatedReq:
 		return nil // no validation needed
 	default:
@@ -15096,7 +15096,7 @@ func (s UsersDeleteEmailForAuthenticatedReq0) Validate() error {
 		if s.Emails == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "emails",
@@ -15114,12 +15114,12 @@ func (s UsersGetAuthenticatedOK) Validate() error {
 		if err := s.PrivateUser.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PublicUserUsersGetAuthenticatedOK:
 		if err := s.PublicUser.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -15131,12 +15131,12 @@ func (s UsersGetByUsernameOK) Validate() error {
 		if err := s.PrivateUser.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PublicUserUsersGetByUsernameOK:
 		if err := s.PublicUser.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -15160,7 +15160,7 @@ func (s UsersListBlockedByAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListEmailsForAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -15172,7 +15172,7 @@ func (s UsersListEmailsForAuthenticatedOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -15183,19 +15183,19 @@ func (s UsersListEmailsForAuthenticatedOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListFollowedByAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListFollowersForAuthenticatedUserOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListGpgKeysForAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -15207,7 +15207,7 @@ func (s UsersListGpgKeysForAuthenticatedOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -15218,13 +15218,13 @@ func (s UsersListGpgKeysForAuthenticatedOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListPublicEmailsForAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -15236,7 +15236,7 @@ func (s UsersListPublicEmailsForAuthenticatedOKApplicationJSON) Validate() error
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -15247,13 +15247,13 @@ func (s UsersListPublicEmailsForAuthenticatedOKApplicationJSON) Validate() error
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersListPublicSSHKeysForAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersSetPrimaryEmailVisibilityForAuthenticatedOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -15265,7 +15265,7 @@ func (s UsersSetPrimaryEmailVisibilityForAuthenticatedOKApplicationJSON) Validat
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -15276,7 +15276,7 @@ func (s UsersSetPrimaryEmailVisibilityForAuthenticatedOKApplicationJSON) Validat
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s UsersSetPrimaryEmailVisibilityForAuthenticatedReq) Validate() error {
 	var failures []validate.FieldError
@@ -15284,7 +15284,7 @@ func (s UsersSetPrimaryEmailVisibilityForAuthenticatedReq) Validate() error {
 		if err := s.Visibility.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visibility",
@@ -15315,7 +15315,7 @@ func (s ValidationError) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15326,7 +15326,7 @@ func (s ValidationError) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "errors",
@@ -15346,13 +15346,13 @@ func (s ValidationErrorErrorsItem) Validate() error {
 				if err := s.Value.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "value",
@@ -15374,7 +15374,7 @@ func (s ValidationErrorErrorsItemValue) Validate() error {
 		if s.StringArray == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -15386,7 +15386,7 @@ func (s ViewTraffic) Validate() error {
 		if s.Views == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "views",
@@ -15406,13 +15406,13 @@ func (s WebhookConfig) Validate() error {
 				if err := s.InsecureSsl.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "insecure_ssl",
@@ -15432,7 +15432,7 @@ func (s WebhookConfigInsecureSsl) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Float64)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -15444,7 +15444,7 @@ func (s Workflow) Validate() error {
 		if err := s.State.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "state",

--- a/examples/ex_gotd/oas_client_gen.go
+++ b/examples/ex_gotd/oas_client_gen.go
@@ -59,7 +59,7 @@ func (c *Client) AddStickerToSet(ctx context.Context, request AddStickerToSet) (
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -124,7 +124,7 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request AnswerCallback
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -189,7 +189,7 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request AnswerInlineQuer
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -311,7 +311,7 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request AnswerShipping
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -376,7 +376,7 @@ func (c *Client) AnswerWebAppQuery(ctx context.Context, request AnswerWebAppQuer
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -655,7 +655,7 @@ func (c *Client) CopyMessage(ctx context.Context, request CopyMessage) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -720,7 +720,7 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request CreateChatInv
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -785,7 +785,7 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request CreateNewStick
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1249,7 +1249,7 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request EditChatInviteL
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1314,7 +1314,7 @@ func (c *Client) EditMessageCaption(ctx context.Context, request EditMessageCapt
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1379,7 +1379,7 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request EditMessag
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1444,7 +1444,7 @@ func (c *Client) EditMessageMedia(ctx context.Context, request EditMessageMedia)
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1509,7 +1509,7 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request EditMessage
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1574,7 +1574,7 @@ func (c *Client) EditMessageText(ctx context.Context, request EditMessageText) (
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2368,13 +2368,13 @@ func (c *Client) GetUpdates(ctx context.Context, request OptGetUpdates) (res Res
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2439,7 +2439,7 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request GetUserProfil
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2875,7 +2875,7 @@ func (c *Client) SendAnimation(ctx context.Context, request SendAnimation) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2940,7 +2940,7 @@ func (c *Client) SendAudio(ctx context.Context, request SendAudio) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3062,7 +3062,7 @@ func (c *Client) SendContact(ctx context.Context, request SendContact) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3127,7 +3127,7 @@ func (c *Client) SendDice(ctx context.Context, request SendDice) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3192,7 +3192,7 @@ func (c *Client) SendDocument(ctx context.Context, request SendDocument) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3257,7 +3257,7 @@ func (c *Client) SendGame(ctx context.Context, request SendGame) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3322,7 +3322,7 @@ func (c *Client) SendInvoice(ctx context.Context, request SendInvoice) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3387,7 +3387,7 @@ func (c *Client) SendLocation(ctx context.Context, request SendLocation) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3452,7 +3452,7 @@ func (c *Client) SendMediaGroup(ctx context.Context, request SendMediaGroup) (re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3517,7 +3517,7 @@ func (c *Client) SendMessage(ctx context.Context, request SendMessage) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3582,7 +3582,7 @@ func (c *Client) SendPhoto(ctx context.Context, request SendPhoto) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3647,7 +3647,7 @@ func (c *Client) SendPoll(ctx context.Context, request SendPoll) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3712,7 +3712,7 @@ func (c *Client) SendSticker(ctx context.Context, request SendSticker) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3777,7 +3777,7 @@ func (c *Client) SendVenue(ctx context.Context, request SendVenue) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3842,7 +3842,7 @@ func (c *Client) SendVideo(ctx context.Context, request SendVideo) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3907,7 +3907,7 @@ func (c *Client) SendVideoNote(ctx context.Context, request SendVideoNote) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3972,7 +3972,7 @@ func (c *Client) SendVoice(ctx context.Context, request SendVoice) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4037,7 +4037,7 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request Se
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4102,7 +4102,7 @@ func (c *Client) SetChatDescription(ctx context.Context, request SetChatDescript
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4395,7 +4395,7 @@ func (c *Client) SetChatTitle(ctx context.Context, request SetChatTitle) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4517,7 +4517,7 @@ func (c *Client) SetMyCommands(ctx context.Context, request SetMyCommands) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4639,7 +4639,7 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request SetPassportD
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4875,7 +4875,7 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request StopMessag
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4940,7 +4940,7 @@ func (c *Client) StopPoll(ctx context.Context, request StopPoll) (res ResultPoll
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_gotd/oas_handlers_gen.go
+++ b/examples/ex_gotd/oas_handlers_gen.go
@@ -36,8 +36,8 @@ func (s *Server) handleAddStickerToSetRequest(args [0]string, w http.ResponseWri
 	request, err := decodeAddStickerToSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AddStickerToSet",
-			err,
+			Operation: "AddStickerToSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -90,8 +90,8 @@ func (s *Server) handleAnswerCallbackQueryRequest(args [0]string, w http.Respons
 	request, err := decodeAnswerCallbackQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerCallbackQuery",
-			err,
+			Operation: "AnswerCallbackQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -144,8 +144,8 @@ func (s *Server) handleAnswerInlineQueryRequest(args [0]string, w http.ResponseW
 	request, err := decodeAnswerInlineQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerInlineQuery",
-			err,
+			Operation: "AnswerInlineQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -198,8 +198,8 @@ func (s *Server) handleAnswerPreCheckoutQueryRequest(args [0]string, w http.Resp
 	request, err := decodeAnswerPreCheckoutQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerPreCheckoutQuery",
-			err,
+			Operation: "AnswerPreCheckoutQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -252,8 +252,8 @@ func (s *Server) handleAnswerShippingQueryRequest(args [0]string, w http.Respons
 	request, err := decodeAnswerShippingQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerShippingQuery",
-			err,
+			Operation: "AnswerShippingQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -306,8 +306,8 @@ func (s *Server) handleAnswerWebAppQueryRequest(args [0]string, w http.ResponseW
 	request, err := decodeAnswerWebAppQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerWebAppQuery",
-			err,
+			Operation: "AnswerWebAppQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -360,8 +360,8 @@ func (s *Server) handleApproveChatJoinRequestRequest(args [0]string, w http.Resp
 	request, err := decodeApproveChatJoinRequestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ApproveChatJoinRequest",
-			err,
+			Operation: "ApproveChatJoinRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -414,8 +414,8 @@ func (s *Server) handleBanChatMemberRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeBanChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"BanChatMember",
-			err,
+			Operation: "BanChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -468,8 +468,8 @@ func (s *Server) handleBanChatSenderChatRequest(args [0]string, w http.ResponseW
 	request, err := decodeBanChatSenderChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"BanChatSenderChat",
-			err,
+			Operation: "BanChatSenderChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -567,8 +567,8 @@ func (s *Server) handleCopyMessageRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeCopyMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CopyMessage",
-			err,
+			Operation: "CopyMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -621,8 +621,8 @@ func (s *Server) handleCreateChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeCreateChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateChatInviteLink",
-			err,
+			Operation: "CreateChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -675,8 +675,8 @@ func (s *Server) handleCreateNewStickerSetRequest(args [0]string, w http.Respons
 	request, err := decodeCreateNewStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateNewStickerSet",
-			err,
+			Operation: "CreateNewStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -729,8 +729,8 @@ func (s *Server) handleDeclineChatJoinRequestRequest(args [0]string, w http.Resp
 	request, err := decodeDeclineChatJoinRequestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeclineChatJoinRequest",
-			err,
+			Operation: "DeclineChatJoinRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -783,8 +783,8 @@ func (s *Server) handleDeleteChatPhotoRequest(args [0]string, w http.ResponseWri
 	request, err := decodeDeleteChatPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteChatPhoto",
-			err,
+			Operation: "DeleteChatPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -837,8 +837,8 @@ func (s *Server) handleDeleteChatStickerSetRequest(args [0]string, w http.Respon
 	request, err := decodeDeleteChatStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteChatStickerSet",
-			err,
+			Operation: "DeleteChatStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -891,8 +891,8 @@ func (s *Server) handleDeleteMessageRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeDeleteMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteMessage",
-			err,
+			Operation: "DeleteMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -945,8 +945,8 @@ func (s *Server) handleDeleteMyCommandsRequest(args [0]string, w http.ResponseWr
 	request, err := decodeDeleteMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteMyCommands",
-			err,
+			Operation: "DeleteMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -999,8 +999,8 @@ func (s *Server) handleDeleteStickerFromSetRequest(args [0]string, w http.Respon
 	request, err := decodeDeleteStickerFromSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteStickerFromSet",
-			err,
+			Operation: "DeleteStickerFromSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1053,8 +1053,8 @@ func (s *Server) handleDeleteWebhookRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeDeleteWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteWebhook",
-			err,
+			Operation: "DeleteWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1107,8 +1107,8 @@ func (s *Server) handleEditChatInviteLinkRequest(args [0]string, w http.Response
 	request, err := decodeEditChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditChatInviteLink",
-			err,
+			Operation: "EditChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1161,8 +1161,8 @@ func (s *Server) handleEditMessageCaptionRequest(args [0]string, w http.Response
 	request, err := decodeEditMessageCaptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageCaption",
-			err,
+			Operation: "EditMessageCaption",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1215,8 +1215,8 @@ func (s *Server) handleEditMessageLiveLocationRequest(args [0]string, w http.Res
 	request, err := decodeEditMessageLiveLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageLiveLocation",
-			err,
+			Operation: "EditMessageLiveLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1269,8 +1269,8 @@ func (s *Server) handleEditMessageMediaRequest(args [0]string, w http.ResponseWr
 	request, err := decodeEditMessageMediaRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageMedia",
-			err,
+			Operation: "EditMessageMedia",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1323,8 +1323,8 @@ func (s *Server) handleEditMessageReplyMarkupRequest(args [0]string, w http.Resp
 	request, err := decodeEditMessageReplyMarkupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageReplyMarkup",
-			err,
+			Operation: "EditMessageReplyMarkup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1377,8 +1377,8 @@ func (s *Server) handleEditMessageTextRequest(args [0]string, w http.ResponseWri
 	request, err := decodeEditMessageTextRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageText",
-			err,
+			Operation: "EditMessageText",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1431,8 +1431,8 @@ func (s *Server) handleExportChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeExportChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ExportChatInviteLink",
-			err,
+			Operation: "ExportChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1485,8 +1485,8 @@ func (s *Server) handleForwardMessageRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeForwardMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ForwardMessage",
-			err,
+			Operation: "ForwardMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1539,8 +1539,8 @@ func (s *Server) handleGetChatRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodeGetChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChat",
-			err,
+			Operation: "GetChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1593,8 +1593,8 @@ func (s *Server) handleGetChatAdministratorsRequest(args [0]string, w http.Respo
 	request, err := decodeGetChatAdministratorsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatAdministrators",
-			err,
+			Operation: "GetChatAdministrators",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1647,8 +1647,8 @@ func (s *Server) handleGetChatMemberRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatMember",
-			err,
+			Operation: "GetChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1701,8 +1701,8 @@ func (s *Server) handleGetChatMemberCountRequest(args [0]string, w http.Response
 	request, err := decodeGetChatMemberCountRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatMemberCount",
-			err,
+			Operation: "GetChatMemberCount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1755,8 +1755,8 @@ func (s *Server) handleGetChatMenuButtonRequest(args [0]string, w http.ResponseW
 	request, err := decodeGetChatMenuButtonRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatMenuButton",
-			err,
+			Operation: "GetChatMenuButton",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1809,8 +1809,8 @@ func (s *Server) handleGetFileRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodeGetFileRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetFile",
-			err,
+			Operation: "GetFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1863,8 +1863,8 @@ func (s *Server) handleGetGameHighScoresRequest(args [0]string, w http.ResponseW
 	request, err := decodeGetGameHighScoresRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetGameHighScores",
-			err,
+			Operation: "GetGameHighScores",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1962,8 +1962,8 @@ func (s *Server) handleGetMyCommandsRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetMyCommands",
-			err,
+			Operation: "GetMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2016,8 +2016,8 @@ func (s *Server) handleGetMyDefaultAdministratorRightsRequest(args [0]string, w 
 	request, err := decodeGetMyDefaultAdministratorRightsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetMyDefaultAdministratorRights",
-			err,
+			Operation: "GetMyDefaultAdministratorRights",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2070,8 +2070,8 @@ func (s *Server) handleGetStickerSetRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetStickerSet",
-			err,
+			Operation: "GetStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2124,8 +2124,8 @@ func (s *Server) handleGetUpdatesRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeGetUpdatesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetUpdates",
-			err,
+			Operation: "GetUpdates",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2178,8 +2178,8 @@ func (s *Server) handleGetUserProfilePhotosRequest(args [0]string, w http.Respon
 	request, err := decodeGetUserProfilePhotosRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetUserProfilePhotos",
-			err,
+			Operation: "GetUserProfilePhotos",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2277,8 +2277,8 @@ func (s *Server) handleLeaveChatRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeLeaveChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"LeaveChat",
-			err,
+			Operation: "LeaveChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2376,8 +2376,8 @@ func (s *Server) handlePinChatMessageRequest(args [0]string, w http.ResponseWrit
 	request, err := decodePinChatMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PinChatMessage",
-			err,
+			Operation: "PinChatMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2430,8 +2430,8 @@ func (s *Server) handlePromoteChatMemberRequest(args [0]string, w http.ResponseW
 	request, err := decodePromoteChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PromoteChatMember",
-			err,
+			Operation: "PromoteChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2484,8 +2484,8 @@ func (s *Server) handleRestrictChatMemberRequest(args [0]string, w http.Response
 	request, err := decodeRestrictChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"RestrictChatMember",
-			err,
+			Operation: "RestrictChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2538,8 +2538,8 @@ func (s *Server) handleRevokeChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeRevokeChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"RevokeChatInviteLink",
-			err,
+			Operation: "RevokeChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2592,8 +2592,8 @@ func (s *Server) handleSendAnimationRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSendAnimationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendAnimation",
-			err,
+			Operation: "SendAnimation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2646,8 +2646,8 @@ func (s *Server) handleSendAudioRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendAudioRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendAudio",
-			err,
+			Operation: "SendAudio",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2700,8 +2700,8 @@ func (s *Server) handleSendChatActionRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeSendChatActionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendChatAction",
-			err,
+			Operation: "SendChatAction",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2754,8 +2754,8 @@ func (s *Server) handleSendContactRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendContactRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendContact",
-			err,
+			Operation: "SendContact",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2808,8 +2808,8 @@ func (s *Server) handleSendDiceRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendDiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendDice",
-			err,
+			Operation: "SendDice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2862,8 +2862,8 @@ func (s *Server) handleSendDocumentRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSendDocumentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendDocument",
-			err,
+			Operation: "SendDocument",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2916,8 +2916,8 @@ func (s *Server) handleSendGameRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendGameRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendGame",
-			err,
+			Operation: "SendGame",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2970,8 +2970,8 @@ func (s *Server) handleSendInvoiceRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendInvoiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendInvoice",
-			err,
+			Operation: "SendInvoice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3024,8 +3024,8 @@ func (s *Server) handleSendLocationRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSendLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendLocation",
-			err,
+			Operation: "SendLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3078,8 +3078,8 @@ func (s *Server) handleSendMediaGroupRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeSendMediaGroupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendMediaGroup",
-			err,
+			Operation: "SendMediaGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3132,8 +3132,8 @@ func (s *Server) handleSendMessageRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendMessage",
-			err,
+			Operation: "SendMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3186,8 +3186,8 @@ func (s *Server) handleSendPhotoRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendPhoto",
-			err,
+			Operation: "SendPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3240,8 +3240,8 @@ func (s *Server) handleSendPollRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendPollRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendPoll",
-			err,
+			Operation: "SendPoll",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3294,8 +3294,8 @@ func (s *Server) handleSendStickerRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendStickerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendSticker",
-			err,
+			Operation: "SendSticker",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3348,8 +3348,8 @@ func (s *Server) handleSendVenueRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVenueRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVenue",
-			err,
+			Operation: "SendVenue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3402,8 +3402,8 @@ func (s *Server) handleSendVideoRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVideoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVideo",
-			err,
+			Operation: "SendVideo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3456,8 +3456,8 @@ func (s *Server) handleSendVideoNoteRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSendVideoNoteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVideoNote",
-			err,
+			Operation: "SendVideoNote",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3510,8 +3510,8 @@ func (s *Server) handleSendVoiceRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVoiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVoice",
-			err,
+			Operation: "SendVoice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3564,8 +3564,8 @@ func (s *Server) handleSetChatAdministratorCustomTitleRequest(args [0]string, w 
 	request, err := decodeSetChatAdministratorCustomTitleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatAdministratorCustomTitle",
-			err,
+			Operation: "SetChatAdministratorCustomTitle",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3618,8 +3618,8 @@ func (s *Server) handleSetChatDescriptionRequest(args [0]string, w http.Response
 	request, err := decodeSetChatDescriptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatDescription",
-			err,
+			Operation: "SetChatDescription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3672,8 +3672,8 @@ func (s *Server) handleSetChatMenuButtonRequest(args [0]string, w http.ResponseW
 	request, err := decodeSetChatMenuButtonRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatMenuButton",
-			err,
+			Operation: "SetChatMenuButton",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3726,8 +3726,8 @@ func (s *Server) handleSetChatPermissionsRequest(args [0]string, w http.Response
 	request, err := decodeSetChatPermissionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatPermissions",
-			err,
+			Operation: "SetChatPermissions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3780,8 +3780,8 @@ func (s *Server) handleSetChatPhotoRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetChatPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatPhoto",
-			err,
+			Operation: "SetChatPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3834,8 +3834,8 @@ func (s *Server) handleSetChatStickerSetRequest(args [0]string, w http.ResponseW
 	request, err := decodeSetChatStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatStickerSet",
-			err,
+			Operation: "SetChatStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3888,8 +3888,8 @@ func (s *Server) handleSetChatTitleRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetChatTitleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatTitle",
-			err,
+			Operation: "SetChatTitle",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3942,8 +3942,8 @@ func (s *Server) handleSetGameScoreRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetGameScoreRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetGameScore",
-			err,
+			Operation: "SetGameScore",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3996,8 +3996,8 @@ func (s *Server) handleSetMyCommandsRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSetMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetMyCommands",
-			err,
+			Operation: "SetMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4050,8 +4050,8 @@ func (s *Server) handleSetMyDefaultAdministratorRightsRequest(args [0]string, w 
 	request, err := decodeSetMyDefaultAdministratorRightsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetMyDefaultAdministratorRights",
-			err,
+			Operation: "SetMyDefaultAdministratorRights",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4104,8 +4104,8 @@ func (s *Server) handleSetPassportDataErrorsRequest(args [0]string, w http.Respo
 	request, err := decodeSetPassportDataErrorsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetPassportDataErrors",
-			err,
+			Operation: "SetPassportDataErrors",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4158,8 +4158,8 @@ func (s *Server) handleSetStickerPositionInSetRequest(args [0]string, w http.Res
 	request, err := decodeSetStickerPositionInSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetStickerPositionInSet",
-			err,
+			Operation: "SetStickerPositionInSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4212,8 +4212,8 @@ func (s *Server) handleSetStickerSetThumbRequest(args [0]string, w http.Response
 	request, err := decodeSetStickerSetThumbRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetStickerSetThumb",
-			err,
+			Operation: "SetStickerSetThumb",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4266,8 +4266,8 @@ func (s *Server) handleSetWebhookRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeSetWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetWebhook",
-			err,
+			Operation: "SetWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4320,8 +4320,8 @@ func (s *Server) handleStopMessageLiveLocationRequest(args [0]string, w http.Res
 	request, err := decodeStopMessageLiveLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"StopMessageLiveLocation",
-			err,
+			Operation: "StopMessageLiveLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4374,8 +4374,8 @@ func (s *Server) handleStopPollRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeStopPollRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"StopPoll",
-			err,
+			Operation: "StopPoll",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4428,8 +4428,8 @@ func (s *Server) handleUnbanChatMemberRequest(args [0]string, w http.ResponseWri
 	request, err := decodeUnbanChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnbanChatMember",
-			err,
+			Operation: "UnbanChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4482,8 +4482,8 @@ func (s *Server) handleUnbanChatSenderChatRequest(args [0]string, w http.Respons
 	request, err := decodeUnbanChatSenderChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnbanChatSenderChat",
-			err,
+			Operation: "UnbanChatSenderChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4536,8 +4536,8 @@ func (s *Server) handleUnpinAllChatMessagesRequest(args [0]string, w http.Respon
 	request, err := decodeUnpinAllChatMessagesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnpinAllChatMessages",
-			err,
+			Operation: "UnpinAllChatMessages",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4590,8 +4590,8 @@ func (s *Server) handleUnpinChatMessageRequest(args [0]string, w http.ResponseWr
 	request, err := decodeUnpinChatMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnpinChatMessage",
-			err,
+			Operation: "UnpinChatMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4644,8 +4644,8 @@ func (s *Server) handleUploadStickerFileRequest(args [0]string, w http.ResponseW
 	request, err := decodeUploadStickerFileRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UploadStickerFile",
-			err,
+			Operation: "UploadStickerFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_gotd/oas_req_dec_gen.go
+++ b/examples/ex_gotd/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeAddStickerToSetRequest(r *http.Request, span trace.Span) (req AddStic
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AddStickerToSet request")
 		}
@@ -91,7 +91,7 @@ func decodeAnswerCallbackQueryRequest(r *http.Request, span trace.Span) (req Ans
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerCallbackQuery request")
 		}
@@ -135,7 +135,7 @@ func decodeAnswerInlineQueryRequest(r *http.Request, span trace.Span) (req Answe
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerInlineQuery request")
 		}
@@ -215,7 +215,7 @@ func decodeAnswerShippingQueryRequest(r *http.Request, span trace.Span) (req Ans
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerShippingQuery request")
 		}
@@ -259,7 +259,7 @@ func decodeAnswerWebAppQueryRequest(r *http.Request, span trace.Span) (req Answe
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerWebAppQuery request")
 		}
@@ -411,7 +411,7 @@ func decodeCopyMessageRequest(r *http.Request, span trace.Span) (req CopyMessage
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CopyMessage request")
 		}
@@ -455,7 +455,7 @@ func decodeCreateChatInviteLinkRequest(r *http.Request, span trace.Span) (req Cr
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateChatInviteLink request")
 		}
@@ -499,7 +499,7 @@ func decodeCreateNewStickerSetRequest(r *http.Request, span trace.Span) (req Cre
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateNewStickerSet request")
 		}
@@ -797,7 +797,7 @@ func decodeEditChatInviteLinkRequest(r *http.Request, span trace.Span) (req Edit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditChatInviteLink request")
 		}
@@ -841,7 +841,7 @@ func decodeEditMessageCaptionRequest(r *http.Request, span trace.Span) (req Edit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageCaption request")
 		}
@@ -885,7 +885,7 @@ func decodeEditMessageLiveLocationRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageLiveLocation request")
 		}
@@ -929,7 +929,7 @@ func decodeEditMessageMediaRequest(r *http.Request, span trace.Span) (req EditMe
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageMedia request")
 		}
@@ -973,7 +973,7 @@ func decodeEditMessageReplyMarkupRequest(r *http.Request, span trace.Span) (req 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageReplyMarkup request")
 		}
@@ -1017,7 +1017,7 @@ func decodeEditMessageTextRequest(r *http.Request, span trace.Span) (req EditMes
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageText request")
 		}
@@ -1499,13 +1499,13 @@ func decodeGetUpdatesRequest(r *http.Request, span trace.Span) (req OptGetUpdate
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GetUpdates request")
 		}
@@ -1549,7 +1549,7 @@ func decodeGetUserProfilePhotosRequest(r *http.Request, span trace.Span) (req Ge
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GetUserProfilePhotos request")
 		}
@@ -1773,7 +1773,7 @@ func decodeSendAnimationRequest(r *http.Request, span trace.Span) (req SendAnima
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendAnimation request")
 		}
@@ -1817,7 +1817,7 @@ func decodeSendAudioRequest(r *http.Request, span trace.Span) (req SendAudio, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendAudio request")
 		}
@@ -1897,7 +1897,7 @@ func decodeSendContactRequest(r *http.Request, span trace.Span) (req SendContact
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendContact request")
 		}
@@ -1941,7 +1941,7 @@ func decodeSendDiceRequest(r *http.Request, span trace.Span) (req SendDice, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendDice request")
 		}
@@ -1985,7 +1985,7 @@ func decodeSendDocumentRequest(r *http.Request, span trace.Span) (req SendDocume
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendDocument request")
 		}
@@ -2029,7 +2029,7 @@ func decodeSendGameRequest(r *http.Request, span trace.Span) (req SendGame, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendGame request")
 		}
@@ -2073,7 +2073,7 @@ func decodeSendInvoiceRequest(r *http.Request, span trace.Span) (req SendInvoice
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendInvoice request")
 		}
@@ -2117,7 +2117,7 @@ func decodeSendLocationRequest(r *http.Request, span trace.Span) (req SendLocati
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendLocation request")
 		}
@@ -2161,7 +2161,7 @@ func decodeSendMediaGroupRequest(r *http.Request, span trace.Span) (req SendMedi
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendMediaGroup request")
 		}
@@ -2205,7 +2205,7 @@ func decodeSendMessageRequest(r *http.Request, span trace.Span) (req SendMessage
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendMessage request")
 		}
@@ -2249,7 +2249,7 @@ func decodeSendPhotoRequest(r *http.Request, span trace.Span) (req SendPhoto, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendPhoto request")
 		}
@@ -2293,7 +2293,7 @@ func decodeSendPollRequest(r *http.Request, span trace.Span) (req SendPoll, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendPoll request")
 		}
@@ -2337,7 +2337,7 @@ func decodeSendStickerRequest(r *http.Request, span trace.Span) (req SendSticker
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendSticker request")
 		}
@@ -2381,7 +2381,7 @@ func decodeSendVenueRequest(r *http.Request, span trace.Span) (req SendVenue, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVenue request")
 		}
@@ -2425,7 +2425,7 @@ func decodeSendVideoRequest(r *http.Request, span trace.Span) (req SendVideo, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVideo request")
 		}
@@ -2469,7 +2469,7 @@ func decodeSendVideoNoteRequest(r *http.Request, span trace.Span) (req SendVideo
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVideoNote request")
 		}
@@ -2513,7 +2513,7 @@ func decodeSendVoiceRequest(r *http.Request, span trace.Span) (req SendVoice, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVoice request")
 		}
@@ -2557,7 +2557,7 @@ func decodeSetChatAdministratorCustomTitleRequest(r *http.Request, span trace.Sp
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatAdministratorCustomTitle request")
 		}
@@ -2601,7 +2601,7 @@ func decodeSetChatDescriptionRequest(r *http.Request, span trace.Span) (req SetC
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatDescription request")
 		}
@@ -2790,7 +2790,7 @@ func decodeSetChatTitleRequest(r *http.Request, span trace.Span) (req SetChatTit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatTitle request")
 		}
@@ -2870,7 +2870,7 @@ func decodeSetMyCommandsRequest(r *http.Request, span trace.Span) (req SetMyComm
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetMyCommands request")
 		}
@@ -2951,7 +2951,7 @@ func decodeSetPassportDataErrorsRequest(r *http.Request, span trace.Span) (req S
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetPassportDataErrors request")
 		}
@@ -3103,7 +3103,7 @@ func decodeStopMessageLiveLocationRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate StopMessageLiveLocation request")
 		}
@@ -3147,7 +3147,7 @@ func decodeStopPollRequest(r *http.Request, span trace.Span) (req StopPoll, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate StopPoll request")
 		}

--- a/examples/ex_gotd/oas_validators_gen.go
+++ b/examples/ex_gotd/oas_validators_gen.go
@@ -18,13 +18,13 @@ func (s AddStickerToSet) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -51,7 +51,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -71,7 +71,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -91,7 +91,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -104,13 +104,13 @@ func (s Animation) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -138,13 +138,13 @@ func (s AnswerCallbackQuery) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -168,7 +168,7 @@ func (s AnswerInlineQuery) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -179,7 +179,7 @@ func (s AnswerInlineQuery) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "results",
@@ -200,13 +200,13 @@ func (s AnswerInlineQuery) Validate() error {
 				}).Validate(string(s.SwitchPmParameter.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "switch_pm_parameter",
@@ -227,7 +227,7 @@ func (s AnswerShippingQuery) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -238,7 +238,7 @@ func (s AnswerShippingQuery) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "shipping_options",
@@ -256,7 +256,7 @@ func (s AnswerWebAppQuery) Validate() error {
 		if err := s.Result.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -283,7 +283,7 @@ func (s Audio) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -296,13 +296,13 @@ func (s Audio) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -328,7 +328,7 @@ func (s BotCommand) Validate() error {
 		}).Validate(string(s.Command)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "command",
@@ -347,7 +347,7 @@ func (s BotCommand) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -367,13 +367,13 @@ func (s CallbackQuery) Validate() error {
 				if err := s.Message.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message",
@@ -391,7 +391,7 @@ func (s Chat) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -406,11 +406,11 @@ func (s Chat) Validate() error {
 			if err := s.PinnedMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pinned_message",
@@ -423,13 +423,13 @@ func (s Chat) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -458,13 +458,13 @@ func (s ChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -482,7 +482,7 @@ func (s ChatJoinRequest) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -495,13 +495,13 @@ func (s ChatJoinRequest) Validate() error {
 				if err := s.InviteLink.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "invite_link",
@@ -519,7 +519,7 @@ func (s ChatLocation) Validate() error {
 		if err := s.Location.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -538,7 +538,7 @@ func (s ChatLocation) Validate() error {
 		}).Validate(string(s.Address)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "address",
@@ -556,7 +556,7 @@ func (s ChatMemberUpdated) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -569,13 +569,13 @@ func (s ChatMemberUpdated) Validate() error {
 				if err := s.InviteLink.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "invite_link",
@@ -609,13 +609,13 @@ func (s ChosenInlineResult) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -643,13 +643,13 @@ func (s CopyMessage) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -663,7 +663,7 @@ func (s CopyMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -674,7 +674,7 @@ func (s CopyMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -687,13 +687,13 @@ func (s CopyMessage) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -721,13 +721,13 @@ func (s CreateChatInviteLink) Validate() error {
 				}).Validate(string(s.Name.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -749,13 +749,13 @@ func (s CreateChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -781,7 +781,7 @@ func (s CreateNewStickerSet) Validate() error {
 		}).Validate(string(s.Name)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -800,7 +800,7 @@ func (s CreateNewStickerSet) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -813,13 +813,13 @@ func (s CreateNewStickerSet) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -839,13 +839,13 @@ func (s Document) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -873,13 +873,13 @@ func (s EditChatInviteLink) Validate() error {
 				}).Validate(string(s.Name.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -901,13 +901,13 @@ func (s EditChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -935,13 +935,13 @@ func (s EditMessageCaption) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -955,7 +955,7 @@ func (s EditMessageCaption) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -966,7 +966,7 @@ func (s EditMessageCaption) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -979,13 +979,13 @@ func (s EditMessageCaption) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1003,7 +1003,7 @@ func (s EditMessageLiveLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -1014,7 +1014,7 @@ func (s EditMessageLiveLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -1027,13 +1027,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -1055,13 +1055,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -1083,13 +1083,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -1102,13 +1102,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1126,7 +1126,7 @@ func (s EditMessageMedia) Validate() error {
 		if err := s.Media.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "media",
@@ -1139,13 +1139,13 @@ func (s EditMessageMedia) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1165,13 +1165,13 @@ func (s EditMessageReplyMarkup) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1197,7 +1197,7 @@ func (s EditMessageText) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -1211,7 +1211,7 @@ func (s EditMessageText) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1222,7 +1222,7 @@ func (s EditMessageText) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -1235,13 +1235,13 @@ func (s EditMessageText) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1259,7 +1259,7 @@ func (s EncryptedPassportElement) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -1319,13 +1319,13 @@ func (s ForceReply) Validate() error {
 				}).Validate(string(s.InputFieldPlaceholder.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_field_placeholder",
@@ -1349,7 +1349,7 @@ func (s Game) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1360,7 +1360,7 @@ func (s Game) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo",
@@ -1381,13 +1381,13 @@ func (s Game) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -1401,7 +1401,7 @@ func (s Game) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1412,7 +1412,7 @@ func (s Game) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_entities",
@@ -1425,13 +1425,13 @@ func (s Game) Validate() error {
 				if err := s.Animation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "animation",
@@ -1460,13 +1460,13 @@ func (s GetUpdates) Validate() error {
 				}).Validate(int64(s.Limit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -1495,13 +1495,13 @@ func (s GetUserProfilePhotos) Validate() error {
 				}).Validate(int64(s.Limit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -1529,13 +1529,13 @@ func (s InlineKeyboardButton) Validate() error {
 				}).Validate(string(s.CallbackData.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callback_data",
@@ -1565,7 +1565,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1576,7 +1576,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1587,7 +1587,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "inline_keyboard",
@@ -1607,13 +1607,13 @@ func (s InlineQuery) Validate() error {
 				if err := s.ChatType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_type",
@@ -1626,13 +1626,13 @@ func (s InlineQuery) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -1666,102 +1666,102 @@ func (s InlineQueryResult) Validate() error {
 		if err := s.InlineQueryResultCachedAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedDocumentInlineQueryResult:
 		if err := s.InlineQueryResultCachedDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedGifInlineQueryResult:
 		if err := s.InlineQueryResultCachedGif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedMpeg4GifInlineQueryResult:
 		if err := s.InlineQueryResultCachedMpeg4Gif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedPhotoInlineQueryResult:
 		if err := s.InlineQueryResultCachedPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedStickerInlineQueryResult:
 		if err := s.InlineQueryResultCachedSticker.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedVideoInlineQueryResult:
 		if err := s.InlineQueryResultCachedVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedVoiceInlineQueryResult:
 		if err := s.InlineQueryResultCachedVoice.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultArticleInlineQueryResult:
 		if err := s.InlineQueryResultArticle.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultAudioInlineQueryResult:
 		if err := s.InlineQueryResultAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultContactInlineQueryResult:
 		if err := s.InlineQueryResultContact.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultGameInlineQueryResult:
 		if err := s.InlineQueryResultGame.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultDocumentInlineQueryResult:
 		if err := s.InlineQueryResultDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultGifInlineQueryResult:
 		if err := s.InlineQueryResultGif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultLocationInlineQueryResult:
 		if err := s.InlineQueryResultLocation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultMpeg4GifInlineQueryResult:
 		if err := s.InlineQueryResultMpeg4Gif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultPhotoInlineQueryResult:
 		if err := s.InlineQueryResultPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVenueInlineQueryResult:
 		if err := s.InlineQueryResultVenue.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVideoInlineQueryResult:
 		if err := s.InlineQueryResultVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVoiceInlineQueryResult:
 		if err := s.InlineQueryResultVoice.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -1773,7 +1773,7 @@ func (s InlineQueryResultArticle) Validate() error {
 		if err := s.InputMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -1786,13 +1786,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1814,13 +1814,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -1842,13 +1842,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -1874,7 +1874,7 @@ func (s InlineQueryResultAudio) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -1895,13 +1895,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -1915,7 +1915,7 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1926,7 +1926,7 @@ func (s InlineQueryResultAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -1948,13 +1948,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				}).Validate(int64(s.AudioDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "audio_duration",
@@ -1967,13 +1967,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1986,13 +1986,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2018,7 +2018,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2039,13 +2039,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2059,7 +2059,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2070,7 +2070,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2083,13 +2083,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2102,13 +2102,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2134,7 +2134,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2155,13 +2155,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2175,7 +2175,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2186,7 +2186,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2199,13 +2199,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2218,13 +2218,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2250,7 +2250,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2271,13 +2271,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2291,7 +2291,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2302,7 +2302,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2315,13 +2315,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2334,13 +2334,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2366,7 +2366,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2387,13 +2387,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2407,7 +2407,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2418,7 +2418,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2431,13 +2431,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2450,13 +2450,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2482,7 +2482,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2503,13 +2503,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2523,7 +2523,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2534,7 +2534,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2547,13 +2547,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2566,13 +2566,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2598,7 +2598,7 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2611,13 +2611,13 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2630,13 +2630,13 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2662,7 +2662,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2683,13 +2683,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2703,7 +2703,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2714,7 +2714,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2727,13 +2727,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2746,13 +2746,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2778,7 +2778,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2799,13 +2799,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2819,7 +2819,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2830,7 +2830,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2843,13 +2843,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2862,13 +2862,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2896,13 +2896,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -2915,13 +2915,13 @@ func (s InlineQueryResultContact) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2934,13 +2934,13 @@ func (s InlineQueryResultContact) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2962,13 +2962,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -2990,13 +2990,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3022,7 +3022,7 @@ func (s InlineQueryResultDocument) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3043,13 +3043,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3063,7 +3063,7 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3074,7 +3074,7 @@ func (s InlineQueryResultDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3087,13 +3087,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3106,13 +3106,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3134,13 +3134,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -3162,13 +3162,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3194,7 +3194,7 @@ func (s InlineQueryResultGame) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3207,13 +3207,13 @@ func (s InlineQueryResultGame) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3239,7 +3239,7 @@ func (s InlineQueryResultGif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3261,13 +3261,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_width",
@@ -3289,13 +3289,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_height",
@@ -3317,13 +3317,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_duration",
@@ -3344,13 +3344,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3364,7 +3364,7 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3375,7 +3375,7 @@ func (s InlineQueryResultGif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3388,13 +3388,13 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3407,13 +3407,13 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3431,7 +3431,7 @@ func (s InlineQueryResultLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -3442,7 +3442,7 @@ func (s InlineQueryResultLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -3455,13 +3455,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -3483,13 +3483,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -3511,13 +3511,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -3539,13 +3539,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -3558,13 +3558,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3577,13 +3577,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3605,13 +3605,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -3633,13 +3633,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3665,7 +3665,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3687,13 +3687,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_width",
@@ -3715,13 +3715,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_height",
@@ -3743,13 +3743,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_duration",
@@ -3770,13 +3770,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3790,7 +3790,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3801,7 +3801,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3814,13 +3814,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3833,13 +3833,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3865,7 +3865,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3887,13 +3887,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -3915,13 +3915,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -3942,13 +3942,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3962,7 +3962,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3973,7 +3973,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3986,13 +3986,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4005,13 +4005,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4029,7 +4029,7 @@ func (s InlineQueryResultVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -4040,7 +4040,7 @@ func (s InlineQueryResultVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -4053,13 +4053,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4072,13 +4072,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4100,13 +4100,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -4128,13 +4128,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -4160,7 +4160,7 @@ func (s InlineQueryResultVideo) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -4181,13 +4181,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4201,7 +4201,7 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4212,7 +4212,7 @@ func (s InlineQueryResultVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4234,13 +4234,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_width",
@@ -4262,13 +4262,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_height",
@@ -4290,13 +4290,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_duration",
@@ -4309,13 +4309,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4328,13 +4328,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4360,7 +4360,7 @@ func (s InlineQueryResultVoice) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -4381,13 +4381,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4401,7 +4401,7 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4412,7 +4412,7 @@ func (s InlineQueryResultVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4434,13 +4434,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				}).Validate(int64(s.VoiceDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "voice_duration",
@@ -4453,13 +4453,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4472,13 +4472,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4506,13 +4506,13 @@ func (s InputContactMessageContent) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -4538,7 +4538,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -4557,7 +4557,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -4576,7 +4576,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Payload)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -4587,7 +4587,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -4609,13 +4609,13 @@ func (s InputInvoiceMessageContent) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -4637,13 +4637,13 @@ func (s InputInvoiceMessageContent) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -4661,7 +4661,7 @@ func (s InputLocationMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -4672,7 +4672,7 @@ func (s InputLocationMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -4685,13 +4685,13 @@ func (s InputLocationMessageContent) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -4713,13 +4713,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -4741,13 +4741,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -4769,13 +4769,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -4793,27 +4793,27 @@ func (s InputMedia) Validate() error {
 		if err := s.InputMediaAnimation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaDocumentInputMedia:
 		if err := s.InputMediaDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaAudioInputMedia:
 		if err := s.InputMediaAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaPhotoInputMedia:
 		if err := s.InputMediaPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaVideoInputMedia:
 		if err := s.InputMediaVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -4835,13 +4835,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4855,7 +4855,7 @@ func (s InputMediaAnimation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4866,7 +4866,7 @@ func (s InputMediaAnimation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4888,13 +4888,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -4916,13 +4916,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -4944,13 +4944,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -4978,13 +4978,13 @@ func (s InputMediaAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4998,7 +4998,7 @@ func (s InputMediaAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5009,7 +5009,7 @@ func (s InputMediaAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5031,13 +5031,13 @@ func (s InputMediaAudio) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5065,13 +5065,13 @@ func (s InputMediaDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5085,7 +5085,7 @@ func (s InputMediaDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5096,7 +5096,7 @@ func (s InputMediaDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5124,13 +5124,13 @@ func (s InputMediaPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5144,7 +5144,7 @@ func (s InputMediaPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5155,7 +5155,7 @@ func (s InputMediaPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5183,13 +5183,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5203,7 +5203,7 @@ func (s InputMediaVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5214,7 +5214,7 @@ func (s InputMediaVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5236,13 +5236,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -5264,13 +5264,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -5292,13 +5292,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5316,27 +5316,27 @@ func (s InputMessageContent) Validate() error {
 		if err := s.InputTextMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputLocationMessageContentInputMessageContent:
 		if err := s.InputLocationMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputVenueMessageContentInputMessageContent:
 		if err := s.InputVenueMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputContactMessageContentInputMessageContent:
 		if err := s.InputContactMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputInvoiceMessageContentInputMessageContent:
 		if err := s.InputInvoiceMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -5356,7 +5356,7 @@ func (s InputTextMessageContent) Validate() error {
 		}).Validate(string(s.MessageText)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message_text",
@@ -5370,7 +5370,7 @@ func (s InputTextMessageContent) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5381,7 +5381,7 @@ func (s InputTextMessageContent) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -5399,7 +5399,7 @@ func (s InputVenueMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -5410,7 +5410,7 @@ func (s InputVenueMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -5428,7 +5428,7 @@ func (s Location) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -5439,7 +5439,7 @@ func (s Location) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -5452,13 +5452,13 @@ func (s Location) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -5480,13 +5480,13 @@ func (s Location) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -5504,7 +5504,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.XShift)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "x_shift",
@@ -5515,7 +5515,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.YShift)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "y_shift",
@@ -5526,7 +5526,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Scale)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scale",
@@ -5546,13 +5546,13 @@ func (s Message) Validate() error {
 				if err := s.SenderChat.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sender_chat",
@@ -5563,7 +5563,7 @@ func (s Message) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -5576,13 +5576,13 @@ func (s Message) Validate() error {
 				if err := s.ForwardFromChat.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "forward_from_chat",
@@ -5597,11 +5597,11 @@ func (s Message) Validate() error {
 			if err := s.ReplyToMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_to_message",
@@ -5622,13 +5622,13 @@ func (s Message) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -5642,7 +5642,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5653,7 +5653,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -5666,13 +5666,13 @@ func (s Message) Validate() error {
 				if err := s.Animation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "animation",
@@ -5685,13 +5685,13 @@ func (s Message) Validate() error {
 				if err := s.Audio.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "audio",
@@ -5704,13 +5704,13 @@ func (s Message) Validate() error {
 				if err := s.Document.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "document",
@@ -5724,7 +5724,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5735,7 +5735,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo",
@@ -5748,13 +5748,13 @@ func (s Message) Validate() error {
 				if err := s.Sticker.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sticker",
@@ -5767,13 +5767,13 @@ func (s Message) Validate() error {
 				if err := s.Video.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video",
@@ -5786,13 +5786,13 @@ func (s Message) Validate() error {
 				if err := s.VideoNote.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_note",
@@ -5805,13 +5805,13 @@ func (s Message) Validate() error {
 				if err := s.Voice.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "voice",
@@ -5832,13 +5832,13 @@ func (s Message) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5852,7 +5852,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5863,7 +5863,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5876,13 +5876,13 @@ func (s Message) Validate() error {
 				if err := s.Game.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "game",
@@ -5895,13 +5895,13 @@ func (s Message) Validate() error {
 				if err := s.Poll.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll",
@@ -5914,13 +5914,13 @@ func (s Message) Validate() error {
 				if err := s.Venue.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "venue",
@@ -5933,13 +5933,13 @@ func (s Message) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -5953,7 +5953,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5964,7 +5964,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "new_chat_photo",
@@ -5979,11 +5979,11 @@ func (s Message) Validate() error {
 			if err := s.PinnedMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pinned_message",
@@ -5996,13 +5996,13 @@ func (s Message) Validate() error {
 				if err := s.PassportData.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "passport_data",
@@ -6015,13 +6015,13 @@ func (s Message) Validate() error {
 				if err := s.VideoChatEnded.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_chat_ended",
@@ -6034,13 +6034,13 @@ func (s Message) Validate() error {
 				if err := s.VideoChatParticipantsInvited.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_chat_participants_invited",
@@ -6053,13 +6053,13 @@ func (s Message) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -6077,7 +6077,7 @@ func (s MessageEntity) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -6140,7 +6140,7 @@ func (s PassportData) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6151,7 +6151,7 @@ func (s PassportData) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "data",
@@ -6179,14 +6179,14 @@ func (s PassportElementError) Validate() error {
 		if err := s.PassportElementErrorFiles.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PassportElementErrorTranslationFilePassportElementError:
 		return nil // no validation needed
 	case PassportElementErrorTranslationFilesPassportElementError:
 		if err := s.PassportElementErrorTranslationFiles.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PassportElementErrorUnspecifiedPassportElementError:
 		return nil // no validation needed
 	default:
@@ -6234,7 +6234,7 @@ func (s PassportElementErrorFiles) Validate() error {
 		if s.FileHashes == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "file_hashes",
@@ -6330,7 +6330,7 @@ func (s PassportElementErrorTranslationFiles) Validate() error {
 		if s.FileHashes == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "file_hashes",
@@ -6381,7 +6381,7 @@ func (s PhotoSize) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -6401,7 +6401,7 @@ func (s PhotoSize) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -6427,7 +6427,7 @@ func (s Poll) Validate() error {
 		}).Validate(string(s.Question)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "question",
@@ -6444,7 +6444,7 @@ func (s Poll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6455,7 +6455,7 @@ func (s Poll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "options",
@@ -6466,7 +6466,7 @@ func (s Poll) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -6487,13 +6487,13 @@ func (s Poll) Validate() error {
 				}).Validate(string(s.Explanation.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation",
@@ -6507,7 +6507,7 @@ func (s Poll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6518,7 +6518,7 @@ func (s Poll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation_entities",
@@ -6536,7 +6536,7 @@ func (s PollAnswer) Validate() error {
 		if s.OptionIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "option_ids",
@@ -6562,7 +6562,7 @@ func (s PollOption) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -6596,7 +6596,7 @@ func (s ReplyKeyboardMarkup) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6607,7 +6607,7 @@ func (s ReplyKeyboardMarkup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "keyboard",
@@ -6628,13 +6628,13 @@ func (s ReplyKeyboardMarkup) Validate() error {
 				}).Validate(string(s.InputFieldPlaceholder.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_field_placeholder",
@@ -6655,7 +6655,7 @@ func (s ResultArrayOfBotCommand) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6666,7 +6666,7 @@ func (s ResultArrayOfBotCommand) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6687,7 +6687,7 @@ func (s ResultArrayOfMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6698,7 +6698,7 @@ func (s ResultArrayOfMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6719,7 +6719,7 @@ func (s ResultArrayOfUpdate) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6730,7 +6730,7 @@ func (s ResultArrayOfUpdate) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6750,13 +6750,13 @@ func (s ResultChat) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6776,13 +6776,13 @@ func (s ResultChatInviteLink) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6802,13 +6802,13 @@ func (s ResultMessage) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6828,13 +6828,13 @@ func (s ResultMessageOrBoolean) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6852,7 +6852,7 @@ func (s ResultMessageOrBooleanResult) Validate() error {
 		if err := s.Message.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case BoolResultMessageOrBooleanResult:
 		return nil // no validation needed
 	default:
@@ -6868,13 +6868,13 @@ func (s ResultPoll) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6894,13 +6894,13 @@ func (s ResultStickerSet) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6920,13 +6920,13 @@ func (s ResultUserProfilePhotos) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6955,13 +6955,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -6983,13 +6983,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -7011,13 +7011,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -7038,13 +7038,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7058,7 +7058,7 @@ func (s SendAnimation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7069,7 +7069,7 @@ func (s SendAnimation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7082,13 +7082,13 @@ func (s SendAnimation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7116,13 +7116,13 @@ func (s SendAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7136,7 +7136,7 @@ func (s SendAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7147,7 +7147,7 @@ func (s SendAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7169,13 +7169,13 @@ func (s SendAudio) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -7188,13 +7188,13 @@ func (s SendAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7222,13 +7222,13 @@ func (s SendContact) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -7241,13 +7241,13 @@ func (s SendContact) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7267,13 +7267,13 @@ func (s SendDice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7301,13 +7301,13 @@ func (s SendDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7321,7 +7321,7 @@ func (s SendDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7332,7 +7332,7 @@ func (s SendDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7345,13 +7345,13 @@ func (s SendDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7371,13 +7371,13 @@ func (s SendGame) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7403,7 +7403,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -7422,7 +7422,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -7441,7 +7441,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Payload)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -7452,7 +7452,7 @@ func (s SendInvoice) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -7474,13 +7474,13 @@ func (s SendInvoice) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -7502,13 +7502,13 @@ func (s SendInvoice) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -7521,13 +7521,13 @@ func (s SendInvoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7545,7 +7545,7 @@ func (s SendLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -7556,7 +7556,7 @@ func (s SendLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -7569,13 +7569,13 @@ func (s SendLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -7597,13 +7597,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -7625,13 +7625,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -7653,13 +7653,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -7672,13 +7672,13 @@ func (s SendLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7702,7 +7702,7 @@ func (s SendMediaGroup) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7713,7 +7713,7 @@ func (s SendMediaGroup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "media",
@@ -7731,22 +7731,22 @@ func (s SendMediaGroupMediaItem) Validate() error {
 		if err := s.InputMediaAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaDocumentSendMediaGroupMediaItem:
 		if err := s.InputMediaDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaPhotoSendMediaGroupMediaItem:
 		if err := s.InputMediaPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaVideoSendMediaGroupMediaItem:
 		if err := s.InputMediaVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7766,7 +7766,7 @@ func (s SendMessage) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -7780,7 +7780,7 @@ func (s SendMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7791,7 +7791,7 @@ func (s SendMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -7804,13 +7804,13 @@ func (s SendMessage) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7838,13 +7838,13 @@ func (s SendPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7858,7 +7858,7 @@ func (s SendPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7869,7 +7869,7 @@ func (s SendPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7882,13 +7882,13 @@ func (s SendPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7914,7 +7914,7 @@ func (s SendPoll) Validate() error {
 		}).Validate(string(s.Question)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "question",
@@ -7925,7 +7925,7 @@ func (s SendPoll) Validate() error {
 		if s.Options == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "options",
@@ -7946,13 +7946,13 @@ func (s SendPoll) Validate() error {
 				}).Validate(string(s.Explanation.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation",
@@ -7966,7 +7966,7 @@ func (s SendPoll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7977,7 +7977,7 @@ func (s SendPoll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation_entities",
@@ -7990,13 +7990,13 @@ func (s SendPoll) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8014,19 +8014,19 @@ func (s SendReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8040,13 +8040,13 @@ func (s SendSticker) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8064,7 +8064,7 @@ func (s SendVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -8075,7 +8075,7 @@ func (s SendVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -8088,13 +8088,13 @@ func (s SendVenue) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8123,13 +8123,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8151,13 +8151,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -8179,13 +8179,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -8206,13 +8206,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -8226,7 +8226,7 @@ func (s SendVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8237,7 +8237,7 @@ func (s SendVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -8250,13 +8250,13 @@ func (s SendVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8285,13 +8285,13 @@ func (s SendVideoNote) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8304,13 +8304,13 @@ func (s SendVideoNote) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8338,13 +8338,13 @@ func (s SendVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -8358,7 +8358,7 @@ func (s SendVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8369,7 +8369,7 @@ func (s SendVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -8391,13 +8391,13 @@ func (s SendVoice) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8410,13 +8410,13 @@ func (s SendVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8442,7 +8442,7 @@ func (s SetChatAdministratorCustomTitle) Validate() error {
 		}).Validate(string(s.CustomTitle)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "custom_title",
@@ -8470,13 +8470,13 @@ func (s SetChatDescription) Validate() error {
 				}).Validate(string(s.Description.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -8502,7 +8502,7 @@ func (s SetChatTitle) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -8526,7 +8526,7 @@ func (s SetMyCommands) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8537,7 +8537,7 @@ func (s SetMyCommands) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commands",
@@ -8561,7 +8561,7 @@ func (s SetPassportDataErrors) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8572,7 +8572,7 @@ func (s SetPassportDataErrors) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "errors",
@@ -8590,7 +8590,7 @@ func (s ShippingOption) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -8617,7 +8617,7 @@ func (s Sticker) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -8637,7 +8637,7 @@ func (s Sticker) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -8650,13 +8650,13 @@ func (s Sticker) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -8669,13 +8669,13 @@ func (s Sticker) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -8699,7 +8699,7 @@ func (s StickerSet) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8710,7 +8710,7 @@ func (s StickerSet) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "stickers",
@@ -8723,13 +8723,13 @@ func (s StickerSet) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -8749,13 +8749,13 @@ func (s StopMessageLiveLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8775,13 +8775,13 @@ func (s StopPoll) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8801,13 +8801,13 @@ func (s Update) Validate() error {
 				if err := s.Message.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message",
@@ -8820,13 +8820,13 @@ func (s Update) Validate() error {
 				if err := s.EditedMessage.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "edited_message",
@@ -8839,13 +8839,13 @@ func (s Update) Validate() error {
 				if err := s.ChannelPost.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "channel_post",
@@ -8858,13 +8858,13 @@ func (s Update) Validate() error {
 				if err := s.EditedChannelPost.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "edited_channel_post",
@@ -8877,13 +8877,13 @@ func (s Update) Validate() error {
 				if err := s.InlineQuery.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "inline_query",
@@ -8896,13 +8896,13 @@ func (s Update) Validate() error {
 				if err := s.ChosenInlineResult.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chosen_inline_result",
@@ -8915,13 +8915,13 @@ func (s Update) Validate() error {
 				if err := s.CallbackQuery.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callback_query",
@@ -8934,13 +8934,13 @@ func (s Update) Validate() error {
 				if err := s.Poll.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll",
@@ -8953,13 +8953,13 @@ func (s Update) Validate() error {
 				if err := s.PollAnswer.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll_answer",
@@ -8972,13 +8972,13 @@ func (s Update) Validate() error {
 				if err := s.MyChatMember.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "my_chat_member",
@@ -8991,13 +8991,13 @@ func (s Update) Validate() error {
 				if err := s.ChatMember.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_member",
@@ -9010,13 +9010,13 @@ func (s Update) Validate() error {
 				if err := s.ChatJoinRequest.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_join_request",
@@ -9046,7 +9046,7 @@ func (s UserProfilePhotos) Validate() error {
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -9057,7 +9057,7 @@ func (s UserProfilePhotos) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9068,7 +9068,7 @@ func (s UserProfilePhotos) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photos",
@@ -9086,7 +9086,7 @@ func (s Venue) Validate() error {
 		if err := s.Location.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -9113,7 +9113,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -9133,7 +9133,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -9153,7 +9153,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9166,13 +9166,13 @@ func (s Video) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -9199,7 +9199,7 @@ func (s VideoChatEnded) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9217,7 +9217,7 @@ func (s VideoChatParticipantsInvited) Validate() error {
 		if s.Users == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "users",
@@ -9244,7 +9244,7 @@ func (s VideoNote) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9257,13 +9257,13 @@ func (s VideoNote) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -9290,7 +9290,7 @@ func (s Voice) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",

--- a/examples/ex_k8s/oas_handlers_gen.go
+++ b/examples/ex_k8s/oas_handlers_gen.go
@@ -2620,8 +2620,8 @@ func (s *Server) handleListAdmissionregistrationV1MutatingWebhookConfigurationRe
 	params, err := decodeListAdmissionregistrationV1MutatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAdmissionregistrationV1MutatingWebhookConfiguration",
-			err,
+			Operation: "ListAdmissionregistrationV1MutatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2675,8 +2675,8 @@ func (s *Server) handleListAdmissionregistrationV1ValidatingWebhookConfiguration
 	params, err := decodeListAdmissionregistrationV1ValidatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAdmissionregistrationV1ValidatingWebhookConfiguration",
-			err,
+			Operation: "ListAdmissionregistrationV1ValidatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2730,8 +2730,8 @@ func (s *Server) handleListApiextensionsV1CustomResourceDefinitionRequest(args [
 	params, err := decodeListApiextensionsV1CustomResourceDefinitionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListApiextensionsV1CustomResourceDefinition",
-			err,
+			Operation: "ListApiextensionsV1CustomResourceDefinition",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2785,8 +2785,8 @@ func (s *Server) handleListApiregistrationV1APIServiceRequest(args [0]string, w 
 	params, err := decodeListApiregistrationV1APIServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListApiregistrationV1APIService",
-			err,
+			Operation: "ListApiregistrationV1APIService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2840,8 +2840,8 @@ func (s *Server) handleListAppsV1ControllerRevisionForAllNamespacesRequest(args 
 	params, err := decodeListAppsV1ControllerRevisionForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1ControllerRevisionForAllNamespaces",
-			err,
+			Operation: "ListAppsV1ControllerRevisionForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2895,8 +2895,8 @@ func (s *Server) handleListAppsV1DaemonSetForAllNamespacesRequest(args [0]string
 	params, err := decodeListAppsV1DaemonSetForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1DaemonSetForAllNamespaces",
-			err,
+			Operation: "ListAppsV1DaemonSetForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2950,8 +2950,8 @@ func (s *Server) handleListAppsV1DeploymentForAllNamespacesRequest(args [0]strin
 	params, err := decodeListAppsV1DeploymentForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1DeploymentForAllNamespaces",
-			err,
+			Operation: "ListAppsV1DeploymentForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3005,8 +3005,8 @@ func (s *Server) handleListAppsV1NamespacedControllerRevisionRequest(args [1]str
 	params, err := decodeListAppsV1NamespacedControllerRevisionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1NamespacedControllerRevision",
-			err,
+			Operation: "ListAppsV1NamespacedControllerRevision",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3060,8 +3060,8 @@ func (s *Server) handleListAppsV1NamespacedDaemonSetRequest(args [1]string, w ht
 	params, err := decodeListAppsV1NamespacedDaemonSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1NamespacedDaemonSet",
-			err,
+			Operation: "ListAppsV1NamespacedDaemonSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3115,8 +3115,8 @@ func (s *Server) handleListAppsV1NamespacedDeploymentRequest(args [1]string, w h
 	params, err := decodeListAppsV1NamespacedDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1NamespacedDeployment",
-			err,
+			Operation: "ListAppsV1NamespacedDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3170,8 +3170,8 @@ func (s *Server) handleListAppsV1NamespacedReplicaSetRequest(args [1]string, w h
 	params, err := decodeListAppsV1NamespacedReplicaSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1NamespacedReplicaSet",
-			err,
+			Operation: "ListAppsV1NamespacedReplicaSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3225,8 +3225,8 @@ func (s *Server) handleListAppsV1NamespacedStatefulSetRequest(args [1]string, w 
 	params, err := decodeListAppsV1NamespacedStatefulSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1NamespacedStatefulSet",
-			err,
+			Operation: "ListAppsV1NamespacedStatefulSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3280,8 +3280,8 @@ func (s *Server) handleListAppsV1ReplicaSetForAllNamespacesRequest(args [0]strin
 	params, err := decodeListAppsV1ReplicaSetForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1ReplicaSetForAllNamespaces",
-			err,
+			Operation: "ListAppsV1ReplicaSetForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3335,8 +3335,8 @@ func (s *Server) handleListAppsV1StatefulSetForAllNamespacesRequest(args [0]stri
 	params, err := decodeListAppsV1StatefulSetForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAppsV1StatefulSetForAllNamespaces",
-			err,
+			Operation: "ListAppsV1StatefulSetForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3390,8 +3390,8 @@ func (s *Server) handleListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesR
 	params, err := decodeListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV1HorizontalPodAutoscalerForAllNamespaces",
-			err,
+			Operation: "ListAutoscalingV1HorizontalPodAutoscalerForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3445,8 +3445,8 @@ func (s *Server) handleListAutoscalingV1NamespacedHorizontalPodAutoscalerRequest
 	params, err := decodeListAutoscalingV1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ListAutoscalingV1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3500,8 +3500,8 @@ func (s *Server) handleListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamesp
 	params, err := decodeListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces",
-			err,
+			Operation: "ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3555,8 +3555,8 @@ func (s *Server) handleListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRe
 	params, err := decodeListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ListAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3610,8 +3610,8 @@ func (s *Server) handleListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamesp
 	params, err := decodeListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces",
-			err,
+			Operation: "ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3665,8 +3665,8 @@ func (s *Server) handleListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRe
 	params, err := decodeListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ListAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3720,8 +3720,8 @@ func (s *Server) handleListBatchV1CronJobForAllNamespacesRequest(args [0]string,
 	params, err := decodeListBatchV1CronJobForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1CronJobForAllNamespaces",
-			err,
+			Operation: "ListBatchV1CronJobForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3775,8 +3775,8 @@ func (s *Server) handleListBatchV1JobForAllNamespacesRequest(args [0]string, w h
 	params, err := decodeListBatchV1JobForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1JobForAllNamespaces",
-			err,
+			Operation: "ListBatchV1JobForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3830,8 +3830,8 @@ func (s *Server) handleListBatchV1NamespacedCronJobRequest(args [1]string, w htt
 	params, err := decodeListBatchV1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1NamespacedCronJob",
-			err,
+			Operation: "ListBatchV1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3885,8 +3885,8 @@ func (s *Server) handleListBatchV1NamespacedJobRequest(args [1]string, w http.Re
 	params, err := decodeListBatchV1NamespacedJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1NamespacedJob",
-			err,
+			Operation: "ListBatchV1NamespacedJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3940,8 +3940,8 @@ func (s *Server) handleListBatchV1beta1CronJobForAllNamespacesRequest(args [0]st
 	params, err := decodeListBatchV1beta1CronJobForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1beta1CronJobForAllNamespaces",
-			err,
+			Operation: "ListBatchV1beta1CronJobForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3995,8 +3995,8 @@ func (s *Server) handleListBatchV1beta1NamespacedCronJobRequest(args [1]string, 
 	params, err := decodeListBatchV1beta1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListBatchV1beta1NamespacedCronJob",
-			err,
+			Operation: "ListBatchV1beta1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4050,8 +4050,8 @@ func (s *Server) handleListCertificatesV1CertificateSigningRequestRequest(args [
 	params, err := decodeListCertificatesV1CertificateSigningRequestParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCertificatesV1CertificateSigningRequest",
-			err,
+			Operation: "ListCertificatesV1CertificateSigningRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4105,8 +4105,8 @@ func (s *Server) handleListCoordinationV1LeaseForAllNamespacesRequest(args [0]st
 	params, err := decodeListCoordinationV1LeaseForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoordinationV1LeaseForAllNamespaces",
-			err,
+			Operation: "ListCoordinationV1LeaseForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4160,8 +4160,8 @@ func (s *Server) handleListCoordinationV1NamespacedLeaseRequest(args [1]string, 
 	params, err := decodeListCoordinationV1NamespacedLeaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoordinationV1NamespacedLease",
-			err,
+			Operation: "ListCoordinationV1NamespacedLease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4215,8 +4215,8 @@ func (s *Server) handleListCoreV1ComponentStatusRequest(args [0]string, w http.R
 	params, err := decodeListCoreV1ComponentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ComponentStatus",
-			err,
+			Operation: "ListCoreV1ComponentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4270,8 +4270,8 @@ func (s *Server) handleListCoreV1ConfigMapForAllNamespacesRequest(args [0]string
 	params, err := decodeListCoreV1ConfigMapForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ConfigMapForAllNamespaces",
-			err,
+			Operation: "ListCoreV1ConfigMapForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4325,8 +4325,8 @@ func (s *Server) handleListCoreV1EndpointsForAllNamespacesRequest(args [0]string
 	params, err := decodeListCoreV1EndpointsForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1EndpointsForAllNamespaces",
-			err,
+			Operation: "ListCoreV1EndpointsForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4380,8 +4380,8 @@ func (s *Server) handleListCoreV1EventForAllNamespacesRequest(args [0]string, w 
 	params, err := decodeListCoreV1EventForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1EventForAllNamespaces",
-			err,
+			Operation: "ListCoreV1EventForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4435,8 +4435,8 @@ func (s *Server) handleListCoreV1LimitRangeForAllNamespacesRequest(args [0]strin
 	params, err := decodeListCoreV1LimitRangeForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1LimitRangeForAllNamespaces",
-			err,
+			Operation: "ListCoreV1LimitRangeForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4490,8 +4490,8 @@ func (s *Server) handleListCoreV1NamespaceRequest(args [0]string, w http.Respons
 	params, err := decodeListCoreV1NamespaceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1Namespace",
-			err,
+			Operation: "ListCoreV1Namespace",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4545,8 +4545,8 @@ func (s *Server) handleListCoreV1NamespacedConfigMapRequest(args [1]string, w ht
 	params, err := decodeListCoreV1NamespacedConfigMapParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedConfigMap",
-			err,
+			Operation: "ListCoreV1NamespacedConfigMap",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4600,8 +4600,8 @@ func (s *Server) handleListCoreV1NamespacedEndpointsRequest(args [1]string, w ht
 	params, err := decodeListCoreV1NamespacedEndpointsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedEndpoints",
-			err,
+			Operation: "ListCoreV1NamespacedEndpoints",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4655,8 +4655,8 @@ func (s *Server) handleListCoreV1NamespacedEventRequest(args [1]string, w http.R
 	params, err := decodeListCoreV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedEvent",
-			err,
+			Operation: "ListCoreV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4710,8 +4710,8 @@ func (s *Server) handleListCoreV1NamespacedLimitRangeRequest(args [1]string, w h
 	params, err := decodeListCoreV1NamespacedLimitRangeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedLimitRange",
-			err,
+			Operation: "ListCoreV1NamespacedLimitRange",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4765,8 +4765,8 @@ func (s *Server) handleListCoreV1NamespacedPersistentVolumeClaimRequest(args [1]
 	params, err := decodeListCoreV1NamespacedPersistentVolumeClaimParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedPersistentVolumeClaim",
-			err,
+			Operation: "ListCoreV1NamespacedPersistentVolumeClaim",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4820,8 +4820,8 @@ func (s *Server) handleListCoreV1NamespacedPodRequest(args [1]string, w http.Res
 	params, err := decodeListCoreV1NamespacedPodParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedPod",
-			err,
+			Operation: "ListCoreV1NamespacedPod",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4875,8 +4875,8 @@ func (s *Server) handleListCoreV1NamespacedPodTemplateRequest(args [1]string, w 
 	params, err := decodeListCoreV1NamespacedPodTemplateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedPodTemplate",
-			err,
+			Operation: "ListCoreV1NamespacedPodTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4930,8 +4930,8 @@ func (s *Server) handleListCoreV1NamespacedReplicationControllerRequest(args [1]
 	params, err := decodeListCoreV1NamespacedReplicationControllerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedReplicationController",
-			err,
+			Operation: "ListCoreV1NamespacedReplicationController",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4985,8 +4985,8 @@ func (s *Server) handleListCoreV1NamespacedResourceQuotaRequest(args [1]string, 
 	params, err := decodeListCoreV1NamespacedResourceQuotaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedResourceQuota",
-			err,
+			Operation: "ListCoreV1NamespacedResourceQuota",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5040,8 +5040,8 @@ func (s *Server) handleListCoreV1NamespacedSecretRequest(args [1]string, w http.
 	params, err := decodeListCoreV1NamespacedSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedSecret",
-			err,
+			Operation: "ListCoreV1NamespacedSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5095,8 +5095,8 @@ func (s *Server) handleListCoreV1NamespacedServiceRequest(args [1]string, w http
 	params, err := decodeListCoreV1NamespacedServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedService",
-			err,
+			Operation: "ListCoreV1NamespacedService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5150,8 +5150,8 @@ func (s *Server) handleListCoreV1NamespacedServiceAccountRequest(args [1]string,
 	params, err := decodeListCoreV1NamespacedServiceAccountParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1NamespacedServiceAccount",
-			err,
+			Operation: "ListCoreV1NamespacedServiceAccount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5205,8 +5205,8 @@ func (s *Server) handleListCoreV1NodeRequest(args [0]string, w http.ResponseWrit
 	params, err := decodeListCoreV1NodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1Node",
-			err,
+			Operation: "ListCoreV1Node",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5260,8 +5260,8 @@ func (s *Server) handleListCoreV1PersistentVolumeRequest(args [0]string, w http.
 	params, err := decodeListCoreV1PersistentVolumeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1PersistentVolume",
-			err,
+			Operation: "ListCoreV1PersistentVolume",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5315,8 +5315,8 @@ func (s *Server) handleListCoreV1PersistentVolumeClaimForAllNamespacesRequest(ar
 	params, err := decodeListCoreV1PersistentVolumeClaimForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1PersistentVolumeClaimForAllNamespaces",
-			err,
+			Operation: "ListCoreV1PersistentVolumeClaimForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5370,8 +5370,8 @@ func (s *Server) handleListCoreV1PodForAllNamespacesRequest(args [0]string, w ht
 	params, err := decodeListCoreV1PodForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1PodForAllNamespaces",
-			err,
+			Operation: "ListCoreV1PodForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5425,8 +5425,8 @@ func (s *Server) handleListCoreV1PodTemplateForAllNamespacesRequest(args [0]stri
 	params, err := decodeListCoreV1PodTemplateForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1PodTemplateForAllNamespaces",
-			err,
+			Operation: "ListCoreV1PodTemplateForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5480,8 +5480,8 @@ func (s *Server) handleListCoreV1ReplicationControllerForAllNamespacesRequest(ar
 	params, err := decodeListCoreV1ReplicationControllerForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ReplicationControllerForAllNamespaces",
-			err,
+			Operation: "ListCoreV1ReplicationControllerForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5535,8 +5535,8 @@ func (s *Server) handleListCoreV1ResourceQuotaForAllNamespacesRequest(args [0]st
 	params, err := decodeListCoreV1ResourceQuotaForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ResourceQuotaForAllNamespaces",
-			err,
+			Operation: "ListCoreV1ResourceQuotaForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5590,8 +5590,8 @@ func (s *Server) handleListCoreV1SecretForAllNamespacesRequest(args [0]string, w
 	params, err := decodeListCoreV1SecretForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1SecretForAllNamespaces",
-			err,
+			Operation: "ListCoreV1SecretForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5645,8 +5645,8 @@ func (s *Server) handleListCoreV1ServiceAccountForAllNamespacesRequest(args [0]s
 	params, err := decodeListCoreV1ServiceAccountForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ServiceAccountForAllNamespaces",
-			err,
+			Operation: "ListCoreV1ServiceAccountForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5700,8 +5700,8 @@ func (s *Server) handleListCoreV1ServiceForAllNamespacesRequest(args [0]string, 
 	params, err := decodeListCoreV1ServiceForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListCoreV1ServiceForAllNamespaces",
-			err,
+			Operation: "ListCoreV1ServiceForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5755,8 +5755,8 @@ func (s *Server) handleListDiscoveryV1EndpointSliceForAllNamespacesRequest(args 
 	params, err := decodeListDiscoveryV1EndpointSliceForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListDiscoveryV1EndpointSliceForAllNamespaces",
-			err,
+			Operation: "ListDiscoveryV1EndpointSliceForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5810,8 +5810,8 @@ func (s *Server) handleListDiscoveryV1NamespacedEndpointSliceRequest(args [1]str
 	params, err := decodeListDiscoveryV1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListDiscoveryV1NamespacedEndpointSlice",
-			err,
+			Operation: "ListDiscoveryV1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5865,8 +5865,8 @@ func (s *Server) handleListDiscoveryV1beta1EndpointSliceForAllNamespacesRequest(
 	params, err := decodeListDiscoveryV1beta1EndpointSliceForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListDiscoveryV1beta1EndpointSliceForAllNamespaces",
-			err,
+			Operation: "ListDiscoveryV1beta1EndpointSliceForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5920,8 +5920,8 @@ func (s *Server) handleListDiscoveryV1beta1NamespacedEndpointSliceRequest(args [
 	params, err := decodeListDiscoveryV1beta1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListDiscoveryV1beta1NamespacedEndpointSlice",
-			err,
+			Operation: "ListDiscoveryV1beta1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5975,8 +5975,8 @@ func (s *Server) handleListEventsV1EventForAllNamespacesRequest(args [0]string, 
 	params, err := decodeListEventsV1EventForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListEventsV1EventForAllNamespaces",
-			err,
+			Operation: "ListEventsV1EventForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6030,8 +6030,8 @@ func (s *Server) handleListEventsV1NamespacedEventRequest(args [1]string, w http
 	params, err := decodeListEventsV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListEventsV1NamespacedEvent",
-			err,
+			Operation: "ListEventsV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6085,8 +6085,8 @@ func (s *Server) handleListEventsV1beta1EventForAllNamespacesRequest(args [0]str
 	params, err := decodeListEventsV1beta1EventForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListEventsV1beta1EventForAllNamespaces",
-			err,
+			Operation: "ListEventsV1beta1EventForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6140,8 +6140,8 @@ func (s *Server) handleListEventsV1beta1NamespacedEventRequest(args [1]string, w
 	params, err := decodeListEventsV1beta1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListEventsV1beta1NamespacedEvent",
-			err,
+			Operation: "ListEventsV1beta1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6195,8 +6195,8 @@ func (s *Server) handleListFlowcontrolApiserverV1beta1FlowSchemaRequest(args [0]
 	params, err := decodeListFlowcontrolApiserverV1beta1FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListFlowcontrolApiserverV1beta1FlowSchema",
-			err,
+			Operation: "ListFlowcontrolApiserverV1beta1FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6250,8 +6250,8 @@ func (s *Server) handleListFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 	params, err := decodeListFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
-			err,
+			Operation: "ListFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6305,8 +6305,8 @@ func (s *Server) handleListFlowcontrolApiserverV1beta2FlowSchemaRequest(args [0]
 	params, err := decodeListFlowcontrolApiserverV1beta2FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListFlowcontrolApiserverV1beta2FlowSchema",
-			err,
+			Operation: "ListFlowcontrolApiserverV1beta2FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6360,8 +6360,8 @@ func (s *Server) handleListFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 	params, err := decodeListFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
-			err,
+			Operation: "ListFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6415,8 +6415,8 @@ func (s *Server) handleListInternalApiserverV1alpha1StorageVersionRequest(args [
 	params, err := decodeListInternalApiserverV1alpha1StorageVersionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListInternalApiserverV1alpha1StorageVersion",
-			err,
+			Operation: "ListInternalApiserverV1alpha1StorageVersion",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6470,8 +6470,8 @@ func (s *Server) handleListNetworkingV1IngressClassRequest(args [0]string, w htt
 	params, err := decodeListNetworkingV1IngressClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNetworkingV1IngressClass",
-			err,
+			Operation: "ListNetworkingV1IngressClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6525,8 +6525,8 @@ func (s *Server) handleListNetworkingV1IngressForAllNamespacesRequest(args [0]st
 	params, err := decodeListNetworkingV1IngressForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNetworkingV1IngressForAllNamespaces",
-			err,
+			Operation: "ListNetworkingV1IngressForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6580,8 +6580,8 @@ func (s *Server) handleListNetworkingV1NamespacedIngressRequest(args [1]string, 
 	params, err := decodeListNetworkingV1NamespacedIngressParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNetworkingV1NamespacedIngress",
-			err,
+			Operation: "ListNetworkingV1NamespacedIngress",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6635,8 +6635,8 @@ func (s *Server) handleListNetworkingV1NamespacedNetworkPolicyRequest(args [1]st
 	params, err := decodeListNetworkingV1NamespacedNetworkPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNetworkingV1NamespacedNetworkPolicy",
-			err,
+			Operation: "ListNetworkingV1NamespacedNetworkPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6690,8 +6690,8 @@ func (s *Server) handleListNetworkingV1NetworkPolicyForAllNamespacesRequest(args
 	params, err := decodeListNetworkingV1NetworkPolicyForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNetworkingV1NetworkPolicyForAllNamespaces",
-			err,
+			Operation: "ListNetworkingV1NetworkPolicyForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6745,8 +6745,8 @@ func (s *Server) handleListNodeV1RuntimeClassRequest(args [0]string, w http.Resp
 	params, err := decodeListNodeV1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNodeV1RuntimeClass",
-			err,
+			Operation: "ListNodeV1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6800,8 +6800,8 @@ func (s *Server) handleListNodeV1alpha1RuntimeClassRequest(args [0]string, w htt
 	params, err := decodeListNodeV1alpha1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNodeV1alpha1RuntimeClass",
-			err,
+			Operation: "ListNodeV1alpha1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6855,8 +6855,8 @@ func (s *Server) handleListNodeV1beta1RuntimeClassRequest(args [0]string, w http
 	params, err := decodeListNodeV1beta1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListNodeV1beta1RuntimeClass",
-			err,
+			Operation: "ListNodeV1beta1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6910,8 +6910,8 @@ func (s *Server) handleListPolicyV1NamespacedPodDisruptionBudgetRequest(args [1]
 	params, err := decodeListPolicyV1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPolicyV1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "ListPolicyV1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6965,8 +6965,8 @@ func (s *Server) handleListPolicyV1PodDisruptionBudgetForAllNamespacesRequest(ar
 	params, err := decodeListPolicyV1PodDisruptionBudgetForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPolicyV1PodDisruptionBudgetForAllNamespaces",
-			err,
+			Operation: "ListPolicyV1PodDisruptionBudgetForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7020,8 +7020,8 @@ func (s *Server) handleListPolicyV1beta1NamespacedPodDisruptionBudgetRequest(arg
 	params, err := decodeListPolicyV1beta1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPolicyV1beta1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "ListPolicyV1beta1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7075,8 +7075,8 @@ func (s *Server) handleListPolicyV1beta1PodDisruptionBudgetForAllNamespacesReque
 	params, err := decodeListPolicyV1beta1PodDisruptionBudgetForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPolicyV1beta1PodDisruptionBudgetForAllNamespaces",
-			err,
+			Operation: "ListPolicyV1beta1PodDisruptionBudgetForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7130,8 +7130,8 @@ func (s *Server) handleListPolicyV1beta1PodSecurityPolicyRequest(args [0]string,
 	params, err := decodeListPolicyV1beta1PodSecurityPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPolicyV1beta1PodSecurityPolicy",
-			err,
+			Operation: "ListPolicyV1beta1PodSecurityPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7185,8 +7185,8 @@ func (s *Server) handleListRbacAuthorizationV1ClusterRoleRequest(args [0]string,
 	params, err := decodeListRbacAuthorizationV1ClusterRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1ClusterRole",
-			err,
+			Operation: "ListRbacAuthorizationV1ClusterRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7240,8 +7240,8 @@ func (s *Server) handleListRbacAuthorizationV1ClusterRoleBindingRequest(args [0]
 	params, err := decodeListRbacAuthorizationV1ClusterRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1ClusterRoleBinding",
-			err,
+			Operation: "ListRbacAuthorizationV1ClusterRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7295,8 +7295,8 @@ func (s *Server) handleListRbacAuthorizationV1NamespacedRoleRequest(args [1]stri
 	params, err := decodeListRbacAuthorizationV1NamespacedRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1NamespacedRole",
-			err,
+			Operation: "ListRbacAuthorizationV1NamespacedRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7350,8 +7350,8 @@ func (s *Server) handleListRbacAuthorizationV1NamespacedRoleBindingRequest(args 
 	params, err := decodeListRbacAuthorizationV1NamespacedRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1NamespacedRoleBinding",
-			err,
+			Operation: "ListRbacAuthorizationV1NamespacedRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7405,8 +7405,8 @@ func (s *Server) handleListRbacAuthorizationV1RoleBindingForAllNamespacesRequest
 	params, err := decodeListRbacAuthorizationV1RoleBindingForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1RoleBindingForAllNamespaces",
-			err,
+			Operation: "ListRbacAuthorizationV1RoleBindingForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7460,8 +7460,8 @@ func (s *Server) handleListRbacAuthorizationV1RoleForAllNamespacesRequest(args [
 	params, err := decodeListRbacAuthorizationV1RoleForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListRbacAuthorizationV1RoleForAllNamespaces",
-			err,
+			Operation: "ListRbacAuthorizationV1RoleForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7515,8 +7515,8 @@ func (s *Server) handleListSchedulingV1PriorityClassRequest(args [0]string, w ht
 	params, err := decodeListSchedulingV1PriorityClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListSchedulingV1PriorityClass",
-			err,
+			Operation: "ListSchedulingV1PriorityClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7570,8 +7570,8 @@ func (s *Server) handleListStorageV1CSIDriverRequest(args [0]string, w http.Resp
 	params, err := decodeListStorageV1CSIDriverParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1CSIDriver",
-			err,
+			Operation: "ListStorageV1CSIDriver",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7625,8 +7625,8 @@ func (s *Server) handleListStorageV1CSINodeRequest(args [0]string, w http.Respon
 	params, err := decodeListStorageV1CSINodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1CSINode",
-			err,
+			Operation: "ListStorageV1CSINode",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7680,8 +7680,8 @@ func (s *Server) handleListStorageV1StorageClassRequest(args [0]string, w http.R
 	params, err := decodeListStorageV1StorageClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1StorageClass",
-			err,
+			Operation: "ListStorageV1StorageClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7735,8 +7735,8 @@ func (s *Server) handleListStorageV1VolumeAttachmentRequest(args [0]string, w ht
 	params, err := decodeListStorageV1VolumeAttachmentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1VolumeAttachment",
-			err,
+			Operation: "ListStorageV1VolumeAttachment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7790,8 +7790,8 @@ func (s *Server) handleListStorageV1alpha1CSIStorageCapacityForAllNamespacesRequ
 	params, err := decodeListStorageV1alpha1CSIStorageCapacityForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1alpha1CSIStorageCapacityForAllNamespaces",
-			err,
+			Operation: "ListStorageV1alpha1CSIStorageCapacityForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7845,8 +7845,8 @@ func (s *Server) handleListStorageV1alpha1NamespacedCSIStorageCapacityRequest(ar
 	params, err := decodeListStorageV1alpha1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1alpha1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "ListStorageV1alpha1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7900,8 +7900,8 @@ func (s *Server) handleListStorageV1beta1CSIStorageCapacityForAllNamespacesReque
 	params, err := decodeListStorageV1beta1CSIStorageCapacityForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1beta1CSIStorageCapacityForAllNamespaces",
-			err,
+			Operation: "ListStorageV1beta1CSIStorageCapacityForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7955,8 +7955,8 @@ func (s *Server) handleListStorageV1beta1NamespacedCSIStorageCapacityRequest(arg
 	params, err := decodeListStorageV1beta1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListStorageV1beta1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "ListStorageV1beta1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8010,8 +8010,8 @@ func (s *Server) handleLogFileHandlerRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeLogFileHandlerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"LogFileHandler",
-			err,
+			Operation: "LogFileHandler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8111,8 +8111,8 @@ func (s *Server) handleReadAdmissionregistrationV1MutatingWebhookConfigurationRe
 	params, err := decodeReadAdmissionregistrationV1MutatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAdmissionregistrationV1MutatingWebhookConfiguration",
-			err,
+			Operation: "ReadAdmissionregistrationV1MutatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8166,8 +8166,8 @@ func (s *Server) handleReadAdmissionregistrationV1ValidatingWebhookConfiguration
 	params, err := decodeReadAdmissionregistrationV1ValidatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAdmissionregistrationV1ValidatingWebhookConfiguration",
-			err,
+			Operation: "ReadAdmissionregistrationV1ValidatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8221,8 +8221,8 @@ func (s *Server) handleReadApiextensionsV1CustomResourceDefinitionRequest(args [
 	params, err := decodeReadApiextensionsV1CustomResourceDefinitionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadApiextensionsV1CustomResourceDefinition",
-			err,
+			Operation: "ReadApiextensionsV1CustomResourceDefinition",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8276,8 +8276,8 @@ func (s *Server) handleReadApiextensionsV1CustomResourceDefinitionStatusRequest(
 	params, err := decodeReadApiextensionsV1CustomResourceDefinitionStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadApiextensionsV1CustomResourceDefinitionStatus",
-			err,
+			Operation: "ReadApiextensionsV1CustomResourceDefinitionStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8331,8 +8331,8 @@ func (s *Server) handleReadApiregistrationV1APIServiceRequest(args [1]string, w 
 	params, err := decodeReadApiregistrationV1APIServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadApiregistrationV1APIService",
-			err,
+			Operation: "ReadApiregistrationV1APIService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8386,8 +8386,8 @@ func (s *Server) handleReadApiregistrationV1APIServiceStatusRequest(args [1]stri
 	params, err := decodeReadApiregistrationV1APIServiceStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadApiregistrationV1APIServiceStatus",
-			err,
+			Operation: "ReadApiregistrationV1APIServiceStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8441,8 +8441,8 @@ func (s *Server) handleReadAppsV1NamespacedControllerRevisionRequest(args [2]str
 	params, err := decodeReadAppsV1NamespacedControllerRevisionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedControllerRevision",
-			err,
+			Operation: "ReadAppsV1NamespacedControllerRevision",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8496,8 +8496,8 @@ func (s *Server) handleReadAppsV1NamespacedDaemonSetRequest(args [2]string, w ht
 	params, err := decodeReadAppsV1NamespacedDaemonSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedDaemonSet",
-			err,
+			Operation: "ReadAppsV1NamespacedDaemonSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8551,8 +8551,8 @@ func (s *Server) handleReadAppsV1NamespacedDaemonSetStatusRequest(args [2]string
 	params, err := decodeReadAppsV1NamespacedDaemonSetStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedDaemonSetStatus",
-			err,
+			Operation: "ReadAppsV1NamespacedDaemonSetStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8606,8 +8606,8 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentRequest(args [2]string, w h
 	params, err := decodeReadAppsV1NamespacedDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedDeployment",
-			err,
+			Operation: "ReadAppsV1NamespacedDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8661,8 +8661,8 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentScaleRequest(args [2]string
 	params, err := decodeReadAppsV1NamespacedDeploymentScaleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedDeploymentScale",
-			err,
+			Operation: "ReadAppsV1NamespacedDeploymentScale",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8716,8 +8716,8 @@ func (s *Server) handleReadAppsV1NamespacedDeploymentStatusRequest(args [2]strin
 	params, err := decodeReadAppsV1NamespacedDeploymentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedDeploymentStatus",
-			err,
+			Operation: "ReadAppsV1NamespacedDeploymentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8771,8 +8771,8 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetRequest(args [2]string, w h
 	params, err := decodeReadAppsV1NamespacedReplicaSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedReplicaSet",
-			err,
+			Operation: "ReadAppsV1NamespacedReplicaSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8826,8 +8826,8 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetScaleRequest(args [2]string
 	params, err := decodeReadAppsV1NamespacedReplicaSetScaleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedReplicaSetScale",
-			err,
+			Operation: "ReadAppsV1NamespacedReplicaSetScale",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8881,8 +8881,8 @@ func (s *Server) handleReadAppsV1NamespacedReplicaSetStatusRequest(args [2]strin
 	params, err := decodeReadAppsV1NamespacedReplicaSetStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedReplicaSetStatus",
-			err,
+			Operation: "ReadAppsV1NamespacedReplicaSetStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8936,8 +8936,8 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetRequest(args [2]string, w 
 	params, err := decodeReadAppsV1NamespacedStatefulSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedStatefulSet",
-			err,
+			Operation: "ReadAppsV1NamespacedStatefulSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8991,8 +8991,8 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetScaleRequest(args [2]strin
 	params, err := decodeReadAppsV1NamespacedStatefulSetScaleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedStatefulSetScale",
-			err,
+			Operation: "ReadAppsV1NamespacedStatefulSetScale",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9046,8 +9046,8 @@ func (s *Server) handleReadAppsV1NamespacedStatefulSetStatusRequest(args [2]stri
 	params, err := decodeReadAppsV1NamespacedStatefulSetStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAppsV1NamespacedStatefulSetStatus",
-			err,
+			Operation: "ReadAppsV1NamespacedStatefulSetStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9101,8 +9101,8 @@ func (s *Server) handleReadAutoscalingV1NamespacedHorizontalPodAutoscalerRequest
 	params, err := decodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ReadAutoscalingV1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9156,8 +9156,8 @@ func (s *Server) handleReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusR
 	params, err := decodeReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
-			err,
+			Operation: "ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9211,8 +9211,8 @@ func (s *Server) handleReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRe
 	params, err := decodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9266,8 +9266,8 @@ func (s *Server) handleReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerSt
 	params, err := decodeReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus",
-			err,
+			Operation: "ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9321,8 +9321,8 @@ func (s *Server) handleReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRe
 	params, err := decodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9376,8 +9376,8 @@ func (s *Server) handleReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerSt
 	params, err := decodeReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus",
-			err,
+			Operation: "ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9431,8 +9431,8 @@ func (s *Server) handleReadBatchV1NamespacedCronJobRequest(args [2]string, w htt
 	params, err := decodeReadBatchV1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1NamespacedCronJob",
-			err,
+			Operation: "ReadBatchV1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9486,8 +9486,8 @@ func (s *Server) handleReadBatchV1NamespacedCronJobStatusRequest(args [2]string,
 	params, err := decodeReadBatchV1NamespacedCronJobStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1NamespacedCronJobStatus",
-			err,
+			Operation: "ReadBatchV1NamespacedCronJobStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9541,8 +9541,8 @@ func (s *Server) handleReadBatchV1NamespacedJobRequest(args [2]string, w http.Re
 	params, err := decodeReadBatchV1NamespacedJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1NamespacedJob",
-			err,
+			Operation: "ReadBatchV1NamespacedJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9596,8 +9596,8 @@ func (s *Server) handleReadBatchV1NamespacedJobStatusRequest(args [2]string, w h
 	params, err := decodeReadBatchV1NamespacedJobStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1NamespacedJobStatus",
-			err,
+			Operation: "ReadBatchV1NamespacedJobStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9651,8 +9651,8 @@ func (s *Server) handleReadBatchV1beta1NamespacedCronJobRequest(args [2]string, 
 	params, err := decodeReadBatchV1beta1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1beta1NamespacedCronJob",
-			err,
+			Operation: "ReadBatchV1beta1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9706,8 +9706,8 @@ func (s *Server) handleReadBatchV1beta1NamespacedCronJobStatusRequest(args [2]st
 	params, err := decodeReadBatchV1beta1NamespacedCronJobStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadBatchV1beta1NamespacedCronJobStatus",
-			err,
+			Operation: "ReadBatchV1beta1NamespacedCronJobStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9761,8 +9761,8 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestRequest(args [
 	params, err := decodeReadCertificatesV1CertificateSigningRequestParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCertificatesV1CertificateSigningRequest",
-			err,
+			Operation: "ReadCertificatesV1CertificateSigningRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9816,8 +9816,8 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestApprovalReques
 	params, err := decodeReadCertificatesV1CertificateSigningRequestApprovalParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCertificatesV1CertificateSigningRequestApproval",
-			err,
+			Operation: "ReadCertificatesV1CertificateSigningRequestApproval",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9871,8 +9871,8 @@ func (s *Server) handleReadCertificatesV1CertificateSigningRequestStatusRequest(
 	params, err := decodeReadCertificatesV1CertificateSigningRequestStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCertificatesV1CertificateSigningRequestStatus",
-			err,
+			Operation: "ReadCertificatesV1CertificateSigningRequestStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9926,8 +9926,8 @@ func (s *Server) handleReadCoordinationV1NamespacedLeaseRequest(args [2]string, 
 	params, err := decodeReadCoordinationV1NamespacedLeaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoordinationV1NamespacedLease",
-			err,
+			Operation: "ReadCoordinationV1NamespacedLease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9981,8 +9981,8 @@ func (s *Server) handleReadCoreV1ComponentStatusRequest(args [1]string, w http.R
 	params, err := decodeReadCoreV1ComponentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1ComponentStatus",
-			err,
+			Operation: "ReadCoreV1ComponentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10036,8 +10036,8 @@ func (s *Server) handleReadCoreV1NamespaceRequest(args [1]string, w http.Respons
 	params, err := decodeReadCoreV1NamespaceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1Namespace",
-			err,
+			Operation: "ReadCoreV1Namespace",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10091,8 +10091,8 @@ func (s *Server) handleReadCoreV1NamespaceStatusRequest(args [1]string, w http.R
 	params, err := decodeReadCoreV1NamespaceStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespaceStatus",
-			err,
+			Operation: "ReadCoreV1NamespaceStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10146,8 +10146,8 @@ func (s *Server) handleReadCoreV1NamespacedConfigMapRequest(args [2]string, w ht
 	params, err := decodeReadCoreV1NamespacedConfigMapParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedConfigMap",
-			err,
+			Operation: "ReadCoreV1NamespacedConfigMap",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10201,8 +10201,8 @@ func (s *Server) handleReadCoreV1NamespacedEndpointsRequest(args [2]string, w ht
 	params, err := decodeReadCoreV1NamespacedEndpointsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedEndpoints",
-			err,
+			Operation: "ReadCoreV1NamespacedEndpoints",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10256,8 +10256,8 @@ func (s *Server) handleReadCoreV1NamespacedEventRequest(args [2]string, w http.R
 	params, err := decodeReadCoreV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedEvent",
-			err,
+			Operation: "ReadCoreV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10311,8 +10311,8 @@ func (s *Server) handleReadCoreV1NamespacedLimitRangeRequest(args [2]string, w h
 	params, err := decodeReadCoreV1NamespacedLimitRangeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedLimitRange",
-			err,
+			Operation: "ReadCoreV1NamespacedLimitRange",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10366,8 +10366,8 @@ func (s *Server) handleReadCoreV1NamespacedPersistentVolumeClaimRequest(args [2]
 	params, err := decodeReadCoreV1NamespacedPersistentVolumeClaimParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPersistentVolumeClaim",
-			err,
+			Operation: "ReadCoreV1NamespacedPersistentVolumeClaim",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10421,8 +10421,8 @@ func (s *Server) handleReadCoreV1NamespacedPersistentVolumeClaimStatusRequest(ar
 	params, err := decodeReadCoreV1NamespacedPersistentVolumeClaimStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPersistentVolumeClaimStatus",
-			err,
+			Operation: "ReadCoreV1NamespacedPersistentVolumeClaimStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10476,8 +10476,8 @@ func (s *Server) handleReadCoreV1NamespacedPodRequest(args [2]string, w http.Res
 	params, err := decodeReadCoreV1NamespacedPodParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPod",
-			err,
+			Operation: "ReadCoreV1NamespacedPod",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10531,8 +10531,8 @@ func (s *Server) handleReadCoreV1NamespacedPodEphemeralcontainersRequest(args [2
 	params, err := decodeReadCoreV1NamespacedPodEphemeralcontainersParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPodEphemeralcontainers",
-			err,
+			Operation: "ReadCoreV1NamespacedPodEphemeralcontainers",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10586,8 +10586,8 @@ func (s *Server) handleReadCoreV1NamespacedPodLogRequest(args [2]string, w http.
 	params, err := decodeReadCoreV1NamespacedPodLogParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPodLog",
-			err,
+			Operation: "ReadCoreV1NamespacedPodLog",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10641,8 +10641,8 @@ func (s *Server) handleReadCoreV1NamespacedPodStatusRequest(args [2]string, w ht
 	params, err := decodeReadCoreV1NamespacedPodStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPodStatus",
-			err,
+			Operation: "ReadCoreV1NamespacedPodStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10696,8 +10696,8 @@ func (s *Server) handleReadCoreV1NamespacedPodTemplateRequest(args [2]string, w 
 	params, err := decodeReadCoreV1NamespacedPodTemplateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedPodTemplate",
-			err,
+			Operation: "ReadCoreV1NamespacedPodTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10751,8 +10751,8 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerRequest(args [2]
 	params, err := decodeReadCoreV1NamespacedReplicationControllerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedReplicationController",
-			err,
+			Operation: "ReadCoreV1NamespacedReplicationController",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10806,8 +10806,8 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerScaleRequest(arg
 	params, err := decodeReadCoreV1NamespacedReplicationControllerScaleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedReplicationControllerScale",
-			err,
+			Operation: "ReadCoreV1NamespacedReplicationControllerScale",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10861,8 +10861,8 @@ func (s *Server) handleReadCoreV1NamespacedReplicationControllerStatusRequest(ar
 	params, err := decodeReadCoreV1NamespacedReplicationControllerStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedReplicationControllerStatus",
-			err,
+			Operation: "ReadCoreV1NamespacedReplicationControllerStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10916,8 +10916,8 @@ func (s *Server) handleReadCoreV1NamespacedResourceQuotaRequest(args [2]string, 
 	params, err := decodeReadCoreV1NamespacedResourceQuotaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedResourceQuota",
-			err,
+			Operation: "ReadCoreV1NamespacedResourceQuota",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10971,8 +10971,8 @@ func (s *Server) handleReadCoreV1NamespacedResourceQuotaStatusRequest(args [2]st
 	params, err := decodeReadCoreV1NamespacedResourceQuotaStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedResourceQuotaStatus",
-			err,
+			Operation: "ReadCoreV1NamespacedResourceQuotaStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11026,8 +11026,8 @@ func (s *Server) handleReadCoreV1NamespacedSecretRequest(args [2]string, w http.
 	params, err := decodeReadCoreV1NamespacedSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedSecret",
-			err,
+			Operation: "ReadCoreV1NamespacedSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11081,8 +11081,8 @@ func (s *Server) handleReadCoreV1NamespacedServiceRequest(args [2]string, w http
 	params, err := decodeReadCoreV1NamespacedServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedService",
-			err,
+			Operation: "ReadCoreV1NamespacedService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11136,8 +11136,8 @@ func (s *Server) handleReadCoreV1NamespacedServiceAccountRequest(args [2]string,
 	params, err := decodeReadCoreV1NamespacedServiceAccountParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedServiceAccount",
-			err,
+			Operation: "ReadCoreV1NamespacedServiceAccount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11191,8 +11191,8 @@ func (s *Server) handleReadCoreV1NamespacedServiceStatusRequest(args [2]string, 
 	params, err := decodeReadCoreV1NamespacedServiceStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NamespacedServiceStatus",
-			err,
+			Operation: "ReadCoreV1NamespacedServiceStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11246,8 +11246,8 @@ func (s *Server) handleReadCoreV1NodeRequest(args [1]string, w http.ResponseWrit
 	params, err := decodeReadCoreV1NodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1Node",
-			err,
+			Operation: "ReadCoreV1Node",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11301,8 +11301,8 @@ func (s *Server) handleReadCoreV1NodeStatusRequest(args [1]string, w http.Respon
 	params, err := decodeReadCoreV1NodeStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1NodeStatus",
-			err,
+			Operation: "ReadCoreV1NodeStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11356,8 +11356,8 @@ func (s *Server) handleReadCoreV1PersistentVolumeRequest(args [1]string, w http.
 	params, err := decodeReadCoreV1PersistentVolumeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1PersistentVolume",
-			err,
+			Operation: "ReadCoreV1PersistentVolume",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11411,8 +11411,8 @@ func (s *Server) handleReadCoreV1PersistentVolumeStatusRequest(args [1]string, w
 	params, err := decodeReadCoreV1PersistentVolumeStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadCoreV1PersistentVolumeStatus",
-			err,
+			Operation: "ReadCoreV1PersistentVolumeStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11466,8 +11466,8 @@ func (s *Server) handleReadDiscoveryV1NamespacedEndpointSliceRequest(args [2]str
 	params, err := decodeReadDiscoveryV1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadDiscoveryV1NamespacedEndpointSlice",
-			err,
+			Operation: "ReadDiscoveryV1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11521,8 +11521,8 @@ func (s *Server) handleReadDiscoveryV1beta1NamespacedEndpointSliceRequest(args [
 	params, err := decodeReadDiscoveryV1beta1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadDiscoveryV1beta1NamespacedEndpointSlice",
-			err,
+			Operation: "ReadDiscoveryV1beta1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11576,8 +11576,8 @@ func (s *Server) handleReadEventsV1NamespacedEventRequest(args [2]string, w http
 	params, err := decodeReadEventsV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadEventsV1NamespacedEvent",
-			err,
+			Operation: "ReadEventsV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11631,8 +11631,8 @@ func (s *Server) handleReadEventsV1beta1NamespacedEventRequest(args [2]string, w
 	params, err := decodeReadEventsV1beta1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadEventsV1beta1NamespacedEvent",
-			err,
+			Operation: "ReadEventsV1beta1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11686,8 +11686,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1FlowSchemaRequest(args [1]
 	params, err := decodeReadFlowcontrolApiserverV1beta1FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta1FlowSchema",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta1FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11741,8 +11741,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1FlowSchemaStatusRequest(ar
 	params, err := decodeReadFlowcontrolApiserverV1beta1FlowSchemaStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta1FlowSchemaStatus",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta1FlowSchemaStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11796,8 +11796,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 	params, err := decodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11851,8 +11851,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration
 	params, err := decodeReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11906,8 +11906,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2FlowSchemaRequest(args [1]
 	params, err := decodeReadFlowcontrolApiserverV1beta2FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta2FlowSchema",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta2FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11961,8 +11961,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2FlowSchemaStatusRequest(ar
 	params, err := decodeReadFlowcontrolApiserverV1beta2FlowSchemaStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta2FlowSchemaStatus",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta2FlowSchemaStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12016,8 +12016,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 	params, err := decodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12071,8 +12071,8 @@ func (s *Server) handleReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration
 	params, err := decodeReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatus",
-			err,
+			Operation: "ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12126,8 +12126,8 @@ func (s *Server) handleReadInternalApiserverV1alpha1StorageVersionRequest(args [
 	params, err := decodeReadInternalApiserverV1alpha1StorageVersionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadInternalApiserverV1alpha1StorageVersion",
-			err,
+			Operation: "ReadInternalApiserverV1alpha1StorageVersion",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12181,8 +12181,8 @@ func (s *Server) handleReadInternalApiserverV1alpha1StorageVersionStatusRequest(
 	params, err := decodeReadInternalApiserverV1alpha1StorageVersionStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadInternalApiserverV1alpha1StorageVersionStatus",
-			err,
+			Operation: "ReadInternalApiserverV1alpha1StorageVersionStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12236,8 +12236,8 @@ func (s *Server) handleReadNetworkingV1IngressClassRequest(args [1]string, w htt
 	params, err := decodeReadNetworkingV1IngressClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNetworkingV1IngressClass",
-			err,
+			Operation: "ReadNetworkingV1IngressClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12291,8 +12291,8 @@ func (s *Server) handleReadNetworkingV1NamespacedIngressRequest(args [2]string, 
 	params, err := decodeReadNetworkingV1NamespacedIngressParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNetworkingV1NamespacedIngress",
-			err,
+			Operation: "ReadNetworkingV1NamespacedIngress",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12346,8 +12346,8 @@ func (s *Server) handleReadNetworkingV1NamespacedIngressStatusRequest(args [2]st
 	params, err := decodeReadNetworkingV1NamespacedIngressStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNetworkingV1NamespacedIngressStatus",
-			err,
+			Operation: "ReadNetworkingV1NamespacedIngressStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12401,8 +12401,8 @@ func (s *Server) handleReadNetworkingV1NamespacedNetworkPolicyRequest(args [2]st
 	params, err := decodeReadNetworkingV1NamespacedNetworkPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNetworkingV1NamespacedNetworkPolicy",
-			err,
+			Operation: "ReadNetworkingV1NamespacedNetworkPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12456,8 +12456,8 @@ func (s *Server) handleReadNodeV1RuntimeClassRequest(args [1]string, w http.Resp
 	params, err := decodeReadNodeV1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNodeV1RuntimeClass",
-			err,
+			Operation: "ReadNodeV1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12511,8 +12511,8 @@ func (s *Server) handleReadNodeV1alpha1RuntimeClassRequest(args [1]string, w htt
 	params, err := decodeReadNodeV1alpha1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNodeV1alpha1RuntimeClass",
-			err,
+			Operation: "ReadNodeV1alpha1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12566,8 +12566,8 @@ func (s *Server) handleReadNodeV1beta1RuntimeClassRequest(args [1]string, w http
 	params, err := decodeReadNodeV1beta1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadNodeV1beta1RuntimeClass",
-			err,
+			Operation: "ReadNodeV1beta1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12621,8 +12621,8 @@ func (s *Server) handleReadPolicyV1NamespacedPodDisruptionBudgetRequest(args [2]
 	params, err := decodeReadPolicyV1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPolicyV1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "ReadPolicyV1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12676,8 +12676,8 @@ func (s *Server) handleReadPolicyV1NamespacedPodDisruptionBudgetStatusRequest(ar
 	params, err := decodeReadPolicyV1NamespacedPodDisruptionBudgetStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPolicyV1NamespacedPodDisruptionBudgetStatus",
-			err,
+			Operation: "ReadPolicyV1NamespacedPodDisruptionBudgetStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12731,8 +12731,8 @@ func (s *Server) handleReadPolicyV1beta1NamespacedPodDisruptionBudgetRequest(arg
 	params, err := decodeReadPolicyV1beta1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPolicyV1beta1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "ReadPolicyV1beta1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12786,8 +12786,8 @@ func (s *Server) handleReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusReque
 	params, err := decodeReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatus",
-			err,
+			Operation: "ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12841,8 +12841,8 @@ func (s *Server) handleReadPolicyV1beta1PodSecurityPolicyRequest(args [1]string,
 	params, err := decodeReadPolicyV1beta1PodSecurityPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadPolicyV1beta1PodSecurityPolicy",
-			err,
+			Operation: "ReadPolicyV1beta1PodSecurityPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12896,8 +12896,8 @@ func (s *Server) handleReadRbacAuthorizationV1ClusterRoleRequest(args [1]string,
 	params, err := decodeReadRbacAuthorizationV1ClusterRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadRbacAuthorizationV1ClusterRole",
-			err,
+			Operation: "ReadRbacAuthorizationV1ClusterRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12951,8 +12951,8 @@ func (s *Server) handleReadRbacAuthorizationV1ClusterRoleBindingRequest(args [1]
 	params, err := decodeReadRbacAuthorizationV1ClusterRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadRbacAuthorizationV1ClusterRoleBinding",
-			err,
+			Operation: "ReadRbacAuthorizationV1ClusterRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13006,8 +13006,8 @@ func (s *Server) handleReadRbacAuthorizationV1NamespacedRoleRequest(args [2]stri
 	params, err := decodeReadRbacAuthorizationV1NamespacedRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadRbacAuthorizationV1NamespacedRole",
-			err,
+			Operation: "ReadRbacAuthorizationV1NamespacedRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13061,8 +13061,8 @@ func (s *Server) handleReadRbacAuthorizationV1NamespacedRoleBindingRequest(args 
 	params, err := decodeReadRbacAuthorizationV1NamespacedRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadRbacAuthorizationV1NamespacedRoleBinding",
-			err,
+			Operation: "ReadRbacAuthorizationV1NamespacedRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13116,8 +13116,8 @@ func (s *Server) handleReadSchedulingV1PriorityClassRequest(args [1]string, w ht
 	params, err := decodeReadSchedulingV1PriorityClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadSchedulingV1PriorityClass",
-			err,
+			Operation: "ReadSchedulingV1PriorityClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13171,8 +13171,8 @@ func (s *Server) handleReadStorageV1CSIDriverRequest(args [1]string, w http.Resp
 	params, err := decodeReadStorageV1CSIDriverParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1CSIDriver",
-			err,
+			Operation: "ReadStorageV1CSIDriver",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13226,8 +13226,8 @@ func (s *Server) handleReadStorageV1CSINodeRequest(args [1]string, w http.Respon
 	params, err := decodeReadStorageV1CSINodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1CSINode",
-			err,
+			Operation: "ReadStorageV1CSINode",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13281,8 +13281,8 @@ func (s *Server) handleReadStorageV1StorageClassRequest(args [1]string, w http.R
 	params, err := decodeReadStorageV1StorageClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1StorageClass",
-			err,
+			Operation: "ReadStorageV1StorageClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13336,8 +13336,8 @@ func (s *Server) handleReadStorageV1VolumeAttachmentRequest(args [1]string, w ht
 	params, err := decodeReadStorageV1VolumeAttachmentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1VolumeAttachment",
-			err,
+			Operation: "ReadStorageV1VolumeAttachment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13391,8 +13391,8 @@ func (s *Server) handleReadStorageV1VolumeAttachmentStatusRequest(args [1]string
 	params, err := decodeReadStorageV1VolumeAttachmentStatusParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1VolumeAttachmentStatus",
-			err,
+			Operation: "ReadStorageV1VolumeAttachmentStatus",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13446,8 +13446,8 @@ func (s *Server) handleReadStorageV1alpha1NamespacedCSIStorageCapacityRequest(ar
 	params, err := decodeReadStorageV1alpha1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1alpha1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "ReadStorageV1alpha1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13501,8 +13501,8 @@ func (s *Server) handleReadStorageV1beta1NamespacedCSIStorageCapacityRequest(arg
 	params, err := decodeReadStorageV1beta1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ReadStorageV1beta1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "ReadStorageV1beta1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13556,8 +13556,8 @@ func (s *Server) handleWatchAdmissionregistrationV1MutatingWebhookConfigurationR
 	params, err := decodeWatchAdmissionregistrationV1MutatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAdmissionregistrationV1MutatingWebhookConfiguration",
-			err,
+			Operation: "WatchAdmissionregistrationV1MutatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13611,8 +13611,8 @@ func (s *Server) handleWatchAdmissionregistrationV1MutatingWebhookConfigurationL
 	params, err := decodeWatchAdmissionregistrationV1MutatingWebhookConfigurationListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAdmissionregistrationV1MutatingWebhookConfigurationList",
-			err,
+			Operation: "WatchAdmissionregistrationV1MutatingWebhookConfigurationList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13666,8 +13666,8 @@ func (s *Server) handleWatchAdmissionregistrationV1ValidatingWebhookConfiguratio
 	params, err := decodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAdmissionregistrationV1ValidatingWebhookConfiguration",
-			err,
+			Operation: "WatchAdmissionregistrationV1ValidatingWebhookConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13721,8 +13721,8 @@ func (s *Server) handleWatchAdmissionregistrationV1ValidatingWebhookConfiguratio
 	params, err := decodeWatchAdmissionregistrationV1ValidatingWebhookConfigurationListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAdmissionregistrationV1ValidatingWebhookConfigurationList",
-			err,
+			Operation: "WatchAdmissionregistrationV1ValidatingWebhookConfigurationList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13776,8 +13776,8 @@ func (s *Server) handleWatchApiextensionsV1CustomResourceDefinitionRequest(args 
 	params, err := decodeWatchApiextensionsV1CustomResourceDefinitionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchApiextensionsV1CustomResourceDefinition",
-			err,
+			Operation: "WatchApiextensionsV1CustomResourceDefinition",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13831,8 +13831,8 @@ func (s *Server) handleWatchApiextensionsV1CustomResourceDefinitionListRequest(a
 	params, err := decodeWatchApiextensionsV1CustomResourceDefinitionListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchApiextensionsV1CustomResourceDefinitionList",
-			err,
+			Operation: "WatchApiextensionsV1CustomResourceDefinitionList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13886,8 +13886,8 @@ func (s *Server) handleWatchApiregistrationV1APIServiceRequest(args [1]string, w
 	params, err := decodeWatchApiregistrationV1APIServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchApiregistrationV1APIService",
-			err,
+			Operation: "WatchApiregistrationV1APIService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13941,8 +13941,8 @@ func (s *Server) handleWatchApiregistrationV1APIServiceListRequest(args [0]strin
 	params, err := decodeWatchApiregistrationV1APIServiceListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchApiregistrationV1APIServiceList",
-			err,
+			Operation: "WatchApiregistrationV1APIServiceList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13996,8 +13996,8 @@ func (s *Server) handleWatchAppsV1ControllerRevisionListForAllNamespacesRequest(
 	params, err := decodeWatchAppsV1ControllerRevisionListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1ControllerRevisionListForAllNamespaces",
-			err,
+			Operation: "WatchAppsV1ControllerRevisionListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14051,8 +14051,8 @@ func (s *Server) handleWatchAppsV1DaemonSetListForAllNamespacesRequest(args [0]s
 	params, err := decodeWatchAppsV1DaemonSetListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1DaemonSetListForAllNamespaces",
-			err,
+			Operation: "WatchAppsV1DaemonSetListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14106,8 +14106,8 @@ func (s *Server) handleWatchAppsV1DeploymentListForAllNamespacesRequest(args [0]
 	params, err := decodeWatchAppsV1DeploymentListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1DeploymentListForAllNamespaces",
-			err,
+			Operation: "WatchAppsV1DeploymentListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14161,8 +14161,8 @@ func (s *Server) handleWatchAppsV1NamespacedControllerRevisionRequest(args [2]st
 	params, err := decodeWatchAppsV1NamespacedControllerRevisionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedControllerRevision",
-			err,
+			Operation: "WatchAppsV1NamespacedControllerRevision",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14216,8 +14216,8 @@ func (s *Server) handleWatchAppsV1NamespacedControllerRevisionListRequest(args [
 	params, err := decodeWatchAppsV1NamespacedControllerRevisionListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedControllerRevisionList",
-			err,
+			Operation: "WatchAppsV1NamespacedControllerRevisionList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14271,8 +14271,8 @@ func (s *Server) handleWatchAppsV1NamespacedDaemonSetRequest(args [2]string, w h
 	params, err := decodeWatchAppsV1NamespacedDaemonSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedDaemonSet",
-			err,
+			Operation: "WatchAppsV1NamespacedDaemonSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14326,8 +14326,8 @@ func (s *Server) handleWatchAppsV1NamespacedDaemonSetListRequest(args [1]string,
 	params, err := decodeWatchAppsV1NamespacedDaemonSetListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedDaemonSetList",
-			err,
+			Operation: "WatchAppsV1NamespacedDaemonSetList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14381,8 +14381,8 @@ func (s *Server) handleWatchAppsV1NamespacedDeploymentRequest(args [2]string, w 
 	params, err := decodeWatchAppsV1NamespacedDeploymentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedDeployment",
-			err,
+			Operation: "WatchAppsV1NamespacedDeployment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14436,8 +14436,8 @@ func (s *Server) handleWatchAppsV1NamespacedDeploymentListRequest(args [1]string
 	params, err := decodeWatchAppsV1NamespacedDeploymentListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedDeploymentList",
-			err,
+			Operation: "WatchAppsV1NamespacedDeploymentList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14491,8 +14491,8 @@ func (s *Server) handleWatchAppsV1NamespacedReplicaSetRequest(args [2]string, w 
 	params, err := decodeWatchAppsV1NamespacedReplicaSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedReplicaSet",
-			err,
+			Operation: "WatchAppsV1NamespacedReplicaSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14546,8 +14546,8 @@ func (s *Server) handleWatchAppsV1NamespacedReplicaSetListRequest(args [1]string
 	params, err := decodeWatchAppsV1NamespacedReplicaSetListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedReplicaSetList",
-			err,
+			Operation: "WatchAppsV1NamespacedReplicaSetList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14601,8 +14601,8 @@ func (s *Server) handleWatchAppsV1NamespacedStatefulSetRequest(args [2]string, w
 	params, err := decodeWatchAppsV1NamespacedStatefulSetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedStatefulSet",
-			err,
+			Operation: "WatchAppsV1NamespacedStatefulSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14656,8 +14656,8 @@ func (s *Server) handleWatchAppsV1NamespacedStatefulSetListRequest(args [1]strin
 	params, err := decodeWatchAppsV1NamespacedStatefulSetListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1NamespacedStatefulSetList",
-			err,
+			Operation: "WatchAppsV1NamespacedStatefulSetList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14711,8 +14711,8 @@ func (s *Server) handleWatchAppsV1ReplicaSetListForAllNamespacesRequest(args [0]
 	params, err := decodeWatchAppsV1ReplicaSetListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1ReplicaSetListForAllNamespaces",
-			err,
+			Operation: "WatchAppsV1ReplicaSetListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14766,8 +14766,8 @@ func (s *Server) handleWatchAppsV1StatefulSetListForAllNamespacesRequest(args [0
 	params, err := decodeWatchAppsV1StatefulSetListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAppsV1StatefulSetListForAllNamespaces",
-			err,
+			Operation: "WatchAppsV1StatefulSetListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14821,8 +14821,8 @@ func (s *Server) handleWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamesp
 	params, err := decodeWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces",
-			err,
+			Operation: "WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14876,8 +14876,8 @@ func (s *Server) handleWatchAutoscalingV1NamespacedHorizontalPodAutoscalerReques
 	params, err := decodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "WatchAutoscalingV1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14931,8 +14931,8 @@ func (s *Server) handleWatchAutoscalingV1NamespacedHorizontalPodAutoscalerListRe
 	params, err := decodeWatchAutoscalingV1NamespacedHorizontalPodAutoscalerListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV1NamespacedHorizontalPodAutoscalerList",
-			err,
+			Operation: "WatchAutoscalingV1NamespacedHorizontalPodAutoscalerList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14986,8 +14986,8 @@ func (s *Server) handleWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllN
 	params, err := decodeWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespaces",
-			err,
+			Operation: "WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15041,8 +15041,8 @@ func (s *Server) handleWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerR
 	params, err := decodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15096,8 +15096,8 @@ func (s *Server) handleWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerL
 	params, err := decodeWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerList",
-			err,
+			Operation: "WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15151,8 +15151,8 @@ func (s *Server) handleWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllN
 	params, err := decodeWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespaces",
-			err,
+			Operation: "WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15206,8 +15206,8 @@ func (s *Server) handleWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerR
 	params, err := decodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
-			err,
+			Operation: "WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscaler",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15261,8 +15261,8 @@ func (s *Server) handleWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerL
 	params, err := decodeWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerList",
-			err,
+			Operation: "WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15316,8 +15316,8 @@ func (s *Server) handleWatchBatchV1CronJobListForAllNamespacesRequest(args [0]st
 	params, err := decodeWatchBatchV1CronJobListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1CronJobListForAllNamespaces",
-			err,
+			Operation: "WatchBatchV1CronJobListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15371,8 +15371,8 @@ func (s *Server) handleWatchBatchV1JobListForAllNamespacesRequest(args [0]string
 	params, err := decodeWatchBatchV1JobListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1JobListForAllNamespaces",
-			err,
+			Operation: "WatchBatchV1JobListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15426,8 +15426,8 @@ func (s *Server) handleWatchBatchV1NamespacedCronJobRequest(args [2]string, w ht
 	params, err := decodeWatchBatchV1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1NamespacedCronJob",
-			err,
+			Operation: "WatchBatchV1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15481,8 +15481,8 @@ func (s *Server) handleWatchBatchV1NamespacedCronJobListRequest(args [1]string, 
 	params, err := decodeWatchBatchV1NamespacedCronJobListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1NamespacedCronJobList",
-			err,
+			Operation: "WatchBatchV1NamespacedCronJobList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15536,8 +15536,8 @@ func (s *Server) handleWatchBatchV1NamespacedJobRequest(args [2]string, w http.R
 	params, err := decodeWatchBatchV1NamespacedJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1NamespacedJob",
-			err,
+			Operation: "WatchBatchV1NamespacedJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15591,8 +15591,8 @@ func (s *Server) handleWatchBatchV1NamespacedJobListRequest(args [1]string, w ht
 	params, err := decodeWatchBatchV1NamespacedJobListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1NamespacedJobList",
-			err,
+			Operation: "WatchBatchV1NamespacedJobList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15646,8 +15646,8 @@ func (s *Server) handleWatchBatchV1beta1CronJobListForAllNamespacesRequest(args 
 	params, err := decodeWatchBatchV1beta1CronJobListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1beta1CronJobListForAllNamespaces",
-			err,
+			Operation: "WatchBatchV1beta1CronJobListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15701,8 +15701,8 @@ func (s *Server) handleWatchBatchV1beta1NamespacedCronJobRequest(args [2]string,
 	params, err := decodeWatchBatchV1beta1NamespacedCronJobParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1beta1NamespacedCronJob",
-			err,
+			Operation: "WatchBatchV1beta1NamespacedCronJob",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15756,8 +15756,8 @@ func (s *Server) handleWatchBatchV1beta1NamespacedCronJobListRequest(args [1]str
 	params, err := decodeWatchBatchV1beta1NamespacedCronJobListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchBatchV1beta1NamespacedCronJobList",
-			err,
+			Operation: "WatchBatchV1beta1NamespacedCronJobList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15811,8 +15811,8 @@ func (s *Server) handleWatchCertificatesV1CertificateSigningRequestRequest(args 
 	params, err := decodeWatchCertificatesV1CertificateSigningRequestParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCertificatesV1CertificateSigningRequest",
-			err,
+			Operation: "WatchCertificatesV1CertificateSigningRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15866,8 +15866,8 @@ func (s *Server) handleWatchCertificatesV1CertificateSigningRequestListRequest(a
 	params, err := decodeWatchCertificatesV1CertificateSigningRequestListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCertificatesV1CertificateSigningRequestList",
-			err,
+			Operation: "WatchCertificatesV1CertificateSigningRequestList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15921,8 +15921,8 @@ func (s *Server) handleWatchCoordinationV1LeaseListForAllNamespacesRequest(args 
 	params, err := decodeWatchCoordinationV1LeaseListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoordinationV1LeaseListForAllNamespaces",
-			err,
+			Operation: "WatchCoordinationV1LeaseListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15976,8 +15976,8 @@ func (s *Server) handleWatchCoordinationV1NamespacedLeaseRequest(args [2]string,
 	params, err := decodeWatchCoordinationV1NamespacedLeaseParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoordinationV1NamespacedLease",
-			err,
+			Operation: "WatchCoordinationV1NamespacedLease",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16031,8 +16031,8 @@ func (s *Server) handleWatchCoordinationV1NamespacedLeaseListRequest(args [1]str
 	params, err := decodeWatchCoordinationV1NamespacedLeaseListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoordinationV1NamespacedLeaseList",
-			err,
+			Operation: "WatchCoordinationV1NamespacedLeaseList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16086,8 +16086,8 @@ func (s *Server) handleWatchCoreV1ConfigMapListForAllNamespacesRequest(args [0]s
 	params, err := decodeWatchCoreV1ConfigMapListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1ConfigMapListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1ConfigMapListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16141,8 +16141,8 @@ func (s *Server) handleWatchCoreV1EndpointsListForAllNamespacesRequest(args [0]s
 	params, err := decodeWatchCoreV1EndpointsListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1EndpointsListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1EndpointsListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16196,8 +16196,8 @@ func (s *Server) handleWatchCoreV1EventListForAllNamespacesRequest(args [0]strin
 	params, err := decodeWatchCoreV1EventListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1EventListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1EventListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16251,8 +16251,8 @@ func (s *Server) handleWatchCoreV1LimitRangeListForAllNamespacesRequest(args [0]
 	params, err := decodeWatchCoreV1LimitRangeListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1LimitRangeListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1LimitRangeListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16306,8 +16306,8 @@ func (s *Server) handleWatchCoreV1NamespaceRequest(args [1]string, w http.Respon
 	params, err := decodeWatchCoreV1NamespaceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1Namespace",
-			err,
+			Operation: "WatchCoreV1Namespace",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16361,8 +16361,8 @@ func (s *Server) handleWatchCoreV1NamespaceListRequest(args [0]string, w http.Re
 	params, err := decodeWatchCoreV1NamespaceListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespaceList",
-			err,
+			Operation: "WatchCoreV1NamespaceList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16416,8 +16416,8 @@ func (s *Server) handleWatchCoreV1NamespacedConfigMapRequest(args [2]string, w h
 	params, err := decodeWatchCoreV1NamespacedConfigMapParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedConfigMap",
-			err,
+			Operation: "WatchCoreV1NamespacedConfigMap",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16471,8 +16471,8 @@ func (s *Server) handleWatchCoreV1NamespacedConfigMapListRequest(args [1]string,
 	params, err := decodeWatchCoreV1NamespacedConfigMapListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedConfigMapList",
-			err,
+			Operation: "WatchCoreV1NamespacedConfigMapList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16526,8 +16526,8 @@ func (s *Server) handleWatchCoreV1NamespacedEndpointsRequest(args [2]string, w h
 	params, err := decodeWatchCoreV1NamespacedEndpointsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedEndpoints",
-			err,
+			Operation: "WatchCoreV1NamespacedEndpoints",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16581,8 +16581,8 @@ func (s *Server) handleWatchCoreV1NamespacedEndpointsListRequest(args [1]string,
 	params, err := decodeWatchCoreV1NamespacedEndpointsListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedEndpointsList",
-			err,
+			Operation: "WatchCoreV1NamespacedEndpointsList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16636,8 +16636,8 @@ func (s *Server) handleWatchCoreV1NamespacedEventRequest(args [2]string, w http.
 	params, err := decodeWatchCoreV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedEvent",
-			err,
+			Operation: "WatchCoreV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16691,8 +16691,8 @@ func (s *Server) handleWatchCoreV1NamespacedEventListRequest(args [1]string, w h
 	params, err := decodeWatchCoreV1NamespacedEventListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedEventList",
-			err,
+			Operation: "WatchCoreV1NamespacedEventList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16746,8 +16746,8 @@ func (s *Server) handleWatchCoreV1NamespacedLimitRangeRequest(args [2]string, w 
 	params, err := decodeWatchCoreV1NamespacedLimitRangeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedLimitRange",
-			err,
+			Operation: "WatchCoreV1NamespacedLimitRange",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16801,8 +16801,8 @@ func (s *Server) handleWatchCoreV1NamespacedLimitRangeListRequest(args [1]string
 	params, err := decodeWatchCoreV1NamespacedLimitRangeListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedLimitRangeList",
-			err,
+			Operation: "WatchCoreV1NamespacedLimitRangeList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16856,8 +16856,8 @@ func (s *Server) handleWatchCoreV1NamespacedPersistentVolumeClaimRequest(args [2
 	params, err := decodeWatchCoreV1NamespacedPersistentVolumeClaimParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPersistentVolumeClaim",
-			err,
+			Operation: "WatchCoreV1NamespacedPersistentVolumeClaim",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16911,8 +16911,8 @@ func (s *Server) handleWatchCoreV1NamespacedPersistentVolumeClaimListRequest(arg
 	params, err := decodeWatchCoreV1NamespacedPersistentVolumeClaimListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPersistentVolumeClaimList",
-			err,
+			Operation: "WatchCoreV1NamespacedPersistentVolumeClaimList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16966,8 +16966,8 @@ func (s *Server) handleWatchCoreV1NamespacedPodRequest(args [2]string, w http.Re
 	params, err := decodeWatchCoreV1NamespacedPodParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPod",
-			err,
+			Operation: "WatchCoreV1NamespacedPod",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17021,8 +17021,8 @@ func (s *Server) handleWatchCoreV1NamespacedPodListRequest(args [1]string, w htt
 	params, err := decodeWatchCoreV1NamespacedPodListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPodList",
-			err,
+			Operation: "WatchCoreV1NamespacedPodList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17076,8 +17076,8 @@ func (s *Server) handleWatchCoreV1NamespacedPodTemplateRequest(args [2]string, w
 	params, err := decodeWatchCoreV1NamespacedPodTemplateParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPodTemplate",
-			err,
+			Operation: "WatchCoreV1NamespacedPodTemplate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17131,8 +17131,8 @@ func (s *Server) handleWatchCoreV1NamespacedPodTemplateListRequest(args [1]strin
 	params, err := decodeWatchCoreV1NamespacedPodTemplateListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedPodTemplateList",
-			err,
+			Operation: "WatchCoreV1NamespacedPodTemplateList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17186,8 +17186,8 @@ func (s *Server) handleWatchCoreV1NamespacedReplicationControllerRequest(args [2
 	params, err := decodeWatchCoreV1NamespacedReplicationControllerParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedReplicationController",
-			err,
+			Operation: "WatchCoreV1NamespacedReplicationController",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17241,8 +17241,8 @@ func (s *Server) handleWatchCoreV1NamespacedReplicationControllerListRequest(arg
 	params, err := decodeWatchCoreV1NamespacedReplicationControllerListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedReplicationControllerList",
-			err,
+			Operation: "WatchCoreV1NamespacedReplicationControllerList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17296,8 +17296,8 @@ func (s *Server) handleWatchCoreV1NamespacedResourceQuotaRequest(args [2]string,
 	params, err := decodeWatchCoreV1NamespacedResourceQuotaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedResourceQuota",
-			err,
+			Operation: "WatchCoreV1NamespacedResourceQuota",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17351,8 +17351,8 @@ func (s *Server) handleWatchCoreV1NamespacedResourceQuotaListRequest(args [1]str
 	params, err := decodeWatchCoreV1NamespacedResourceQuotaListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedResourceQuotaList",
-			err,
+			Operation: "WatchCoreV1NamespacedResourceQuotaList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17406,8 +17406,8 @@ func (s *Server) handleWatchCoreV1NamespacedSecretRequest(args [2]string, w http
 	params, err := decodeWatchCoreV1NamespacedSecretParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedSecret",
-			err,
+			Operation: "WatchCoreV1NamespacedSecret",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17461,8 +17461,8 @@ func (s *Server) handleWatchCoreV1NamespacedSecretListRequest(args [1]string, w 
 	params, err := decodeWatchCoreV1NamespacedSecretListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedSecretList",
-			err,
+			Operation: "WatchCoreV1NamespacedSecretList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17516,8 +17516,8 @@ func (s *Server) handleWatchCoreV1NamespacedServiceRequest(args [2]string, w htt
 	params, err := decodeWatchCoreV1NamespacedServiceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedService",
-			err,
+			Operation: "WatchCoreV1NamespacedService",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17571,8 +17571,8 @@ func (s *Server) handleWatchCoreV1NamespacedServiceAccountRequest(args [2]string
 	params, err := decodeWatchCoreV1NamespacedServiceAccountParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedServiceAccount",
-			err,
+			Operation: "WatchCoreV1NamespacedServiceAccount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17626,8 +17626,8 @@ func (s *Server) handleWatchCoreV1NamespacedServiceAccountListRequest(args [1]st
 	params, err := decodeWatchCoreV1NamespacedServiceAccountListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedServiceAccountList",
-			err,
+			Operation: "WatchCoreV1NamespacedServiceAccountList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17681,8 +17681,8 @@ func (s *Server) handleWatchCoreV1NamespacedServiceListRequest(args [1]string, w
 	params, err := decodeWatchCoreV1NamespacedServiceListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NamespacedServiceList",
-			err,
+			Operation: "WatchCoreV1NamespacedServiceList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17736,8 +17736,8 @@ func (s *Server) handleWatchCoreV1NodeRequest(args [1]string, w http.ResponseWri
 	params, err := decodeWatchCoreV1NodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1Node",
-			err,
+			Operation: "WatchCoreV1Node",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17791,8 +17791,8 @@ func (s *Server) handleWatchCoreV1NodeListRequest(args [0]string, w http.Respons
 	params, err := decodeWatchCoreV1NodeListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1NodeList",
-			err,
+			Operation: "WatchCoreV1NodeList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17846,8 +17846,8 @@ func (s *Server) handleWatchCoreV1PersistentVolumeRequest(args [1]string, w http
 	params, err := decodeWatchCoreV1PersistentVolumeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1PersistentVolume",
-			err,
+			Operation: "WatchCoreV1PersistentVolume",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17901,8 +17901,8 @@ func (s *Server) handleWatchCoreV1PersistentVolumeClaimListForAllNamespacesReque
 	params, err := decodeWatchCoreV1PersistentVolumeClaimListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1PersistentVolumeClaimListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1PersistentVolumeClaimListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17956,8 +17956,8 @@ func (s *Server) handleWatchCoreV1PersistentVolumeListRequest(args [0]string, w 
 	params, err := decodeWatchCoreV1PersistentVolumeListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1PersistentVolumeList",
-			err,
+			Operation: "WatchCoreV1PersistentVolumeList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18011,8 +18011,8 @@ func (s *Server) handleWatchCoreV1PodListForAllNamespacesRequest(args [0]string,
 	params, err := decodeWatchCoreV1PodListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1PodListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1PodListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18066,8 +18066,8 @@ func (s *Server) handleWatchCoreV1PodTemplateListForAllNamespacesRequest(args [0
 	params, err := decodeWatchCoreV1PodTemplateListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1PodTemplateListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1PodTemplateListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18121,8 +18121,8 @@ func (s *Server) handleWatchCoreV1ReplicationControllerListForAllNamespacesReque
 	params, err := decodeWatchCoreV1ReplicationControllerListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1ReplicationControllerListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1ReplicationControllerListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18176,8 +18176,8 @@ func (s *Server) handleWatchCoreV1ResourceQuotaListForAllNamespacesRequest(args 
 	params, err := decodeWatchCoreV1ResourceQuotaListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1ResourceQuotaListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1ResourceQuotaListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18231,8 +18231,8 @@ func (s *Server) handleWatchCoreV1SecretListForAllNamespacesRequest(args [0]stri
 	params, err := decodeWatchCoreV1SecretListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1SecretListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1SecretListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18286,8 +18286,8 @@ func (s *Server) handleWatchCoreV1ServiceAccountListForAllNamespacesRequest(args
 	params, err := decodeWatchCoreV1ServiceAccountListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1ServiceAccountListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1ServiceAccountListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18341,8 +18341,8 @@ func (s *Server) handleWatchCoreV1ServiceListForAllNamespacesRequest(args [0]str
 	params, err := decodeWatchCoreV1ServiceListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchCoreV1ServiceListForAllNamespaces",
-			err,
+			Operation: "WatchCoreV1ServiceListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18396,8 +18396,8 @@ func (s *Server) handleWatchDiscoveryV1EndpointSliceListForAllNamespacesRequest(
 	params, err := decodeWatchDiscoveryV1EndpointSliceListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1EndpointSliceListForAllNamespaces",
-			err,
+			Operation: "WatchDiscoveryV1EndpointSliceListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18451,8 +18451,8 @@ func (s *Server) handleWatchDiscoveryV1NamespacedEndpointSliceRequest(args [2]st
 	params, err := decodeWatchDiscoveryV1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1NamespacedEndpointSlice",
-			err,
+			Operation: "WatchDiscoveryV1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18506,8 +18506,8 @@ func (s *Server) handleWatchDiscoveryV1NamespacedEndpointSliceListRequest(args [
 	params, err := decodeWatchDiscoveryV1NamespacedEndpointSliceListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1NamespacedEndpointSliceList",
-			err,
+			Operation: "WatchDiscoveryV1NamespacedEndpointSliceList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18561,8 +18561,8 @@ func (s *Server) handleWatchDiscoveryV1beta1EndpointSliceListForAllNamespacesReq
 	params, err := decodeWatchDiscoveryV1beta1EndpointSliceListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1beta1EndpointSliceListForAllNamespaces",
-			err,
+			Operation: "WatchDiscoveryV1beta1EndpointSliceListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18616,8 +18616,8 @@ func (s *Server) handleWatchDiscoveryV1beta1NamespacedEndpointSliceRequest(args 
 	params, err := decodeWatchDiscoveryV1beta1NamespacedEndpointSliceParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1beta1NamespacedEndpointSlice",
-			err,
+			Operation: "WatchDiscoveryV1beta1NamespacedEndpointSlice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18671,8 +18671,8 @@ func (s *Server) handleWatchDiscoveryV1beta1NamespacedEndpointSliceListRequest(a
 	params, err := decodeWatchDiscoveryV1beta1NamespacedEndpointSliceListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchDiscoveryV1beta1NamespacedEndpointSliceList",
-			err,
+			Operation: "WatchDiscoveryV1beta1NamespacedEndpointSliceList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18726,8 +18726,8 @@ func (s *Server) handleWatchEventsV1EventListForAllNamespacesRequest(args [0]str
 	params, err := decodeWatchEventsV1EventListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1EventListForAllNamespaces",
-			err,
+			Operation: "WatchEventsV1EventListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18781,8 +18781,8 @@ func (s *Server) handleWatchEventsV1NamespacedEventRequest(args [2]string, w htt
 	params, err := decodeWatchEventsV1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1NamespacedEvent",
-			err,
+			Operation: "WatchEventsV1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18836,8 +18836,8 @@ func (s *Server) handleWatchEventsV1NamespacedEventListRequest(args [1]string, w
 	params, err := decodeWatchEventsV1NamespacedEventListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1NamespacedEventList",
-			err,
+			Operation: "WatchEventsV1NamespacedEventList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18891,8 +18891,8 @@ func (s *Server) handleWatchEventsV1beta1EventListForAllNamespacesRequest(args [
 	params, err := decodeWatchEventsV1beta1EventListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1beta1EventListForAllNamespaces",
-			err,
+			Operation: "WatchEventsV1beta1EventListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18946,8 +18946,8 @@ func (s *Server) handleWatchEventsV1beta1NamespacedEventRequest(args [2]string, 
 	params, err := decodeWatchEventsV1beta1NamespacedEventParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1beta1NamespacedEvent",
-			err,
+			Operation: "WatchEventsV1beta1NamespacedEvent",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19001,8 +19001,8 @@ func (s *Server) handleWatchEventsV1beta1NamespacedEventListRequest(args [1]stri
 	params, err := decodeWatchEventsV1beta1NamespacedEventListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchEventsV1beta1NamespacedEventList",
-			err,
+			Operation: "WatchEventsV1beta1NamespacedEventList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19056,8 +19056,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1FlowSchemaRequest(args [1
 	params, err := decodeWatchFlowcontrolApiserverV1beta1FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta1FlowSchema",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta1FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19111,8 +19111,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1FlowSchemaListRequest(arg
 	params, err := decodeWatchFlowcontrolApiserverV1beta1FlowSchemaListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta1FlowSchemaList",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta1FlowSchemaList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19166,8 +19166,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1PriorityLevelConfiguratio
 	params, err := decodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta1PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19221,8 +19221,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta1PriorityLevelConfiguratio
 	params, err := decodeWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationList",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19276,8 +19276,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2FlowSchemaRequest(args [1
 	params, err := decodeWatchFlowcontrolApiserverV1beta2FlowSchemaParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta2FlowSchema",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta2FlowSchema",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19331,8 +19331,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2FlowSchemaListRequest(arg
 	params, err := decodeWatchFlowcontrolApiserverV1beta2FlowSchemaListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta2FlowSchemaList",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta2FlowSchemaList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19386,8 +19386,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2PriorityLevelConfiguratio
 	params, err := decodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta2PriorityLevelConfiguration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19441,8 +19441,8 @@ func (s *Server) handleWatchFlowcontrolApiserverV1beta2PriorityLevelConfiguratio
 	params, err := decodeWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationList",
-			err,
+			Operation: "WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19496,8 +19496,8 @@ func (s *Server) handleWatchInternalApiserverV1alpha1StorageVersionRequest(args 
 	params, err := decodeWatchInternalApiserverV1alpha1StorageVersionParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchInternalApiserverV1alpha1StorageVersion",
-			err,
+			Operation: "WatchInternalApiserverV1alpha1StorageVersion",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19551,8 +19551,8 @@ func (s *Server) handleWatchInternalApiserverV1alpha1StorageVersionListRequest(a
 	params, err := decodeWatchInternalApiserverV1alpha1StorageVersionListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchInternalApiserverV1alpha1StorageVersionList",
-			err,
+			Operation: "WatchInternalApiserverV1alpha1StorageVersionList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19606,8 +19606,8 @@ func (s *Server) handleWatchNetworkingV1IngressClassRequest(args [1]string, w ht
 	params, err := decodeWatchNetworkingV1IngressClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1IngressClass",
-			err,
+			Operation: "WatchNetworkingV1IngressClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19661,8 +19661,8 @@ func (s *Server) handleWatchNetworkingV1IngressClassListRequest(args [0]string, 
 	params, err := decodeWatchNetworkingV1IngressClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1IngressClassList",
-			err,
+			Operation: "WatchNetworkingV1IngressClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19716,8 +19716,8 @@ func (s *Server) handleWatchNetworkingV1IngressListForAllNamespacesRequest(args 
 	params, err := decodeWatchNetworkingV1IngressListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1IngressListForAllNamespaces",
-			err,
+			Operation: "WatchNetworkingV1IngressListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19771,8 +19771,8 @@ func (s *Server) handleWatchNetworkingV1NamespacedIngressRequest(args [2]string,
 	params, err := decodeWatchNetworkingV1NamespacedIngressParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1NamespacedIngress",
-			err,
+			Operation: "WatchNetworkingV1NamespacedIngress",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19826,8 +19826,8 @@ func (s *Server) handleWatchNetworkingV1NamespacedIngressListRequest(args [1]str
 	params, err := decodeWatchNetworkingV1NamespacedIngressListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1NamespacedIngressList",
-			err,
+			Operation: "WatchNetworkingV1NamespacedIngressList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19881,8 +19881,8 @@ func (s *Server) handleWatchNetworkingV1NamespacedNetworkPolicyRequest(args [2]s
 	params, err := decodeWatchNetworkingV1NamespacedNetworkPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1NamespacedNetworkPolicy",
-			err,
+			Operation: "WatchNetworkingV1NamespacedNetworkPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19936,8 +19936,8 @@ func (s *Server) handleWatchNetworkingV1NamespacedNetworkPolicyListRequest(args 
 	params, err := decodeWatchNetworkingV1NamespacedNetworkPolicyListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1NamespacedNetworkPolicyList",
-			err,
+			Operation: "WatchNetworkingV1NamespacedNetworkPolicyList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19991,8 +19991,8 @@ func (s *Server) handleWatchNetworkingV1NetworkPolicyListForAllNamespacesRequest
 	params, err := decodeWatchNetworkingV1NetworkPolicyListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNetworkingV1NetworkPolicyListForAllNamespaces",
-			err,
+			Operation: "WatchNetworkingV1NetworkPolicyListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20046,8 +20046,8 @@ func (s *Server) handleWatchNodeV1RuntimeClassRequest(args [1]string, w http.Res
 	params, err := decodeWatchNodeV1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1RuntimeClass",
-			err,
+			Operation: "WatchNodeV1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20101,8 +20101,8 @@ func (s *Server) handleWatchNodeV1RuntimeClassListRequest(args [0]string, w http
 	params, err := decodeWatchNodeV1RuntimeClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1RuntimeClassList",
-			err,
+			Operation: "WatchNodeV1RuntimeClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20156,8 +20156,8 @@ func (s *Server) handleWatchNodeV1alpha1RuntimeClassRequest(args [1]string, w ht
 	params, err := decodeWatchNodeV1alpha1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1alpha1RuntimeClass",
-			err,
+			Operation: "WatchNodeV1alpha1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20211,8 +20211,8 @@ func (s *Server) handleWatchNodeV1alpha1RuntimeClassListRequest(args [0]string, 
 	params, err := decodeWatchNodeV1alpha1RuntimeClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1alpha1RuntimeClassList",
-			err,
+			Operation: "WatchNodeV1alpha1RuntimeClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20266,8 +20266,8 @@ func (s *Server) handleWatchNodeV1beta1RuntimeClassRequest(args [1]string, w htt
 	params, err := decodeWatchNodeV1beta1RuntimeClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1beta1RuntimeClass",
-			err,
+			Operation: "WatchNodeV1beta1RuntimeClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20321,8 +20321,8 @@ func (s *Server) handleWatchNodeV1beta1RuntimeClassListRequest(args [0]string, w
 	params, err := decodeWatchNodeV1beta1RuntimeClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchNodeV1beta1RuntimeClassList",
-			err,
+			Operation: "WatchNodeV1beta1RuntimeClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20376,8 +20376,8 @@ func (s *Server) handleWatchPolicyV1NamespacedPodDisruptionBudgetRequest(args [2
 	params, err := decodeWatchPolicyV1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "WatchPolicyV1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20431,8 +20431,8 @@ func (s *Server) handleWatchPolicyV1NamespacedPodDisruptionBudgetListRequest(arg
 	params, err := decodeWatchPolicyV1NamespacedPodDisruptionBudgetListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1NamespacedPodDisruptionBudgetList",
-			err,
+			Operation: "WatchPolicyV1NamespacedPodDisruptionBudgetList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20486,8 +20486,8 @@ func (s *Server) handleWatchPolicyV1PodDisruptionBudgetListForAllNamespacesReque
 	params, err := decodeWatchPolicyV1PodDisruptionBudgetListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1PodDisruptionBudgetListForAllNamespaces",
-			err,
+			Operation: "WatchPolicyV1PodDisruptionBudgetListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20541,8 +20541,8 @@ func (s *Server) handleWatchPolicyV1beta1NamespacedPodDisruptionBudgetRequest(ar
 	params, err := decodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1beta1NamespacedPodDisruptionBudget",
-			err,
+			Operation: "WatchPolicyV1beta1NamespacedPodDisruptionBudget",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20596,8 +20596,8 @@ func (s *Server) handleWatchPolicyV1beta1NamespacedPodDisruptionBudgetListReques
 	params, err := decodeWatchPolicyV1beta1NamespacedPodDisruptionBudgetListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1beta1NamespacedPodDisruptionBudgetList",
-			err,
+			Operation: "WatchPolicyV1beta1NamespacedPodDisruptionBudgetList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20651,8 +20651,8 @@ func (s *Server) handleWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces
 	params, err := decodeWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces",
-			err,
+			Operation: "WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20706,8 +20706,8 @@ func (s *Server) handleWatchPolicyV1beta1PodSecurityPolicyRequest(args [1]string
 	params, err := decodeWatchPolicyV1beta1PodSecurityPolicyParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1beta1PodSecurityPolicy",
-			err,
+			Operation: "WatchPolicyV1beta1PodSecurityPolicy",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20761,8 +20761,8 @@ func (s *Server) handleWatchPolicyV1beta1PodSecurityPolicyListRequest(args [0]st
 	params, err := decodeWatchPolicyV1beta1PodSecurityPolicyListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchPolicyV1beta1PodSecurityPolicyList",
-			err,
+			Operation: "WatchPolicyV1beta1PodSecurityPolicyList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20816,8 +20816,8 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleRequest(args [1]string
 	params, err := decodeWatchRbacAuthorizationV1ClusterRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1ClusterRole",
-			err,
+			Operation: "WatchRbacAuthorizationV1ClusterRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20871,8 +20871,8 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleBindingRequest(args [1
 	params, err := decodeWatchRbacAuthorizationV1ClusterRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1ClusterRoleBinding",
-			err,
+			Operation: "WatchRbacAuthorizationV1ClusterRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20926,8 +20926,8 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleBindingListRequest(arg
 	params, err := decodeWatchRbacAuthorizationV1ClusterRoleBindingListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1ClusterRoleBindingList",
-			err,
+			Operation: "WatchRbacAuthorizationV1ClusterRoleBindingList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20981,8 +20981,8 @@ func (s *Server) handleWatchRbacAuthorizationV1ClusterRoleListRequest(args [0]st
 	params, err := decodeWatchRbacAuthorizationV1ClusterRoleListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1ClusterRoleList",
-			err,
+			Operation: "WatchRbacAuthorizationV1ClusterRoleList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21036,8 +21036,8 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleRequest(args [2]str
 	params, err := decodeWatchRbacAuthorizationV1NamespacedRoleParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1NamespacedRole",
-			err,
+			Operation: "WatchRbacAuthorizationV1NamespacedRole",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21091,8 +21091,8 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleBindingRequest(args
 	params, err := decodeWatchRbacAuthorizationV1NamespacedRoleBindingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1NamespacedRoleBinding",
-			err,
+			Operation: "WatchRbacAuthorizationV1NamespacedRoleBinding",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21146,8 +21146,8 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleBindingListRequest(
 	params, err := decodeWatchRbacAuthorizationV1NamespacedRoleBindingListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1NamespacedRoleBindingList",
-			err,
+			Operation: "WatchRbacAuthorizationV1NamespacedRoleBindingList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21201,8 +21201,8 @@ func (s *Server) handleWatchRbacAuthorizationV1NamespacedRoleListRequest(args [1
 	params, err := decodeWatchRbacAuthorizationV1NamespacedRoleListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1NamespacedRoleList",
-			err,
+			Operation: "WatchRbacAuthorizationV1NamespacedRoleList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21256,8 +21256,8 @@ func (s *Server) handleWatchRbacAuthorizationV1RoleBindingListForAllNamespacesRe
 	params, err := decodeWatchRbacAuthorizationV1RoleBindingListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1RoleBindingListForAllNamespaces",
-			err,
+			Operation: "WatchRbacAuthorizationV1RoleBindingListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21311,8 +21311,8 @@ func (s *Server) handleWatchRbacAuthorizationV1RoleListForAllNamespacesRequest(a
 	params, err := decodeWatchRbacAuthorizationV1RoleListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchRbacAuthorizationV1RoleListForAllNamespaces",
-			err,
+			Operation: "WatchRbacAuthorizationV1RoleListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21366,8 +21366,8 @@ func (s *Server) handleWatchSchedulingV1PriorityClassRequest(args [1]string, w h
 	params, err := decodeWatchSchedulingV1PriorityClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchSchedulingV1PriorityClass",
-			err,
+			Operation: "WatchSchedulingV1PriorityClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21421,8 +21421,8 @@ func (s *Server) handleWatchSchedulingV1PriorityClassListRequest(args [0]string,
 	params, err := decodeWatchSchedulingV1PriorityClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchSchedulingV1PriorityClassList",
-			err,
+			Operation: "WatchSchedulingV1PriorityClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21476,8 +21476,8 @@ func (s *Server) handleWatchStorageV1CSIDriverRequest(args [1]string, w http.Res
 	params, err := decodeWatchStorageV1CSIDriverParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1CSIDriver",
-			err,
+			Operation: "WatchStorageV1CSIDriver",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21531,8 +21531,8 @@ func (s *Server) handleWatchStorageV1CSIDriverListRequest(args [0]string, w http
 	params, err := decodeWatchStorageV1CSIDriverListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1CSIDriverList",
-			err,
+			Operation: "WatchStorageV1CSIDriverList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21586,8 +21586,8 @@ func (s *Server) handleWatchStorageV1CSINodeRequest(args [1]string, w http.Respo
 	params, err := decodeWatchStorageV1CSINodeParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1CSINode",
-			err,
+			Operation: "WatchStorageV1CSINode",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21641,8 +21641,8 @@ func (s *Server) handleWatchStorageV1CSINodeListRequest(args [0]string, w http.R
 	params, err := decodeWatchStorageV1CSINodeListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1CSINodeList",
-			err,
+			Operation: "WatchStorageV1CSINodeList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21696,8 +21696,8 @@ func (s *Server) handleWatchStorageV1StorageClassRequest(args [1]string, w http.
 	params, err := decodeWatchStorageV1StorageClassParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1StorageClass",
-			err,
+			Operation: "WatchStorageV1StorageClass",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21751,8 +21751,8 @@ func (s *Server) handleWatchStorageV1StorageClassListRequest(args [0]string, w h
 	params, err := decodeWatchStorageV1StorageClassListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1StorageClassList",
-			err,
+			Operation: "WatchStorageV1StorageClassList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21806,8 +21806,8 @@ func (s *Server) handleWatchStorageV1VolumeAttachmentRequest(args [1]string, w h
 	params, err := decodeWatchStorageV1VolumeAttachmentParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1VolumeAttachment",
-			err,
+			Operation: "WatchStorageV1VolumeAttachment",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21861,8 +21861,8 @@ func (s *Server) handleWatchStorageV1VolumeAttachmentListRequest(args [0]string,
 	params, err := decodeWatchStorageV1VolumeAttachmentListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1VolumeAttachmentList",
-			err,
+			Operation: "WatchStorageV1VolumeAttachmentList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21916,8 +21916,8 @@ func (s *Server) handleWatchStorageV1alpha1CSIStorageCapacityListForAllNamespace
 	params, err := decodeWatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1alpha1CSIStorageCapacityListForAllNamespaces",
-			err,
+			Operation: "WatchStorageV1alpha1CSIStorageCapacityListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21971,8 +21971,8 @@ func (s *Server) handleWatchStorageV1alpha1NamespacedCSIStorageCapacityRequest(a
 	params, err := decodeWatchStorageV1alpha1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1alpha1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "WatchStorageV1alpha1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22026,8 +22026,8 @@ func (s *Server) handleWatchStorageV1alpha1NamespacedCSIStorageCapacityListReque
 	params, err := decodeWatchStorageV1alpha1NamespacedCSIStorageCapacityListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1alpha1NamespacedCSIStorageCapacityList",
-			err,
+			Operation: "WatchStorageV1alpha1NamespacedCSIStorageCapacityList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22081,8 +22081,8 @@ func (s *Server) handleWatchStorageV1beta1CSIStorageCapacityListForAllNamespaces
 	params, err := decodeWatchStorageV1beta1CSIStorageCapacityListForAllNamespacesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1beta1CSIStorageCapacityListForAllNamespaces",
-			err,
+			Operation: "WatchStorageV1beta1CSIStorageCapacityListForAllNamespaces",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22136,8 +22136,8 @@ func (s *Server) handleWatchStorageV1beta1NamespacedCSIStorageCapacityRequest(ar
 	params, err := decodeWatchStorageV1beta1NamespacedCSIStorageCapacityParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1beta1NamespacedCSIStorageCapacity",
-			err,
+			Operation: "WatchStorageV1beta1NamespacedCSIStorageCapacity",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22191,8 +22191,8 @@ func (s *Server) handleWatchStorageV1beta1NamespacedCSIStorageCapacityListReques
 	params, err := decodeWatchStorageV1beta1NamespacedCSIStorageCapacityListParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"WatchStorageV1beta1NamespacedCSIStorageCapacityList",
-			err,
+			Operation: "WatchStorageV1beta1NamespacedCSIStorageCapacityList",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_k8s/oas_validators_gen.go
+++ b/examples/ex_k8s/oas_validators_gen.go
@@ -16,7 +16,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhook) Validate() error {
 		if s.AdmissionReviewVersions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "admissionReviewVersions",
@@ -27,7 +27,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhook) Validate() error {
 		if err := s.ClientConfig.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "clientConfig",
@@ -48,7 +48,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhookConfiguration) Validate() 
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -59,7 +59,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhookConfiguration) Validate() 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "webhooks",
@@ -83,7 +83,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhookConfigurationList) Validat
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -94,7 +94,7 @@ func (s IoK8sAPIAdmissionregistrationV1MutatingWebhookConfigurationList) Validat
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -112,7 +112,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhook) Validate() error {
 		if s.AdmissionReviewVersions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "admissionReviewVersions",
@@ -123,7 +123,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhook) Validate() error {
 		if err := s.ClientConfig.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "clientConfig",
@@ -144,7 +144,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfiguration) Validate(
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -155,7 +155,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfiguration) Validate(
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "webhooks",
@@ -179,7 +179,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfigurationList) Valid
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -190,7 +190,7 @@ func (s IoK8sAPIAdmissionregistrationV1ValidatingWebhookConfigurationList) Valid
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -216,7 +216,7 @@ func (s IoK8sAPIAdmissionregistrationV1WebhookClientConfig) Validate() error {
 		}).Validate(string(s.CaBundle)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caBundle",
@@ -234,7 +234,7 @@ func (s IoK8sAPIApiserverinternalV1alpha1StorageVersionList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -252,7 +252,7 @@ func (s IoK8sAPIAppsV1ControllerRevisionList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -272,13 +272,13 @@ func (s IoK8sAPIAppsV1DaemonSet) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -302,7 +302,7 @@ func (s IoK8sAPIAppsV1DaemonSetList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -313,7 +313,7 @@ func (s IoK8sAPIAppsV1DaemonSetList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -331,7 +331,7 @@ func (s IoK8sAPIAppsV1DaemonSetSpec) Validate() error {
 		if err := s.Template.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -351,13 +351,13 @@ func (s IoK8sAPIAppsV1Deployment) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -381,7 +381,7 @@ func (s IoK8sAPIAppsV1DeploymentList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -392,7 +392,7 @@ func (s IoK8sAPIAppsV1DeploymentList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -410,7 +410,7 @@ func (s IoK8sAPIAppsV1DeploymentSpec) Validate() error {
 		if err := s.Template.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -430,13 +430,13 @@ func (s IoK8sAPIAppsV1ReplicaSet) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -460,7 +460,7 @@ func (s IoK8sAPIAppsV1ReplicaSetList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -471,7 +471,7 @@ func (s IoK8sAPIAppsV1ReplicaSetList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -491,13 +491,13 @@ func (s IoK8sAPIAppsV1ReplicaSetSpec) Validate() error {
 				if err := s.Template.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -517,13 +517,13 @@ func (s IoK8sAPIAppsV1StatefulSet) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -547,7 +547,7 @@ func (s IoK8sAPIAppsV1StatefulSetList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -558,7 +558,7 @@ func (s IoK8sAPIAppsV1StatefulSetList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -576,7 +576,7 @@ func (s IoK8sAPIAppsV1StatefulSetSpec) Validate() error {
 		if err := s.Template.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -594,7 +594,7 @@ func (s IoK8sAPIAutoscalingV1HorizontalPodAutoscalerList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -614,13 +614,13 @@ func (s IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscaler) Validate() error {
 				if err := s.Status.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -644,7 +644,7 @@ func (s IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscalerList) Validate() error 
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -655,7 +655,7 @@ func (s IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscalerList) Validate() error 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -673,7 +673,7 @@ func (s IoK8sAPIAutoscalingV2beta1HorizontalPodAutoscalerStatus) Validate() erro
 		if s.Conditions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conditions",
@@ -693,13 +693,13 @@ func (s IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscaler) Validate() error {
 				if err := s.Status.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -723,7 +723,7 @@ func (s IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscalerList) Validate() error 
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -734,7 +734,7 @@ func (s IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscalerList) Validate() error 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -752,7 +752,7 @@ func (s IoK8sAPIAutoscalingV2beta2HorizontalPodAutoscalerStatus) Validate() erro
 		if s.Conditions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conditions",
@@ -772,13 +772,13 @@ func (s IoK8sAPIBatchV1CronJob) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -802,7 +802,7 @@ func (s IoK8sAPIBatchV1CronJobList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -813,7 +813,7 @@ func (s IoK8sAPIBatchV1CronJobList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -831,7 +831,7 @@ func (s IoK8sAPIBatchV1CronJobSpec) Validate() error {
 		if err := s.JobTemplate.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "jobTemplate",
@@ -851,13 +851,13 @@ func (s IoK8sAPIBatchV1Job) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -881,7 +881,7 @@ func (s IoK8sAPIBatchV1JobList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -892,7 +892,7 @@ func (s IoK8sAPIBatchV1JobList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -910,7 +910,7 @@ func (s IoK8sAPIBatchV1JobSpec) Validate() error {
 		if err := s.Template.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -930,13 +930,13 @@ func (s IoK8sAPIBatchV1JobTemplateSpec) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -956,13 +956,13 @@ func (s IoK8sAPIBatchV1beta1CronJob) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -986,7 +986,7 @@ func (s IoK8sAPIBatchV1beta1CronJobList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -997,7 +997,7 @@ func (s IoK8sAPIBatchV1beta1CronJobList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1015,7 +1015,7 @@ func (s IoK8sAPIBatchV1beta1CronJobSpec) Validate() error {
 		if err := s.JobTemplate.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "jobTemplate",
@@ -1035,13 +1035,13 @@ func (s IoK8sAPIBatchV1beta1JobTemplateSpec) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1059,7 +1059,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequest) Validate() error {
 		if err := s.Spec.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1072,13 +1072,13 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequest) Validate() error {
 				if err := s.Status.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -1102,7 +1102,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1113,7 +1113,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1133,13 +1133,13 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestSpec) Validate() error {
 				if err := s.Extra.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "extra",
@@ -1158,7 +1158,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestSpec) Validate() error {
 		}).Validate(string(s.Request)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "request",
@@ -1177,7 +1177,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestSpecExtra) Validate() err
 			if elem == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -1205,7 +1205,7 @@ func (s IoK8sAPICertificatesV1CertificateSigningRequestStatus) Validate() error 
 		}).Validate(string(s.Certificate)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "certificate",
@@ -1223,7 +1223,7 @@ func (s IoK8sAPICoordinationV1LeaseList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1243,13 +1243,13 @@ func (s IoK8sAPICoreV1Affinity) Validate() error {
 				if err := s.NodeAffinity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nodeAffinity",
@@ -1267,7 +1267,7 @@ func (s IoK8sAPICoreV1CephFSPersistentVolumeSource) Validate() error {
 		if s.Monitors == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "monitors",
@@ -1285,7 +1285,7 @@ func (s IoK8sAPICoreV1CephFSVolumeSource) Validate() error {
 		if s.Monitors == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "monitors",
@@ -1303,7 +1303,7 @@ func (s IoK8sAPICoreV1ComponentStatusList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1323,13 +1323,13 @@ func (s IoK8sAPICoreV1ConfigMap) Validate() error {
 				if err := s.BinaryData.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "binaryData",
@@ -1356,7 +1356,7 @@ func (s IoK8sAPICoreV1ConfigMapBinaryData) Validate() error {
 			}).Validate(string(elem)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -1382,7 +1382,7 @@ func (s IoK8sAPICoreV1ConfigMapList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1393,7 +1393,7 @@ func (s IoK8sAPICoreV1ConfigMapList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1411,7 +1411,7 @@ func (s IoK8sAPICoreV1EndpointsList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1429,7 +1429,7 @@ func (s IoK8sAPICoreV1EventList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1449,13 +1449,13 @@ func (s IoK8sAPICoreV1LimitRange) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1479,7 +1479,7 @@ func (s IoK8sAPICoreV1LimitRangeList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1490,7 +1490,7 @@ func (s IoK8sAPICoreV1LimitRangeList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1508,7 +1508,7 @@ func (s IoK8sAPICoreV1LimitRangeSpec) Validate() error {
 		if s.Limits == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limits",
@@ -1526,7 +1526,7 @@ func (s IoK8sAPICoreV1NamespaceList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1546,13 +1546,13 @@ func (s IoK8sAPICoreV1NodeAffinity) Validate() error {
 				if err := s.RequiredDuringSchedulingIgnoredDuringExecution.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requiredDuringSchedulingIgnoredDuringExecution",
@@ -1570,7 +1570,7 @@ func (s IoK8sAPICoreV1NodeList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1588,7 +1588,7 @@ func (s IoK8sAPICoreV1NodeSelector) Validate() error {
 		if s.NodeSelectorTerms == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nodeSelectorTerms",
@@ -1608,13 +1608,13 @@ func (s IoK8sAPICoreV1PersistentVolume) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1632,7 +1632,7 @@ func (s IoK8sAPICoreV1PersistentVolumeClaimList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1656,7 +1656,7 @@ func (s IoK8sAPICoreV1PersistentVolumeList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1667,7 +1667,7 @@ func (s IoK8sAPICoreV1PersistentVolumeList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1687,13 +1687,13 @@ func (s IoK8sAPICoreV1PersistentVolumeSpec) Validate() error {
 				if err := s.Cephfs.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "cephfs",
@@ -1706,13 +1706,13 @@ func (s IoK8sAPICoreV1PersistentVolumeSpec) Validate() error {
 				if err := s.NodeAffinity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nodeAffinity",
@@ -1725,13 +1725,13 @@ func (s IoK8sAPICoreV1PersistentVolumeSpec) Validate() error {
 				if err := s.Rbd.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rbd",
@@ -1751,13 +1751,13 @@ func (s IoK8sAPICoreV1Pod) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1781,7 +1781,7 @@ func (s IoK8sAPICoreV1PodList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1792,7 +1792,7 @@ func (s IoK8sAPICoreV1PodList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1812,13 +1812,13 @@ func (s IoK8sAPICoreV1PodSpec) Validate() error {
 				if err := s.Affinity.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "affinity",
@@ -1829,7 +1829,7 @@ func (s IoK8sAPICoreV1PodSpec) Validate() error {
 		if s.Containers == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "containers",
@@ -1843,7 +1843,7 @@ func (s IoK8sAPICoreV1PodSpec) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1854,7 +1854,7 @@ func (s IoK8sAPICoreV1PodSpec) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "volumes",
@@ -1874,13 +1874,13 @@ func (s IoK8sAPICoreV1PodTemplate) Validate() error {
 				if err := s.Template.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -1904,7 +1904,7 @@ func (s IoK8sAPICoreV1PodTemplateList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1915,7 +1915,7 @@ func (s IoK8sAPICoreV1PodTemplateList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -1935,13 +1935,13 @@ func (s IoK8sAPICoreV1PodTemplateSpec) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -1959,7 +1959,7 @@ func (s IoK8sAPICoreV1RBDPersistentVolumeSource) Validate() error {
 		if s.Monitors == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "monitors",
@@ -1977,7 +1977,7 @@ func (s IoK8sAPICoreV1RBDVolumeSource) Validate() error {
 		if s.Monitors == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "monitors",
@@ -1997,13 +1997,13 @@ func (s IoK8sAPICoreV1ReplicationController) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -2027,7 +2027,7 @@ func (s IoK8sAPICoreV1ReplicationControllerList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2038,7 +2038,7 @@ func (s IoK8sAPICoreV1ReplicationControllerList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2058,13 +2058,13 @@ func (s IoK8sAPICoreV1ReplicationControllerSpec) Validate() error {
 				if err := s.Template.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "template",
@@ -2082,7 +2082,7 @@ func (s IoK8sAPICoreV1ResourceQuotaList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2102,13 +2102,13 @@ func (s IoK8sAPICoreV1Secret) Validate() error {
 				if err := s.Data.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "data",
@@ -2135,7 +2135,7 @@ func (s IoK8sAPICoreV1SecretData) Validate() error {
 			}).Validate(string(elem)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -2161,7 +2161,7 @@ func (s IoK8sAPICoreV1SecretList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2172,7 +2172,7 @@ func (s IoK8sAPICoreV1SecretList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2190,7 +2190,7 @@ func (s IoK8sAPICoreV1ServiceAccountList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2208,7 +2208,7 @@ func (s IoK8sAPICoreV1ServiceList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2226,7 +2226,7 @@ func (s IoK8sAPICoreV1TopologySelectorLabelRequirement) Validate() error {
 		if s.Values == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "values",
@@ -2247,7 +2247,7 @@ func (s IoK8sAPICoreV1TopologySelectorTerm) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2258,7 +2258,7 @@ func (s IoK8sAPICoreV1TopologySelectorTerm) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "matchLabelExpressions",
@@ -2278,13 +2278,13 @@ func (s IoK8sAPICoreV1Volume) Validate() error {
 				if err := s.Cephfs.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "cephfs",
@@ -2297,13 +2297,13 @@ func (s IoK8sAPICoreV1Volume) Validate() error {
 				if err := s.Rbd.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rbd",
@@ -2323,13 +2323,13 @@ func (s IoK8sAPICoreV1VolumeNodeAffinity) Validate() error {
 				if err := s.Required.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required",
@@ -2347,7 +2347,7 @@ func (s IoK8sAPIDiscoveryV1Endpoint) Validate() error {
 		if s.Addresses == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "addresses",
@@ -2371,7 +2371,7 @@ func (s IoK8sAPIDiscoveryV1EndpointSlice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2382,7 +2382,7 @@ func (s IoK8sAPIDiscoveryV1EndpointSlice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "endpoints",
@@ -2406,7 +2406,7 @@ func (s IoK8sAPIDiscoveryV1EndpointSliceList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2417,7 +2417,7 @@ func (s IoK8sAPIDiscoveryV1EndpointSliceList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2435,7 +2435,7 @@ func (s IoK8sAPIDiscoveryV1beta1Endpoint) Validate() error {
 		if s.Addresses == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "addresses",
@@ -2459,7 +2459,7 @@ func (s IoK8sAPIDiscoveryV1beta1EndpointSlice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2470,7 +2470,7 @@ func (s IoK8sAPIDiscoveryV1beta1EndpointSlice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "endpoints",
@@ -2494,7 +2494,7 @@ func (s IoK8sAPIDiscoveryV1beta1EndpointSliceList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2505,7 +2505,7 @@ func (s IoK8sAPIDiscoveryV1beta1EndpointSliceList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2523,7 +2523,7 @@ func (s IoK8sAPIEventsV1EventList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2541,7 +2541,7 @@ func (s IoK8sAPIEventsV1beta1EventList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2561,13 +2561,13 @@ func (s IoK8sAPIFlowcontrolV1beta1FlowSchema) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -2591,7 +2591,7 @@ func (s IoK8sAPIFlowcontrolV1beta1FlowSchemaList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2602,7 +2602,7 @@ func (s IoK8sAPIFlowcontrolV1beta1FlowSchemaList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2623,7 +2623,7 @@ func (s IoK8sAPIFlowcontrolV1beta1FlowSchemaSpec) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2634,7 +2634,7 @@ func (s IoK8sAPIFlowcontrolV1beta1FlowSchemaSpec) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rules",
@@ -2652,7 +2652,7 @@ func (s IoK8sAPIFlowcontrolV1beta1NonResourcePolicyRule) Validate() error {
 		if s.NonResourceURLs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nonResourceURLs",
@@ -2663,7 +2663,7 @@ func (s IoK8sAPIFlowcontrolV1beta1NonResourcePolicyRule) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -2684,7 +2684,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PolicyRulesWithSubjects) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2695,7 +2695,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PolicyRulesWithSubjects) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nonResourceRules",
@@ -2709,7 +2709,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PolicyRulesWithSubjects) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2720,7 +2720,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PolicyRulesWithSubjects) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resourceRules",
@@ -2731,7 +2731,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PolicyRulesWithSubjects) Validate() error {
 		if s.Subjects == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "subjects",
@@ -2749,7 +2749,7 @@ func (s IoK8sAPIFlowcontrolV1beta1PriorityLevelConfigurationList) Validate() err
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2767,7 +2767,7 @@ func (s IoK8sAPIFlowcontrolV1beta1ResourcePolicyRule) Validate() error {
 		if s.ApiGroups == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apiGroups",
@@ -2778,7 +2778,7 @@ func (s IoK8sAPIFlowcontrolV1beta1ResourcePolicyRule) Validate() error {
 		if s.Resources == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resources",
@@ -2789,7 +2789,7 @@ func (s IoK8sAPIFlowcontrolV1beta1ResourcePolicyRule) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -2809,13 +2809,13 @@ func (s IoK8sAPIFlowcontrolV1beta2FlowSchema) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -2839,7 +2839,7 @@ func (s IoK8sAPIFlowcontrolV1beta2FlowSchemaList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2850,7 +2850,7 @@ func (s IoK8sAPIFlowcontrolV1beta2FlowSchemaList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -2871,7 +2871,7 @@ func (s IoK8sAPIFlowcontrolV1beta2FlowSchemaSpec) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2882,7 +2882,7 @@ func (s IoK8sAPIFlowcontrolV1beta2FlowSchemaSpec) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rules",
@@ -2900,7 +2900,7 @@ func (s IoK8sAPIFlowcontrolV1beta2NonResourcePolicyRule) Validate() error {
 		if s.NonResourceURLs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nonResourceURLs",
@@ -2911,7 +2911,7 @@ func (s IoK8sAPIFlowcontrolV1beta2NonResourcePolicyRule) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -2932,7 +2932,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PolicyRulesWithSubjects) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2943,7 +2943,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PolicyRulesWithSubjects) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nonResourceRules",
@@ -2957,7 +2957,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PolicyRulesWithSubjects) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2968,7 +2968,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PolicyRulesWithSubjects) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resourceRules",
@@ -2979,7 +2979,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PolicyRulesWithSubjects) Validate() error {
 		if s.Subjects == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "subjects",
@@ -2997,7 +2997,7 @@ func (s IoK8sAPIFlowcontrolV1beta2PriorityLevelConfigurationList) Validate() err
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3015,7 +3015,7 @@ func (s IoK8sAPIFlowcontrolV1beta2ResourcePolicyRule) Validate() error {
 		if s.ApiGroups == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "apiGroups",
@@ -3026,7 +3026,7 @@ func (s IoK8sAPIFlowcontrolV1beta2ResourcePolicyRule) Validate() error {
 		if s.Resources == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resources",
@@ -3037,7 +3037,7 @@ func (s IoK8sAPIFlowcontrolV1beta2ResourcePolicyRule) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -3055,7 +3055,7 @@ func (s IoK8sAPINetworkingV1HTTPIngressRuleValue) Validate() error {
 		if s.Paths == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "paths",
@@ -3075,13 +3075,13 @@ func (s IoK8sAPINetworkingV1Ingress) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -3099,7 +3099,7 @@ func (s IoK8sAPINetworkingV1IngressClassList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3123,7 +3123,7 @@ func (s IoK8sAPINetworkingV1IngressList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3134,7 +3134,7 @@ func (s IoK8sAPINetworkingV1IngressList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3154,13 +3154,13 @@ func (s IoK8sAPINetworkingV1IngressRule) Validate() error {
 				if err := s.HTTP.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "http",
@@ -3181,7 +3181,7 @@ func (s IoK8sAPINetworkingV1IngressSpec) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3192,7 +3192,7 @@ func (s IoK8sAPINetworkingV1IngressSpec) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rules",
@@ -3210,7 +3210,7 @@ func (s IoK8sAPINetworkingV1NetworkPolicyList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3228,7 +3228,7 @@ func (s IoK8sAPINodeV1RuntimeClassList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3246,7 +3246,7 @@ func (s IoK8sAPINodeV1alpha1RuntimeClassList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3264,7 +3264,7 @@ func (s IoK8sAPINodeV1beta1RuntimeClassList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3282,7 +3282,7 @@ func (s IoK8sAPIPolicyV1PodDisruptionBudgetList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3300,7 +3300,7 @@ func (s IoK8sAPIPolicyV1beta1PodDisruptionBudgetList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3320,13 +3320,13 @@ func (s IoK8sAPIPolicyV1beta1PodSecurityPolicy) Validate() error {
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -3350,7 +3350,7 @@ func (s IoK8sAPIPolicyV1beta1PodSecurityPolicyList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3361,7 +3361,7 @@ func (s IoK8sAPIPolicyV1beta1PodSecurityPolicyList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3381,13 +3381,13 @@ func (s IoK8sAPIPolicyV1beta1PodSecurityPolicySpec) Validate() error {
 				if err := s.RuntimeClass.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "runtimeClass",
@@ -3405,7 +3405,7 @@ func (s IoK8sAPIPolicyV1beta1RuntimeClassStrategyOptions) Validate() error {
 		if s.AllowedRuntimeClassNames == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowedRuntimeClassNames",
@@ -3426,7 +3426,7 @@ func (s IoK8sAPIRbacV1ClusterRole) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3437,7 +3437,7 @@ func (s IoK8sAPIRbacV1ClusterRole) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rules",
@@ -3455,7 +3455,7 @@ func (s IoK8sAPIRbacV1ClusterRoleBindingList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3479,7 +3479,7 @@ func (s IoK8sAPIRbacV1ClusterRoleList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3490,7 +3490,7 @@ func (s IoK8sAPIRbacV1ClusterRoleList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3508,7 +3508,7 @@ func (s IoK8sAPIRbacV1PolicyRule) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -3529,7 +3529,7 @@ func (s IoK8sAPIRbacV1Role) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3540,7 +3540,7 @@ func (s IoK8sAPIRbacV1Role) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "rules",
@@ -3558,7 +3558,7 @@ func (s IoK8sAPIRbacV1RoleBindingList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3582,7 +3582,7 @@ func (s IoK8sAPIRbacV1RoleList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3593,7 +3593,7 @@ func (s IoK8sAPIRbacV1RoleList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3611,7 +3611,7 @@ func (s IoK8sAPISchedulingV1PriorityClassList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3629,7 +3629,7 @@ func (s IoK8sAPIStorageV1CSIDriverList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3647,7 +3647,7 @@ func (s IoK8sAPIStorageV1CSINode) Validate() error {
 		if err := s.Spec.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -3671,7 +3671,7 @@ func (s IoK8sAPIStorageV1CSINodeList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3682,7 +3682,7 @@ func (s IoK8sAPIStorageV1CSINodeList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3700,7 +3700,7 @@ func (s IoK8sAPIStorageV1CSINodeSpec) Validate() error {
 		if s.Drivers == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "drivers",
@@ -3721,7 +3721,7 @@ func (s IoK8sAPIStorageV1StorageClass) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3732,7 +3732,7 @@ func (s IoK8sAPIStorageV1StorageClass) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allowedTopologies",
@@ -3756,7 +3756,7 @@ func (s IoK8sAPIStorageV1StorageClassList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3767,7 +3767,7 @@ func (s IoK8sAPIStorageV1StorageClassList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3785,7 +3785,7 @@ func (s IoK8sAPIStorageV1VolumeAttachment) Validate() error {
 		if err := s.Spec.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -3809,7 +3809,7 @@ func (s IoK8sAPIStorageV1VolumeAttachmentList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3820,7 +3820,7 @@ func (s IoK8sAPIStorageV1VolumeAttachmentList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3840,13 +3840,13 @@ func (s IoK8sAPIStorageV1VolumeAttachmentSource) Validate() error {
 				if err := s.InlineVolumeSpec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "inlineVolumeSpec",
@@ -3864,7 +3864,7 @@ func (s IoK8sAPIStorageV1VolumeAttachmentSpec) Validate() error {
 		if err := s.Source.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "source",
@@ -3882,7 +3882,7 @@ func (s IoK8sAPIStorageV1alpha1CSIStorageCapacityList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3900,7 +3900,7 @@ func (s IoK8sAPIStorageV1beta1CSIStorageCapacityList) Validate() error {
 		if s.Items == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3920,13 +3920,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceConversio
 				if err := s.Webhook.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "webhook",
@@ -3944,7 +3944,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 		if err := s.Spec.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -3968,7 +3968,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3979,7 +3979,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -3999,13 +3999,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 				if err := s.Conversion.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conversion",
@@ -4022,7 +4022,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4033,7 +4033,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "versions",
@@ -4053,13 +4053,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceDefinitio
 				if err := s.Schema.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schema",
@@ -4079,13 +4079,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceValidatio
 				if err := s.OpenAPIV3Schema.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "openAPIV3Schema",
@@ -4106,7 +4106,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4117,7 +4117,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allOf",
@@ -4131,7 +4131,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4142,7 +4142,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "anyOf",
@@ -4155,13 +4155,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := s.Definitions.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "definitions",
@@ -4174,13 +4174,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := (validate.Float{}).Validate(float64(s.Maximum.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "maximum",
@@ -4193,13 +4193,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := (validate.Float{}).Validate(float64(s.Minimum.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minimum",
@@ -4212,13 +4212,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := (validate.Float{}).Validate(float64(s.MultipleOf.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "multipleOf",
@@ -4233,11 +4233,11 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 			if err := s.Not.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "not",
@@ -4251,7 +4251,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4262,7 +4262,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "oneOf",
@@ -4275,13 +4275,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := s.PatternProperties.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "patternProperties",
@@ -4294,13 +4294,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaProps) Valida
 				if err := s.Properties.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "properties",
@@ -4319,7 +4319,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsDefiniti
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -4340,7 +4340,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsPatternP
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -4361,7 +4361,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsProperti
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -4389,7 +4389,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1WebhookClientConfig) Va
 		}).Validate(string(s.CaBundle)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caBundle",
@@ -4409,13 +4409,13 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1WebhookConversion) Vali
 				if err := s.ClientConfig.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "clientConfig",
@@ -4426,7 +4426,7 @@ func (s IoK8sApiextensionsApiserverPkgApisApiextensionsV1WebhookConversion) Vali
 		if s.ConversionReviewVersions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "conversionReviewVersions",
@@ -4444,7 +4444,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIGroup) Validate() error {
 		if s.Versions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "versions",
@@ -4468,7 +4468,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIGroupList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4479,7 +4479,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIGroupList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "groups",
@@ -4497,7 +4497,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIResource) Validate() error {
 		if s.Verbs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "verbs",
@@ -4521,7 +4521,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIResourceList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4532,7 +4532,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIResourceList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "resources",
@@ -4550,7 +4550,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIVersions) Validate() error {
 		if s.ServerAddressByClientCIDRs == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "serverAddressByClientCIDRs",
@@ -4561,7 +4561,7 @@ func (s IoK8sApimachineryPkgApisMetaV1APIVersions) Validate() error {
 		if s.Versions == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "versions",
@@ -4581,13 +4581,13 @@ func (s IoK8sKubeAggregatorPkgApisApiregistrationV1APIService) Validate() error 
 				if err := s.Spec.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "spec",
@@ -4611,7 +4611,7 @@ func (s IoK8sKubeAggregatorPkgApisApiregistrationV1APIServiceList) Validate() er
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4622,7 +4622,7 @@ func (s IoK8sKubeAggregatorPkgApisApiregistrationV1APIServiceList) Validate() er
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -4648,7 +4648,7 @@ func (s IoK8sKubeAggregatorPkgApisApiregistrationV1APIServiceSpec) Validate() er
 		}).Validate(string(s.CaBundle)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caBundle",

--- a/examples/ex_manga/oas_handlers_gen.go
+++ b/examples/ex_manga/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleGetBookRequest(args [1]string, w http.ResponseWriter, r *
 	params, err := decodeGetBookParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GetBook",
-			err,
+			Operation: "GetBook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleSearchRequest(args [0]string, w http.ResponseWriter, r *h
 	params, err := decodeSearchParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"Search",
-			err,
+			Operation: "Search",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -124,8 +124,8 @@ func (s *Server) handleSearchByTagIDRequest(args [0]string, w http.ResponseWrite
 	params, err := decodeSearchByTagIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SearchByTagID",
-			err,
+			Operation: "SearchByTagID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_manga/oas_validators_gen.go
+++ b/examples/ex_manga/oas_validators_gen.go
@@ -27,13 +27,13 @@ func (s Book) Validate() error {
 				}).Validate(int64(s.ID.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -55,13 +55,13 @@ func (s Book) Validate() error {
 				}).Validate(int64(s.MediaID.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "media_id",
@@ -74,13 +74,13 @@ func (s Book) Validate() error {
 				if err := s.Images.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "images",
@@ -94,7 +94,7 @@ func (s Book) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -105,7 +105,7 @@ func (s Book) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tags",
@@ -127,13 +127,13 @@ func (s Book) Validate() error {
 				}).Validate(int64(s.NumPages.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "num_pages",
@@ -155,13 +155,13 @@ func (s Book) Validate() error {
 				}).Validate(int64(s.NumFavorites.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "num_favorites",
@@ -190,13 +190,13 @@ func (s Image) Validate() error {
 				}).Validate(int64(s.W.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "w",
@@ -218,13 +218,13 @@ func (s Image) Validate() error {
 				}).Validate(int64(s.H.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "h",
@@ -245,7 +245,7 @@ func (s Images) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -256,7 +256,7 @@ func (s Images) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pages",
@@ -269,13 +269,13 @@ func (s Images) Validate() error {
 				if err := s.Cover.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "cover",
@@ -288,13 +288,13 @@ func (s Images) Validate() error {
 				if err := s.Thumbnail.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumbnail",
@@ -317,7 +317,7 @@ func (s SearchByTagIDOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -328,7 +328,7 @@ func (s SearchByTagIDOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s SearchOKApplicationJSON) Validate() error {
 	if s == nil {
@@ -340,7 +340,7 @@ func (s SearchOKApplicationJSON) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -351,7 +351,7 @@ func (s SearchOKApplicationJSON) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s SearchResponse) Validate() error {
 	var failures []validate.FieldError
@@ -362,7 +362,7 @@ func (s SearchResponse) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -373,7 +373,7 @@ func (s SearchResponse) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -402,13 +402,13 @@ func (s Tag) Validate() error {
 				}).Validate(int64(s.ID.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -421,13 +421,13 @@ func (s Tag) Validate() error {
 				if err := s.Type.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",

--- a/examples/ex_openapi/output.gen.go
+++ b/examples/ex_openapi/output.gen.go
@@ -14924,7 +14924,7 @@ func (s Callback) Validate() error {
 		if err := s.Pattern0Props.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Pattern0Props",
@@ -14942,7 +14942,7 @@ func (s CallbackOrReference) Validate() error {
 		if err := s.Callback.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceCallbackOrReference:
 		return nil // no validation needed
 	default:
@@ -14957,7 +14957,7 @@ func (s CallbackPattern0) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -14978,7 +14978,7 @@ func (s CallbacksOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15000,13 +15000,13 @@ func (s Components) Validate() error {
 				if err := s.Schemas.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schemas",
@@ -15019,13 +15019,13 @@ func (s Components) Validate() error {
 				if err := s.Responses.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "responses",
@@ -15038,13 +15038,13 @@ func (s Components) Validate() error {
 				if err := s.Parameters.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parameters",
@@ -15057,13 +15057,13 @@ func (s Components) Validate() error {
 				if err := s.RequestBodies.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requestBodies",
@@ -15076,13 +15076,13 @@ func (s Components) Validate() error {
 				if err := s.Headers.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "headers",
@@ -15095,13 +15095,13 @@ func (s Components) Validate() error {
 				if err := s.Callbacks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callbacks",
@@ -15121,13 +15121,13 @@ func (s Encoding) Validate() error {
 				if err := s.Headers.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "headers",
@@ -15146,7 +15146,7 @@ func (s Encodings) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15168,13 +15168,13 @@ func (s Header) Validate() error {
 				if err := s.Schema.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schema",
@@ -15187,13 +15187,13 @@ func (s Header) Validate() error {
 				if err := s.Content.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -15211,7 +15211,7 @@ func (s HeaderOrReference) Validate() error {
 		if err := s.Header.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceHeaderOrReference:
 		return nil // no validation needed
 	default:
@@ -15226,7 +15226,7 @@ func (s HeadersOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15252,19 +15252,19 @@ func (s JsonschemaDraft4PropertiesEnum) Validate() error {
 	}).ValidateLength(len(s)); err != nil {
 		return errors.Wrap(err, "array")
 	}
-	return nil
+	return nil // return 1
 }
 func (s JsonschemaDraft4PropertiesMaximum) Validate() error {
 	if err := (validate.Float{}).Validate(float64(s)); err != nil {
 		return errors.Wrap(err, "float")
 	}
-	return nil
+	return nil // return 1
 }
 func (s JsonschemaDraft4PropertiesMinimum) Validate() error {
 	if err := (validate.Float{}).Validate(float64(s)); err != nil {
 		return errors.Wrap(err, "float")
 	}
-	return nil
+	return nil // return 1
 }
 func (s JsonschemaDraft4PropertiesMultipleOf) Validate() error {
 	if err := (validate.Float{
@@ -15279,7 +15279,7 @@ func (s JsonschemaDraft4PropertiesMultipleOf) Validate() error {
 	}).Validate(float64(s)); err != nil {
 		return errors.Wrap(err, "float")
 	}
-	return nil
+	return nil // return 1
 }
 func (s MediaType) Validate() error {
 	var failures []validate.FieldError
@@ -15289,13 +15289,13 @@ func (s MediaType) Validate() error {
 				if err := s.Schema.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schema",
@@ -15308,13 +15308,13 @@ func (s MediaType) Validate() error {
 				if err := s.Encoding.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "encoding",
@@ -15333,7 +15333,7 @@ func (s MediaTypes) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15356,7 +15356,7 @@ func (s Operation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15367,7 +15367,7 @@ func (s Operation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parameters",
@@ -15380,13 +15380,13 @@ func (s Operation) Validate() error {
 				if err := s.RequestBody.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "requestBody",
@@ -15397,7 +15397,7 @@ func (s Operation) Validate() error {
 		if err := s.Responses.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "responses",
@@ -15410,13 +15410,13 @@ func (s Operation) Validate() error {
 				if err := s.Callbacks.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callbacks",
@@ -15430,7 +15430,7 @@ func (s Operation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15441,7 +15441,7 @@ func (s Operation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "security",
@@ -15460,7 +15460,7 @@ func (s Parameter) Validate() error {
 		if err := s.In.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "in",
@@ -15473,13 +15473,13 @@ func (s Parameter) Validate() error {
 				if err := s.Style.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "style",
@@ -15492,13 +15492,13 @@ func (s Parameter) Validate() error {
 				if err := s.Schema.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "schema",
@@ -15511,13 +15511,13 @@ func (s Parameter) Validate() error {
 				if err := s.Content.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -15549,7 +15549,7 @@ func (s ParameterOrReference) Validate() error {
 		if err := s.Parameter.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceParameterOrReference:
 		return nil // no validation needed
 	default:
@@ -15584,7 +15584,7 @@ func (s ParametersOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15606,13 +15606,13 @@ func (s PathItem) Validate() error {
 				if err := s.Get.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "get",
@@ -15625,13 +15625,13 @@ func (s PathItem) Validate() error {
 				if err := s.Put.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "put",
@@ -15644,13 +15644,13 @@ func (s PathItem) Validate() error {
 				if err := s.Post.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "post",
@@ -15663,13 +15663,13 @@ func (s PathItem) Validate() error {
 				if err := s.Delete.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "delete",
@@ -15682,13 +15682,13 @@ func (s PathItem) Validate() error {
 				if err := s.Options.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "options",
@@ -15701,13 +15701,13 @@ func (s PathItem) Validate() error {
 				if err := s.Head.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "head",
@@ -15720,13 +15720,13 @@ func (s PathItem) Validate() error {
 				if err := s.Patch.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "patch",
@@ -15739,13 +15739,13 @@ func (s PathItem) Validate() error {
 				if err := s.Trace.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "trace",
@@ -15759,7 +15759,7 @@ func (s PathItem) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15770,7 +15770,7 @@ func (s PathItem) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "parameters",
@@ -15788,7 +15788,7 @@ func (s Paths) Validate() error {
 		if err := s.Pattern0Props.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Pattern0Props",
@@ -15807,7 +15807,7 @@ func (s PathsPattern0) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15834,7 +15834,7 @@ func (s PositiveInteger) Validate() error {
 	}).Validate(int64(s)); err != nil {
 		return errors.Wrap(err, "int")
 	}
-	return nil
+	return nil // return 1
 }
 func (s RequestBodiesOrReferences) Validate() error {
 	var failures []validate.FieldError
@@ -15843,7 +15843,7 @@ func (s RequestBodiesOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -15863,7 +15863,7 @@ func (s RequestBody) Validate() error {
 		if err := s.Content.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -15881,7 +15881,7 @@ func (s RequestBodyOrReference) Validate() error {
 		if err := s.RequestBody.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceRequestBodyOrReference:
 		return nil // no validation needed
 	default:
@@ -15897,13 +15897,13 @@ func (s Response) Validate() error {
 				if err := s.Headers.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "headers",
@@ -15916,13 +15916,13 @@ func (s Response) Validate() error {
 				if err := s.Content.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "content",
@@ -15940,7 +15940,7 @@ func (s ResponseOrReference) Validate() error {
 		if err := s.Response.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceResponseOrReference:
 		return nil // no validation needed
 	default:
@@ -15956,13 +15956,13 @@ func (s Responses) Validate() error {
 				if err := s.Default.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "default",
@@ -15973,7 +15973,7 @@ func (s Responses) Validate() error {
 		if err := s.Pattern0Props.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Pattern0Props",
@@ -15992,7 +15992,7 @@ func (s ResponsesOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -16013,7 +16013,7 @@ func (s ResponsesPattern0) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -16035,13 +16035,13 @@ func (s Schema) Validate() error {
 				if err := s.MultipleOf.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "multipleOf",
@@ -16054,13 +16054,13 @@ func (s Schema) Validate() error {
 				if err := s.Maximum.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "maximum",
@@ -16073,13 +16073,13 @@ func (s Schema) Validate() error {
 				if err := s.Minimum.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minimum",
@@ -16092,13 +16092,13 @@ func (s Schema) Validate() error {
 				if err := s.MaxLength.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "maxLength",
@@ -16111,13 +16111,13 @@ func (s Schema) Validate() error {
 				if err := s.MinLength.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minLength",
@@ -16130,13 +16130,13 @@ func (s Schema) Validate() error {
 				if err := s.MaxItems.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "maxItems",
@@ -16149,13 +16149,13 @@ func (s Schema) Validate() error {
 				if err := s.MinItems.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minItems",
@@ -16168,13 +16168,13 @@ func (s Schema) Validate() error {
 				if err := s.MaxProperties.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "maxProperties",
@@ -16187,13 +16187,13 @@ func (s Schema) Validate() error {
 				if err := s.MinProperties.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minProperties",
@@ -16208,11 +16208,11 @@ func (s Schema) Validate() error {
 			if err := s.Required.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required",
@@ -16227,11 +16227,11 @@ func (s Schema) Validate() error {
 			if err := s.Enum.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enum",
@@ -16244,13 +16244,13 @@ func (s Schema) Validate() error {
 				if err := s.Type.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -16272,7 +16272,7 @@ func (s Schema) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16283,7 +16283,7 @@ func (s Schema) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "allOf",
@@ -16305,7 +16305,7 @@ func (s Schema) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16316,7 +16316,7 @@ func (s Schema) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "oneOf",
@@ -16338,7 +16338,7 @@ func (s Schema) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16349,7 +16349,7 @@ func (s Schema) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "anyOf",
@@ -16364,11 +16364,11 @@ func (s Schema) Validate() error {
 			if err := s.Not.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "not",
@@ -16383,11 +16383,11 @@ func (s Schema) Validate() error {
 			if err := s.Items.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "items",
@@ -16400,13 +16400,13 @@ func (s Schema) Validate() error {
 				if err := s.Properties.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "properties",
@@ -16421,11 +16421,11 @@ func (s Schema) Validate() error {
 			if err := s.AdditionalProperties.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "additionalProperties",
@@ -16443,7 +16443,7 @@ func (s SchemaAdditionalProperties) Validate() error {
 		if err := s.SchemaOrReference.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case BoolSchemaAdditionalProperties:
 		return nil // no validation needed
 	default:
@@ -16457,7 +16457,7 @@ func (s SchemaOrReference) Validate() error {
 		if err := s.Schema.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReferenceSchemaOrReference:
 		return nil // no validation needed
 	default:
@@ -16472,7 +16472,7 @@ func (s SchemaProperties) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -16513,7 +16513,7 @@ func (s SchemasOrReferences) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -16534,7 +16534,7 @@ func (s SecurityRequirement) Validate() error {
 			if elem == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -16554,7 +16554,7 @@ func (s Spec) Validate() error {
 		if err := s.Paths.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "paths",
@@ -16567,13 +16567,13 @@ func (s Spec) Validate() error {
 				if err := s.Components.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "components",
@@ -16587,7 +16587,7 @@ func (s Spec) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16598,7 +16598,7 @@ func (s Spec) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "security",
@@ -16622,5 +16622,5 @@ func (s StringArray) Validate() error {
 	}).ValidateLength(len(s)); err != nil {
 		return errors.Wrap(err, "array")
 	}
-	return nil
+	return nil // return 1
 }

--- a/examples/ex_petstore/oas_handlers_gen.go
+++ b/examples/ex_petstore/oas_handlers_gen.go
@@ -70,8 +70,8 @@ func (s *Server) handleListPetsRequest(args [0]string, w http.ResponseWriter, r 
 	params, err := decodeListPetsParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ListPets",
-			err,
+			Operation: "ListPets",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -115,8 +115,8 @@ func (s *Server) handleShowPetByIdRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodeShowPetByIdParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"ShowPetById",
-			err,
+			Operation: "ShowPetById",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_petstore/oas_validators_gen.go
+++ b/examples/ex_petstore/oas_validators_gen.go
@@ -10,5 +10,5 @@ func (s Pets) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }

--- a/examples/ex_petstore_expanded/oas_handlers_gen.go
+++ b/examples/ex_petstore_expanded/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleDeletePetRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeDeletePetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DeletePet",
-			err,
+			Operation: "DeletePet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_route_params/oas_handlers_gen.go
+++ b/examples/ex_route_params/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleDataGetRequest(args [2]string, w http.ResponseWriter, r *
 	params, err := decodeDataGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DataGet",
-			err,
+			Operation: "DataGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -115,8 +115,8 @@ func (s *Server) handleDataGetIDRequest(args [1]string, w http.ResponseWriter, r
 	params, err := decodeDataGetIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DataGetID",
-			err,
+			Operation: "DataGetID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_telegram/oas_client_gen.go
+++ b/examples/ex_telegram/oas_client_gen.go
@@ -59,7 +59,7 @@ func (c *Client) AddStickerToSet(ctx context.Context, request AddStickerToSet) (
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -124,7 +124,7 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request AnswerCallback
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -189,7 +189,7 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request AnswerInlineQuer
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -311,7 +311,7 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request AnswerShipping
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -590,7 +590,7 @@ func (c *Client) CopyMessage(ctx context.Context, request CopyMessage) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -655,7 +655,7 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request CreateChatInv
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -720,7 +720,7 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request CreateNewStick
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1184,7 +1184,7 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request EditChatInviteL
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1249,7 +1249,7 @@ func (c *Client) EditMessageCaption(ctx context.Context, request EditMessageCapt
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1314,7 +1314,7 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request EditMessag
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1379,7 +1379,7 @@ func (c *Client) EditMessageMedia(ctx context.Context, request EditMessageMedia)
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1444,7 +1444,7 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request EditMessage
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1509,7 +1509,7 @@ func (c *Client) EditMessageText(ctx context.Context, request EditMessageText) (
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2189,13 +2189,13 @@ func (c *Client) GetUpdates(ctx context.Context, request OptGetUpdates) (res Res
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2260,7 +2260,7 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request GetUserProfil
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2696,7 +2696,7 @@ func (c *Client) SendAnimation(ctx context.Context, request SendAnimation) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2761,7 +2761,7 @@ func (c *Client) SendAudio(ctx context.Context, request SendAudio) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2883,7 +2883,7 @@ func (c *Client) SendContact(ctx context.Context, request SendContact) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2948,7 +2948,7 @@ func (c *Client) SendDice(ctx context.Context, request SendDice) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3013,7 +3013,7 @@ func (c *Client) SendDocument(ctx context.Context, request SendDocument) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3078,7 +3078,7 @@ func (c *Client) SendGame(ctx context.Context, request SendGame) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3143,7 +3143,7 @@ func (c *Client) SendInvoice(ctx context.Context, request SendInvoice) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3208,7 +3208,7 @@ func (c *Client) SendLocation(ctx context.Context, request SendLocation) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3273,7 +3273,7 @@ func (c *Client) SendMediaGroup(ctx context.Context, request SendMediaGroup) (re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3338,7 +3338,7 @@ func (c *Client) SendMessage(ctx context.Context, request SendMessage) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3403,7 +3403,7 @@ func (c *Client) SendPhoto(ctx context.Context, request SendPhoto) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3468,7 +3468,7 @@ func (c *Client) SendPoll(ctx context.Context, request SendPoll) (res ResultMess
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3533,7 +3533,7 @@ func (c *Client) SendSticker(ctx context.Context, request SendSticker) (res Resu
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3598,7 +3598,7 @@ func (c *Client) SendVenue(ctx context.Context, request SendVenue) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3663,7 +3663,7 @@ func (c *Client) SendVideo(ctx context.Context, request SendVideo) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3728,7 +3728,7 @@ func (c *Client) SendVideoNote(ctx context.Context, request SendVideoNote) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3793,7 +3793,7 @@ func (c *Client) SendVoice(ctx context.Context, request SendVoice) (res ResultMe
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3858,7 +3858,7 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request Se
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3923,7 +3923,7 @@ func (c *Client) SetChatDescription(ctx context.Context, request SetChatDescript
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4159,7 +4159,7 @@ func (c *Client) SetChatTitle(ctx context.Context, request SetChatTitle) (res Re
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4281,7 +4281,7 @@ func (c *Client) SetMyCommands(ctx context.Context, request SetMyCommands) (res 
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4346,7 +4346,7 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request SetPassportD
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4582,7 +4582,7 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request StopMessag
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4647,7 +4647,7 @@ func (c *Client) StopPoll(ctx context.Context, request StopPoll) (res ResultPoll
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_telegram/oas_handlers_gen.go
+++ b/examples/ex_telegram/oas_handlers_gen.go
@@ -36,8 +36,8 @@ func (s *Server) handleAddStickerToSetRequest(args [0]string, w http.ResponseWri
 	request, err := decodeAddStickerToSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AddStickerToSet",
-			err,
+			Operation: "AddStickerToSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -90,8 +90,8 @@ func (s *Server) handleAnswerCallbackQueryRequest(args [0]string, w http.Respons
 	request, err := decodeAnswerCallbackQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerCallbackQuery",
-			err,
+			Operation: "AnswerCallbackQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -144,8 +144,8 @@ func (s *Server) handleAnswerInlineQueryRequest(args [0]string, w http.ResponseW
 	request, err := decodeAnswerInlineQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerInlineQuery",
-			err,
+			Operation: "AnswerInlineQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -198,8 +198,8 @@ func (s *Server) handleAnswerPreCheckoutQueryRequest(args [0]string, w http.Resp
 	request, err := decodeAnswerPreCheckoutQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerPreCheckoutQuery",
-			err,
+			Operation: "AnswerPreCheckoutQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -252,8 +252,8 @@ func (s *Server) handleAnswerShippingQueryRequest(args [0]string, w http.Respons
 	request, err := decodeAnswerShippingQueryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"AnswerShippingQuery",
-			err,
+			Operation: "AnswerShippingQuery",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -306,8 +306,8 @@ func (s *Server) handleApproveChatJoinRequestRequest(args [0]string, w http.Resp
 	request, err := decodeApproveChatJoinRequestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ApproveChatJoinRequest",
-			err,
+			Operation: "ApproveChatJoinRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -360,8 +360,8 @@ func (s *Server) handleBanChatMemberRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeBanChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"BanChatMember",
-			err,
+			Operation: "BanChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -414,8 +414,8 @@ func (s *Server) handleBanChatSenderChatRequest(args [0]string, w http.ResponseW
 	request, err := decodeBanChatSenderChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"BanChatSenderChat",
-			err,
+			Operation: "BanChatSenderChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -513,8 +513,8 @@ func (s *Server) handleCopyMessageRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeCopyMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CopyMessage",
-			err,
+			Operation: "CopyMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -567,8 +567,8 @@ func (s *Server) handleCreateChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeCreateChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateChatInviteLink",
-			err,
+			Operation: "CreateChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -621,8 +621,8 @@ func (s *Server) handleCreateNewStickerSetRequest(args [0]string, w http.Respons
 	request, err := decodeCreateNewStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"CreateNewStickerSet",
-			err,
+			Operation: "CreateNewStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -675,8 +675,8 @@ func (s *Server) handleDeclineChatJoinRequestRequest(args [0]string, w http.Resp
 	request, err := decodeDeclineChatJoinRequestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeclineChatJoinRequest",
-			err,
+			Operation: "DeclineChatJoinRequest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -729,8 +729,8 @@ func (s *Server) handleDeleteChatPhotoRequest(args [0]string, w http.ResponseWri
 	request, err := decodeDeleteChatPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteChatPhoto",
-			err,
+			Operation: "DeleteChatPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -783,8 +783,8 @@ func (s *Server) handleDeleteChatStickerSetRequest(args [0]string, w http.Respon
 	request, err := decodeDeleteChatStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteChatStickerSet",
-			err,
+			Operation: "DeleteChatStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -837,8 +837,8 @@ func (s *Server) handleDeleteMessageRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeDeleteMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteMessage",
-			err,
+			Operation: "DeleteMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -891,8 +891,8 @@ func (s *Server) handleDeleteMyCommandsRequest(args [0]string, w http.ResponseWr
 	request, err := decodeDeleteMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteMyCommands",
-			err,
+			Operation: "DeleteMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -945,8 +945,8 @@ func (s *Server) handleDeleteStickerFromSetRequest(args [0]string, w http.Respon
 	request, err := decodeDeleteStickerFromSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteStickerFromSet",
-			err,
+			Operation: "DeleteStickerFromSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -999,8 +999,8 @@ func (s *Server) handleDeleteWebhookRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeDeleteWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DeleteWebhook",
-			err,
+			Operation: "DeleteWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1053,8 +1053,8 @@ func (s *Server) handleEditChatInviteLinkRequest(args [0]string, w http.Response
 	request, err := decodeEditChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditChatInviteLink",
-			err,
+			Operation: "EditChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1107,8 +1107,8 @@ func (s *Server) handleEditMessageCaptionRequest(args [0]string, w http.Response
 	request, err := decodeEditMessageCaptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageCaption",
-			err,
+			Operation: "EditMessageCaption",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1161,8 +1161,8 @@ func (s *Server) handleEditMessageLiveLocationRequest(args [0]string, w http.Res
 	request, err := decodeEditMessageLiveLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageLiveLocation",
-			err,
+			Operation: "EditMessageLiveLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1215,8 +1215,8 @@ func (s *Server) handleEditMessageMediaRequest(args [0]string, w http.ResponseWr
 	request, err := decodeEditMessageMediaRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageMedia",
-			err,
+			Operation: "EditMessageMedia",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1269,8 +1269,8 @@ func (s *Server) handleEditMessageReplyMarkupRequest(args [0]string, w http.Resp
 	request, err := decodeEditMessageReplyMarkupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageReplyMarkup",
-			err,
+			Operation: "EditMessageReplyMarkup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1323,8 +1323,8 @@ func (s *Server) handleEditMessageTextRequest(args [0]string, w http.ResponseWri
 	request, err := decodeEditMessageTextRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"EditMessageText",
-			err,
+			Operation: "EditMessageText",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1377,8 +1377,8 @@ func (s *Server) handleExportChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeExportChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ExportChatInviteLink",
-			err,
+			Operation: "ExportChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1431,8 +1431,8 @@ func (s *Server) handleForwardMessageRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeForwardMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"ForwardMessage",
-			err,
+			Operation: "ForwardMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1485,8 +1485,8 @@ func (s *Server) handleGetChatRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodeGetChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChat",
-			err,
+			Operation: "GetChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1539,8 +1539,8 @@ func (s *Server) handleGetChatAdministratorsRequest(args [0]string, w http.Respo
 	request, err := decodeGetChatAdministratorsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatAdministrators",
-			err,
+			Operation: "GetChatAdministrators",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1593,8 +1593,8 @@ func (s *Server) handleGetChatMemberRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatMember",
-			err,
+			Operation: "GetChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1647,8 +1647,8 @@ func (s *Server) handleGetChatMemberCountRequest(args [0]string, w http.Response
 	request, err := decodeGetChatMemberCountRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetChatMemberCount",
-			err,
+			Operation: "GetChatMemberCount",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1701,8 +1701,8 @@ func (s *Server) handleGetFileRequest(args [0]string, w http.ResponseWriter, r *
 	request, err := decodeGetFileRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetFile",
-			err,
+			Operation: "GetFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1755,8 +1755,8 @@ func (s *Server) handleGetGameHighScoresRequest(args [0]string, w http.ResponseW
 	request, err := decodeGetGameHighScoresRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetGameHighScores",
-			err,
+			Operation: "GetGameHighScores",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1854,8 +1854,8 @@ func (s *Server) handleGetMyCommandsRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetMyCommands",
-			err,
+			Operation: "GetMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1908,8 +1908,8 @@ func (s *Server) handleGetStickerSetRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeGetStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetStickerSet",
-			err,
+			Operation: "GetStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1962,8 +1962,8 @@ func (s *Server) handleGetUpdatesRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeGetUpdatesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetUpdates",
-			err,
+			Operation: "GetUpdates",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2016,8 +2016,8 @@ func (s *Server) handleGetUserProfilePhotosRequest(args [0]string, w http.Respon
 	request, err := decodeGetUserProfilePhotosRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"GetUserProfilePhotos",
-			err,
+			Operation: "GetUserProfilePhotos",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2115,8 +2115,8 @@ func (s *Server) handleLeaveChatRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeLeaveChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"LeaveChat",
-			err,
+			Operation: "LeaveChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2214,8 +2214,8 @@ func (s *Server) handlePinChatMessageRequest(args [0]string, w http.ResponseWrit
 	request, err := decodePinChatMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PinChatMessage",
-			err,
+			Operation: "PinChatMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2268,8 +2268,8 @@ func (s *Server) handlePromoteChatMemberRequest(args [0]string, w http.ResponseW
 	request, err := decodePromoteChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PromoteChatMember",
-			err,
+			Operation: "PromoteChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2322,8 +2322,8 @@ func (s *Server) handleRestrictChatMemberRequest(args [0]string, w http.Response
 	request, err := decodeRestrictChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"RestrictChatMember",
-			err,
+			Operation: "RestrictChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2376,8 +2376,8 @@ func (s *Server) handleRevokeChatInviteLinkRequest(args [0]string, w http.Respon
 	request, err := decodeRevokeChatInviteLinkRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"RevokeChatInviteLink",
-			err,
+			Operation: "RevokeChatInviteLink",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2430,8 +2430,8 @@ func (s *Server) handleSendAnimationRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSendAnimationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendAnimation",
-			err,
+			Operation: "SendAnimation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2484,8 +2484,8 @@ func (s *Server) handleSendAudioRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendAudioRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendAudio",
-			err,
+			Operation: "SendAudio",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2538,8 +2538,8 @@ func (s *Server) handleSendChatActionRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeSendChatActionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendChatAction",
-			err,
+			Operation: "SendChatAction",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2592,8 +2592,8 @@ func (s *Server) handleSendContactRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendContactRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendContact",
-			err,
+			Operation: "SendContact",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2646,8 +2646,8 @@ func (s *Server) handleSendDiceRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendDiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendDice",
-			err,
+			Operation: "SendDice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2700,8 +2700,8 @@ func (s *Server) handleSendDocumentRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSendDocumentRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendDocument",
-			err,
+			Operation: "SendDocument",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2754,8 +2754,8 @@ func (s *Server) handleSendGameRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendGameRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendGame",
-			err,
+			Operation: "SendGame",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2808,8 +2808,8 @@ func (s *Server) handleSendInvoiceRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendInvoiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendInvoice",
-			err,
+			Operation: "SendInvoice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2862,8 +2862,8 @@ func (s *Server) handleSendLocationRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSendLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendLocation",
-			err,
+			Operation: "SendLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2916,8 +2916,8 @@ func (s *Server) handleSendMediaGroupRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeSendMediaGroupRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendMediaGroup",
-			err,
+			Operation: "SendMediaGroup",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2970,8 +2970,8 @@ func (s *Server) handleSendMessageRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendMessage",
-			err,
+			Operation: "SendMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3024,8 +3024,8 @@ func (s *Server) handleSendPhotoRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendPhoto",
-			err,
+			Operation: "SendPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3078,8 +3078,8 @@ func (s *Server) handleSendPollRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeSendPollRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendPoll",
-			err,
+			Operation: "SendPoll",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3132,8 +3132,8 @@ func (s *Server) handleSendStickerRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeSendStickerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendSticker",
-			err,
+			Operation: "SendSticker",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3186,8 +3186,8 @@ func (s *Server) handleSendVenueRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVenueRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVenue",
-			err,
+			Operation: "SendVenue",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3240,8 +3240,8 @@ func (s *Server) handleSendVideoRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVideoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVideo",
-			err,
+			Operation: "SendVideo",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3294,8 +3294,8 @@ func (s *Server) handleSendVideoNoteRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSendVideoNoteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVideoNote",
-			err,
+			Operation: "SendVideoNote",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3348,8 +3348,8 @@ func (s *Server) handleSendVoiceRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodeSendVoiceRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SendVoice",
-			err,
+			Operation: "SendVoice",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3402,8 +3402,8 @@ func (s *Server) handleSetChatAdministratorCustomTitleRequest(args [0]string, w 
 	request, err := decodeSetChatAdministratorCustomTitleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatAdministratorCustomTitle",
-			err,
+			Operation: "SetChatAdministratorCustomTitle",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3456,8 +3456,8 @@ func (s *Server) handleSetChatDescriptionRequest(args [0]string, w http.Response
 	request, err := decodeSetChatDescriptionRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatDescription",
-			err,
+			Operation: "SetChatDescription",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3510,8 +3510,8 @@ func (s *Server) handleSetChatPermissionsRequest(args [0]string, w http.Response
 	request, err := decodeSetChatPermissionsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatPermissions",
-			err,
+			Operation: "SetChatPermissions",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3564,8 +3564,8 @@ func (s *Server) handleSetChatPhotoRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetChatPhotoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatPhoto",
-			err,
+			Operation: "SetChatPhoto",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3618,8 +3618,8 @@ func (s *Server) handleSetChatStickerSetRequest(args [0]string, w http.ResponseW
 	request, err := decodeSetChatStickerSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatStickerSet",
-			err,
+			Operation: "SetChatStickerSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3672,8 +3672,8 @@ func (s *Server) handleSetChatTitleRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetChatTitleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetChatTitle",
-			err,
+			Operation: "SetChatTitle",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3726,8 +3726,8 @@ func (s *Server) handleSetGameScoreRequest(args [0]string, w http.ResponseWriter
 	request, err := decodeSetGameScoreRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetGameScore",
-			err,
+			Operation: "SetGameScore",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3780,8 +3780,8 @@ func (s *Server) handleSetMyCommandsRequest(args [0]string, w http.ResponseWrite
 	request, err := decodeSetMyCommandsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetMyCommands",
-			err,
+			Operation: "SetMyCommands",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3834,8 +3834,8 @@ func (s *Server) handleSetPassportDataErrorsRequest(args [0]string, w http.Respo
 	request, err := decodeSetPassportDataErrorsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetPassportDataErrors",
-			err,
+			Operation: "SetPassportDataErrors",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3888,8 +3888,8 @@ func (s *Server) handleSetStickerPositionInSetRequest(args [0]string, w http.Res
 	request, err := decodeSetStickerPositionInSetRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetStickerPositionInSet",
-			err,
+			Operation: "SetStickerPositionInSet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3942,8 +3942,8 @@ func (s *Server) handleSetStickerSetThumbRequest(args [0]string, w http.Response
 	request, err := decodeSetStickerSetThumbRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetStickerSetThumb",
-			err,
+			Operation: "SetStickerSetThumb",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3996,8 +3996,8 @@ func (s *Server) handleSetWebhookRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeSetWebhookRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SetWebhook",
-			err,
+			Operation: "SetWebhook",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4050,8 +4050,8 @@ func (s *Server) handleStopMessageLiveLocationRequest(args [0]string, w http.Res
 	request, err := decodeStopMessageLiveLocationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"StopMessageLiveLocation",
-			err,
+			Operation: "StopMessageLiveLocation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4104,8 +4104,8 @@ func (s *Server) handleStopPollRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeStopPollRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"StopPoll",
-			err,
+			Operation: "StopPoll",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4158,8 +4158,8 @@ func (s *Server) handleUnbanChatMemberRequest(args [0]string, w http.ResponseWri
 	request, err := decodeUnbanChatMemberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnbanChatMember",
-			err,
+			Operation: "UnbanChatMember",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4212,8 +4212,8 @@ func (s *Server) handleUnbanChatSenderChatRequest(args [0]string, w http.Respons
 	request, err := decodeUnbanChatSenderChatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnbanChatSenderChat",
-			err,
+			Operation: "UnbanChatSenderChat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4266,8 +4266,8 @@ func (s *Server) handleUnpinAllChatMessagesRequest(args [0]string, w http.Respon
 	request, err := decodeUnpinAllChatMessagesRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnpinAllChatMessages",
-			err,
+			Operation: "UnpinAllChatMessages",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4320,8 +4320,8 @@ func (s *Server) handleUnpinChatMessageRequest(args [0]string, w http.ResponseWr
 	request, err := decodeUnpinChatMessageRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UnpinChatMessage",
-			err,
+			Operation: "UnpinChatMessage",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4374,8 +4374,8 @@ func (s *Server) handleUploadStickerFileRequest(args [0]string, w http.ResponseW
 	request, err := decodeUploadStickerFileRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"UploadStickerFile",
-			err,
+			Operation: "UploadStickerFile",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_telegram/oas_req_dec_gen.go
+++ b/examples/ex_telegram/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeAddStickerToSetRequest(r *http.Request, span trace.Span) (req AddStic
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AddStickerToSet request")
 		}
@@ -91,7 +91,7 @@ func decodeAnswerCallbackQueryRequest(r *http.Request, span trace.Span) (req Ans
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerCallbackQuery request")
 		}
@@ -135,7 +135,7 @@ func decodeAnswerInlineQueryRequest(r *http.Request, span trace.Span) (req Answe
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerInlineQuery request")
 		}
@@ -215,7 +215,7 @@ func decodeAnswerShippingQueryRequest(r *http.Request, span trace.Span) (req Ans
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate AnswerShippingQuery request")
 		}
@@ -367,7 +367,7 @@ func decodeCopyMessageRequest(r *http.Request, span trace.Span) (req CopyMessage
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CopyMessage request")
 		}
@@ -411,7 +411,7 @@ func decodeCreateChatInviteLinkRequest(r *http.Request, span trace.Span) (req Cr
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateChatInviteLink request")
 		}
@@ -455,7 +455,7 @@ func decodeCreateNewStickerSetRequest(r *http.Request, span trace.Span) (req Cre
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate CreateNewStickerSet request")
 		}
@@ -753,7 +753,7 @@ func decodeEditChatInviteLinkRequest(r *http.Request, span trace.Span) (req Edit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditChatInviteLink request")
 		}
@@ -797,7 +797,7 @@ func decodeEditMessageCaptionRequest(r *http.Request, span trace.Span) (req Edit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageCaption request")
 		}
@@ -841,7 +841,7 @@ func decodeEditMessageLiveLocationRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageLiveLocation request")
 		}
@@ -885,7 +885,7 @@ func decodeEditMessageMediaRequest(r *http.Request, span trace.Span) (req EditMe
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageMedia request")
 		}
@@ -929,7 +929,7 @@ func decodeEditMessageReplyMarkupRequest(r *http.Request, span trace.Span) (req 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageReplyMarkup request")
 		}
@@ -973,7 +973,7 @@ func decodeEditMessageTextRequest(r *http.Request, span trace.Span) (req EditMes
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate EditMessageText request")
 		}
@@ -1381,13 +1381,13 @@ func decodeGetUpdatesRequest(r *http.Request, span trace.Span) (req OptGetUpdate
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GetUpdates request")
 		}
@@ -1431,7 +1431,7 @@ func decodeGetUserProfilePhotosRequest(r *http.Request, span trace.Span) (req Ge
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate GetUserProfilePhotos request")
 		}
@@ -1655,7 +1655,7 @@ func decodeSendAnimationRequest(r *http.Request, span trace.Span) (req SendAnima
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendAnimation request")
 		}
@@ -1699,7 +1699,7 @@ func decodeSendAudioRequest(r *http.Request, span trace.Span) (req SendAudio, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendAudio request")
 		}
@@ -1779,7 +1779,7 @@ func decodeSendContactRequest(r *http.Request, span trace.Span) (req SendContact
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendContact request")
 		}
@@ -1823,7 +1823,7 @@ func decodeSendDiceRequest(r *http.Request, span trace.Span) (req SendDice, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendDice request")
 		}
@@ -1867,7 +1867,7 @@ func decodeSendDocumentRequest(r *http.Request, span trace.Span) (req SendDocume
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendDocument request")
 		}
@@ -1911,7 +1911,7 @@ func decodeSendGameRequest(r *http.Request, span trace.Span) (req SendGame, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendGame request")
 		}
@@ -1955,7 +1955,7 @@ func decodeSendInvoiceRequest(r *http.Request, span trace.Span) (req SendInvoice
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendInvoice request")
 		}
@@ -1999,7 +1999,7 @@ func decodeSendLocationRequest(r *http.Request, span trace.Span) (req SendLocati
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendLocation request")
 		}
@@ -2043,7 +2043,7 @@ func decodeSendMediaGroupRequest(r *http.Request, span trace.Span) (req SendMedi
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendMediaGroup request")
 		}
@@ -2087,7 +2087,7 @@ func decodeSendMessageRequest(r *http.Request, span trace.Span) (req SendMessage
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendMessage request")
 		}
@@ -2131,7 +2131,7 @@ func decodeSendPhotoRequest(r *http.Request, span trace.Span) (req SendPhoto, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendPhoto request")
 		}
@@ -2175,7 +2175,7 @@ func decodeSendPollRequest(r *http.Request, span trace.Span) (req SendPoll, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendPoll request")
 		}
@@ -2219,7 +2219,7 @@ func decodeSendStickerRequest(r *http.Request, span trace.Span) (req SendSticker
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendSticker request")
 		}
@@ -2263,7 +2263,7 @@ func decodeSendVenueRequest(r *http.Request, span trace.Span) (req SendVenue, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVenue request")
 		}
@@ -2307,7 +2307,7 @@ func decodeSendVideoRequest(r *http.Request, span trace.Span) (req SendVideo, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVideo request")
 		}
@@ -2351,7 +2351,7 @@ func decodeSendVideoNoteRequest(r *http.Request, span trace.Span) (req SendVideo
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVideoNote request")
 		}
@@ -2395,7 +2395,7 @@ func decodeSendVoiceRequest(r *http.Request, span trace.Span) (req SendVoice, er
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SendVoice request")
 		}
@@ -2439,7 +2439,7 @@ func decodeSetChatAdministratorCustomTitleRequest(r *http.Request, span trace.Sp
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatAdministratorCustomTitle request")
 		}
@@ -2483,7 +2483,7 @@ func decodeSetChatDescriptionRequest(r *http.Request, span trace.Span) (req SetC
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatDescription request")
 		}
@@ -2635,7 +2635,7 @@ func decodeSetChatTitleRequest(r *http.Request, span trace.Span) (req SetChatTit
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetChatTitle request")
 		}
@@ -2715,7 +2715,7 @@ func decodeSetMyCommandsRequest(r *http.Request, span trace.Span) (req SetMyComm
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetMyCommands request")
 		}
@@ -2759,7 +2759,7 @@ func decodeSetPassportDataErrorsRequest(r *http.Request, span trace.Span) (req S
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SetPassportDataErrors request")
 		}
@@ -2911,7 +2911,7 @@ func decodeStopMessageLiveLocationRequest(r *http.Request, span trace.Span) (req
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate StopMessageLiveLocation request")
 		}
@@ -2955,7 +2955,7 @@ func decodeStopPollRequest(r *http.Request, span trace.Span) (req StopPoll, err 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate StopPoll request")
 		}

--- a/examples/ex_telegram/oas_validators_gen.go
+++ b/examples/ex_telegram/oas_validators_gen.go
@@ -18,13 +18,13 @@ func (s AddStickerToSet) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -51,7 +51,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -71,7 +71,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -91,7 +91,7 @@ func (s Animation) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -104,13 +104,13 @@ func (s Animation) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -138,13 +138,13 @@ func (s AnswerCallbackQuery) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -168,7 +168,7 @@ func (s AnswerInlineQuery) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -179,7 +179,7 @@ func (s AnswerInlineQuery) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "results",
@@ -200,13 +200,13 @@ func (s AnswerInlineQuery) Validate() error {
 				}).Validate(string(s.SwitchPmParameter.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "switch_pm_parameter",
@@ -227,7 +227,7 @@ func (s AnswerShippingQuery) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -238,7 +238,7 @@ func (s AnswerShippingQuery) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "shipping_options",
@@ -265,7 +265,7 @@ func (s Audio) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -278,13 +278,13 @@ func (s Audio) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -310,7 +310,7 @@ func (s BotCommand) Validate() error {
 		}).Validate(string(s.Command)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "command",
@@ -329,7 +329,7 @@ func (s BotCommand) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -349,13 +349,13 @@ func (s CallbackQuery) Validate() error {
 				if err := s.Message.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message",
@@ -373,7 +373,7 @@ func (s Chat) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -388,11 +388,11 @@ func (s Chat) Validate() error {
 			if err := s.PinnedMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pinned_message",
@@ -405,13 +405,13 @@ func (s Chat) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -440,13 +440,13 @@ func (s ChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -464,7 +464,7 @@ func (s ChatJoinRequest) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -477,13 +477,13 @@ func (s ChatJoinRequest) Validate() error {
 				if err := s.InviteLink.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "invite_link",
@@ -501,7 +501,7 @@ func (s ChatLocation) Validate() error {
 		if err := s.Location.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -520,7 +520,7 @@ func (s ChatLocation) Validate() error {
 		}).Validate(string(s.Address)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "address",
@@ -538,7 +538,7 @@ func (s ChatMemberUpdated) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -551,13 +551,13 @@ func (s ChatMemberUpdated) Validate() error {
 				if err := s.InviteLink.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "invite_link",
@@ -591,13 +591,13 @@ func (s ChosenInlineResult) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -625,13 +625,13 @@ func (s CopyMessage) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -645,7 +645,7 @@ func (s CopyMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -656,7 +656,7 @@ func (s CopyMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -669,13 +669,13 @@ func (s CopyMessage) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -693,19 +693,19 @@ func (s CopyMessageReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupCopyMessageReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveCopyMessageReplyMarkup:
 		return nil // no validation needed
 	case ForceReplyCopyMessageReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -727,13 +727,13 @@ func (s CreateChatInviteLink) Validate() error {
 				}).Validate(string(s.Name.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -755,13 +755,13 @@ func (s CreateChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -787,7 +787,7 @@ func (s CreateNewStickerSet) Validate() error {
 		}).Validate(string(s.Name)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -806,7 +806,7 @@ func (s CreateNewStickerSet) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -819,13 +819,13 @@ func (s CreateNewStickerSet) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -845,13 +845,13 @@ func (s Document) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -879,13 +879,13 @@ func (s EditChatInviteLink) Validate() error {
 				}).Validate(string(s.Name.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -907,13 +907,13 @@ func (s EditChatInviteLink) Validate() error {
 				}).Validate(int64(s.MemberLimit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "member_limit",
@@ -941,13 +941,13 @@ func (s EditMessageCaption) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -961,7 +961,7 @@ func (s EditMessageCaption) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -972,7 +972,7 @@ func (s EditMessageCaption) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -985,13 +985,13 @@ func (s EditMessageCaption) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1009,7 +1009,7 @@ func (s EditMessageLiveLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -1020,7 +1020,7 @@ func (s EditMessageLiveLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -1033,13 +1033,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -1061,13 +1061,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -1089,13 +1089,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -1108,13 +1108,13 @@ func (s EditMessageLiveLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1132,7 +1132,7 @@ func (s EditMessageMedia) Validate() error {
 		if err := s.Media.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "media",
@@ -1145,13 +1145,13 @@ func (s EditMessageMedia) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1171,13 +1171,13 @@ func (s EditMessageReplyMarkup) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1203,7 +1203,7 @@ func (s EditMessageText) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -1217,7 +1217,7 @@ func (s EditMessageText) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1228,7 +1228,7 @@ func (s EditMessageText) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -1241,13 +1241,13 @@ func (s EditMessageText) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1265,7 +1265,7 @@ func (s EncryptedPassportElement) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -1325,13 +1325,13 @@ func (s ForceReply) Validate() error {
 				}).Validate(string(s.InputFieldPlaceholder.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_field_placeholder",
@@ -1355,7 +1355,7 @@ func (s Game) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1366,7 +1366,7 @@ func (s Game) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo",
@@ -1387,13 +1387,13 @@ func (s Game) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -1407,7 +1407,7 @@ func (s Game) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1418,7 +1418,7 @@ func (s Game) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text_entities",
@@ -1431,13 +1431,13 @@ func (s Game) Validate() error {
 				if err := s.Animation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "animation",
@@ -1466,13 +1466,13 @@ func (s GetUpdates) Validate() error {
 				}).Validate(int64(s.Limit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -1501,13 +1501,13 @@ func (s GetUserProfilePhotos) Validate() error {
 				}).Validate(int64(s.Limit.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limit",
@@ -1535,13 +1535,13 @@ func (s InlineKeyboardButton) Validate() error {
 				}).Validate(string(s.CallbackData.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callback_data",
@@ -1571,7 +1571,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1582,7 +1582,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1593,7 +1593,7 @@ func (s InlineKeyboardMarkup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "inline_keyboard",
@@ -1613,13 +1613,13 @@ func (s InlineQuery) Validate() error {
 				if err := s.ChatType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_type",
@@ -1632,13 +1632,13 @@ func (s InlineQuery) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -1672,102 +1672,102 @@ func (s InlineQueryResult) Validate() error {
 		if err := s.InlineQueryResultCachedAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedDocumentInlineQueryResult:
 		if err := s.InlineQueryResultCachedDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedGifInlineQueryResult:
 		if err := s.InlineQueryResultCachedGif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedMpeg4GifInlineQueryResult:
 		if err := s.InlineQueryResultCachedMpeg4Gif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedPhotoInlineQueryResult:
 		if err := s.InlineQueryResultCachedPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedStickerInlineQueryResult:
 		if err := s.InlineQueryResultCachedSticker.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedVideoInlineQueryResult:
 		if err := s.InlineQueryResultCachedVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultCachedVoiceInlineQueryResult:
 		if err := s.InlineQueryResultCachedVoice.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultArticleInlineQueryResult:
 		if err := s.InlineQueryResultArticle.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultAudioInlineQueryResult:
 		if err := s.InlineQueryResultAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultContactInlineQueryResult:
 		if err := s.InlineQueryResultContact.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultGameInlineQueryResult:
 		if err := s.InlineQueryResultGame.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultDocumentInlineQueryResult:
 		if err := s.InlineQueryResultDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultGifInlineQueryResult:
 		if err := s.InlineQueryResultGif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultLocationInlineQueryResult:
 		if err := s.InlineQueryResultLocation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultMpeg4GifInlineQueryResult:
 		if err := s.InlineQueryResultMpeg4Gif.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultPhotoInlineQueryResult:
 		if err := s.InlineQueryResultPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVenueInlineQueryResult:
 		if err := s.InlineQueryResultVenue.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVideoInlineQueryResult:
 		if err := s.InlineQueryResultVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InlineQueryResultVoiceInlineQueryResult:
 		if err := s.InlineQueryResultVoice.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -1779,7 +1779,7 @@ func (s InlineQueryResultArticle) Validate() error {
 		if err := s.InputMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -1792,13 +1792,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1820,13 +1820,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -1848,13 +1848,13 @@ func (s InlineQueryResultArticle) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -1880,7 +1880,7 @@ func (s InlineQueryResultAudio) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -1901,13 +1901,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -1921,7 +1921,7 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1932,7 +1932,7 @@ func (s InlineQueryResultAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -1954,13 +1954,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				}).Validate(int64(s.AudioDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "audio_duration",
@@ -1973,13 +1973,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -1992,13 +1992,13 @@ func (s InlineQueryResultAudio) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2024,7 +2024,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2045,13 +2045,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2065,7 +2065,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2076,7 +2076,7 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2089,13 +2089,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2108,13 +2108,13 @@ func (s InlineQueryResultCachedAudio) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2140,7 +2140,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2161,13 +2161,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2181,7 +2181,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2192,7 +2192,7 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2205,13 +2205,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2224,13 +2224,13 @@ func (s InlineQueryResultCachedDocument) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2256,7 +2256,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2277,13 +2277,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2297,7 +2297,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2308,7 +2308,7 @@ func (s InlineQueryResultCachedGif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2321,13 +2321,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2340,13 +2340,13 @@ func (s InlineQueryResultCachedGif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2372,7 +2372,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2393,13 +2393,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2413,7 +2413,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2424,7 +2424,7 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2437,13 +2437,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2456,13 +2456,13 @@ func (s InlineQueryResultCachedMpeg4Gif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2488,7 +2488,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2509,13 +2509,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2529,7 +2529,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2540,7 +2540,7 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2553,13 +2553,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2572,13 +2572,13 @@ func (s InlineQueryResultCachedPhoto) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2604,7 +2604,7 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2617,13 +2617,13 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2636,13 +2636,13 @@ func (s InlineQueryResultCachedSticker) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2668,7 +2668,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2689,13 +2689,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2709,7 +2709,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2720,7 +2720,7 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2733,13 +2733,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2752,13 +2752,13 @@ func (s InlineQueryResultCachedVideo) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2784,7 +2784,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -2805,13 +2805,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -2825,7 +2825,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2836,7 +2836,7 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -2849,13 +2849,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2868,13 +2868,13 @@ func (s InlineQueryResultCachedVoice) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2902,13 +2902,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -2921,13 +2921,13 @@ func (s InlineQueryResultContact) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -2940,13 +2940,13 @@ func (s InlineQueryResultContact) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -2968,13 +2968,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -2996,13 +2996,13 @@ func (s InlineQueryResultContact) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3028,7 +3028,7 @@ func (s InlineQueryResultDocument) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3049,13 +3049,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3069,7 +3069,7 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3080,7 +3080,7 @@ func (s InlineQueryResultDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3093,13 +3093,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3112,13 +3112,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3140,13 +3140,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -3168,13 +3168,13 @@ func (s InlineQueryResultDocument) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3200,7 +3200,7 @@ func (s InlineQueryResultGame) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3213,13 +3213,13 @@ func (s InlineQueryResultGame) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3245,7 +3245,7 @@ func (s InlineQueryResultGif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3267,13 +3267,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_width",
@@ -3295,13 +3295,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_height",
@@ -3323,13 +3323,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(int64(s.GIFDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "gif_duration",
@@ -3350,13 +3350,13 @@ func (s InlineQueryResultGif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3370,7 +3370,7 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3381,7 +3381,7 @@ func (s InlineQueryResultGif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3394,13 +3394,13 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3413,13 +3413,13 @@ func (s InlineQueryResultGif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3437,7 +3437,7 @@ func (s InlineQueryResultLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -3448,7 +3448,7 @@ func (s InlineQueryResultLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -3461,13 +3461,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -3489,13 +3489,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -3517,13 +3517,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -3545,13 +3545,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -3564,13 +3564,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3583,13 +3583,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3611,13 +3611,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -3639,13 +3639,13 @@ func (s InlineQueryResultLocation) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -3671,7 +3671,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3693,13 +3693,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_width",
@@ -3721,13 +3721,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_height",
@@ -3749,13 +3749,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(int64(s.Mpeg4Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mpeg4_duration",
@@ -3776,13 +3776,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3796,7 +3796,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3807,7 +3807,7 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3820,13 +3820,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -3839,13 +3839,13 @@ func (s InlineQueryResultMpeg4Gif) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -3871,7 +3871,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -3893,13 +3893,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -3921,13 +3921,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -3948,13 +3948,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -3968,7 +3968,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3979,7 +3979,7 @@ func (s InlineQueryResultPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -3992,13 +3992,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4011,13 +4011,13 @@ func (s InlineQueryResultPhoto) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4035,7 +4035,7 @@ func (s InlineQueryResultVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -4046,7 +4046,7 @@ func (s InlineQueryResultVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -4059,13 +4059,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4078,13 +4078,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4106,13 +4106,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				}).Validate(int64(s.ThumbWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_width",
@@ -4134,13 +4134,13 @@ func (s InlineQueryResultVenue) Validate() error {
 				}).Validate(int64(s.ThumbHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb_height",
@@ -4166,7 +4166,7 @@ func (s InlineQueryResultVideo) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -4187,13 +4187,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4207,7 +4207,7 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4218,7 +4218,7 @@ func (s InlineQueryResultVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4240,13 +4240,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_width",
@@ -4268,13 +4268,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_height",
@@ -4296,13 +4296,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				}).Validate(int64(s.VideoDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_duration",
@@ -4315,13 +4315,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4334,13 +4334,13 @@ func (s InlineQueryResultVideo) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4366,7 +4366,7 @@ func (s InlineQueryResultVoice) Validate() error {
 		}).Validate(string(s.ID)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -4387,13 +4387,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4407,7 +4407,7 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4418,7 +4418,7 @@ func (s InlineQueryResultVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4440,13 +4440,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				}).Validate(int64(s.VoiceDuration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "voice_duration",
@@ -4459,13 +4459,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -4478,13 +4478,13 @@ func (s InlineQueryResultVoice) Validate() error {
 				if err := s.InputMessageContent.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_message_content",
@@ -4512,13 +4512,13 @@ func (s InputContactMessageContent) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -4544,7 +4544,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -4563,7 +4563,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -4582,7 +4582,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		}).Validate(string(s.Payload)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -4593,7 +4593,7 @@ func (s InputInvoiceMessageContent) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -4615,13 +4615,13 @@ func (s InputInvoiceMessageContent) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -4643,13 +4643,13 @@ func (s InputInvoiceMessageContent) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -4667,7 +4667,7 @@ func (s InputLocationMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -4678,7 +4678,7 @@ func (s InputLocationMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -4691,13 +4691,13 @@ func (s InputLocationMessageContent) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -4719,13 +4719,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -4747,13 +4747,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -4775,13 +4775,13 @@ func (s InputLocationMessageContent) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -4799,27 +4799,27 @@ func (s InputMedia) Validate() error {
 		if err := s.InputMediaAnimation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaDocumentInputMedia:
 		if err := s.InputMediaDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaAudioInputMedia:
 		if err := s.InputMediaAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaPhotoInputMedia:
 		if err := s.InputMediaPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaVideoInputMedia:
 		if err := s.InputMediaVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -4841,13 +4841,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -4861,7 +4861,7 @@ func (s InputMediaAnimation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4872,7 +4872,7 @@ func (s InputMediaAnimation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -4894,13 +4894,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -4922,13 +4922,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -4950,13 +4950,13 @@ func (s InputMediaAnimation) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -4984,13 +4984,13 @@ func (s InputMediaAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5004,7 +5004,7 @@ func (s InputMediaAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5015,7 +5015,7 @@ func (s InputMediaAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5037,13 +5037,13 @@ func (s InputMediaAudio) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5071,13 +5071,13 @@ func (s InputMediaDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5091,7 +5091,7 @@ func (s InputMediaDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5102,7 +5102,7 @@ func (s InputMediaDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5130,13 +5130,13 @@ func (s InputMediaPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5150,7 +5150,7 @@ func (s InputMediaPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5161,7 +5161,7 @@ func (s InputMediaPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5189,13 +5189,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5209,7 +5209,7 @@ func (s InputMediaVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5220,7 +5220,7 @@ func (s InputMediaVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5242,13 +5242,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -5270,13 +5270,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -5298,13 +5298,13 @@ func (s InputMediaVideo) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -5322,27 +5322,27 @@ func (s InputMessageContent) Validate() error {
 		if err := s.InputTextMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputLocationMessageContentInputMessageContent:
 		if err := s.InputLocationMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputVenueMessageContentInputMessageContent:
 		if err := s.InputVenueMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputContactMessageContentInputMessageContent:
 		if err := s.InputContactMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputInvoiceMessageContentInputMessageContent:
 		if err := s.InputInvoiceMessageContent.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -5362,7 +5362,7 @@ func (s InputTextMessageContent) Validate() error {
 		}).Validate(string(s.MessageText)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message_text",
@@ -5376,7 +5376,7 @@ func (s InputTextMessageContent) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5387,7 +5387,7 @@ func (s InputTextMessageContent) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -5405,7 +5405,7 @@ func (s InputVenueMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -5416,7 +5416,7 @@ func (s InputVenueMessageContent) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -5434,7 +5434,7 @@ func (s Location) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -5445,7 +5445,7 @@ func (s Location) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -5458,13 +5458,13 @@ func (s Location) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -5486,13 +5486,13 @@ func (s Location) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -5510,7 +5510,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.XShift)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "x_shift",
@@ -5521,7 +5521,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.YShift)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "y_shift",
@@ -5532,7 +5532,7 @@ func (s MaskPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Scale)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "scale",
@@ -5552,13 +5552,13 @@ func (s Message) Validate() error {
 				if err := s.SenderChat.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sender_chat",
@@ -5569,7 +5569,7 @@ func (s Message) Validate() error {
 		if err := s.Chat.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat",
@@ -5582,13 +5582,13 @@ func (s Message) Validate() error {
 				if err := s.ForwardFromChat.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "forward_from_chat",
@@ -5603,11 +5603,11 @@ func (s Message) Validate() error {
 			if err := s.ReplyToMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_to_message",
@@ -5628,13 +5628,13 @@ func (s Message) Validate() error {
 				}).Validate(string(s.Text.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -5648,7 +5648,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5659,7 +5659,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -5672,13 +5672,13 @@ func (s Message) Validate() error {
 				if err := s.Animation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "animation",
@@ -5691,13 +5691,13 @@ func (s Message) Validate() error {
 				if err := s.Audio.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "audio",
@@ -5710,13 +5710,13 @@ func (s Message) Validate() error {
 				if err := s.Document.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "document",
@@ -5730,7 +5730,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5741,7 +5741,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo",
@@ -5754,13 +5754,13 @@ func (s Message) Validate() error {
 				if err := s.Sticker.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sticker",
@@ -5773,13 +5773,13 @@ func (s Message) Validate() error {
 				if err := s.Video.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video",
@@ -5792,13 +5792,13 @@ func (s Message) Validate() error {
 				if err := s.VideoNote.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "video_note",
@@ -5811,13 +5811,13 @@ func (s Message) Validate() error {
 				if err := s.Voice.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "voice",
@@ -5838,13 +5838,13 @@ func (s Message) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -5858,7 +5858,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5869,7 +5869,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -5882,13 +5882,13 @@ func (s Message) Validate() error {
 				if err := s.Game.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "game",
@@ -5901,13 +5901,13 @@ func (s Message) Validate() error {
 				if err := s.Poll.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll",
@@ -5920,13 +5920,13 @@ func (s Message) Validate() error {
 				if err := s.Venue.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "venue",
@@ -5939,13 +5939,13 @@ func (s Message) Validate() error {
 				if err := s.Location.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -5959,7 +5959,7 @@ func (s Message) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5970,7 +5970,7 @@ func (s Message) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "new_chat_photo",
@@ -5985,11 +5985,11 @@ func (s Message) Validate() error {
 			if err := s.PinnedMessage.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "pinned_message",
@@ -6002,13 +6002,13 @@ func (s Message) Validate() error {
 				if err := s.PassportData.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "passport_data",
@@ -6021,13 +6021,13 @@ func (s Message) Validate() error {
 				if err := s.VoiceChatEnded.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "voice_chat_ended",
@@ -6040,13 +6040,13 @@ func (s Message) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -6064,7 +6064,7 @@ func (s MessageEntity) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -6125,7 +6125,7 @@ func (s PassportData) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6136,7 +6136,7 @@ func (s PassportData) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "data",
@@ -6164,14 +6164,14 @@ func (s PassportElementError) Validate() error {
 		if err := s.PassportElementErrorFiles.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PassportElementErrorTranslationFilePassportElementError:
 		return nil // no validation needed
 	case PassportElementErrorTranslationFilesPassportElementError:
 		if err := s.PassportElementErrorTranslationFiles.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case PassportElementErrorUnspecifiedPassportElementError:
 		return nil // no validation needed
 	default:
@@ -6219,7 +6219,7 @@ func (s PassportElementErrorFiles) Validate() error {
 		if s.FileHashes == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "file_hashes",
@@ -6315,7 +6315,7 @@ func (s PassportElementErrorTranslationFiles) Validate() error {
 		if s.FileHashes == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "file_hashes",
@@ -6366,7 +6366,7 @@ func (s PhotoSize) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -6386,7 +6386,7 @@ func (s PhotoSize) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -6412,7 +6412,7 @@ func (s Poll) Validate() error {
 		}).Validate(string(s.Question)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "question",
@@ -6429,7 +6429,7 @@ func (s Poll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6440,7 +6440,7 @@ func (s Poll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "options",
@@ -6451,7 +6451,7 @@ func (s Poll) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -6472,13 +6472,13 @@ func (s Poll) Validate() error {
 				}).Validate(string(s.Explanation.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation",
@@ -6492,7 +6492,7 @@ func (s Poll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6503,7 +6503,7 @@ func (s Poll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation_entities",
@@ -6521,7 +6521,7 @@ func (s PollAnswer) Validate() error {
 		if s.OptionIds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "option_ids",
@@ -6547,7 +6547,7 @@ func (s PollOption) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -6581,7 +6581,7 @@ func (s ReplyKeyboardMarkup) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6592,7 +6592,7 @@ func (s ReplyKeyboardMarkup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "keyboard",
@@ -6613,13 +6613,13 @@ func (s ReplyKeyboardMarkup) Validate() error {
 				}).Validate(string(s.InputFieldPlaceholder.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "input_field_placeholder",
@@ -6640,7 +6640,7 @@ func (s ResultArrayOfBotCommand) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6651,7 +6651,7 @@ func (s ResultArrayOfBotCommand) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6672,7 +6672,7 @@ func (s ResultArrayOfMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6683,7 +6683,7 @@ func (s ResultArrayOfMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6704,7 +6704,7 @@ func (s ResultArrayOfUpdate) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6715,7 +6715,7 @@ func (s ResultArrayOfUpdate) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6735,13 +6735,13 @@ func (s ResultChat) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6761,13 +6761,13 @@ func (s ResultChatInviteLink) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6787,13 +6787,13 @@ func (s ResultMessage) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6813,13 +6813,13 @@ func (s ResultPoll) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6839,13 +6839,13 @@ func (s ResultUserProfilePhotos) Validate() error {
 				if err := s.Result.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "result",
@@ -6874,13 +6874,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -6902,13 +6902,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -6930,13 +6930,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -6957,13 +6957,13 @@ func (s SendAnimation) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -6977,7 +6977,7 @@ func (s SendAnimation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6988,7 +6988,7 @@ func (s SendAnimation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7001,13 +7001,13 @@ func (s SendAnimation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7025,19 +7025,19 @@ func (s SendAnimationReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendAnimationReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendAnimationReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendAnimationReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7059,13 +7059,13 @@ func (s SendAudio) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7079,7 +7079,7 @@ func (s SendAudio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7090,7 +7090,7 @@ func (s SendAudio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7112,13 +7112,13 @@ func (s SendAudio) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -7131,13 +7131,13 @@ func (s SendAudio) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7155,19 +7155,19 @@ func (s SendAudioReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendAudioReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendAudioReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendAudioReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7189,13 +7189,13 @@ func (s SendContact) Validate() error {
 				}).Validate(string(s.Vcard.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "vcard",
@@ -7208,13 +7208,13 @@ func (s SendContact) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7232,19 +7232,19 @@ func (s SendContactReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendContactReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendContactReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendContactReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7258,13 +7258,13 @@ func (s SendDice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7282,19 +7282,19 @@ func (s SendDiceReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendDiceReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendDiceReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendDiceReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7316,13 +7316,13 @@ func (s SendDocument) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7336,7 +7336,7 @@ func (s SendDocument) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7347,7 +7347,7 @@ func (s SendDocument) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7360,13 +7360,13 @@ func (s SendDocument) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7384,19 +7384,19 @@ func (s SendDocumentReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendDocumentReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendDocumentReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendDocumentReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7410,13 +7410,13 @@ func (s SendGame) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7442,7 +7442,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -7461,7 +7461,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Description)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -7480,7 +7480,7 @@ func (s SendInvoice) Validate() error {
 		}).Validate(string(s.Payload)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -7491,7 +7491,7 @@ func (s SendInvoice) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -7513,13 +7513,13 @@ func (s SendInvoice) Validate() error {
 				}).Validate(int64(s.PhotoWidth.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_width",
@@ -7541,13 +7541,13 @@ func (s SendInvoice) Validate() error {
 				}).Validate(int64(s.PhotoHeight.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photo_height",
@@ -7560,13 +7560,13 @@ func (s SendInvoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7584,7 +7584,7 @@ func (s SendLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -7595,7 +7595,7 @@ func (s SendLocation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -7608,13 +7608,13 @@ func (s SendLocation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.HorizontalAccuracy.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "horizontal_accuracy",
@@ -7636,13 +7636,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.LivePeriod.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "live_period",
@@ -7664,13 +7664,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.Heading.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "heading",
@@ -7692,13 +7692,13 @@ func (s SendLocation) Validate() error {
 				}).Validate(int64(s.ProximityAlertRadius.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "proximity_alert_radius",
@@ -7711,13 +7711,13 @@ func (s SendLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7735,19 +7735,19 @@ func (s SendLocationReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendLocationReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendLocationReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendLocationReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7765,7 +7765,7 @@ func (s SendMediaGroup) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7776,7 +7776,7 @@ func (s SendMediaGroup) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "media",
@@ -7794,22 +7794,22 @@ func (s SendMediaGroupMediaItem) Validate() error {
 		if err := s.InputMediaAudio.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaDocumentSendMediaGroupMediaItem:
 		if err := s.InputMediaDocument.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaPhotoSendMediaGroupMediaItem:
 		if err := s.InputMediaPhoto.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case InputMediaVideoSendMediaGroupMediaItem:
 		if err := s.InputMediaVideo.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7829,7 +7829,7 @@ func (s SendMessage) Validate() error {
 		}).Validate(string(s.Text)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "text",
@@ -7843,7 +7843,7 @@ func (s SendMessage) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7854,7 +7854,7 @@ func (s SendMessage) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "entities",
@@ -7867,13 +7867,13 @@ func (s SendMessage) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7891,19 +7891,19 @@ func (s SendMessageReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendMessageReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendMessageReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendMessageReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -7925,13 +7925,13 @@ func (s SendPhoto) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -7945,7 +7945,7 @@ func (s SendPhoto) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7956,7 +7956,7 @@ func (s SendPhoto) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -7969,13 +7969,13 @@ func (s SendPhoto) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -7993,19 +7993,19 @@ func (s SendPhotoReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendPhotoReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendPhotoReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendPhotoReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8025,7 +8025,7 @@ func (s SendPoll) Validate() error {
 		}).Validate(string(s.Question)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "question",
@@ -8036,7 +8036,7 @@ func (s SendPoll) Validate() error {
 		if s.Options == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "options",
@@ -8057,13 +8057,13 @@ func (s SendPoll) Validate() error {
 				}).Validate(string(s.Explanation.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation",
@@ -8077,7 +8077,7 @@ func (s SendPoll) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8088,7 +8088,7 @@ func (s SendPoll) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "explanation_entities",
@@ -8101,13 +8101,13 @@ func (s SendPoll) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8125,19 +8125,19 @@ func (s SendPollReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendPollReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendPollReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendPollReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8151,13 +8151,13 @@ func (s SendSticker) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8175,19 +8175,19 @@ func (s SendStickerReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendStickerReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendStickerReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendStickerReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8199,7 +8199,7 @@ func (s SendVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Latitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "latitude",
@@ -8210,7 +8210,7 @@ func (s SendVenue) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Longitude)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "longitude",
@@ -8223,13 +8223,13 @@ func (s SendVenue) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8247,19 +8247,19 @@ func (s SendVenueReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendVenueReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendVenueReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendVenueReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8282,13 +8282,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8310,13 +8310,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Width.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -8338,13 +8338,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(int64(s.Height.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -8365,13 +8365,13 @@ func (s SendVideo) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -8385,7 +8385,7 @@ func (s SendVideo) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8396,7 +8396,7 @@ func (s SendVideo) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -8409,13 +8409,13 @@ func (s SendVideo) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8444,13 +8444,13 @@ func (s SendVideoNote) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8463,13 +8463,13 @@ func (s SendVideoNote) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8487,19 +8487,19 @@ func (s SendVideoNoteReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendVideoNoteReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendVideoNoteReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendVideoNoteReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8511,19 +8511,19 @@ func (s SendVideoReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendVideoReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendVideoReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendVideoReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8545,13 +8545,13 @@ func (s SendVoice) Validate() error {
 				}).Validate(string(s.Caption.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption",
@@ -8565,7 +8565,7 @@ func (s SendVoice) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8576,7 +8576,7 @@ func (s SendVoice) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "caption_entities",
@@ -8598,13 +8598,13 @@ func (s SendVoice) Validate() error {
 				}).Validate(int64(s.Duration.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -8617,13 +8617,13 @@ func (s SendVoice) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8641,19 +8641,19 @@ func (s SendVoiceReplyMarkup) Validate() error {
 		if err := s.InlineKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardMarkupSendVoiceReplyMarkup:
 		if err := s.ReplyKeyboardMarkup.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	case ReplyKeyboardRemoveSendVoiceReplyMarkup:
 		return nil // no validation needed
 	case ForceReplySendVoiceReplyMarkup:
 		if err := s.ForceReply.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -8673,7 +8673,7 @@ func (s SetChatAdministratorCustomTitle) Validate() error {
 		}).Validate(string(s.CustomTitle)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "custom_title",
@@ -8701,13 +8701,13 @@ func (s SetChatDescription) Validate() error {
 				}).Validate(string(s.Description.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "description",
@@ -8733,7 +8733,7 @@ func (s SetChatTitle) Validate() error {
 		}).Validate(string(s.Title)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "title",
@@ -8757,7 +8757,7 @@ func (s SetMyCommands) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8768,7 +8768,7 @@ func (s SetMyCommands) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commands",
@@ -8792,7 +8792,7 @@ func (s SetPassportDataErrors) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8803,7 +8803,7 @@ func (s SetPassportDataErrors) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "errors",
@@ -8821,7 +8821,7 @@ func (s ShippingOption) Validate() error {
 		if s.Prices == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "prices",
@@ -8848,7 +8848,7 @@ func (s Sticker) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -8868,7 +8868,7 @@ func (s Sticker) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -8881,13 +8881,13 @@ func (s Sticker) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -8900,13 +8900,13 @@ func (s Sticker) Validate() error {
 				if err := s.MaskPosition.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "mask_position",
@@ -8926,13 +8926,13 @@ func (s StopMessageLiveLocation) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8952,13 +8952,13 @@ func (s StopPoll) Validate() error {
 				if err := s.ReplyMarkup.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "reply_markup",
@@ -8978,13 +8978,13 @@ func (s Update) Validate() error {
 				if err := s.Message.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "message",
@@ -8997,13 +8997,13 @@ func (s Update) Validate() error {
 				if err := s.EditedMessage.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "edited_message",
@@ -9016,13 +9016,13 @@ func (s Update) Validate() error {
 				if err := s.ChannelPost.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "channel_post",
@@ -9035,13 +9035,13 @@ func (s Update) Validate() error {
 				if err := s.EditedChannelPost.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "edited_channel_post",
@@ -9054,13 +9054,13 @@ func (s Update) Validate() error {
 				if err := s.InlineQuery.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "inline_query",
@@ -9073,13 +9073,13 @@ func (s Update) Validate() error {
 				if err := s.ChosenInlineResult.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chosen_inline_result",
@@ -9092,13 +9092,13 @@ func (s Update) Validate() error {
 				if err := s.CallbackQuery.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "callback_query",
@@ -9111,13 +9111,13 @@ func (s Update) Validate() error {
 				if err := s.Poll.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll",
@@ -9130,13 +9130,13 @@ func (s Update) Validate() error {
 				if err := s.PollAnswer.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "poll_answer",
@@ -9149,13 +9149,13 @@ func (s Update) Validate() error {
 				if err := s.MyChatMember.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "my_chat_member",
@@ -9168,13 +9168,13 @@ func (s Update) Validate() error {
 				if err := s.ChatMember.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_member",
@@ -9187,13 +9187,13 @@ func (s Update) Validate() error {
 				if err := s.ChatJoinRequest.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "chat_join_request",
@@ -9223,7 +9223,7 @@ func (s UserProfilePhotos) Validate() error {
 						if err := elem.Validate(); err != nil {
 							return err
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -9234,7 +9234,7 @@ func (s UserProfilePhotos) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9245,7 +9245,7 @@ func (s UserProfilePhotos) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "photos",
@@ -9263,7 +9263,7 @@ func (s Venue) Validate() error {
 		if err := s.Location.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "location",
@@ -9290,7 +9290,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Width)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "width",
@@ -9310,7 +9310,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Height)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "height",
@@ -9330,7 +9330,7 @@ func (s Video) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9343,13 +9343,13 @@ func (s Video) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -9376,7 +9376,7 @@ func (s VideoNote) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9389,13 +9389,13 @@ func (s VideoNote) Validate() error {
 				if err := s.Thumb.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "thumb",
@@ -9422,7 +9422,7 @@ func (s Voice) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",
@@ -9449,7 +9449,7 @@ func (s VoiceChatEnded) Validate() error {
 		}).Validate(int64(s.Duration)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "duration",

--- a/examples/ex_test_format/oas_client_gen.go
+++ b/examples/ex_test_format/oas_client_gen.go
@@ -237,7 +237,7 @@ func (c *Client) TestRequestBooleanArrayArray(ctx context.Context, request [][]b
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -248,7 +248,7 @@ func (c *Client) TestRequestBooleanArrayArray(ctx context.Context, request [][]b
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -430,7 +430,7 @@ func (c *Client) TestRequestBooleanNullableArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -441,7 +441,7 @@ func (c *Client) TestRequestBooleanNullableArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -565,13 +565,13 @@ func (c *Client) TestRequestFormatTest(ctx context.Context, request OptTestReque
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -753,7 +753,7 @@ func (c *Client) TestRequestIntegerArrayArray(ctx context.Context, request [][]i
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -764,7 +764,7 @@ func (c *Client) TestRequestIntegerArrayArray(ctx context.Context, request [][]i
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -946,7 +946,7 @@ func (c *Client) TestRequestIntegerInt32ArrayArray(ctx context.Context, request 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -957,7 +957,7 @@ func (c *Client) TestRequestIntegerInt32ArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1139,7 +1139,7 @@ func (c *Client) TestRequestIntegerInt32NullableArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1150,7 +1150,7 @@ func (c *Client) TestRequestIntegerInt32NullableArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1332,7 +1332,7 @@ func (c *Client) TestRequestIntegerInt64ArrayArray(ctx context.Context, request 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1343,7 +1343,7 @@ func (c *Client) TestRequestIntegerInt64ArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1525,7 +1525,7 @@ func (c *Client) TestRequestIntegerInt64NullableArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1536,7 +1536,7 @@ func (c *Client) TestRequestIntegerInt64NullableArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1718,7 +1718,7 @@ func (c *Client) TestRequestIntegerNullableArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1729,7 +1729,7 @@ func (c *Client) TestRequestIntegerNullableArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1911,7 +1911,7 @@ func (c *Client) TestRequestNullArrayArray(ctx context.Context, request [][]stru
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1922,7 +1922,7 @@ func (c *Client) TestRequestNullArrayArray(ctx context.Context, request [][]stru
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2104,7 +2104,7 @@ func (c *Client) TestRequestNullNullableArrayArray(ctx context.Context, request 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2115,7 +2115,7 @@ func (c *Client) TestRequestNullNullableArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2182,13 +2182,13 @@ func (c *Client) TestRequestNumber(ctx context.Context, request OptFloat64) (res
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2256,7 +2256,7 @@ func (c *Client) TestRequestNumberArray(ctx context.Context, request []float64) 
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2267,7 +2267,7 @@ func (c *Client) TestRequestNumberArray(ctx context.Context, request []float64) 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2341,7 +2341,7 @@ func (c *Client) TestRequestNumberArrayArray(ctx context.Context, request [][]fl
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -2352,7 +2352,7 @@ func (c *Client) TestRequestNumberArrayArray(ctx context.Context, request [][]fl
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2363,7 +2363,7 @@ func (c *Client) TestRequestNumberArrayArray(ctx context.Context, request [][]fl
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2430,13 +2430,13 @@ func (c *Client) TestRequestNumberDouble(ctx context.Context, request OptFloat64
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2504,7 +2504,7 @@ func (c *Client) TestRequestNumberDoubleArray(ctx context.Context, request []flo
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2515,7 +2515,7 @@ func (c *Client) TestRequestNumberDoubleArray(ctx context.Context, request []flo
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2589,7 +2589,7 @@ func (c *Client) TestRequestNumberDoubleArrayArray(ctx context.Context, request 
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -2600,7 +2600,7 @@ func (c *Client) TestRequestNumberDoubleArrayArray(ctx context.Context, request 
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2611,7 +2611,7 @@ func (c *Client) TestRequestNumberDoubleArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2678,13 +2678,13 @@ func (c *Client) TestRequestNumberDoubleNullable(ctx context.Context, request Op
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2752,7 +2752,7 @@ func (c *Client) TestRequestNumberDoubleNullableArray(ctx context.Context, reque
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2763,7 +2763,7 @@ func (c *Client) TestRequestNumberDoubleNullableArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2837,7 +2837,7 @@ func (c *Client) TestRequestNumberDoubleNullableArrayArray(ctx context.Context, 
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -2848,7 +2848,7 @@ func (c *Client) TestRequestNumberDoubleNullableArrayArray(ctx context.Context, 
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2859,7 +2859,7 @@ func (c *Client) TestRequestNumberDoubleNullableArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -2926,13 +2926,13 @@ func (c *Client) TestRequestNumberFloat(ctx context.Context, request OptFloat32)
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3000,7 +3000,7 @@ func (c *Client) TestRequestNumberFloatArray(ctx context.Context, request []floa
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3011,7 +3011,7 @@ func (c *Client) TestRequestNumberFloatArray(ctx context.Context, request []floa
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3085,7 +3085,7 @@ func (c *Client) TestRequestNumberFloatArrayArray(ctx context.Context, request [
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3096,7 +3096,7 @@ func (c *Client) TestRequestNumberFloatArrayArray(ctx context.Context, request [
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3107,7 +3107,7 @@ func (c *Client) TestRequestNumberFloatArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3174,13 +3174,13 @@ func (c *Client) TestRequestNumberFloatNullable(ctx context.Context, request Opt
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3248,7 +3248,7 @@ func (c *Client) TestRequestNumberFloatNullableArray(ctx context.Context, reques
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3259,7 +3259,7 @@ func (c *Client) TestRequestNumberFloatNullableArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3333,7 +3333,7 @@ func (c *Client) TestRequestNumberFloatNullableArrayArray(ctx context.Context, r
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3344,7 +3344,7 @@ func (c *Client) TestRequestNumberFloatNullableArrayArray(ctx context.Context, r
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3355,7 +3355,7 @@ func (c *Client) TestRequestNumberFloatNullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3537,7 +3537,7 @@ func (c *Client) TestRequestNumberInt32ArrayArray(ctx context.Context, request [
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3548,7 +3548,7 @@ func (c *Client) TestRequestNumberInt32ArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3730,7 +3730,7 @@ func (c *Client) TestRequestNumberInt32NullableArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3741,7 +3741,7 @@ func (c *Client) TestRequestNumberInt32NullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -3923,7 +3923,7 @@ func (c *Client) TestRequestNumberInt64ArrayArray(ctx context.Context, request [
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3934,7 +3934,7 @@ func (c *Client) TestRequestNumberInt64ArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4116,7 +4116,7 @@ func (c *Client) TestRequestNumberInt64NullableArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4127,7 +4127,7 @@ func (c *Client) TestRequestNumberInt64NullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4194,13 +4194,13 @@ func (c *Client) TestRequestNumberNullable(ctx context.Context, request OptNilFl
 				if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4268,7 +4268,7 @@ func (c *Client) TestRequestNumberNullableArray(ctx context.Context, request []f
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4279,7 +4279,7 @@ func (c *Client) TestRequestNumberNullableArray(ctx context.Context, request []f
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4353,7 +4353,7 @@ func (c *Client) TestRequestNumberNullableArrayArray(ctx context.Context, reques
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4364,7 +4364,7 @@ func (c *Client) TestRequestNumberNullableArrayArray(ctx context.Context, reques
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4375,7 +4375,7 @@ func (c *Client) TestRequestNumberNullableArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4554,7 +4554,7 @@ func (c *Client) TestRequestRequiredBooleanArray(ctx context.Context, request []
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4625,7 +4625,7 @@ func (c *Client) TestRequestRequiredBooleanArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4636,7 +4636,7 @@ func (c *Client) TestRequestRequiredBooleanArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4758,7 +4758,7 @@ func (c *Client) TestRequestRequiredBooleanNullableArray(ctx context.Context, re
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4829,7 +4829,7 @@ func (c *Client) TestRequestRequiredBooleanNullableArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4840,7 +4840,7 @@ func (c *Client) TestRequestRequiredBooleanNullableArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -4962,7 +4962,7 @@ func (c *Client) TestRequestRequiredFormatTest(ctx context.Context, request Test
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5084,7 +5084,7 @@ func (c *Client) TestRequestRequiredIntegerArray(ctx context.Context, request []
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5155,7 +5155,7 @@ func (c *Client) TestRequestRequiredIntegerArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5166,7 +5166,7 @@ func (c *Client) TestRequestRequiredIntegerArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5288,7 +5288,7 @@ func (c *Client) TestRequestRequiredIntegerInt32Array(ctx context.Context, reque
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5359,7 +5359,7 @@ func (c *Client) TestRequestRequiredIntegerInt32ArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5370,7 +5370,7 @@ func (c *Client) TestRequestRequiredIntegerInt32ArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5492,7 +5492,7 @@ func (c *Client) TestRequestRequiredIntegerInt32NullableArray(ctx context.Contex
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5563,7 +5563,7 @@ func (c *Client) TestRequestRequiredIntegerInt32NullableArrayArray(ctx context.C
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5574,7 +5574,7 @@ func (c *Client) TestRequestRequiredIntegerInt32NullableArrayArray(ctx context.C
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5696,7 +5696,7 @@ func (c *Client) TestRequestRequiredIntegerInt64Array(ctx context.Context, reque
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5767,7 +5767,7 @@ func (c *Client) TestRequestRequiredIntegerInt64ArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5778,7 +5778,7 @@ func (c *Client) TestRequestRequiredIntegerInt64ArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5900,7 +5900,7 @@ func (c *Client) TestRequestRequiredIntegerInt64NullableArray(ctx context.Contex
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -5971,7 +5971,7 @@ func (c *Client) TestRequestRequiredIntegerInt64NullableArrayArray(ctx context.C
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5982,7 +5982,7 @@ func (c *Client) TestRequestRequiredIntegerInt64NullableArrayArray(ctx context.C
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6104,7 +6104,7 @@ func (c *Client) TestRequestRequiredIntegerNullableArray(ctx context.Context, re
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6175,7 +6175,7 @@ func (c *Client) TestRequestRequiredIntegerNullableArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6186,7 +6186,7 @@ func (c *Client) TestRequestRequiredIntegerNullableArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6308,7 +6308,7 @@ func (c *Client) TestRequestRequiredNullArray(ctx context.Context, request []str
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6379,7 +6379,7 @@ func (c *Client) TestRequestRequiredNullArrayArray(ctx context.Context, request 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6390,7 +6390,7 @@ func (c *Client) TestRequestRequiredNullArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6512,7 +6512,7 @@ func (c *Client) TestRequestRequiredNullNullableArray(ctx context.Context, reque
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6583,7 +6583,7 @@ func (c *Client) TestRequestRequiredNullNullableArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6594,7 +6594,7 @@ func (c *Client) TestRequestRequiredNullNullableArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6659,7 +6659,7 @@ func (c *Client) TestRequestRequiredNumber(ctx context.Context, request float64)
 		if err := (validate.Float{}).Validate(float64(request)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6730,7 +6730,7 @@ func (c *Client) TestRequestRequiredNumberArray(ctx context.Context, request []f
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6741,7 +6741,7 @@ func (c *Client) TestRequestRequiredNumberArray(ctx context.Context, request []f
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6818,7 +6818,7 @@ func (c *Client) TestRequestRequiredNumberArrayArray(ctx context.Context, reques
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6829,7 +6829,7 @@ func (c *Client) TestRequestRequiredNumberArrayArray(ctx context.Context, reques
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6840,7 +6840,7 @@ func (c *Client) TestRequestRequiredNumberArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6905,7 +6905,7 @@ func (c *Client) TestRequestRequiredNumberDouble(ctx context.Context, request fl
 		if err := (validate.Float{}).Validate(float64(request)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -6976,7 +6976,7 @@ func (c *Client) TestRequestRequiredNumberDoubleArray(ctx context.Context, reque
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6987,7 +6987,7 @@ func (c *Client) TestRequestRequiredNumberDoubleArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7064,7 +7064,7 @@ func (c *Client) TestRequestRequiredNumberDoubleArrayArray(ctx context.Context, 
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7075,7 +7075,7 @@ func (c *Client) TestRequestRequiredNumberDoubleArrayArray(ctx context.Context, 
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7086,7 +7086,7 @@ func (c *Client) TestRequestRequiredNumberDoubleArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7151,8 +7151,8 @@ func (c *Client) TestRequestRequiredNumberDoubleNullable(ctx context.Context, re
 		if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7223,7 +7223,7 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArray(ctx context.Contex
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7234,7 +7234,7 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7311,7 +7311,7 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArrayArray(ctx context.C
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7322,7 +7322,7 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArrayArray(ctx context.C
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7333,7 +7333,7 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArrayArray(ctx context.C
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7398,7 +7398,7 @@ func (c *Client) TestRequestRequiredNumberFloat(ctx context.Context, request flo
 		if err := (validate.Float{}).Validate(float64(request)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7469,7 +7469,7 @@ func (c *Client) TestRequestRequiredNumberFloatArray(ctx context.Context, reques
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7480,7 +7480,7 @@ func (c *Client) TestRequestRequiredNumberFloatArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7557,7 +7557,7 @@ func (c *Client) TestRequestRequiredNumberFloatArrayArray(ctx context.Context, r
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7568,7 +7568,7 @@ func (c *Client) TestRequestRequiredNumberFloatArrayArray(ctx context.Context, r
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7579,7 +7579,7 @@ func (c *Client) TestRequestRequiredNumberFloatArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7644,8 +7644,8 @@ func (c *Client) TestRequestRequiredNumberFloatNullable(ctx context.Context, req
 		if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7716,7 +7716,7 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArray(ctx context.Context
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7727,7 +7727,7 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7804,7 +7804,7 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArrayArray(ctx context.Co
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7815,7 +7815,7 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArrayArray(ctx context.Co
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7826,7 +7826,7 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -7948,7 +7948,7 @@ func (c *Client) TestRequestRequiredNumberInt32Array(ctx context.Context, reques
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8019,7 +8019,7 @@ func (c *Client) TestRequestRequiredNumberInt32ArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8030,7 +8030,7 @@ func (c *Client) TestRequestRequiredNumberInt32ArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8152,7 +8152,7 @@ func (c *Client) TestRequestRequiredNumberInt32NullableArray(ctx context.Context
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8223,7 +8223,7 @@ func (c *Client) TestRequestRequiredNumberInt32NullableArrayArray(ctx context.Co
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8234,7 +8234,7 @@ func (c *Client) TestRequestRequiredNumberInt32NullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8356,7 +8356,7 @@ func (c *Client) TestRequestRequiredNumberInt64Array(ctx context.Context, reques
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8427,7 +8427,7 @@ func (c *Client) TestRequestRequiredNumberInt64ArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8438,7 +8438,7 @@ func (c *Client) TestRequestRequiredNumberInt64ArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8560,7 +8560,7 @@ func (c *Client) TestRequestRequiredNumberInt64NullableArray(ctx context.Context
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8631,7 +8631,7 @@ func (c *Client) TestRequestRequiredNumberInt64NullableArrayArray(ctx context.Co
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8642,7 +8642,7 @@ func (c *Client) TestRequestRequiredNumberInt64NullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8707,8 +8707,8 @@ func (c *Client) TestRequestRequiredNumberNullable(ctx context.Context, request 
 		if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8779,7 +8779,7 @@ func (c *Client) TestRequestRequiredNumberNullableArray(ctx context.Context, req
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8790,7 +8790,7 @@ func (c *Client) TestRequestRequiredNumberNullableArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -8867,7 +8867,7 @@ func (c *Client) TestRequestRequiredNumberNullableArrayArray(ctx context.Context
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -8878,7 +8878,7 @@ func (c *Client) TestRequestRequiredNumberNullableArrayArray(ctx context.Context
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8889,7 +8889,7 @@ func (c *Client) TestRequestRequiredNumberNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9011,7 +9011,7 @@ func (c *Client) TestRequestRequiredStringArray(ctx context.Context, request []s
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9082,7 +9082,7 @@ func (c *Client) TestRequestRequiredStringArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9093,7 +9093,7 @@ func (c *Client) TestRequestRequiredStringArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9215,7 +9215,7 @@ func (c *Client) TestRequestRequiredStringBinaryArray(ctx context.Context, reque
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9286,7 +9286,7 @@ func (c *Client) TestRequestRequiredStringBinaryArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9297,7 +9297,7 @@ func (c *Client) TestRequestRequiredStringBinaryArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9419,7 +9419,7 @@ func (c *Client) TestRequestRequiredStringBinaryNullableArray(ctx context.Contex
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9490,7 +9490,7 @@ func (c *Client) TestRequestRequiredStringBinaryNullableArrayArray(ctx context.C
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9501,7 +9501,7 @@ func (c *Client) TestRequestRequiredStringBinaryNullableArrayArray(ctx context.C
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9623,7 +9623,7 @@ func (c *Client) TestRequestRequiredStringByteArray(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9694,7 +9694,7 @@ func (c *Client) TestRequestRequiredStringByteArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9705,7 +9705,7 @@ func (c *Client) TestRequestRequiredStringByteArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9827,7 +9827,7 @@ func (c *Client) TestRequestRequiredStringByteNullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -9898,7 +9898,7 @@ func (c *Client) TestRequestRequiredStringByteNullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -9909,7 +9909,7 @@ func (c *Client) TestRequestRequiredStringByteNullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10031,7 +10031,7 @@ func (c *Client) TestRequestRequiredStringDateArray(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10102,7 +10102,7 @@ func (c *Client) TestRequestRequiredStringDateArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -10113,7 +10113,7 @@ func (c *Client) TestRequestRequiredStringDateArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10235,7 +10235,7 @@ func (c *Client) TestRequestRequiredStringDateNullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10306,7 +10306,7 @@ func (c *Client) TestRequestRequiredStringDateNullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -10317,7 +10317,7 @@ func (c *Client) TestRequestRequiredStringDateNullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10439,7 +10439,7 @@ func (c *Client) TestRequestRequiredStringDateTimeArray(ctx context.Context, req
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10510,7 +10510,7 @@ func (c *Client) TestRequestRequiredStringDateTimeArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -10521,7 +10521,7 @@ func (c *Client) TestRequestRequiredStringDateTimeArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10643,7 +10643,7 @@ func (c *Client) TestRequestRequiredStringDateTimeNullableArray(ctx context.Cont
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10714,7 +10714,7 @@ func (c *Client) TestRequestRequiredStringDateTimeNullableArrayArray(ctx context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -10725,7 +10725,7 @@ func (c *Client) TestRequestRequiredStringDateTimeNullableArrayArray(ctx context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10847,7 +10847,7 @@ func (c *Client) TestRequestRequiredStringDurationArray(ctx context.Context, req
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -10918,7 +10918,7 @@ func (c *Client) TestRequestRequiredStringDurationArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -10929,7 +10929,7 @@ func (c *Client) TestRequestRequiredStringDurationArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11051,7 +11051,7 @@ func (c *Client) TestRequestRequiredStringDurationNullableArray(ctx context.Cont
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11122,7 +11122,7 @@ func (c *Client) TestRequestRequiredStringDurationNullableArrayArray(ctx context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11133,7 +11133,7 @@ func (c *Client) TestRequestRequiredStringDurationNullableArrayArray(ctx context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11206,7 +11206,7 @@ func (c *Client) TestRequestRequiredStringEmail(ctx context.Context, request str
 		}).Validate(string(request)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11285,7 +11285,7 @@ func (c *Client) TestRequestRequiredStringEmailArray(ctx context.Context, reques
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11296,7 +11296,7 @@ func (c *Client) TestRequestRequiredStringEmailArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11381,7 +11381,7 @@ func (c *Client) TestRequestRequiredStringEmailArrayArray(ctx context.Context, r
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -11392,7 +11392,7 @@ func (c *Client) TestRequestRequiredStringEmailArrayArray(ctx context.Context, r
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11403,7 +11403,7 @@ func (c *Client) TestRequestRequiredStringEmailArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11476,8 +11476,8 @@ func (c *Client) TestRequestRequiredStringEmailNullable(ctx context.Context, req
 		}).Validate(string(request.Value)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11556,7 +11556,7 @@ func (c *Client) TestRequestRequiredStringEmailNullableArray(ctx context.Context
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11567,7 +11567,7 @@ func (c *Client) TestRequestRequiredStringEmailNullableArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11652,7 +11652,7 @@ func (c *Client) TestRequestRequiredStringEmailNullableArrayArray(ctx context.Co
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -11663,7 +11663,7 @@ func (c *Client) TestRequestRequiredStringEmailNullableArrayArray(ctx context.Co
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11674,7 +11674,7 @@ func (c *Client) TestRequestRequiredStringEmailNullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11747,7 +11747,7 @@ func (c *Client) TestRequestRequiredStringHostname(ctx context.Context, request 
 		}).Validate(string(request)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11826,7 +11826,7 @@ func (c *Client) TestRequestRequiredStringHostnameArray(ctx context.Context, req
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11837,7 +11837,7 @@ func (c *Client) TestRequestRequiredStringHostnameArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -11922,7 +11922,7 @@ func (c *Client) TestRequestRequiredStringHostnameArrayArray(ctx context.Context
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -11933,7 +11933,7 @@ func (c *Client) TestRequestRequiredStringHostnameArrayArray(ctx context.Context
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -11944,7 +11944,7 @@ func (c *Client) TestRequestRequiredStringHostnameArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12017,8 +12017,8 @@ func (c *Client) TestRequestRequiredStringHostnameNullable(ctx context.Context, 
 		}).Validate(string(request.Value)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12097,7 +12097,7 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArray(ctx context.Cont
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -12108,7 +12108,7 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArray(ctx context.Cont
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12193,7 +12193,7 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArrayArray(ctx context
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -12204,7 +12204,7 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArrayArray(ctx context
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -12215,7 +12215,7 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArrayArray(ctx context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12337,7 +12337,7 @@ func (c *Client) TestRequestRequiredStringIPArray(ctx context.Context, request [
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12408,7 +12408,7 @@ func (c *Client) TestRequestRequiredStringIPArrayArray(ctx context.Context, requ
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -12419,7 +12419,7 @@ func (c *Client) TestRequestRequiredStringIPArrayArray(ctx context.Context, requ
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12541,7 +12541,7 @@ func (c *Client) TestRequestRequiredStringIPNullableArray(ctx context.Context, r
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12612,7 +12612,7 @@ func (c *Client) TestRequestRequiredStringIPNullableArrayArray(ctx context.Conte
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -12623,7 +12623,7 @@ func (c *Client) TestRequestRequiredStringIPNullableArrayArray(ctx context.Conte
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12745,7 +12745,7 @@ func (c *Client) TestRequestRequiredStringInt32Array(ctx context.Context, reques
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12816,7 +12816,7 @@ func (c *Client) TestRequestRequiredStringInt32ArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -12827,7 +12827,7 @@ func (c *Client) TestRequestRequiredStringInt32ArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -12949,7 +12949,7 @@ func (c *Client) TestRequestRequiredStringInt32NullableArray(ctx context.Context
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13020,7 +13020,7 @@ func (c *Client) TestRequestRequiredStringInt32NullableArrayArray(ctx context.Co
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13031,7 +13031,7 @@ func (c *Client) TestRequestRequiredStringInt32NullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13153,7 +13153,7 @@ func (c *Client) TestRequestRequiredStringInt64Array(ctx context.Context, reques
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13224,7 +13224,7 @@ func (c *Client) TestRequestRequiredStringInt64ArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13235,7 +13235,7 @@ func (c *Client) TestRequestRequiredStringInt64ArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13357,7 +13357,7 @@ func (c *Client) TestRequestRequiredStringInt64NullableArray(ctx context.Context
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13428,7 +13428,7 @@ func (c *Client) TestRequestRequiredStringInt64NullableArrayArray(ctx context.Co
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13439,7 +13439,7 @@ func (c *Client) TestRequestRequiredStringInt64NullableArrayArray(ctx context.Co
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13561,7 +13561,7 @@ func (c *Client) TestRequestRequiredStringIpv4Array(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13632,7 +13632,7 @@ func (c *Client) TestRequestRequiredStringIpv4ArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13643,7 +13643,7 @@ func (c *Client) TestRequestRequiredStringIpv4ArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13765,7 +13765,7 @@ func (c *Client) TestRequestRequiredStringIpv4NullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13836,7 +13836,7 @@ func (c *Client) TestRequestRequiredStringIpv4NullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -13847,7 +13847,7 @@ func (c *Client) TestRequestRequiredStringIpv4NullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -13969,7 +13969,7 @@ func (c *Client) TestRequestRequiredStringIpv6Array(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14040,7 +14040,7 @@ func (c *Client) TestRequestRequiredStringIpv6ArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -14051,7 +14051,7 @@ func (c *Client) TestRequestRequiredStringIpv6ArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14173,7 +14173,7 @@ func (c *Client) TestRequestRequiredStringIpv6NullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14244,7 +14244,7 @@ func (c *Client) TestRequestRequiredStringIpv6NullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -14255,7 +14255,7 @@ func (c *Client) TestRequestRequiredStringIpv6NullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14377,7 +14377,7 @@ func (c *Client) TestRequestRequiredStringNullableArray(ctx context.Context, req
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14448,7 +14448,7 @@ func (c *Client) TestRequestRequiredStringNullableArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -14459,7 +14459,7 @@ func (c *Client) TestRequestRequiredStringNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14581,7 +14581,7 @@ func (c *Client) TestRequestRequiredStringPasswordArray(ctx context.Context, req
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14652,7 +14652,7 @@ func (c *Client) TestRequestRequiredStringPasswordArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -14663,7 +14663,7 @@ func (c *Client) TestRequestRequiredStringPasswordArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14785,7 +14785,7 @@ func (c *Client) TestRequestRequiredStringPasswordNullableArray(ctx context.Cont
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14856,7 +14856,7 @@ func (c *Client) TestRequestRequiredStringPasswordNullableArrayArray(ctx context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -14867,7 +14867,7 @@ func (c *Client) TestRequestRequiredStringPasswordNullableArrayArray(ctx context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -14989,7 +14989,7 @@ func (c *Client) TestRequestRequiredStringTimeArray(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15060,7 +15060,7 @@ func (c *Client) TestRequestRequiredStringTimeArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15071,7 +15071,7 @@ func (c *Client) TestRequestRequiredStringTimeArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15193,7 +15193,7 @@ func (c *Client) TestRequestRequiredStringTimeNullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15264,7 +15264,7 @@ func (c *Client) TestRequestRequiredStringTimeNullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15275,7 +15275,7 @@ func (c *Client) TestRequestRequiredStringTimeNullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15397,7 +15397,7 @@ func (c *Client) TestRequestRequiredStringURIArray(ctx context.Context, request 
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15468,7 +15468,7 @@ func (c *Client) TestRequestRequiredStringURIArrayArray(ctx context.Context, req
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15479,7 +15479,7 @@ func (c *Client) TestRequestRequiredStringURIArrayArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15601,7 +15601,7 @@ func (c *Client) TestRequestRequiredStringURINullableArray(ctx context.Context, 
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15672,7 +15672,7 @@ func (c *Client) TestRequestRequiredStringURINullableArrayArray(ctx context.Cont
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15683,7 +15683,7 @@ func (c *Client) TestRequestRequiredStringURINullableArrayArray(ctx context.Cont
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15805,7 +15805,7 @@ func (c *Client) TestRequestRequiredStringUUIDArray(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -15876,7 +15876,7 @@ func (c *Client) TestRequestRequiredStringUUIDArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -15887,7 +15887,7 @@ func (c *Client) TestRequestRequiredStringUUIDArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16009,7 +16009,7 @@ func (c *Client) TestRequestRequiredStringUUIDNullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16080,7 +16080,7 @@ func (c *Client) TestRequestRequiredStringUUIDNullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16091,7 +16091,7 @@ func (c *Client) TestRequestRequiredStringUUIDNullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16213,7 +16213,7 @@ func (c *Client) TestRequestRequiredStringUnixArray(ctx context.Context, request
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16284,7 +16284,7 @@ func (c *Client) TestRequestRequiredStringUnixArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16295,7 +16295,7 @@ func (c *Client) TestRequestRequiredStringUnixArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16417,7 +16417,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroArray(ctx context.Context, re
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16488,7 +16488,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16499,7 +16499,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16621,7 +16621,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullableArray(ctx context.Con
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16692,7 +16692,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullableArrayArray(ctx contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16703,7 +16703,7 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullableArrayArray(ctx contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16825,7 +16825,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliArray(ctx context.Context, re
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -16896,7 +16896,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -16907,7 +16907,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17029,7 +17029,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullableArray(ctx context.Con
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17100,7 +17100,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullableArrayArray(ctx contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -17111,7 +17111,7 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullableArrayArray(ctx contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17233,7 +17233,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoArray(ctx context.Context, req
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17304,7 +17304,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -17315,7 +17315,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17437,7 +17437,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullableArray(ctx context.Cont
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17508,7 +17508,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullableArrayArray(ctx context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -17519,7 +17519,7 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullableArrayArray(ctx context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17641,7 +17641,7 @@ func (c *Client) TestRequestRequiredStringUnixNullableArray(ctx context.Context,
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17712,7 +17712,7 @@ func (c *Client) TestRequestRequiredStringUnixNullableArrayArray(ctx context.Con
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -17723,7 +17723,7 @@ func (c *Client) TestRequestRequiredStringUnixNullableArrayArray(ctx context.Con
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17845,7 +17845,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsArray(ctx context.Context, 
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -17916,7 +17916,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsArrayArray(ctx context.Cont
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -17927,7 +17927,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsArrayArray(ctx context.Cont
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18049,7 +18049,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullableArray(ctx context.C
 		if request == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18120,7 +18120,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullableArrayArray(ctx cont
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -18131,7 +18131,7 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullableArrayArray(ctx cont
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18313,7 +18313,7 @@ func (c *Client) TestRequestStringArrayArray(ctx context.Context, request [][]st
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -18324,7 +18324,7 @@ func (c *Client) TestRequestStringArrayArray(ctx context.Context, request [][]st
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18506,7 +18506,7 @@ func (c *Client) TestRequestStringBinaryArrayArray(ctx context.Context, request 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -18517,7 +18517,7 @@ func (c *Client) TestRequestStringBinaryArrayArray(ctx context.Context, request 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18699,7 +18699,7 @@ func (c *Client) TestRequestStringBinaryNullableArrayArray(ctx context.Context, 
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -18710,7 +18710,7 @@ func (c *Client) TestRequestStringBinaryNullableArrayArray(ctx context.Context, 
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -18892,7 +18892,7 @@ func (c *Client) TestRequestStringByteArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -18903,7 +18903,7 @@ func (c *Client) TestRequestStringByteArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19085,7 +19085,7 @@ func (c *Client) TestRequestStringByteNullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -19096,7 +19096,7 @@ func (c *Client) TestRequestStringByteNullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19278,7 +19278,7 @@ func (c *Client) TestRequestStringDateArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -19289,7 +19289,7 @@ func (c *Client) TestRequestStringDateArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19471,7 +19471,7 @@ func (c *Client) TestRequestStringDateNullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -19482,7 +19482,7 @@ func (c *Client) TestRequestStringDateNullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19664,7 +19664,7 @@ func (c *Client) TestRequestStringDateTimeArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -19675,7 +19675,7 @@ func (c *Client) TestRequestStringDateTimeArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -19857,7 +19857,7 @@ func (c *Client) TestRequestStringDateTimeNullableArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -19868,7 +19868,7 @@ func (c *Client) TestRequestStringDateTimeNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20050,7 +20050,7 @@ func (c *Client) TestRequestStringDurationArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20061,7 +20061,7 @@ func (c *Client) TestRequestStringDurationArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20243,7 +20243,7 @@ func (c *Client) TestRequestStringDurationNullableArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20254,7 +20254,7 @@ func (c *Client) TestRequestStringDurationNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20329,13 +20329,13 @@ func (c *Client) TestRequestStringEmail(ctx context.Context, request OptString) 
 				}).Validate(string(request.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20411,7 +20411,7 @@ func (c *Client) TestRequestStringEmailArray(ctx context.Context, request []stri
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20422,7 +20422,7 @@ func (c *Client) TestRequestStringEmailArray(ctx context.Context, request []stri
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20504,7 +20504,7 @@ func (c *Client) TestRequestStringEmailArrayArray(ctx context.Context, request [
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -20515,7 +20515,7 @@ func (c *Client) TestRequestStringEmailArrayArray(ctx context.Context, request [
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20526,7 +20526,7 @@ func (c *Client) TestRequestStringEmailArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20601,13 +20601,13 @@ func (c *Client) TestRequestStringEmailNullable(ctx context.Context, request Opt
 				}).Validate(string(request.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20683,7 +20683,7 @@ func (c *Client) TestRequestStringEmailNullableArray(ctx context.Context, reques
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20694,7 +20694,7 @@ func (c *Client) TestRequestStringEmailNullableArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20776,7 +20776,7 @@ func (c *Client) TestRequestStringEmailNullableArrayArray(ctx context.Context, r
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -20787,7 +20787,7 @@ func (c *Client) TestRequestStringEmailNullableArrayArray(ctx context.Context, r
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20798,7 +20798,7 @@ func (c *Client) TestRequestStringEmailNullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20873,13 +20873,13 @@ func (c *Client) TestRequestStringHostname(ctx context.Context, request OptStrin
 				}).Validate(string(request.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -20955,7 +20955,7 @@ func (c *Client) TestRequestStringHostnameArray(ctx context.Context, request []s
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -20966,7 +20966,7 @@ func (c *Client) TestRequestStringHostnameArray(ctx context.Context, request []s
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21048,7 +21048,7 @@ func (c *Client) TestRequestStringHostnameArrayArray(ctx context.Context, reques
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -21059,7 +21059,7 @@ func (c *Client) TestRequestStringHostnameArrayArray(ctx context.Context, reques
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21070,7 +21070,7 @@ func (c *Client) TestRequestStringHostnameArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21145,13 +21145,13 @@ func (c *Client) TestRequestStringHostnameNullable(ctx context.Context, request 
 				}).Validate(string(request.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21227,7 +21227,7 @@ func (c *Client) TestRequestStringHostnameNullableArray(ctx context.Context, req
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21238,7 +21238,7 @@ func (c *Client) TestRequestStringHostnameNullableArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21320,7 +21320,7 @@ func (c *Client) TestRequestStringHostnameNullableArrayArray(ctx context.Context
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -21331,7 +21331,7 @@ func (c *Client) TestRequestStringHostnameNullableArrayArray(ctx context.Context
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21342,7 +21342,7 @@ func (c *Client) TestRequestStringHostnameNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21524,7 +21524,7 @@ func (c *Client) TestRequestStringIPArrayArray(ctx context.Context, request [][]
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21535,7 +21535,7 @@ func (c *Client) TestRequestStringIPArrayArray(ctx context.Context, request [][]
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21717,7 +21717,7 @@ func (c *Client) TestRequestStringIPNullableArrayArray(ctx context.Context, requ
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21728,7 +21728,7 @@ func (c *Client) TestRequestStringIPNullableArrayArray(ctx context.Context, requ
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -21910,7 +21910,7 @@ func (c *Client) TestRequestStringInt32ArrayArray(ctx context.Context, request [
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -21921,7 +21921,7 @@ func (c *Client) TestRequestStringInt32ArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22103,7 +22103,7 @@ func (c *Client) TestRequestStringInt32NullableArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -22114,7 +22114,7 @@ func (c *Client) TestRequestStringInt32NullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22296,7 +22296,7 @@ func (c *Client) TestRequestStringInt64ArrayArray(ctx context.Context, request [
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -22307,7 +22307,7 @@ func (c *Client) TestRequestStringInt64ArrayArray(ctx context.Context, request [
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22489,7 +22489,7 @@ func (c *Client) TestRequestStringInt64NullableArrayArray(ctx context.Context, r
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -22500,7 +22500,7 @@ func (c *Client) TestRequestStringInt64NullableArrayArray(ctx context.Context, r
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22682,7 +22682,7 @@ func (c *Client) TestRequestStringIpv4ArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -22693,7 +22693,7 @@ func (c *Client) TestRequestStringIpv4ArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -22875,7 +22875,7 @@ func (c *Client) TestRequestStringIpv4NullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -22886,7 +22886,7 @@ func (c *Client) TestRequestStringIpv4NullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23068,7 +23068,7 @@ func (c *Client) TestRequestStringIpv6ArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -23079,7 +23079,7 @@ func (c *Client) TestRequestStringIpv6ArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23261,7 +23261,7 @@ func (c *Client) TestRequestStringIpv6NullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -23272,7 +23272,7 @@ func (c *Client) TestRequestStringIpv6NullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23454,7 +23454,7 @@ func (c *Client) TestRequestStringNullableArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -23465,7 +23465,7 @@ func (c *Client) TestRequestStringNullableArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23647,7 +23647,7 @@ func (c *Client) TestRequestStringPasswordArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -23658,7 +23658,7 @@ func (c *Client) TestRequestStringPasswordArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -23840,7 +23840,7 @@ func (c *Client) TestRequestStringPasswordNullableArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -23851,7 +23851,7 @@ func (c *Client) TestRequestStringPasswordNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24033,7 +24033,7 @@ func (c *Client) TestRequestStringTimeArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -24044,7 +24044,7 @@ func (c *Client) TestRequestStringTimeArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24226,7 +24226,7 @@ func (c *Client) TestRequestStringTimeNullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -24237,7 +24237,7 @@ func (c *Client) TestRequestStringTimeNullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24419,7 +24419,7 @@ func (c *Client) TestRequestStringURIArrayArray(ctx context.Context, request [][
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -24430,7 +24430,7 @@ func (c *Client) TestRequestStringURIArrayArray(ctx context.Context, request [][
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24612,7 +24612,7 @@ func (c *Client) TestRequestStringURINullableArrayArray(ctx context.Context, req
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -24623,7 +24623,7 @@ func (c *Client) TestRequestStringURINullableArrayArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24805,7 +24805,7 @@ func (c *Client) TestRequestStringUUIDArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -24816,7 +24816,7 @@ func (c *Client) TestRequestStringUUIDArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -24998,7 +24998,7 @@ func (c *Client) TestRequestStringUUIDNullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25009,7 +25009,7 @@ func (c *Client) TestRequestStringUUIDNullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25191,7 +25191,7 @@ func (c *Client) TestRequestStringUnixArrayArray(ctx context.Context, request []
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25202,7 +25202,7 @@ func (c *Client) TestRequestStringUnixArrayArray(ctx context.Context, request []
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25384,7 +25384,7 @@ func (c *Client) TestRequestStringUnixMicroArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25395,7 +25395,7 @@ func (c *Client) TestRequestStringUnixMicroArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25577,7 +25577,7 @@ func (c *Client) TestRequestStringUnixMicroNullableArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25588,7 +25588,7 @@ func (c *Client) TestRequestStringUnixMicroNullableArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25770,7 +25770,7 @@ func (c *Client) TestRequestStringUnixMilliArrayArray(ctx context.Context, reque
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25781,7 +25781,7 @@ func (c *Client) TestRequestStringUnixMilliArrayArray(ctx context.Context, reque
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -25963,7 +25963,7 @@ func (c *Client) TestRequestStringUnixMilliNullableArrayArray(ctx context.Contex
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -25974,7 +25974,7 @@ func (c *Client) TestRequestStringUnixMilliNullableArrayArray(ctx context.Contex
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26156,7 +26156,7 @@ func (c *Client) TestRequestStringUnixNanoArrayArray(ctx context.Context, reques
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -26167,7 +26167,7 @@ func (c *Client) TestRequestStringUnixNanoArrayArray(ctx context.Context, reques
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26349,7 +26349,7 @@ func (c *Client) TestRequestStringUnixNanoNullableArrayArray(ctx context.Context
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -26360,7 +26360,7 @@ func (c *Client) TestRequestStringUnixNanoNullableArrayArray(ctx context.Context
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26542,7 +26542,7 @@ func (c *Client) TestRequestStringUnixNullableArrayArray(ctx context.Context, re
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -26553,7 +26553,7 @@ func (c *Client) TestRequestStringUnixNullableArrayArray(ctx context.Context, re
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26735,7 +26735,7 @@ func (c *Client) TestRequestStringUnixSecondsArrayArray(ctx context.Context, req
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -26746,7 +26746,7 @@ func (c *Client) TestRequestStringUnixSecondsArrayArray(ctx context.Context, req
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -26928,7 +26928,7 @@ func (c *Client) TestRequestStringUnixSecondsNullableArrayArray(ctx context.Cont
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -26939,7 +26939,7 @@ func (c *Client) TestRequestStringUnixSecondsNullableArrayArray(ctx context.Cont
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_test_format/oas_handlers_gen.go
+++ b/examples/ex_test_format/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleTestRequestAnyRequest(args [0]string, w http.ResponseWrit
 	request, err := decodeTestRequestAnyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestAny",
-			err,
+			Operation: "TestRequestAny",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleTestRequestBooleanRequest(args [0]string, w http.Response
 	request, err := decodeTestRequestBooleanRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBoolean",
-			err,
+			Operation: "TestRequestBoolean",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -124,8 +124,8 @@ func (s *Server) handleTestRequestBooleanArrayRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestBooleanArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBooleanArray",
-			err,
+			Operation: "TestRequestBooleanArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -169,8 +169,8 @@ func (s *Server) handleTestRequestBooleanArrayArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestBooleanArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBooleanArrayArray",
-			err,
+			Operation: "TestRequestBooleanArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -214,8 +214,8 @@ func (s *Server) handleTestRequestBooleanNullableRequest(args [0]string, w http.
 	request, err := decodeTestRequestBooleanNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBooleanNullable",
-			err,
+			Operation: "TestRequestBooleanNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -259,8 +259,8 @@ func (s *Server) handleTestRequestBooleanNullableArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestBooleanNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBooleanNullableArray",
-			err,
+			Operation: "TestRequestBooleanNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -304,8 +304,8 @@ func (s *Server) handleTestRequestBooleanNullableArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestBooleanNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestBooleanNullableArrayArray",
-			err,
+			Operation: "TestRequestBooleanNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -349,8 +349,8 @@ func (s *Server) handleTestRequestEmptyStructRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestEmptyStructRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestEmptyStruct",
-			err,
+			Operation: "TestRequestEmptyStruct",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -394,8 +394,8 @@ func (s *Server) handleTestRequestFormatTestRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestFormatTestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestFormatTest",
-			err,
+			Operation: "TestRequestFormatTest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -439,8 +439,8 @@ func (s *Server) handleTestRequestIntegerRequest(args [0]string, w http.Response
 	request, err := decodeTestRequestIntegerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestInteger",
-			err,
+			Operation: "TestRequestInteger",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -484,8 +484,8 @@ func (s *Server) handleTestRequestIntegerArrayRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestIntegerArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerArray",
-			err,
+			Operation: "TestRequestIntegerArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -529,8 +529,8 @@ func (s *Server) handleTestRequestIntegerArrayArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestIntegerArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerArrayArray",
-			err,
+			Operation: "TestRequestIntegerArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -574,8 +574,8 @@ func (s *Server) handleTestRequestIntegerInt32Request(args [0]string, w http.Res
 	request, err := decodeTestRequestIntegerInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32",
-			err,
+			Operation: "TestRequestIntegerInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -619,8 +619,8 @@ func (s *Server) handleTestRequestIntegerInt32ArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestIntegerInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32Array",
-			err,
+			Operation: "TestRequestIntegerInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -664,8 +664,8 @@ func (s *Server) handleTestRequestIntegerInt32ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestIntegerInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32ArrayArray",
-			err,
+			Operation: "TestRequestIntegerInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -709,8 +709,8 @@ func (s *Server) handleTestRequestIntegerInt32NullableRequest(args [0]string, w 
 	request, err := decodeTestRequestIntegerInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32Nullable",
-			err,
+			Operation: "TestRequestIntegerInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -754,8 +754,8 @@ func (s *Server) handleTestRequestIntegerInt32NullableArrayRequest(args [0]strin
 	request, err := decodeTestRequestIntegerInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32NullableArray",
-			err,
+			Operation: "TestRequestIntegerInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -799,8 +799,8 @@ func (s *Server) handleTestRequestIntegerInt32NullableArrayArrayRequest(args [0]
 	request, err := decodeTestRequestIntegerInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestIntegerInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -844,8 +844,8 @@ func (s *Server) handleTestRequestIntegerInt64Request(args [0]string, w http.Res
 	request, err := decodeTestRequestIntegerInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64",
-			err,
+			Operation: "TestRequestIntegerInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -889,8 +889,8 @@ func (s *Server) handleTestRequestIntegerInt64ArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestIntegerInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64Array",
-			err,
+			Operation: "TestRequestIntegerInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -934,8 +934,8 @@ func (s *Server) handleTestRequestIntegerInt64ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestIntegerInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64ArrayArray",
-			err,
+			Operation: "TestRequestIntegerInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -979,8 +979,8 @@ func (s *Server) handleTestRequestIntegerInt64NullableRequest(args [0]string, w 
 	request, err := decodeTestRequestIntegerInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64Nullable",
-			err,
+			Operation: "TestRequestIntegerInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1024,8 +1024,8 @@ func (s *Server) handleTestRequestIntegerInt64NullableArrayRequest(args [0]strin
 	request, err := decodeTestRequestIntegerInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64NullableArray",
-			err,
+			Operation: "TestRequestIntegerInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1069,8 +1069,8 @@ func (s *Server) handleTestRequestIntegerInt64NullableArrayArrayRequest(args [0]
 	request, err := decodeTestRequestIntegerInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestIntegerInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1114,8 +1114,8 @@ func (s *Server) handleTestRequestIntegerNullableRequest(args [0]string, w http.
 	request, err := decodeTestRequestIntegerNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerNullable",
-			err,
+			Operation: "TestRequestIntegerNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1159,8 +1159,8 @@ func (s *Server) handleTestRequestIntegerNullableArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestIntegerNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerNullableArray",
-			err,
+			Operation: "TestRequestIntegerNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1204,8 +1204,8 @@ func (s *Server) handleTestRequestIntegerNullableArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestIntegerNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestIntegerNullableArrayArray",
-			err,
+			Operation: "TestRequestIntegerNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1249,8 +1249,8 @@ func (s *Server) handleTestRequestNullRequest(args [0]string, w http.ResponseWri
 	request, err := decodeTestRequestNullRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNull",
-			err,
+			Operation: "TestRequestNull",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1294,8 +1294,8 @@ func (s *Server) handleTestRequestNullArrayRequest(args [0]string, w http.Respon
 	request, err := decodeTestRequestNullArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNullArray",
-			err,
+			Operation: "TestRequestNullArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1339,8 +1339,8 @@ func (s *Server) handleTestRequestNullArrayArrayRequest(args [0]string, w http.R
 	request, err := decodeTestRequestNullArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNullArrayArray",
-			err,
+			Operation: "TestRequestNullArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1384,8 +1384,8 @@ func (s *Server) handleTestRequestNullNullableRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestNullNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNullNullable",
-			err,
+			Operation: "TestRequestNullNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1429,8 +1429,8 @@ func (s *Server) handleTestRequestNullNullableArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestNullNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNullNullableArray",
-			err,
+			Operation: "TestRequestNullNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1474,8 +1474,8 @@ func (s *Server) handleTestRequestNullNullableArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestNullNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNullNullableArrayArray",
-			err,
+			Operation: "TestRequestNullNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1519,8 +1519,8 @@ func (s *Server) handleTestRequestNumberRequest(args [0]string, w http.ResponseW
 	request, err := decodeTestRequestNumberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumber",
-			err,
+			Operation: "TestRequestNumber",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1564,8 +1564,8 @@ func (s *Server) handleTestRequestNumberArrayRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestNumberArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberArray",
-			err,
+			Operation: "TestRequestNumberArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1609,8 +1609,8 @@ func (s *Server) handleTestRequestNumberArrayArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestNumberArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberArrayArray",
-			err,
+			Operation: "TestRequestNumberArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1654,8 +1654,8 @@ func (s *Server) handleTestRequestNumberDoubleRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestNumberDoubleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDouble",
-			err,
+			Operation: "TestRequestNumberDouble",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1699,8 +1699,8 @@ func (s *Server) handleTestRequestNumberDoubleArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestNumberDoubleArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDoubleArray",
-			err,
+			Operation: "TestRequestNumberDoubleArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1744,8 +1744,8 @@ func (s *Server) handleTestRequestNumberDoubleArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestNumberDoubleArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDoubleArrayArray",
-			err,
+			Operation: "TestRequestNumberDoubleArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1789,8 +1789,8 @@ func (s *Server) handleTestRequestNumberDoubleNullableRequest(args [0]string, w 
 	request, err := decodeTestRequestNumberDoubleNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDoubleNullable",
-			err,
+			Operation: "TestRequestNumberDoubleNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1834,8 +1834,8 @@ func (s *Server) handleTestRequestNumberDoubleNullableArrayRequest(args [0]strin
 	request, err := decodeTestRequestNumberDoubleNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDoubleNullableArray",
-			err,
+			Operation: "TestRequestNumberDoubleNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1879,8 +1879,8 @@ func (s *Server) handleTestRequestNumberDoubleNullableArrayArrayRequest(args [0]
 	request, err := decodeTestRequestNumberDoubleNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberDoubleNullableArrayArray",
-			err,
+			Operation: "TestRequestNumberDoubleNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1924,8 +1924,8 @@ func (s *Server) handleTestRequestNumberFloatRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestNumberFloatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloat",
-			err,
+			Operation: "TestRequestNumberFloat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1969,8 +1969,8 @@ func (s *Server) handleTestRequestNumberFloatArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestNumberFloatArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloatArray",
-			err,
+			Operation: "TestRequestNumberFloatArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2014,8 +2014,8 @@ func (s *Server) handleTestRequestNumberFloatArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestNumberFloatArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloatArrayArray",
-			err,
+			Operation: "TestRequestNumberFloatArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2059,8 +2059,8 @@ func (s *Server) handleTestRequestNumberFloatNullableRequest(args [0]string, w h
 	request, err := decodeTestRequestNumberFloatNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloatNullable",
-			err,
+			Operation: "TestRequestNumberFloatNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2104,8 +2104,8 @@ func (s *Server) handleTestRequestNumberFloatNullableArrayRequest(args [0]string
 	request, err := decodeTestRequestNumberFloatNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloatNullableArray",
-			err,
+			Operation: "TestRequestNumberFloatNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2149,8 +2149,8 @@ func (s *Server) handleTestRequestNumberFloatNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestNumberFloatNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberFloatNullableArrayArray",
-			err,
+			Operation: "TestRequestNumberFloatNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2194,8 +2194,8 @@ func (s *Server) handleTestRequestNumberInt32Request(args [0]string, w http.Resp
 	request, err := decodeTestRequestNumberInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32",
-			err,
+			Operation: "TestRequestNumberInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2239,8 +2239,8 @@ func (s *Server) handleTestRequestNumberInt32ArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestNumberInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32Array",
-			err,
+			Operation: "TestRequestNumberInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2284,8 +2284,8 @@ func (s *Server) handleTestRequestNumberInt32ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestNumberInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32ArrayArray",
-			err,
+			Operation: "TestRequestNumberInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2329,8 +2329,8 @@ func (s *Server) handleTestRequestNumberInt32NullableRequest(args [0]string, w h
 	request, err := decodeTestRequestNumberInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32Nullable",
-			err,
+			Operation: "TestRequestNumberInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2374,8 +2374,8 @@ func (s *Server) handleTestRequestNumberInt32NullableArrayRequest(args [0]string
 	request, err := decodeTestRequestNumberInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32NullableArray",
-			err,
+			Operation: "TestRequestNumberInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2419,8 +2419,8 @@ func (s *Server) handleTestRequestNumberInt32NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestNumberInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestNumberInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2464,8 +2464,8 @@ func (s *Server) handleTestRequestNumberInt64Request(args [0]string, w http.Resp
 	request, err := decodeTestRequestNumberInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64",
-			err,
+			Operation: "TestRequestNumberInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2509,8 +2509,8 @@ func (s *Server) handleTestRequestNumberInt64ArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestNumberInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64Array",
-			err,
+			Operation: "TestRequestNumberInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2554,8 +2554,8 @@ func (s *Server) handleTestRequestNumberInt64ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestNumberInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64ArrayArray",
-			err,
+			Operation: "TestRequestNumberInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2599,8 +2599,8 @@ func (s *Server) handleTestRequestNumberInt64NullableRequest(args [0]string, w h
 	request, err := decodeTestRequestNumberInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64Nullable",
-			err,
+			Operation: "TestRequestNumberInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2644,8 +2644,8 @@ func (s *Server) handleTestRequestNumberInt64NullableArrayRequest(args [0]string
 	request, err := decodeTestRequestNumberInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64NullableArray",
-			err,
+			Operation: "TestRequestNumberInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2689,8 +2689,8 @@ func (s *Server) handleTestRequestNumberInt64NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestNumberInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestNumberInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2734,8 +2734,8 @@ func (s *Server) handleTestRequestNumberNullableRequest(args [0]string, w http.R
 	request, err := decodeTestRequestNumberNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberNullable",
-			err,
+			Operation: "TestRequestNumberNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2779,8 +2779,8 @@ func (s *Server) handleTestRequestNumberNullableArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestNumberNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberNullableArray",
-			err,
+			Operation: "TestRequestNumberNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2824,8 +2824,8 @@ func (s *Server) handleTestRequestNumberNullableArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestNumberNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestNumberNullableArrayArray",
-			err,
+			Operation: "TestRequestNumberNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2869,8 +2869,8 @@ func (s *Server) handleTestRequestRequiredAnyRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestRequiredAnyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredAny",
-			err,
+			Operation: "TestRequestRequiredAny",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2914,8 +2914,8 @@ func (s *Server) handleTestRequestRequiredBooleanRequest(args [0]string, w http.
 	request, err := decodeTestRequestRequiredBooleanRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBoolean",
-			err,
+			Operation: "TestRequestRequiredBoolean",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -2959,8 +2959,8 @@ func (s *Server) handleTestRequestRequiredBooleanArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestRequiredBooleanArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBooleanArray",
-			err,
+			Operation: "TestRequestRequiredBooleanArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3004,8 +3004,8 @@ func (s *Server) handleTestRequestRequiredBooleanArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredBooleanArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBooleanArrayArray",
-			err,
+			Operation: "TestRequestRequiredBooleanArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3049,8 +3049,8 @@ func (s *Server) handleTestRequestRequiredBooleanNullableRequest(args [0]string,
 	request, err := decodeTestRequestRequiredBooleanNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBooleanNullable",
-			err,
+			Operation: "TestRequestRequiredBooleanNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3094,8 +3094,8 @@ func (s *Server) handleTestRequestRequiredBooleanNullableArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredBooleanNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBooleanNullableArray",
-			err,
+			Operation: "TestRequestRequiredBooleanNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3139,8 +3139,8 @@ func (s *Server) handleTestRequestRequiredBooleanNullableArrayArrayRequest(args 
 	request, err := decodeTestRequestRequiredBooleanNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredBooleanNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredBooleanNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3184,8 +3184,8 @@ func (s *Server) handleTestRequestRequiredEmptyStructRequest(args [0]string, w h
 	request, err := decodeTestRequestRequiredEmptyStructRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredEmptyStruct",
-			err,
+			Operation: "TestRequestRequiredEmptyStruct",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3229,8 +3229,8 @@ func (s *Server) handleTestRequestRequiredFormatTestRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredFormatTestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredFormatTest",
-			err,
+			Operation: "TestRequestRequiredFormatTest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3274,8 +3274,8 @@ func (s *Server) handleTestRequestRequiredIntegerRequest(args [0]string, w http.
 	request, err := decodeTestRequestRequiredIntegerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredInteger",
-			err,
+			Operation: "TestRequestRequiredInteger",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3319,8 +3319,8 @@ func (s *Server) handleTestRequestRequiredIntegerArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestRequiredIntegerArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerArray",
-			err,
+			Operation: "TestRequestRequiredIntegerArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3364,8 +3364,8 @@ func (s *Server) handleTestRequestRequiredIntegerArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredIntegerArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3409,8 +3409,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32Request(args [0]string, w 
 	request, err := decodeTestRequestRequiredIntegerInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3454,8 +3454,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32ArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredIntegerInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32Array",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3499,8 +3499,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32ArrayArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredIntegerInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32ArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3544,8 +3544,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableRequest(args [0]st
 	request, err := decodeTestRequestRequiredIntegerInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32Nullable",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3589,8 +3589,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableArrayRequest(args 
 	request, err := decodeTestRequestRequiredIntegerInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32NullableArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3634,8 +3634,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt32NullableArrayArrayRequest(
 	request, err := decodeTestRequestRequiredIntegerInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3679,8 +3679,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64Request(args [0]string, w 
 	request, err := decodeTestRequestRequiredIntegerInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3724,8 +3724,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64ArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredIntegerInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64Array",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3769,8 +3769,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64ArrayArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredIntegerInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64ArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3814,8 +3814,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableRequest(args [0]st
 	request, err := decodeTestRequestRequiredIntegerInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64Nullable",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3859,8 +3859,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableArrayRequest(args 
 	request, err := decodeTestRequestRequiredIntegerInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64NullableArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3904,8 +3904,8 @@ func (s *Server) handleTestRequestRequiredIntegerInt64NullableArrayArrayRequest(
 	request, err := decodeTestRequestRequiredIntegerInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3949,8 +3949,8 @@ func (s *Server) handleTestRequestRequiredIntegerNullableRequest(args [0]string,
 	request, err := decodeTestRequestRequiredIntegerNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerNullable",
-			err,
+			Operation: "TestRequestRequiredIntegerNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -3994,8 +3994,8 @@ func (s *Server) handleTestRequestRequiredIntegerNullableArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredIntegerNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerNullableArray",
-			err,
+			Operation: "TestRequestRequiredIntegerNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4039,8 +4039,8 @@ func (s *Server) handleTestRequestRequiredIntegerNullableArrayArrayRequest(args 
 	request, err := decodeTestRequestRequiredIntegerNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredIntegerNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredIntegerNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4084,8 +4084,8 @@ func (s *Server) handleTestRequestRequiredNullRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestRequiredNullRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNull",
-			err,
+			Operation: "TestRequestRequiredNull",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4129,8 +4129,8 @@ func (s *Server) handleTestRequestRequiredNullArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestRequiredNullArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNullArray",
-			err,
+			Operation: "TestRequestRequiredNullArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4174,8 +4174,8 @@ func (s *Server) handleTestRequestRequiredNullArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredNullArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNullArrayArray",
-			err,
+			Operation: "TestRequestRequiredNullArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4219,8 +4219,8 @@ func (s *Server) handleTestRequestRequiredNullNullableRequest(args [0]string, w 
 	request, err := decodeTestRequestRequiredNullNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNullNullable",
-			err,
+			Operation: "TestRequestRequiredNullNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4264,8 +4264,8 @@ func (s *Server) handleTestRequestRequiredNullNullableArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredNullNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNullNullableArray",
-			err,
+			Operation: "TestRequestRequiredNullNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4309,8 +4309,8 @@ func (s *Server) handleTestRequestRequiredNullNullableArrayArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredNullNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNullNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNullNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4354,8 +4354,8 @@ func (s *Server) handleTestRequestRequiredNumberRequest(args [0]string, w http.R
 	request, err := decodeTestRequestRequiredNumberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumber",
-			err,
+			Operation: "TestRequestRequiredNumber",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4399,8 +4399,8 @@ func (s *Server) handleTestRequestRequiredNumberArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestRequiredNumberArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberArray",
-			err,
+			Operation: "TestRequestRequiredNumberArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4444,8 +4444,8 @@ func (s *Server) handleTestRequestRequiredNumberArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredNumberArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4489,8 +4489,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleRequest(args [0]string, w 
 	request, err := decodeTestRequestRequiredNumberDoubleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDouble",
-			err,
+			Operation: "TestRequestRequiredNumberDouble",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4534,8 +4534,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredNumberDoubleArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDoubleArray",
-			err,
+			Operation: "TestRequestRequiredNumberDoubleArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4579,8 +4579,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleArrayArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredNumberDoubleArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDoubleArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberDoubleArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4624,8 +4624,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableRequest(args [0]st
 	request, err := decodeTestRequestRequiredNumberDoubleNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDoubleNullable",
-			err,
+			Operation: "TestRequestRequiredNumberDoubleNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4669,8 +4669,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableArrayRequest(args 
 	request, err := decodeTestRequestRequiredNumberDoubleNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDoubleNullableArray",
-			err,
+			Operation: "TestRequestRequiredNumberDoubleNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4714,8 +4714,8 @@ func (s *Server) handleTestRequestRequiredNumberDoubleNullableArrayArrayRequest(
 	request, err := decodeTestRequestRequiredNumberDoubleNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberDoubleNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberDoubleNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4759,8 +4759,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatRequest(args [0]string, w h
 	request, err := decodeTestRequestRequiredNumberFloatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloat",
-			err,
+			Operation: "TestRequestRequiredNumberFloat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4804,8 +4804,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredNumberFloatArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloatArray",
-			err,
+			Operation: "TestRequestRequiredNumberFloatArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4849,8 +4849,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredNumberFloatArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloatArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberFloatArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4894,8 +4894,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredNumberFloatNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloatNullable",
-			err,
+			Operation: "TestRequestRequiredNumberFloatNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4939,8 +4939,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredNumberFloatNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloatNullableArray",
-			err,
+			Operation: "TestRequestRequiredNumberFloatNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -4984,8 +4984,8 @@ func (s *Server) handleTestRequestRequiredNumberFloatNullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredNumberFloatNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberFloatNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberFloatNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5029,8 +5029,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32Request(args [0]string, w h
 	request, err := decodeTestRequestRequiredNumberInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32",
-			err,
+			Operation: "TestRequestRequiredNumberInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5074,8 +5074,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32ArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredNumberInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32Array",
-			err,
+			Operation: "TestRequestRequiredNumberInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5119,8 +5119,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32ArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredNumberInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32ArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5164,8 +5164,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredNumberInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32Nullable",
-			err,
+			Operation: "TestRequestRequiredNumberInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5209,8 +5209,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredNumberInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32NullableArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5254,8 +5254,8 @@ func (s *Server) handleTestRequestRequiredNumberInt32NullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredNumberInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5299,8 +5299,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64Request(args [0]string, w h
 	request, err := decodeTestRequestRequiredNumberInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64",
-			err,
+			Operation: "TestRequestRequiredNumberInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5344,8 +5344,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64ArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredNumberInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64Array",
-			err,
+			Operation: "TestRequestRequiredNumberInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5389,8 +5389,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64ArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredNumberInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64ArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5434,8 +5434,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredNumberInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64Nullable",
-			err,
+			Operation: "TestRequestRequiredNumberInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5479,8 +5479,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredNumberInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64NullableArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5524,8 +5524,8 @@ func (s *Server) handleTestRequestRequiredNumberInt64NullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredNumberInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5569,8 +5569,8 @@ func (s *Server) handleTestRequestRequiredNumberNullableRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredNumberNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberNullable",
-			err,
+			Operation: "TestRequestRequiredNumberNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5614,8 +5614,8 @@ func (s *Server) handleTestRequestRequiredNumberNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredNumberNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberNullableArray",
-			err,
+			Operation: "TestRequestRequiredNumberNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5659,8 +5659,8 @@ func (s *Server) handleTestRequestRequiredNumberNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredNumberNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredNumberNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredNumberNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5704,8 +5704,8 @@ func (s *Server) handleTestRequestRequiredStringRequest(args [0]string, w http.R
 	request, err := decodeTestRequestRequiredStringRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredString",
-			err,
+			Operation: "TestRequestRequiredString",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5749,8 +5749,8 @@ func (s *Server) handleTestRequestRequiredStringArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestRequiredStringArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringArray",
-			err,
+			Operation: "TestRequestRequiredStringArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5794,8 +5794,8 @@ func (s *Server) handleTestRequestRequiredStringArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredStringArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5839,8 +5839,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryRequest(args [0]string, w 
 	request, err := decodeTestRequestRequiredStringBinaryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinary",
-			err,
+			Operation: "TestRequestRequiredStringBinary",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5884,8 +5884,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryArrayRequest(args [0]strin
 	request, err := decodeTestRequestRequiredStringBinaryArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinaryArray",
-			err,
+			Operation: "TestRequestRequiredStringBinaryArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5929,8 +5929,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryArrayArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredStringBinaryArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinaryArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringBinaryArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -5974,8 +5974,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringBinaryNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinaryNullable",
-			err,
+			Operation: "TestRequestRequiredStringBinaryNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6019,8 +6019,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableArrayRequest(args 
 	request, err := decodeTestRequestRequiredStringBinaryNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinaryNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringBinaryNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6064,8 +6064,8 @@ func (s *Server) handleTestRequestRequiredStringBinaryNullableArrayArrayRequest(
 	request, err := decodeTestRequestRequiredStringBinaryNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringBinaryNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringBinaryNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6109,8 +6109,8 @@ func (s *Server) handleTestRequestRequiredStringByteRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringByteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByte",
-			err,
+			Operation: "TestRequestRequiredStringByte",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6154,8 +6154,8 @@ func (s *Server) handleTestRequestRequiredStringByteArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringByteArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByteArray",
-			err,
+			Operation: "TestRequestRequiredStringByteArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6199,8 +6199,8 @@ func (s *Server) handleTestRequestRequiredStringByteArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringByteArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByteArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringByteArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6244,8 +6244,8 @@ func (s *Server) handleTestRequestRequiredStringByteNullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringByteNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByteNullable",
-			err,
+			Operation: "TestRequestRequiredStringByteNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6289,8 +6289,8 @@ func (s *Server) handleTestRequestRequiredStringByteNullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringByteNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByteNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringByteNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6334,8 +6334,8 @@ func (s *Server) handleTestRequestRequiredStringByteNullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringByteNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringByteNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringByteNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6379,8 +6379,8 @@ func (s *Server) handleTestRequestRequiredStringDateRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringDateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDate",
-			err,
+			Operation: "TestRequestRequiredStringDate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6424,8 +6424,8 @@ func (s *Server) handleTestRequestRequiredStringDateArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringDateArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateArray",
-			err,
+			Operation: "TestRequestRequiredStringDateArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6469,8 +6469,8 @@ func (s *Server) handleTestRequestRequiredStringDateArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringDateArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDateArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6514,8 +6514,8 @@ func (s *Server) handleTestRequestRequiredStringDateNullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringDateNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateNullable",
-			err,
+			Operation: "TestRequestRequiredStringDateNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6559,8 +6559,8 @@ func (s *Server) handleTestRequestRequiredStringDateNullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringDateNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringDateNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6604,8 +6604,8 @@ func (s *Server) handleTestRequestRequiredStringDateNullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringDateNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDateNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6649,8 +6649,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringDateTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTime",
-			err,
+			Operation: "TestRequestRequiredStringDateTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6694,8 +6694,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringDateTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTimeArray",
-			err,
+			Operation: "TestRequestRequiredStringDateTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6739,8 +6739,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringDateTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTimeArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDateTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6784,8 +6784,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableRequest(args [0]
 	request, err := decodeTestRequestRequiredStringDateTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTimeNullable",
-			err,
+			Operation: "TestRequestRequiredStringDateTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6829,8 +6829,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringDateTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTimeNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringDateTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6874,8 +6874,8 @@ func (s *Server) handleTestRequestRequiredStringDateTimeNullableArrayArrayReques
 	request, err := decodeTestRequestRequiredStringDateTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDateTimeNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDateTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6919,8 +6919,8 @@ func (s *Server) handleTestRequestRequiredStringDurationRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringDurationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDuration",
-			err,
+			Operation: "TestRequestRequiredStringDuration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -6964,8 +6964,8 @@ func (s *Server) handleTestRequestRequiredStringDurationArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringDurationArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDurationArray",
-			err,
+			Operation: "TestRequestRequiredStringDurationArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7009,8 +7009,8 @@ func (s *Server) handleTestRequestRequiredStringDurationArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringDurationArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDurationArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDurationArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7054,8 +7054,8 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableRequest(args [0]
 	request, err := decodeTestRequestRequiredStringDurationNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDurationNullable",
-			err,
+			Operation: "TestRequestRequiredStringDurationNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7099,8 +7099,8 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringDurationNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDurationNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringDurationNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7144,8 +7144,8 @@ func (s *Server) handleTestRequestRequiredStringDurationNullableArrayArrayReques
 	request, err := decodeTestRequestRequiredStringDurationNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringDurationNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringDurationNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7189,8 +7189,8 @@ func (s *Server) handleTestRequestRequiredStringEmailRequest(args [0]string, w h
 	request, err := decodeTestRequestRequiredStringEmailRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmail",
-			err,
+			Operation: "TestRequestRequiredStringEmail",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7234,8 +7234,8 @@ func (s *Server) handleTestRequestRequiredStringEmailArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredStringEmailArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmailArray",
-			err,
+			Operation: "TestRequestRequiredStringEmailArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7279,8 +7279,8 @@ func (s *Server) handleTestRequestRequiredStringEmailArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredStringEmailArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmailArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringEmailArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7324,8 +7324,8 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringEmailNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmailNullable",
-			err,
+			Operation: "TestRequestRequiredStringEmailNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7369,8 +7369,8 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringEmailNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmailNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringEmailNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7414,8 +7414,8 @@ func (s *Server) handleTestRequestRequiredStringEmailNullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredStringEmailNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringEmailNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringEmailNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7459,8 +7459,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringHostnameRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostname",
-			err,
+			Operation: "TestRequestRequiredStringHostname",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7504,8 +7504,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringHostnameArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostnameArray",
-			err,
+			Operation: "TestRequestRequiredStringHostnameArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7549,8 +7549,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringHostnameArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostnameArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringHostnameArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7594,8 +7594,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableRequest(args [0]
 	request, err := decodeTestRequestRequiredStringHostnameNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostnameNullable",
-			err,
+			Operation: "TestRequestRequiredStringHostnameNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7639,8 +7639,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringHostnameNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostnameNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringHostnameNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7684,8 +7684,8 @@ func (s *Server) handleTestRequestRequiredStringHostnameNullableArrayArrayReques
 	request, err := decodeTestRequestRequiredStringHostnameNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringHostnameNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringHostnameNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7729,8 +7729,8 @@ func (s *Server) handleTestRequestRequiredStringIPRequest(args [0]string, w http
 	request, err := decodeTestRequestRequiredStringIPRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIP",
-			err,
+			Operation: "TestRequestRequiredStringIP",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7774,8 +7774,8 @@ func (s *Server) handleTestRequestRequiredStringIPArrayRequest(args [0]string, w
 	request, err := decodeTestRequestRequiredStringIPArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIPArray",
-			err,
+			Operation: "TestRequestRequiredStringIPArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7819,8 +7819,8 @@ func (s *Server) handleTestRequestRequiredStringIPArrayArrayRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringIPArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIPArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIPArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7864,8 +7864,8 @@ func (s *Server) handleTestRequestRequiredStringIPNullableRequest(args [0]string
 	request, err := decodeTestRequestRequiredStringIPNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIPNullable",
-			err,
+			Operation: "TestRequestRequiredStringIPNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7909,8 +7909,8 @@ func (s *Server) handleTestRequestRequiredStringIPNullableArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredStringIPNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIPNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringIPNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7954,8 +7954,8 @@ func (s *Server) handleTestRequestRequiredStringIPNullableArrayArrayRequest(args
 	request, err := decodeTestRequestRequiredStringIPNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIPNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIPNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -7999,8 +7999,8 @@ func (s *Server) handleTestRequestRequiredStringInt32Request(args [0]string, w h
 	request, err := decodeTestRequestRequiredStringInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32",
-			err,
+			Operation: "TestRequestRequiredStringInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8044,8 +8044,8 @@ func (s *Server) handleTestRequestRequiredStringInt32ArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredStringInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32Array",
-			err,
+			Operation: "TestRequestRequiredStringInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8089,8 +8089,8 @@ func (s *Server) handleTestRequestRequiredStringInt32ArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredStringInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32ArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8134,8 +8134,8 @@ func (s *Server) handleTestRequestRequiredStringInt32NullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32Nullable",
-			err,
+			Operation: "TestRequestRequiredStringInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8179,8 +8179,8 @@ func (s *Server) handleTestRequestRequiredStringInt32NullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32NullableArray",
-			err,
+			Operation: "TestRequestRequiredStringInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8224,8 +8224,8 @@ func (s *Server) handleTestRequestRequiredStringInt32NullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredStringInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8269,8 +8269,8 @@ func (s *Server) handleTestRequestRequiredStringInt64Request(args [0]string, w h
 	request, err := decodeTestRequestRequiredStringInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64",
-			err,
+			Operation: "TestRequestRequiredStringInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8314,8 +8314,8 @@ func (s *Server) handleTestRequestRequiredStringInt64ArrayRequest(args [0]string
 	request, err := decodeTestRequestRequiredStringInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64Array",
-			err,
+			Operation: "TestRequestRequiredStringInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8359,8 +8359,8 @@ func (s *Server) handleTestRequestRequiredStringInt64ArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestRequiredStringInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64ArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8404,8 +8404,8 @@ func (s *Server) handleTestRequestRequiredStringInt64NullableRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64Nullable",
-			err,
+			Operation: "TestRequestRequiredStringInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8449,8 +8449,8 @@ func (s *Server) handleTestRequestRequiredStringInt64NullableArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64NullableArray",
-			err,
+			Operation: "TestRequestRequiredStringInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8494,8 +8494,8 @@ func (s *Server) handleTestRequestRequiredStringInt64NullableArrayArrayRequest(a
 	request, err := decodeTestRequestRequiredStringInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8539,8 +8539,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4Request(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringIpv4Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4",
-			err,
+			Operation: "TestRequestRequiredStringIpv4",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8584,8 +8584,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4ArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringIpv4ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4Array",
-			err,
+			Operation: "TestRequestRequiredStringIpv4Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8629,8 +8629,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4ArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringIpv4ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4ArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv4ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8674,8 +8674,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringIpv4NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4Nullable",
-			err,
+			Operation: "TestRequestRequiredStringIpv4Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8719,8 +8719,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringIpv4NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4NullableArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv4NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8764,8 +8764,8 @@ func (s *Server) handleTestRequestRequiredStringIpv4NullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringIpv4NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv4NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv4NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8809,8 +8809,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6Request(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringIpv6Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6",
-			err,
+			Operation: "TestRequestRequiredStringIpv6",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8854,8 +8854,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6ArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringIpv6ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6Array",
-			err,
+			Operation: "TestRequestRequiredStringIpv6Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8899,8 +8899,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6ArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringIpv6ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6ArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv6ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8944,8 +8944,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringIpv6NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6Nullable",
-			err,
+			Operation: "TestRequestRequiredStringIpv6Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -8989,8 +8989,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringIpv6NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6NullableArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv6NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9034,8 +9034,8 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringIpv6NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringIpv6NullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringIpv6NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9079,8 +9079,8 @@ func (s *Server) handleTestRequestRequiredStringNullableRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringNullable",
-			err,
+			Operation: "TestRequestRequiredStringNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9124,8 +9124,8 @@ func (s *Server) handleTestRequestRequiredStringNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9169,8 +9169,8 @@ func (s *Server) handleTestRequestRequiredStringNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9214,8 +9214,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringPasswordRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPassword",
-			err,
+			Operation: "TestRequestRequiredStringPassword",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9259,8 +9259,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringPasswordArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPasswordArray",
-			err,
+			Operation: "TestRequestRequiredStringPasswordArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9304,8 +9304,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringPasswordArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPasswordArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringPasswordArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9349,8 +9349,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableRequest(args [0]
 	request, err := decodeTestRequestRequiredStringPasswordNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPasswordNullable",
-			err,
+			Operation: "TestRequestRequiredStringPasswordNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9394,8 +9394,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringPasswordNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPasswordNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringPasswordNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9439,8 +9439,8 @@ func (s *Server) handleTestRequestRequiredStringPasswordNullableArrayArrayReques
 	request, err := decodeTestRequestRequiredStringPasswordNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringPasswordNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringPasswordNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9484,8 +9484,8 @@ func (s *Server) handleTestRequestRequiredStringTimeRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTime",
-			err,
+			Operation: "TestRequestRequiredStringTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9529,8 +9529,8 @@ func (s *Server) handleTestRequestRequiredStringTimeArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTimeArray",
-			err,
+			Operation: "TestRequestRequiredStringTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9574,8 +9574,8 @@ func (s *Server) handleTestRequestRequiredStringTimeArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTimeArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9619,8 +9619,8 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTimeNullable",
-			err,
+			Operation: "TestRequestRequiredStringTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9664,8 +9664,8 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTimeNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9709,8 +9709,8 @@ func (s *Server) handleTestRequestRequiredStringTimeNullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringTimeNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9754,8 +9754,8 @@ func (s *Server) handleTestRequestRequiredStringURIRequest(args [0]string, w htt
 	request, err := decodeTestRequestRequiredStringURIRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURI",
-			err,
+			Operation: "TestRequestRequiredStringURI",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9799,8 +9799,8 @@ func (s *Server) handleTestRequestRequiredStringURIArrayRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringURIArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURIArray",
-			err,
+			Operation: "TestRequestRequiredStringURIArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9844,8 +9844,8 @@ func (s *Server) handleTestRequestRequiredStringURIArrayArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringURIArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURIArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringURIArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9889,8 +9889,8 @@ func (s *Server) handleTestRequestRequiredStringURINullableRequest(args [0]strin
 	request, err := decodeTestRequestRequiredStringURINullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURINullable",
-			err,
+			Operation: "TestRequestRequiredStringURINullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9934,8 +9934,8 @@ func (s *Server) handleTestRequestRequiredStringURINullableArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredStringURINullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURINullableArray",
-			err,
+			Operation: "TestRequestRequiredStringURINullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -9979,8 +9979,8 @@ func (s *Server) handleTestRequestRequiredStringURINullableArrayArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringURINullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringURINullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringURINullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10024,8 +10024,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringUUIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUID",
-			err,
+			Operation: "TestRequestRequiredStringUUID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10069,8 +10069,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringUUIDArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUIDArray",
-			err,
+			Operation: "TestRequestRequiredStringUUIDArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10114,8 +10114,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringUUIDArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUIDArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUUIDArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10159,8 +10159,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringUUIDNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUIDNullable",
-			err,
+			Operation: "TestRequestRequiredStringUUIDNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10204,8 +10204,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringUUIDNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUIDNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUUIDNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10249,8 +10249,8 @@ func (s *Server) handleTestRequestRequiredStringUUIDNullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringUUIDNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUUIDNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUUIDNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10294,8 +10294,8 @@ func (s *Server) handleTestRequestRequiredStringUnixRequest(args [0]string, w ht
 	request, err := decodeTestRequestRequiredStringUnixRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnix",
-			err,
+			Operation: "TestRequestRequiredStringUnix",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10339,8 +10339,8 @@ func (s *Server) handleTestRequestRequiredStringUnixArrayRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringUnixArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10384,8 +10384,8 @@ func (s *Server) handleTestRequestRequiredStringUnixArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringUnixArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10429,8 +10429,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringUnixMicroRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicro",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicro",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10474,8 +10474,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringUnixMicroArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicroArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicroArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10519,8 +10519,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroArrayArrayRequest(args 
 	request, err := decodeTestRequestRequiredStringUnixMicroArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicroArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicroArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10564,8 +10564,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroNullableRequest(args [0
 	request, err := decodeTestRequestRequiredStringUnixMicroNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicroNullable",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicroNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10609,8 +10609,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroNullableArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringUnixMicroNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicroNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicroNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10654,8 +10654,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMicroNullableArrayArrayReque
 	request, err := decodeTestRequestRequiredStringUnixMicroNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMicroNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMicroNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10699,8 +10699,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliRequest(args [0]string,
 	request, err := decodeTestRequestRequiredStringUnixMilliRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilli",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilli",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10744,8 +10744,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliArrayRequest(args [0]st
 	request, err := decodeTestRequestRequiredStringUnixMilliArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilliArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilliArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10789,8 +10789,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliArrayArrayRequest(args 
 	request, err := decodeTestRequestRequiredStringUnixMilliArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilliArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilliArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10834,8 +10834,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliNullableRequest(args [0
 	request, err := decodeTestRequestRequiredStringUnixMilliNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilliNullable",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilliNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10879,8 +10879,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliNullableArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringUnixMilliNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilliNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilliNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10924,8 +10924,8 @@ func (s *Server) handleTestRequestRequiredStringUnixMilliNullableArrayArrayReque
 	request, err := decodeTestRequestRequiredStringUnixMilliNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixMilliNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixMilliNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -10969,8 +10969,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoRequest(args [0]string, 
 	request, err := decodeTestRequestRequiredStringUnixNanoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNano",
-			err,
+			Operation: "TestRequestRequiredStringUnixNano",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11014,8 +11014,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoArrayRequest(args [0]str
 	request, err := decodeTestRequestRequiredStringUnixNanoArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNanoArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNanoArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11059,8 +11059,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoArrayArrayRequest(args [
 	request, err := decodeTestRequestRequiredStringUnixNanoArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNanoArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNanoArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11104,8 +11104,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoNullableRequest(args [0]
 	request, err := decodeTestRequestRequiredStringUnixNanoNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNanoNullable",
-			err,
+			Operation: "TestRequestRequiredStringUnixNanoNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11149,8 +11149,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoNullableArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringUnixNanoNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNanoNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNanoNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11194,8 +11194,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNanoNullableArrayArrayReques
 	request, err := decodeTestRequestRequiredStringUnixNanoNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNanoNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNanoNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11239,8 +11239,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNullableRequest(args [0]stri
 	request, err := decodeTestRequestRequiredStringUnixNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNullable",
-			err,
+			Operation: "TestRequestRequiredStringUnixNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11284,8 +11284,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNullableArrayRequest(args [0
 	request, err := decodeTestRequestRequiredStringUnixNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11329,8 +11329,8 @@ func (s *Server) handleTestRequestRequiredStringUnixNullableArrayArrayRequest(ar
 	request, err := decodeTestRequestRequiredStringUnixNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11374,8 +11374,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsRequest(args [0]strin
 	request, err := decodeTestRequestRequiredStringUnixSecondsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSeconds",
-			err,
+			Operation: "TestRequestRequiredStringUnixSeconds",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11419,8 +11419,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsArrayRequest(args [0]
 	request, err := decodeTestRequestRequiredStringUnixSecondsArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSecondsArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixSecondsArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11464,8 +11464,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsArrayArrayRequest(arg
 	request, err := decodeTestRequestRequiredStringUnixSecondsArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSecondsArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixSecondsArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11509,8 +11509,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsNullableRequest(args 
 	request, err := decodeTestRequestRequiredStringUnixSecondsNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSecondsNullable",
-			err,
+			Operation: "TestRequestRequiredStringUnixSecondsNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11554,8 +11554,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsNullableArrayRequest(
 	request, err := decodeTestRequestRequiredStringUnixSecondsNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSecondsNullableArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixSecondsNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11599,8 +11599,8 @@ func (s *Server) handleTestRequestRequiredStringUnixSecondsNullableArrayArrayReq
 	request, err := decodeTestRequestRequiredStringUnixSecondsNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestRequiredStringUnixSecondsNullableArrayArray",
-			err,
+			Operation: "TestRequestRequiredStringUnixSecondsNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11644,8 +11644,8 @@ func (s *Server) handleTestRequestStringRequest(args [0]string, w http.ResponseW
 	request, err := decodeTestRequestStringRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestString",
-			err,
+			Operation: "TestRequestString",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11689,8 +11689,8 @@ func (s *Server) handleTestRequestStringArrayRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestStringArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringArray",
-			err,
+			Operation: "TestRequestStringArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11734,8 +11734,8 @@ func (s *Server) handleTestRequestStringArrayArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestStringArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringArrayArray",
-			err,
+			Operation: "TestRequestStringArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11779,8 +11779,8 @@ func (s *Server) handleTestRequestStringBinaryRequest(args [0]string, w http.Res
 	request, err := decodeTestRequestStringBinaryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinary",
-			err,
+			Operation: "TestRequestStringBinary",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11824,8 +11824,8 @@ func (s *Server) handleTestRequestStringBinaryArrayRequest(args [0]string, w htt
 	request, err := decodeTestRequestStringBinaryArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinaryArray",
-			err,
+			Operation: "TestRequestStringBinaryArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11869,8 +11869,8 @@ func (s *Server) handleTestRequestStringBinaryArrayArrayRequest(args [0]string, 
 	request, err := decodeTestRequestStringBinaryArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinaryArrayArray",
-			err,
+			Operation: "TestRequestStringBinaryArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11914,8 +11914,8 @@ func (s *Server) handleTestRequestStringBinaryNullableRequest(args [0]string, w 
 	request, err := decodeTestRequestStringBinaryNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinaryNullable",
-			err,
+			Operation: "TestRequestStringBinaryNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -11959,8 +11959,8 @@ func (s *Server) handleTestRequestStringBinaryNullableArrayRequest(args [0]strin
 	request, err := decodeTestRequestStringBinaryNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinaryNullableArray",
-			err,
+			Operation: "TestRequestStringBinaryNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12004,8 +12004,8 @@ func (s *Server) handleTestRequestStringBinaryNullableArrayArrayRequest(args [0]
 	request, err := decodeTestRequestStringBinaryNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringBinaryNullableArrayArray",
-			err,
+			Operation: "TestRequestStringBinaryNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12049,8 +12049,8 @@ func (s *Server) handleTestRequestStringByteRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringByteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByte",
-			err,
+			Operation: "TestRequestStringByte",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12094,8 +12094,8 @@ func (s *Server) handleTestRequestStringByteArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringByteArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByteArray",
-			err,
+			Operation: "TestRequestStringByteArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12139,8 +12139,8 @@ func (s *Server) handleTestRequestStringByteArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringByteArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByteArrayArray",
-			err,
+			Operation: "TestRequestStringByteArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12184,8 +12184,8 @@ func (s *Server) handleTestRequestStringByteNullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringByteNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByteNullable",
-			err,
+			Operation: "TestRequestStringByteNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12229,8 +12229,8 @@ func (s *Server) handleTestRequestStringByteNullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringByteNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByteNullableArray",
-			err,
+			Operation: "TestRequestStringByteNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12274,8 +12274,8 @@ func (s *Server) handleTestRequestStringByteNullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringByteNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringByteNullableArrayArray",
-			err,
+			Operation: "TestRequestStringByteNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12319,8 +12319,8 @@ func (s *Server) handleTestRequestStringDateRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringDateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDate",
-			err,
+			Operation: "TestRequestStringDate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12364,8 +12364,8 @@ func (s *Server) handleTestRequestStringDateArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringDateArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateArray",
-			err,
+			Operation: "TestRequestStringDateArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12409,8 +12409,8 @@ func (s *Server) handleTestRequestStringDateArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringDateArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateArrayArray",
-			err,
+			Operation: "TestRequestStringDateArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12454,8 +12454,8 @@ func (s *Server) handleTestRequestStringDateNullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringDateNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateNullable",
-			err,
+			Operation: "TestRequestStringDateNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12499,8 +12499,8 @@ func (s *Server) handleTestRequestStringDateNullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringDateNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateNullableArray",
-			err,
+			Operation: "TestRequestStringDateNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12544,8 +12544,8 @@ func (s *Server) handleTestRequestStringDateNullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringDateNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateNullableArrayArray",
-			err,
+			Operation: "TestRequestStringDateNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12589,8 +12589,8 @@ func (s *Server) handleTestRequestStringDateTimeRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringDateTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTime",
-			err,
+			Operation: "TestRequestStringDateTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12634,8 +12634,8 @@ func (s *Server) handleTestRequestStringDateTimeArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringDateTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTimeArray",
-			err,
+			Operation: "TestRequestStringDateTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12679,8 +12679,8 @@ func (s *Server) handleTestRequestStringDateTimeArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringDateTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTimeArrayArray",
-			err,
+			Operation: "TestRequestStringDateTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12724,8 +12724,8 @@ func (s *Server) handleTestRequestStringDateTimeNullableRequest(args [0]string, 
 	request, err := decodeTestRequestStringDateTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTimeNullable",
-			err,
+			Operation: "TestRequestStringDateTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12769,8 +12769,8 @@ func (s *Server) handleTestRequestStringDateTimeNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestStringDateTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTimeNullableArray",
-			err,
+			Operation: "TestRequestStringDateTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12814,8 +12814,8 @@ func (s *Server) handleTestRequestStringDateTimeNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestStringDateTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDateTimeNullableArrayArray",
-			err,
+			Operation: "TestRequestStringDateTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12859,8 +12859,8 @@ func (s *Server) handleTestRequestStringDurationRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringDurationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDuration",
-			err,
+			Operation: "TestRequestStringDuration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12904,8 +12904,8 @@ func (s *Server) handleTestRequestStringDurationArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringDurationArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDurationArray",
-			err,
+			Operation: "TestRequestStringDurationArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12949,8 +12949,8 @@ func (s *Server) handleTestRequestStringDurationArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringDurationArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDurationArrayArray",
-			err,
+			Operation: "TestRequestStringDurationArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -12994,8 +12994,8 @@ func (s *Server) handleTestRequestStringDurationNullableRequest(args [0]string, 
 	request, err := decodeTestRequestStringDurationNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDurationNullable",
-			err,
+			Operation: "TestRequestStringDurationNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13039,8 +13039,8 @@ func (s *Server) handleTestRequestStringDurationNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestStringDurationNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDurationNullableArray",
-			err,
+			Operation: "TestRequestStringDurationNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13084,8 +13084,8 @@ func (s *Server) handleTestRequestStringDurationNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestStringDurationNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringDurationNullableArrayArray",
-			err,
+			Operation: "TestRequestStringDurationNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13129,8 +13129,8 @@ func (s *Server) handleTestRequestStringEmailRequest(args [0]string, w http.Resp
 	request, err := decodeTestRequestStringEmailRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmail",
-			err,
+			Operation: "TestRequestStringEmail",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13174,8 +13174,8 @@ func (s *Server) handleTestRequestStringEmailArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestStringEmailArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmailArray",
-			err,
+			Operation: "TestRequestStringEmailArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13219,8 +13219,8 @@ func (s *Server) handleTestRequestStringEmailArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestStringEmailArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmailArrayArray",
-			err,
+			Operation: "TestRequestStringEmailArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13264,8 +13264,8 @@ func (s *Server) handleTestRequestStringEmailNullableRequest(args [0]string, w h
 	request, err := decodeTestRequestStringEmailNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmailNullable",
-			err,
+			Operation: "TestRequestStringEmailNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13309,8 +13309,8 @@ func (s *Server) handleTestRequestStringEmailNullableArrayRequest(args [0]string
 	request, err := decodeTestRequestStringEmailNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmailNullableArray",
-			err,
+			Operation: "TestRequestStringEmailNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13354,8 +13354,8 @@ func (s *Server) handleTestRequestStringEmailNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestStringEmailNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringEmailNullableArrayArray",
-			err,
+			Operation: "TestRequestStringEmailNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13399,8 +13399,8 @@ func (s *Server) handleTestRequestStringHostnameRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringHostnameRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostname",
-			err,
+			Operation: "TestRequestStringHostname",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13444,8 +13444,8 @@ func (s *Server) handleTestRequestStringHostnameArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringHostnameArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostnameArray",
-			err,
+			Operation: "TestRequestStringHostnameArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13489,8 +13489,8 @@ func (s *Server) handleTestRequestStringHostnameArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringHostnameArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostnameArrayArray",
-			err,
+			Operation: "TestRequestStringHostnameArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13534,8 +13534,8 @@ func (s *Server) handleTestRequestStringHostnameNullableRequest(args [0]string, 
 	request, err := decodeTestRequestStringHostnameNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostnameNullable",
-			err,
+			Operation: "TestRequestStringHostnameNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13579,8 +13579,8 @@ func (s *Server) handleTestRequestStringHostnameNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestStringHostnameNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostnameNullableArray",
-			err,
+			Operation: "TestRequestStringHostnameNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13624,8 +13624,8 @@ func (s *Server) handleTestRequestStringHostnameNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestStringHostnameNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringHostnameNullableArrayArray",
-			err,
+			Operation: "TestRequestStringHostnameNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13669,8 +13669,8 @@ func (s *Server) handleTestRequestStringIPRequest(args [0]string, w http.Respons
 	request, err := decodeTestRequestStringIPRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIP",
-			err,
+			Operation: "TestRequestStringIP",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13714,8 +13714,8 @@ func (s *Server) handleTestRequestStringIPArrayRequest(args [0]string, w http.Re
 	request, err := decodeTestRequestStringIPArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIPArray",
-			err,
+			Operation: "TestRequestStringIPArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13759,8 +13759,8 @@ func (s *Server) handleTestRequestStringIPArrayArrayRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringIPArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIPArrayArray",
-			err,
+			Operation: "TestRequestStringIPArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13804,8 +13804,8 @@ func (s *Server) handleTestRequestStringIPNullableRequest(args [0]string, w http
 	request, err := decodeTestRequestStringIPNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIPNullable",
-			err,
+			Operation: "TestRequestStringIPNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13849,8 +13849,8 @@ func (s *Server) handleTestRequestStringIPNullableArrayRequest(args [0]string, w
 	request, err := decodeTestRequestStringIPNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIPNullableArray",
-			err,
+			Operation: "TestRequestStringIPNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13894,8 +13894,8 @@ func (s *Server) handleTestRequestStringIPNullableArrayArrayRequest(args [0]stri
 	request, err := decodeTestRequestStringIPNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIPNullableArrayArray",
-			err,
+			Operation: "TestRequestStringIPNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13939,8 +13939,8 @@ func (s *Server) handleTestRequestStringInt32Request(args [0]string, w http.Resp
 	request, err := decodeTestRequestStringInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32",
-			err,
+			Operation: "TestRequestStringInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -13984,8 +13984,8 @@ func (s *Server) handleTestRequestStringInt32ArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestStringInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32Array",
-			err,
+			Operation: "TestRequestStringInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14029,8 +14029,8 @@ func (s *Server) handleTestRequestStringInt32ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestStringInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32ArrayArray",
-			err,
+			Operation: "TestRequestStringInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14074,8 +14074,8 @@ func (s *Server) handleTestRequestStringInt32NullableRequest(args [0]string, w h
 	request, err := decodeTestRequestStringInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32Nullable",
-			err,
+			Operation: "TestRequestStringInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14119,8 +14119,8 @@ func (s *Server) handleTestRequestStringInt32NullableArrayRequest(args [0]string
 	request, err := decodeTestRequestStringInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32NullableArray",
-			err,
+			Operation: "TestRequestStringInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14164,8 +14164,8 @@ func (s *Server) handleTestRequestStringInt32NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestStringInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt32NullableArrayArray",
-			err,
+			Operation: "TestRequestStringInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14209,8 +14209,8 @@ func (s *Server) handleTestRequestStringInt64Request(args [0]string, w http.Resp
 	request, err := decodeTestRequestStringInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64",
-			err,
+			Operation: "TestRequestStringInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14254,8 +14254,8 @@ func (s *Server) handleTestRequestStringInt64ArrayRequest(args [0]string, w http
 	request, err := decodeTestRequestStringInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64Array",
-			err,
+			Operation: "TestRequestStringInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14299,8 +14299,8 @@ func (s *Server) handleTestRequestStringInt64ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestRequestStringInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64ArrayArray",
-			err,
+			Operation: "TestRequestStringInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14344,8 +14344,8 @@ func (s *Server) handleTestRequestStringInt64NullableRequest(args [0]string, w h
 	request, err := decodeTestRequestStringInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64Nullable",
-			err,
+			Operation: "TestRequestStringInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14389,8 +14389,8 @@ func (s *Server) handleTestRequestStringInt64NullableArrayRequest(args [0]string
 	request, err := decodeTestRequestStringInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64NullableArray",
-			err,
+			Operation: "TestRequestStringInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14434,8 +14434,8 @@ func (s *Server) handleTestRequestStringInt64NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestRequestStringInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringInt64NullableArrayArray",
-			err,
+			Operation: "TestRequestStringInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14479,8 +14479,8 @@ func (s *Server) handleTestRequestStringIpv4Request(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringIpv4Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4",
-			err,
+			Operation: "TestRequestStringIpv4",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14524,8 +14524,8 @@ func (s *Server) handleTestRequestStringIpv4ArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringIpv4ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4Array",
-			err,
+			Operation: "TestRequestStringIpv4Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14569,8 +14569,8 @@ func (s *Server) handleTestRequestStringIpv4ArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringIpv4ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4ArrayArray",
-			err,
+			Operation: "TestRequestStringIpv4ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14614,8 +14614,8 @@ func (s *Server) handleTestRequestStringIpv4NullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringIpv4NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4Nullable",
-			err,
+			Operation: "TestRequestStringIpv4Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14659,8 +14659,8 @@ func (s *Server) handleTestRequestStringIpv4NullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringIpv4NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4NullableArray",
-			err,
+			Operation: "TestRequestStringIpv4NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14704,8 +14704,8 @@ func (s *Server) handleTestRequestStringIpv4NullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringIpv4NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv4NullableArrayArray",
-			err,
+			Operation: "TestRequestStringIpv4NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14749,8 +14749,8 @@ func (s *Server) handleTestRequestStringIpv6Request(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringIpv6Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6",
-			err,
+			Operation: "TestRequestStringIpv6",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14794,8 +14794,8 @@ func (s *Server) handleTestRequestStringIpv6ArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringIpv6ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6Array",
-			err,
+			Operation: "TestRequestStringIpv6Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14839,8 +14839,8 @@ func (s *Server) handleTestRequestStringIpv6ArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringIpv6ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6ArrayArray",
-			err,
+			Operation: "TestRequestStringIpv6ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14884,8 +14884,8 @@ func (s *Server) handleTestRequestStringIpv6NullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringIpv6NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6Nullable",
-			err,
+			Operation: "TestRequestStringIpv6Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14929,8 +14929,8 @@ func (s *Server) handleTestRequestStringIpv6NullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringIpv6NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6NullableArray",
-			err,
+			Operation: "TestRequestStringIpv6NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -14974,8 +14974,8 @@ func (s *Server) handleTestRequestStringIpv6NullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringIpv6NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringIpv6NullableArrayArray",
-			err,
+			Operation: "TestRequestStringIpv6NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15019,8 +15019,8 @@ func (s *Server) handleTestRequestStringNullableRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringNullable",
-			err,
+			Operation: "TestRequestStringNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15064,8 +15064,8 @@ func (s *Server) handleTestRequestStringNullableArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringNullableArray",
-			err,
+			Operation: "TestRequestStringNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15109,8 +15109,8 @@ func (s *Server) handleTestRequestStringNullableArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringNullableArrayArray",
-			err,
+			Operation: "TestRequestStringNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15154,8 +15154,8 @@ func (s *Server) handleTestRequestStringPasswordRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringPasswordRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPassword",
-			err,
+			Operation: "TestRequestStringPassword",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15199,8 +15199,8 @@ func (s *Server) handleTestRequestStringPasswordArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringPasswordArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPasswordArray",
-			err,
+			Operation: "TestRequestStringPasswordArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15244,8 +15244,8 @@ func (s *Server) handleTestRequestStringPasswordArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringPasswordArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPasswordArrayArray",
-			err,
+			Operation: "TestRequestStringPasswordArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15289,8 +15289,8 @@ func (s *Server) handleTestRequestStringPasswordNullableRequest(args [0]string, 
 	request, err := decodeTestRequestStringPasswordNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPasswordNullable",
-			err,
+			Operation: "TestRequestStringPasswordNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15334,8 +15334,8 @@ func (s *Server) handleTestRequestStringPasswordNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestStringPasswordNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPasswordNullableArray",
-			err,
+			Operation: "TestRequestStringPasswordNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15379,8 +15379,8 @@ func (s *Server) handleTestRequestStringPasswordNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestStringPasswordNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringPasswordNullableArrayArray",
-			err,
+			Operation: "TestRequestStringPasswordNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15424,8 +15424,8 @@ func (s *Server) handleTestRequestStringTimeRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTime",
-			err,
+			Operation: "TestRequestStringTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15469,8 +15469,8 @@ func (s *Server) handleTestRequestStringTimeArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTimeArray",
-			err,
+			Operation: "TestRequestStringTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15514,8 +15514,8 @@ func (s *Server) handleTestRequestStringTimeArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTimeArrayArray",
-			err,
+			Operation: "TestRequestStringTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15559,8 +15559,8 @@ func (s *Server) handleTestRequestStringTimeNullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTimeNullable",
-			err,
+			Operation: "TestRequestStringTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15604,8 +15604,8 @@ func (s *Server) handleTestRequestStringTimeNullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTimeNullableArray",
-			err,
+			Operation: "TestRequestStringTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15649,8 +15649,8 @@ func (s *Server) handleTestRequestStringTimeNullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringTimeNullableArrayArray",
-			err,
+			Operation: "TestRequestStringTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15694,8 +15694,8 @@ func (s *Server) handleTestRequestStringURIRequest(args [0]string, w http.Respon
 	request, err := decodeTestRequestStringURIRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURI",
-			err,
+			Operation: "TestRequestStringURI",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15739,8 +15739,8 @@ func (s *Server) handleTestRequestStringURIArrayRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringURIArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURIArray",
-			err,
+			Operation: "TestRequestStringURIArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15784,8 +15784,8 @@ func (s *Server) handleTestRequestStringURIArrayArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringURIArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURIArrayArray",
-			err,
+			Operation: "TestRequestStringURIArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15829,8 +15829,8 @@ func (s *Server) handleTestRequestStringURINullableRequest(args [0]string, w htt
 	request, err := decodeTestRequestStringURINullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURINullable",
-			err,
+			Operation: "TestRequestStringURINullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15874,8 +15874,8 @@ func (s *Server) handleTestRequestStringURINullableArrayRequest(args [0]string, 
 	request, err := decodeTestRequestStringURINullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURINullableArray",
-			err,
+			Operation: "TestRequestStringURINullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15919,8 +15919,8 @@ func (s *Server) handleTestRequestStringURINullableArrayArrayRequest(args [0]str
 	request, err := decodeTestRequestStringURINullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringURINullableArrayArray",
-			err,
+			Operation: "TestRequestStringURINullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -15964,8 +15964,8 @@ func (s *Server) handleTestRequestStringUUIDRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringUUIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUID",
-			err,
+			Operation: "TestRequestStringUUID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16009,8 +16009,8 @@ func (s *Server) handleTestRequestStringUUIDArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringUUIDArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUIDArray",
-			err,
+			Operation: "TestRequestStringUUIDArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16054,8 +16054,8 @@ func (s *Server) handleTestRequestStringUUIDArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringUUIDArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUIDArrayArray",
-			err,
+			Operation: "TestRequestStringUUIDArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16099,8 +16099,8 @@ func (s *Server) handleTestRequestStringUUIDNullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringUUIDNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUIDNullable",
-			err,
+			Operation: "TestRequestStringUUIDNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16144,8 +16144,8 @@ func (s *Server) handleTestRequestStringUUIDNullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringUUIDNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUIDNullableArray",
-			err,
+			Operation: "TestRequestStringUUIDNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16189,8 +16189,8 @@ func (s *Server) handleTestRequestStringUUIDNullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringUUIDNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUUIDNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUUIDNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16234,8 +16234,8 @@ func (s *Server) handleTestRequestStringUnixRequest(args [0]string, w http.Respo
 	request, err := decodeTestRequestStringUnixRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnix",
-			err,
+			Operation: "TestRequestStringUnix",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16279,8 +16279,8 @@ func (s *Server) handleTestRequestStringUnixArrayRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringUnixArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixArray",
-			err,
+			Operation: "TestRequestStringUnixArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16324,8 +16324,8 @@ func (s *Server) handleTestRequestStringUnixArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringUnixArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixArrayArray",
-			err,
+			Operation: "TestRequestStringUnixArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16369,8 +16369,8 @@ func (s *Server) handleTestRequestStringUnixMicroRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringUnixMicroRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicro",
-			err,
+			Operation: "TestRequestStringUnixMicro",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16414,8 +16414,8 @@ func (s *Server) handleTestRequestStringUnixMicroArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringUnixMicroArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicroArray",
-			err,
+			Operation: "TestRequestStringUnixMicroArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16459,8 +16459,8 @@ func (s *Server) handleTestRequestStringUnixMicroArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestStringUnixMicroArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicroArrayArray",
-			err,
+			Operation: "TestRequestStringUnixMicroArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16504,8 +16504,8 @@ func (s *Server) handleTestRequestStringUnixMicroNullableRequest(args [0]string,
 	request, err := decodeTestRequestStringUnixMicroNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicroNullable",
-			err,
+			Operation: "TestRequestStringUnixMicroNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16549,8 +16549,8 @@ func (s *Server) handleTestRequestStringUnixMicroNullableArrayRequest(args [0]st
 	request, err := decodeTestRequestStringUnixMicroNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicroNullableArray",
-			err,
+			Operation: "TestRequestStringUnixMicroNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16594,8 +16594,8 @@ func (s *Server) handleTestRequestStringUnixMicroNullableArrayArrayRequest(args 
 	request, err := decodeTestRequestStringUnixMicroNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMicroNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUnixMicroNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16639,8 +16639,8 @@ func (s *Server) handleTestRequestStringUnixMilliRequest(args [0]string, w http.
 	request, err := decodeTestRequestStringUnixMilliRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilli",
-			err,
+			Operation: "TestRequestStringUnixMilli",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16684,8 +16684,8 @@ func (s *Server) handleTestRequestStringUnixMilliArrayRequest(args [0]string, w 
 	request, err := decodeTestRequestStringUnixMilliArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilliArray",
-			err,
+			Operation: "TestRequestStringUnixMilliArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16729,8 +16729,8 @@ func (s *Server) handleTestRequestStringUnixMilliArrayArrayRequest(args [0]strin
 	request, err := decodeTestRequestStringUnixMilliArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilliArrayArray",
-			err,
+			Operation: "TestRequestStringUnixMilliArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16774,8 +16774,8 @@ func (s *Server) handleTestRequestStringUnixMilliNullableRequest(args [0]string,
 	request, err := decodeTestRequestStringUnixMilliNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilliNullable",
-			err,
+			Operation: "TestRequestStringUnixMilliNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16819,8 +16819,8 @@ func (s *Server) handleTestRequestStringUnixMilliNullableArrayRequest(args [0]st
 	request, err := decodeTestRequestStringUnixMilliNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilliNullableArray",
-			err,
+			Operation: "TestRequestStringUnixMilliNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16864,8 +16864,8 @@ func (s *Server) handleTestRequestStringUnixMilliNullableArrayArrayRequest(args 
 	request, err := decodeTestRequestStringUnixMilliNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixMilliNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUnixMilliNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16909,8 +16909,8 @@ func (s *Server) handleTestRequestStringUnixNanoRequest(args [0]string, w http.R
 	request, err := decodeTestRequestStringUnixNanoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNano",
-			err,
+			Operation: "TestRequestStringUnixNano",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16954,8 +16954,8 @@ func (s *Server) handleTestRequestStringUnixNanoArrayRequest(args [0]string, w h
 	request, err := decodeTestRequestStringUnixNanoArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNanoArray",
-			err,
+			Operation: "TestRequestStringUnixNanoArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -16999,8 +16999,8 @@ func (s *Server) handleTestRequestStringUnixNanoArrayArrayRequest(args [0]string
 	request, err := decodeTestRequestStringUnixNanoArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNanoArrayArray",
-			err,
+			Operation: "TestRequestStringUnixNanoArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17044,8 +17044,8 @@ func (s *Server) handleTestRequestStringUnixNanoNullableRequest(args [0]string, 
 	request, err := decodeTestRequestStringUnixNanoNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNanoNullable",
-			err,
+			Operation: "TestRequestStringUnixNanoNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17089,8 +17089,8 @@ func (s *Server) handleTestRequestStringUnixNanoNullableArrayRequest(args [0]str
 	request, err := decodeTestRequestStringUnixNanoNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNanoNullableArray",
-			err,
+			Operation: "TestRequestStringUnixNanoNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17134,8 +17134,8 @@ func (s *Server) handleTestRequestStringUnixNanoNullableArrayArrayRequest(args [
 	request, err := decodeTestRequestStringUnixNanoNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNanoNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUnixNanoNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17179,8 +17179,8 @@ func (s *Server) handleTestRequestStringUnixNullableRequest(args [0]string, w ht
 	request, err := decodeTestRequestStringUnixNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNullable",
-			err,
+			Operation: "TestRequestStringUnixNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17224,8 +17224,8 @@ func (s *Server) handleTestRequestStringUnixNullableArrayRequest(args [0]string,
 	request, err := decodeTestRequestStringUnixNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNullableArray",
-			err,
+			Operation: "TestRequestStringUnixNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17269,8 +17269,8 @@ func (s *Server) handleTestRequestStringUnixNullableArrayArrayRequest(args [0]st
 	request, err := decodeTestRequestStringUnixNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUnixNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17314,8 +17314,8 @@ func (s *Server) handleTestRequestStringUnixSecondsRequest(args [0]string, w htt
 	request, err := decodeTestRequestStringUnixSecondsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSeconds",
-			err,
+			Operation: "TestRequestStringUnixSeconds",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17359,8 +17359,8 @@ func (s *Server) handleTestRequestStringUnixSecondsArrayRequest(args [0]string, 
 	request, err := decodeTestRequestStringUnixSecondsArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSecondsArray",
-			err,
+			Operation: "TestRequestStringUnixSecondsArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17404,8 +17404,8 @@ func (s *Server) handleTestRequestStringUnixSecondsArrayArrayRequest(args [0]str
 	request, err := decodeTestRequestStringUnixSecondsArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSecondsArrayArray",
-			err,
+			Operation: "TestRequestStringUnixSecondsArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17449,8 +17449,8 @@ func (s *Server) handleTestRequestStringUnixSecondsNullableRequest(args [0]strin
 	request, err := decodeTestRequestStringUnixSecondsNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSecondsNullable",
-			err,
+			Operation: "TestRequestStringUnixSecondsNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17494,8 +17494,8 @@ func (s *Server) handleTestRequestStringUnixSecondsNullableArrayRequest(args [0]
 	request, err := decodeTestRequestStringUnixSecondsNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSecondsNullableArray",
-			err,
+			Operation: "TestRequestStringUnixSecondsNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17539,8 +17539,8 @@ func (s *Server) handleTestRequestStringUnixSecondsNullableArrayArrayRequest(arg
 	request, err := decodeTestRequestStringUnixSecondsNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestRequestStringUnixSecondsNullableArrayArray",
-			err,
+			Operation: "TestRequestStringUnixSecondsNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17584,8 +17584,8 @@ func (s *Server) handleTestResponseAnyRequest(args [0]string, w http.ResponseWri
 	request, err := decodeTestResponseAnyRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseAny",
-			err,
+			Operation: "TestResponseAny",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17629,8 +17629,8 @@ func (s *Server) handleTestResponseBooleanRequest(args [0]string, w http.Respons
 	request, err := decodeTestResponseBooleanRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBoolean",
-			err,
+			Operation: "TestResponseBoolean",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17674,8 +17674,8 @@ func (s *Server) handleTestResponseBooleanArrayRequest(args [0]string, w http.Re
 	request, err := decodeTestResponseBooleanArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBooleanArray",
-			err,
+			Operation: "TestResponseBooleanArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17719,8 +17719,8 @@ func (s *Server) handleTestResponseBooleanArrayArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseBooleanArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBooleanArrayArray",
-			err,
+			Operation: "TestResponseBooleanArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17764,8 +17764,8 @@ func (s *Server) handleTestResponseBooleanNullableRequest(args [0]string, w http
 	request, err := decodeTestResponseBooleanNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBooleanNullable",
-			err,
+			Operation: "TestResponseBooleanNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17809,8 +17809,8 @@ func (s *Server) handleTestResponseBooleanNullableArrayRequest(args [0]string, w
 	request, err := decodeTestResponseBooleanNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBooleanNullableArray",
-			err,
+			Operation: "TestResponseBooleanNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17854,8 +17854,8 @@ func (s *Server) handleTestResponseBooleanNullableArrayArrayRequest(args [0]stri
 	request, err := decodeTestResponseBooleanNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseBooleanNullableArrayArray",
-			err,
+			Operation: "TestResponseBooleanNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17899,8 +17899,8 @@ func (s *Server) handleTestResponseEmptyStructRequest(args [0]string, w http.Res
 	request, err := decodeTestResponseEmptyStructRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseEmptyStruct",
-			err,
+			Operation: "TestResponseEmptyStruct",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17944,8 +17944,8 @@ func (s *Server) handleTestResponseFormatTestRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseFormatTestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseFormatTest",
-			err,
+			Operation: "TestResponseFormatTest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -17989,8 +17989,8 @@ func (s *Server) handleTestResponseIntegerRequest(args [0]string, w http.Respons
 	request, err := decodeTestResponseIntegerRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseInteger",
-			err,
+			Operation: "TestResponseInteger",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18034,8 +18034,8 @@ func (s *Server) handleTestResponseIntegerArrayRequest(args [0]string, w http.Re
 	request, err := decodeTestResponseIntegerArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerArray",
-			err,
+			Operation: "TestResponseIntegerArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18079,8 +18079,8 @@ func (s *Server) handleTestResponseIntegerArrayArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseIntegerArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerArrayArray",
-			err,
+			Operation: "TestResponseIntegerArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18124,8 +18124,8 @@ func (s *Server) handleTestResponseIntegerInt32Request(args [0]string, w http.Re
 	request, err := decodeTestResponseIntegerInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32",
-			err,
+			Operation: "TestResponseIntegerInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18169,8 +18169,8 @@ func (s *Server) handleTestResponseIntegerInt32ArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseIntegerInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32Array",
-			err,
+			Operation: "TestResponseIntegerInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18214,8 +18214,8 @@ func (s *Server) handleTestResponseIntegerInt32ArrayArrayRequest(args [0]string,
 	request, err := decodeTestResponseIntegerInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32ArrayArray",
-			err,
+			Operation: "TestResponseIntegerInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18259,8 +18259,8 @@ func (s *Server) handleTestResponseIntegerInt32NullableRequest(args [0]string, w
 	request, err := decodeTestResponseIntegerInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32Nullable",
-			err,
+			Operation: "TestResponseIntegerInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18304,8 +18304,8 @@ func (s *Server) handleTestResponseIntegerInt32NullableArrayRequest(args [0]stri
 	request, err := decodeTestResponseIntegerInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32NullableArray",
-			err,
+			Operation: "TestResponseIntegerInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18349,8 +18349,8 @@ func (s *Server) handleTestResponseIntegerInt32NullableArrayArrayRequest(args [0
 	request, err := decodeTestResponseIntegerInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt32NullableArrayArray",
-			err,
+			Operation: "TestResponseIntegerInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18394,8 +18394,8 @@ func (s *Server) handleTestResponseIntegerInt64Request(args [0]string, w http.Re
 	request, err := decodeTestResponseIntegerInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64",
-			err,
+			Operation: "TestResponseIntegerInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18439,8 +18439,8 @@ func (s *Server) handleTestResponseIntegerInt64ArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseIntegerInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64Array",
-			err,
+			Operation: "TestResponseIntegerInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18484,8 +18484,8 @@ func (s *Server) handleTestResponseIntegerInt64ArrayArrayRequest(args [0]string,
 	request, err := decodeTestResponseIntegerInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64ArrayArray",
-			err,
+			Operation: "TestResponseIntegerInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18529,8 +18529,8 @@ func (s *Server) handleTestResponseIntegerInt64NullableRequest(args [0]string, w
 	request, err := decodeTestResponseIntegerInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64Nullable",
-			err,
+			Operation: "TestResponseIntegerInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18574,8 +18574,8 @@ func (s *Server) handleTestResponseIntegerInt64NullableArrayRequest(args [0]stri
 	request, err := decodeTestResponseIntegerInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64NullableArray",
-			err,
+			Operation: "TestResponseIntegerInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18619,8 +18619,8 @@ func (s *Server) handleTestResponseIntegerInt64NullableArrayArrayRequest(args [0
 	request, err := decodeTestResponseIntegerInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerInt64NullableArrayArray",
-			err,
+			Operation: "TestResponseIntegerInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18664,8 +18664,8 @@ func (s *Server) handleTestResponseIntegerNullableRequest(args [0]string, w http
 	request, err := decodeTestResponseIntegerNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerNullable",
-			err,
+			Operation: "TestResponseIntegerNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18709,8 +18709,8 @@ func (s *Server) handleTestResponseIntegerNullableArrayRequest(args [0]string, w
 	request, err := decodeTestResponseIntegerNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerNullableArray",
-			err,
+			Operation: "TestResponseIntegerNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18754,8 +18754,8 @@ func (s *Server) handleTestResponseIntegerNullableArrayArrayRequest(args [0]stri
 	request, err := decodeTestResponseIntegerNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseIntegerNullableArrayArray",
-			err,
+			Operation: "TestResponseIntegerNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18799,8 +18799,8 @@ func (s *Server) handleTestResponseNullRequest(args [0]string, w http.ResponseWr
 	request, err := decodeTestResponseNullRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNull",
-			err,
+			Operation: "TestResponseNull",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18844,8 +18844,8 @@ func (s *Server) handleTestResponseNullArrayRequest(args [0]string, w http.Respo
 	request, err := decodeTestResponseNullArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNullArray",
-			err,
+			Operation: "TestResponseNullArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18889,8 +18889,8 @@ func (s *Server) handleTestResponseNullArrayArrayRequest(args [0]string, w http.
 	request, err := decodeTestResponseNullArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNullArrayArray",
-			err,
+			Operation: "TestResponseNullArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18934,8 +18934,8 @@ func (s *Server) handleTestResponseNullNullableRequest(args [0]string, w http.Re
 	request, err := decodeTestResponseNullNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNullNullable",
-			err,
+			Operation: "TestResponseNullNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -18979,8 +18979,8 @@ func (s *Server) handleTestResponseNullNullableArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseNullNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNullNullableArray",
-			err,
+			Operation: "TestResponseNullNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19024,8 +19024,8 @@ func (s *Server) handleTestResponseNullNullableArrayArrayRequest(args [0]string,
 	request, err := decodeTestResponseNullNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNullNullableArrayArray",
-			err,
+			Operation: "TestResponseNullNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19069,8 +19069,8 @@ func (s *Server) handleTestResponseNumberRequest(args [0]string, w http.Response
 	request, err := decodeTestResponseNumberRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumber",
-			err,
+			Operation: "TestResponseNumber",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19114,8 +19114,8 @@ func (s *Server) handleTestResponseNumberArrayRequest(args [0]string, w http.Res
 	request, err := decodeTestResponseNumberArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberArray",
-			err,
+			Operation: "TestResponseNumberArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19159,8 +19159,8 @@ func (s *Server) handleTestResponseNumberArrayArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseNumberArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberArrayArray",
-			err,
+			Operation: "TestResponseNumberArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19204,8 +19204,8 @@ func (s *Server) handleTestResponseNumberDoubleRequest(args [0]string, w http.Re
 	request, err := decodeTestResponseNumberDoubleRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDouble",
-			err,
+			Operation: "TestResponseNumberDouble",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19249,8 +19249,8 @@ func (s *Server) handleTestResponseNumberDoubleArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseNumberDoubleArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDoubleArray",
-			err,
+			Operation: "TestResponseNumberDoubleArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19294,8 +19294,8 @@ func (s *Server) handleTestResponseNumberDoubleArrayArrayRequest(args [0]string,
 	request, err := decodeTestResponseNumberDoubleArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDoubleArrayArray",
-			err,
+			Operation: "TestResponseNumberDoubleArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19339,8 +19339,8 @@ func (s *Server) handleTestResponseNumberDoubleNullableRequest(args [0]string, w
 	request, err := decodeTestResponseNumberDoubleNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDoubleNullable",
-			err,
+			Operation: "TestResponseNumberDoubleNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19384,8 +19384,8 @@ func (s *Server) handleTestResponseNumberDoubleNullableArrayRequest(args [0]stri
 	request, err := decodeTestResponseNumberDoubleNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDoubleNullableArray",
-			err,
+			Operation: "TestResponseNumberDoubleNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19429,8 +19429,8 @@ func (s *Server) handleTestResponseNumberDoubleNullableArrayArrayRequest(args [0
 	request, err := decodeTestResponseNumberDoubleNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberDoubleNullableArrayArray",
-			err,
+			Operation: "TestResponseNumberDoubleNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19474,8 +19474,8 @@ func (s *Server) handleTestResponseNumberFloatRequest(args [0]string, w http.Res
 	request, err := decodeTestResponseNumberFloatRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloat",
-			err,
+			Operation: "TestResponseNumberFloat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19519,8 +19519,8 @@ func (s *Server) handleTestResponseNumberFloatArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseNumberFloatArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloatArray",
-			err,
+			Operation: "TestResponseNumberFloatArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19564,8 +19564,8 @@ func (s *Server) handleTestResponseNumberFloatArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseNumberFloatArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloatArrayArray",
-			err,
+			Operation: "TestResponseNumberFloatArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19609,8 +19609,8 @@ func (s *Server) handleTestResponseNumberFloatNullableRequest(args [0]string, w 
 	request, err := decodeTestResponseNumberFloatNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloatNullable",
-			err,
+			Operation: "TestResponseNumberFloatNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19654,8 +19654,8 @@ func (s *Server) handleTestResponseNumberFloatNullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseNumberFloatNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloatNullableArray",
-			err,
+			Operation: "TestResponseNumberFloatNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19699,8 +19699,8 @@ func (s *Server) handleTestResponseNumberFloatNullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseNumberFloatNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberFloatNullableArrayArray",
-			err,
+			Operation: "TestResponseNumberFloatNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19744,8 +19744,8 @@ func (s *Server) handleTestResponseNumberInt32Request(args [0]string, w http.Res
 	request, err := decodeTestResponseNumberInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32",
-			err,
+			Operation: "TestResponseNumberInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19789,8 +19789,8 @@ func (s *Server) handleTestResponseNumberInt32ArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseNumberInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32Array",
-			err,
+			Operation: "TestResponseNumberInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19834,8 +19834,8 @@ func (s *Server) handleTestResponseNumberInt32ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseNumberInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32ArrayArray",
-			err,
+			Operation: "TestResponseNumberInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19879,8 +19879,8 @@ func (s *Server) handleTestResponseNumberInt32NullableRequest(args [0]string, w 
 	request, err := decodeTestResponseNumberInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32Nullable",
-			err,
+			Operation: "TestResponseNumberInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19924,8 +19924,8 @@ func (s *Server) handleTestResponseNumberInt32NullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseNumberInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32NullableArray",
-			err,
+			Operation: "TestResponseNumberInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -19969,8 +19969,8 @@ func (s *Server) handleTestResponseNumberInt32NullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseNumberInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt32NullableArrayArray",
-			err,
+			Operation: "TestResponseNumberInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20014,8 +20014,8 @@ func (s *Server) handleTestResponseNumberInt64Request(args [0]string, w http.Res
 	request, err := decodeTestResponseNumberInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64",
-			err,
+			Operation: "TestResponseNumberInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20059,8 +20059,8 @@ func (s *Server) handleTestResponseNumberInt64ArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseNumberInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64Array",
-			err,
+			Operation: "TestResponseNumberInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20104,8 +20104,8 @@ func (s *Server) handleTestResponseNumberInt64ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseNumberInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64ArrayArray",
-			err,
+			Operation: "TestResponseNumberInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20149,8 +20149,8 @@ func (s *Server) handleTestResponseNumberInt64NullableRequest(args [0]string, w 
 	request, err := decodeTestResponseNumberInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64Nullable",
-			err,
+			Operation: "TestResponseNumberInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20194,8 +20194,8 @@ func (s *Server) handleTestResponseNumberInt64NullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseNumberInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64NullableArray",
-			err,
+			Operation: "TestResponseNumberInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20239,8 +20239,8 @@ func (s *Server) handleTestResponseNumberInt64NullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseNumberInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberInt64NullableArrayArray",
-			err,
+			Operation: "TestResponseNumberInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20284,8 +20284,8 @@ func (s *Server) handleTestResponseNumberNullableRequest(args [0]string, w http.
 	request, err := decodeTestResponseNumberNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberNullable",
-			err,
+			Operation: "TestResponseNumberNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20329,8 +20329,8 @@ func (s *Server) handleTestResponseNumberNullableArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseNumberNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberNullableArray",
-			err,
+			Operation: "TestResponseNumberNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20374,8 +20374,8 @@ func (s *Server) handleTestResponseNumberNullableArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseNumberNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseNumberNullableArrayArray",
-			err,
+			Operation: "TestResponseNumberNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20419,8 +20419,8 @@ func (s *Server) handleTestResponseStringRequest(args [0]string, w http.Response
 	request, err := decodeTestResponseStringRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseString",
-			err,
+			Operation: "TestResponseString",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20464,8 +20464,8 @@ func (s *Server) handleTestResponseStringArrayRequest(args [0]string, w http.Res
 	request, err := decodeTestResponseStringArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringArray",
-			err,
+			Operation: "TestResponseStringArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20509,8 +20509,8 @@ func (s *Server) handleTestResponseStringArrayArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseStringArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringArrayArray",
-			err,
+			Operation: "TestResponseStringArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20554,8 +20554,8 @@ func (s *Server) handleTestResponseStringBinaryRequest(args [0]string, w http.Re
 	request, err := decodeTestResponseStringBinaryRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinary",
-			err,
+			Operation: "TestResponseStringBinary",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20599,8 +20599,8 @@ func (s *Server) handleTestResponseStringBinaryArrayRequest(args [0]string, w ht
 	request, err := decodeTestResponseStringBinaryArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinaryArray",
-			err,
+			Operation: "TestResponseStringBinaryArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20644,8 +20644,8 @@ func (s *Server) handleTestResponseStringBinaryArrayArrayRequest(args [0]string,
 	request, err := decodeTestResponseStringBinaryArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinaryArrayArray",
-			err,
+			Operation: "TestResponseStringBinaryArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20689,8 +20689,8 @@ func (s *Server) handleTestResponseStringBinaryNullableRequest(args [0]string, w
 	request, err := decodeTestResponseStringBinaryNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinaryNullable",
-			err,
+			Operation: "TestResponseStringBinaryNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20734,8 +20734,8 @@ func (s *Server) handleTestResponseStringBinaryNullableArrayRequest(args [0]stri
 	request, err := decodeTestResponseStringBinaryNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinaryNullableArray",
-			err,
+			Operation: "TestResponseStringBinaryNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20779,8 +20779,8 @@ func (s *Server) handleTestResponseStringBinaryNullableArrayArrayRequest(args [0
 	request, err := decodeTestResponseStringBinaryNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringBinaryNullableArrayArray",
-			err,
+			Operation: "TestResponseStringBinaryNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20824,8 +20824,8 @@ func (s *Server) handleTestResponseStringByteRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringByteRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByte",
-			err,
+			Operation: "TestResponseStringByte",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20869,8 +20869,8 @@ func (s *Server) handleTestResponseStringByteArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringByteArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByteArray",
-			err,
+			Operation: "TestResponseStringByteArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20914,8 +20914,8 @@ func (s *Server) handleTestResponseStringByteArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringByteArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByteArrayArray",
-			err,
+			Operation: "TestResponseStringByteArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -20959,8 +20959,8 @@ func (s *Server) handleTestResponseStringByteNullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringByteNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByteNullable",
-			err,
+			Operation: "TestResponseStringByteNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21004,8 +21004,8 @@ func (s *Server) handleTestResponseStringByteNullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringByteNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByteNullableArray",
-			err,
+			Operation: "TestResponseStringByteNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21049,8 +21049,8 @@ func (s *Server) handleTestResponseStringByteNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringByteNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringByteNullableArrayArray",
-			err,
+			Operation: "TestResponseStringByteNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21094,8 +21094,8 @@ func (s *Server) handleTestResponseStringDateRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringDateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDate",
-			err,
+			Operation: "TestResponseStringDate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21139,8 +21139,8 @@ func (s *Server) handleTestResponseStringDateArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringDateArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateArray",
-			err,
+			Operation: "TestResponseStringDateArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21184,8 +21184,8 @@ func (s *Server) handleTestResponseStringDateArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringDateArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateArrayArray",
-			err,
+			Operation: "TestResponseStringDateArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21229,8 +21229,8 @@ func (s *Server) handleTestResponseStringDateNullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringDateNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateNullable",
-			err,
+			Operation: "TestResponseStringDateNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21274,8 +21274,8 @@ func (s *Server) handleTestResponseStringDateNullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringDateNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateNullableArray",
-			err,
+			Operation: "TestResponseStringDateNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21319,8 +21319,8 @@ func (s *Server) handleTestResponseStringDateNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringDateNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateNullableArrayArray",
-			err,
+			Operation: "TestResponseStringDateNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21364,8 +21364,8 @@ func (s *Server) handleTestResponseStringDateTimeRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringDateTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTime",
-			err,
+			Operation: "TestResponseStringDateTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21409,8 +21409,8 @@ func (s *Server) handleTestResponseStringDateTimeArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringDateTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTimeArray",
-			err,
+			Operation: "TestResponseStringDateTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21454,8 +21454,8 @@ func (s *Server) handleTestResponseStringDateTimeArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringDateTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTimeArrayArray",
-			err,
+			Operation: "TestResponseStringDateTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21499,8 +21499,8 @@ func (s *Server) handleTestResponseStringDateTimeNullableRequest(args [0]string,
 	request, err := decodeTestResponseStringDateTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTimeNullable",
-			err,
+			Operation: "TestResponseStringDateTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21544,8 +21544,8 @@ func (s *Server) handleTestResponseStringDateTimeNullableArrayRequest(args [0]st
 	request, err := decodeTestResponseStringDateTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTimeNullableArray",
-			err,
+			Operation: "TestResponseStringDateTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21589,8 +21589,8 @@ func (s *Server) handleTestResponseStringDateTimeNullableArrayArrayRequest(args 
 	request, err := decodeTestResponseStringDateTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDateTimeNullableArrayArray",
-			err,
+			Operation: "TestResponseStringDateTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21634,8 +21634,8 @@ func (s *Server) handleTestResponseStringDurationRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringDurationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDuration",
-			err,
+			Operation: "TestResponseStringDuration",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21679,8 +21679,8 @@ func (s *Server) handleTestResponseStringDurationArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringDurationArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDurationArray",
-			err,
+			Operation: "TestResponseStringDurationArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21724,8 +21724,8 @@ func (s *Server) handleTestResponseStringDurationArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringDurationArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDurationArrayArray",
-			err,
+			Operation: "TestResponseStringDurationArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21769,8 +21769,8 @@ func (s *Server) handleTestResponseStringDurationNullableRequest(args [0]string,
 	request, err := decodeTestResponseStringDurationNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDurationNullable",
-			err,
+			Operation: "TestResponseStringDurationNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21814,8 +21814,8 @@ func (s *Server) handleTestResponseStringDurationNullableArrayRequest(args [0]st
 	request, err := decodeTestResponseStringDurationNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDurationNullableArray",
-			err,
+			Operation: "TestResponseStringDurationNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21859,8 +21859,8 @@ func (s *Server) handleTestResponseStringDurationNullableArrayArrayRequest(args 
 	request, err := decodeTestResponseStringDurationNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringDurationNullableArrayArray",
-			err,
+			Operation: "TestResponseStringDurationNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21904,8 +21904,8 @@ func (s *Server) handleTestResponseStringEmailRequest(args [0]string, w http.Res
 	request, err := decodeTestResponseStringEmailRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmail",
-			err,
+			Operation: "TestResponseStringEmail",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21949,8 +21949,8 @@ func (s *Server) handleTestResponseStringEmailArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseStringEmailArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmailArray",
-			err,
+			Operation: "TestResponseStringEmailArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -21994,8 +21994,8 @@ func (s *Server) handleTestResponseStringEmailArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseStringEmailArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmailArrayArray",
-			err,
+			Operation: "TestResponseStringEmailArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22039,8 +22039,8 @@ func (s *Server) handleTestResponseStringEmailNullableRequest(args [0]string, w 
 	request, err := decodeTestResponseStringEmailNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmailNullable",
-			err,
+			Operation: "TestResponseStringEmailNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22084,8 +22084,8 @@ func (s *Server) handleTestResponseStringEmailNullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringEmailNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmailNullableArray",
-			err,
+			Operation: "TestResponseStringEmailNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22129,8 +22129,8 @@ func (s *Server) handleTestResponseStringEmailNullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseStringEmailNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringEmailNullableArrayArray",
-			err,
+			Operation: "TestResponseStringEmailNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22174,8 +22174,8 @@ func (s *Server) handleTestResponseStringHostnameRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringHostnameRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostname",
-			err,
+			Operation: "TestResponseStringHostname",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22219,8 +22219,8 @@ func (s *Server) handleTestResponseStringHostnameArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringHostnameArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostnameArray",
-			err,
+			Operation: "TestResponseStringHostnameArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22264,8 +22264,8 @@ func (s *Server) handleTestResponseStringHostnameArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringHostnameArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostnameArrayArray",
-			err,
+			Operation: "TestResponseStringHostnameArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22309,8 +22309,8 @@ func (s *Server) handleTestResponseStringHostnameNullableRequest(args [0]string,
 	request, err := decodeTestResponseStringHostnameNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostnameNullable",
-			err,
+			Operation: "TestResponseStringHostnameNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22354,8 +22354,8 @@ func (s *Server) handleTestResponseStringHostnameNullableArrayRequest(args [0]st
 	request, err := decodeTestResponseStringHostnameNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostnameNullableArray",
-			err,
+			Operation: "TestResponseStringHostnameNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22399,8 +22399,8 @@ func (s *Server) handleTestResponseStringHostnameNullableArrayArrayRequest(args 
 	request, err := decodeTestResponseStringHostnameNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringHostnameNullableArrayArray",
-			err,
+			Operation: "TestResponseStringHostnameNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22444,8 +22444,8 @@ func (s *Server) handleTestResponseStringIPRequest(args [0]string, w http.Respon
 	request, err := decodeTestResponseStringIPRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIP",
-			err,
+			Operation: "TestResponseStringIP",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22489,8 +22489,8 @@ func (s *Server) handleTestResponseStringIPArrayRequest(args [0]string, w http.R
 	request, err := decodeTestResponseStringIPArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIPArray",
-			err,
+			Operation: "TestResponseStringIPArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22534,8 +22534,8 @@ func (s *Server) handleTestResponseStringIPArrayArrayRequest(args [0]string, w h
 	request, err := decodeTestResponseStringIPArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIPArrayArray",
-			err,
+			Operation: "TestResponseStringIPArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22579,8 +22579,8 @@ func (s *Server) handleTestResponseStringIPNullableRequest(args [0]string, w htt
 	request, err := decodeTestResponseStringIPNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIPNullable",
-			err,
+			Operation: "TestResponseStringIPNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22624,8 +22624,8 @@ func (s *Server) handleTestResponseStringIPNullableArrayRequest(args [0]string, 
 	request, err := decodeTestResponseStringIPNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIPNullableArray",
-			err,
+			Operation: "TestResponseStringIPNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22669,8 +22669,8 @@ func (s *Server) handleTestResponseStringIPNullableArrayArrayRequest(args [0]str
 	request, err := decodeTestResponseStringIPNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIPNullableArrayArray",
-			err,
+			Operation: "TestResponseStringIPNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22714,8 +22714,8 @@ func (s *Server) handleTestResponseStringInt32Request(args [0]string, w http.Res
 	request, err := decodeTestResponseStringInt32Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32",
-			err,
+			Operation: "TestResponseStringInt32",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22759,8 +22759,8 @@ func (s *Server) handleTestResponseStringInt32ArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseStringInt32ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32Array",
-			err,
+			Operation: "TestResponseStringInt32Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22804,8 +22804,8 @@ func (s *Server) handleTestResponseStringInt32ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseStringInt32ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32ArrayArray",
-			err,
+			Operation: "TestResponseStringInt32ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22849,8 +22849,8 @@ func (s *Server) handleTestResponseStringInt32NullableRequest(args [0]string, w 
 	request, err := decodeTestResponseStringInt32NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32Nullable",
-			err,
+			Operation: "TestResponseStringInt32Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22894,8 +22894,8 @@ func (s *Server) handleTestResponseStringInt32NullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringInt32NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32NullableArray",
-			err,
+			Operation: "TestResponseStringInt32NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22939,8 +22939,8 @@ func (s *Server) handleTestResponseStringInt32NullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseStringInt32NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt32NullableArrayArray",
-			err,
+			Operation: "TestResponseStringInt32NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -22984,8 +22984,8 @@ func (s *Server) handleTestResponseStringInt64Request(args [0]string, w http.Res
 	request, err := decodeTestResponseStringInt64Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64",
-			err,
+			Operation: "TestResponseStringInt64",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23029,8 +23029,8 @@ func (s *Server) handleTestResponseStringInt64ArrayRequest(args [0]string, w htt
 	request, err := decodeTestResponseStringInt64ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64Array",
-			err,
+			Operation: "TestResponseStringInt64Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23074,8 +23074,8 @@ func (s *Server) handleTestResponseStringInt64ArrayArrayRequest(args [0]string, 
 	request, err := decodeTestResponseStringInt64ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64ArrayArray",
-			err,
+			Operation: "TestResponseStringInt64ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23119,8 +23119,8 @@ func (s *Server) handleTestResponseStringInt64NullableRequest(args [0]string, w 
 	request, err := decodeTestResponseStringInt64NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64Nullable",
-			err,
+			Operation: "TestResponseStringInt64Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23164,8 +23164,8 @@ func (s *Server) handleTestResponseStringInt64NullableArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringInt64NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64NullableArray",
-			err,
+			Operation: "TestResponseStringInt64NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23209,8 +23209,8 @@ func (s *Server) handleTestResponseStringInt64NullableArrayArrayRequest(args [0]
 	request, err := decodeTestResponseStringInt64NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringInt64NullableArrayArray",
-			err,
+			Operation: "TestResponseStringInt64NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23254,8 +23254,8 @@ func (s *Server) handleTestResponseStringIpv4Request(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringIpv4Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4",
-			err,
+			Operation: "TestResponseStringIpv4",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23299,8 +23299,8 @@ func (s *Server) handleTestResponseStringIpv4ArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringIpv4ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4Array",
-			err,
+			Operation: "TestResponseStringIpv4Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23344,8 +23344,8 @@ func (s *Server) handleTestResponseStringIpv4ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringIpv4ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4ArrayArray",
-			err,
+			Operation: "TestResponseStringIpv4ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23389,8 +23389,8 @@ func (s *Server) handleTestResponseStringIpv4NullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringIpv4NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4Nullable",
-			err,
+			Operation: "TestResponseStringIpv4Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23434,8 +23434,8 @@ func (s *Server) handleTestResponseStringIpv4NullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringIpv4NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4NullableArray",
-			err,
+			Operation: "TestResponseStringIpv4NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23479,8 +23479,8 @@ func (s *Server) handleTestResponseStringIpv4NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringIpv4NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv4NullableArrayArray",
-			err,
+			Operation: "TestResponseStringIpv4NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23524,8 +23524,8 @@ func (s *Server) handleTestResponseStringIpv6Request(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringIpv6Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6",
-			err,
+			Operation: "TestResponseStringIpv6",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23569,8 +23569,8 @@ func (s *Server) handleTestResponseStringIpv6ArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringIpv6ArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6Array",
-			err,
+			Operation: "TestResponseStringIpv6Array",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23614,8 +23614,8 @@ func (s *Server) handleTestResponseStringIpv6ArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringIpv6ArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6ArrayArray",
-			err,
+			Operation: "TestResponseStringIpv6ArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23659,8 +23659,8 @@ func (s *Server) handleTestResponseStringIpv6NullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringIpv6NullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6Nullable",
-			err,
+			Operation: "TestResponseStringIpv6Nullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23704,8 +23704,8 @@ func (s *Server) handleTestResponseStringIpv6NullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringIpv6NullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6NullableArray",
-			err,
+			Operation: "TestResponseStringIpv6NullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23749,8 +23749,8 @@ func (s *Server) handleTestResponseStringIpv6NullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringIpv6NullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringIpv6NullableArrayArray",
-			err,
+			Operation: "TestResponseStringIpv6NullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23794,8 +23794,8 @@ func (s *Server) handleTestResponseStringNullableRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringNullable",
-			err,
+			Operation: "TestResponseStringNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23839,8 +23839,8 @@ func (s *Server) handleTestResponseStringNullableArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringNullableArray",
-			err,
+			Operation: "TestResponseStringNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23884,8 +23884,8 @@ func (s *Server) handleTestResponseStringNullableArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringNullableArrayArray",
-			err,
+			Operation: "TestResponseStringNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23929,8 +23929,8 @@ func (s *Server) handleTestResponseStringPasswordRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringPasswordRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPassword",
-			err,
+			Operation: "TestResponseStringPassword",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -23974,8 +23974,8 @@ func (s *Server) handleTestResponseStringPasswordArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringPasswordArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPasswordArray",
-			err,
+			Operation: "TestResponseStringPasswordArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24019,8 +24019,8 @@ func (s *Server) handleTestResponseStringPasswordArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringPasswordArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPasswordArrayArray",
-			err,
+			Operation: "TestResponseStringPasswordArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24064,8 +24064,8 @@ func (s *Server) handleTestResponseStringPasswordNullableRequest(args [0]string,
 	request, err := decodeTestResponseStringPasswordNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPasswordNullable",
-			err,
+			Operation: "TestResponseStringPasswordNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24109,8 +24109,8 @@ func (s *Server) handleTestResponseStringPasswordNullableArrayRequest(args [0]st
 	request, err := decodeTestResponseStringPasswordNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPasswordNullableArray",
-			err,
+			Operation: "TestResponseStringPasswordNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24154,8 +24154,8 @@ func (s *Server) handleTestResponseStringPasswordNullableArrayArrayRequest(args 
 	request, err := decodeTestResponseStringPasswordNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringPasswordNullableArrayArray",
-			err,
+			Operation: "TestResponseStringPasswordNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24199,8 +24199,8 @@ func (s *Server) handleTestResponseStringTimeRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringTimeRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTime",
-			err,
+			Operation: "TestResponseStringTime",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24244,8 +24244,8 @@ func (s *Server) handleTestResponseStringTimeArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringTimeArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTimeArray",
-			err,
+			Operation: "TestResponseStringTimeArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24289,8 +24289,8 @@ func (s *Server) handleTestResponseStringTimeArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringTimeArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTimeArrayArray",
-			err,
+			Operation: "TestResponseStringTimeArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24334,8 +24334,8 @@ func (s *Server) handleTestResponseStringTimeNullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringTimeNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTimeNullable",
-			err,
+			Operation: "TestResponseStringTimeNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24379,8 +24379,8 @@ func (s *Server) handleTestResponseStringTimeNullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringTimeNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTimeNullableArray",
-			err,
+			Operation: "TestResponseStringTimeNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24424,8 +24424,8 @@ func (s *Server) handleTestResponseStringTimeNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringTimeNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringTimeNullableArrayArray",
-			err,
+			Operation: "TestResponseStringTimeNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24469,8 +24469,8 @@ func (s *Server) handleTestResponseStringURIRequest(args [0]string, w http.Respo
 	request, err := decodeTestResponseStringURIRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURI",
-			err,
+			Operation: "TestResponseStringURI",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24514,8 +24514,8 @@ func (s *Server) handleTestResponseStringURIArrayRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringURIArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURIArray",
-			err,
+			Operation: "TestResponseStringURIArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24559,8 +24559,8 @@ func (s *Server) handleTestResponseStringURIArrayArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringURIArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURIArrayArray",
-			err,
+			Operation: "TestResponseStringURIArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24604,8 +24604,8 @@ func (s *Server) handleTestResponseStringURINullableRequest(args [0]string, w ht
 	request, err := decodeTestResponseStringURINullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURINullable",
-			err,
+			Operation: "TestResponseStringURINullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24649,8 +24649,8 @@ func (s *Server) handleTestResponseStringURINullableArrayRequest(args [0]string,
 	request, err := decodeTestResponseStringURINullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURINullableArray",
-			err,
+			Operation: "TestResponseStringURINullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24694,8 +24694,8 @@ func (s *Server) handleTestResponseStringURINullableArrayArrayRequest(args [0]st
 	request, err := decodeTestResponseStringURINullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringURINullableArrayArray",
-			err,
+			Operation: "TestResponseStringURINullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24739,8 +24739,8 @@ func (s *Server) handleTestResponseStringUUIDRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringUUIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUID",
-			err,
+			Operation: "TestResponseStringUUID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24784,8 +24784,8 @@ func (s *Server) handleTestResponseStringUUIDArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringUUIDArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUIDArray",
-			err,
+			Operation: "TestResponseStringUUIDArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24829,8 +24829,8 @@ func (s *Server) handleTestResponseStringUUIDArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringUUIDArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUIDArrayArray",
-			err,
+			Operation: "TestResponseStringUUIDArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24874,8 +24874,8 @@ func (s *Server) handleTestResponseStringUUIDNullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringUUIDNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUIDNullable",
-			err,
+			Operation: "TestResponseStringUUIDNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24919,8 +24919,8 @@ func (s *Server) handleTestResponseStringUUIDNullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringUUIDNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUIDNullableArray",
-			err,
+			Operation: "TestResponseStringUUIDNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -24964,8 +24964,8 @@ func (s *Server) handleTestResponseStringUUIDNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringUUIDNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUUIDNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUUIDNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25009,8 +25009,8 @@ func (s *Server) handleTestResponseStringUnixRequest(args [0]string, w http.Resp
 	request, err := decodeTestResponseStringUnixRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnix",
-			err,
+			Operation: "TestResponseStringUnix",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25054,8 +25054,8 @@ func (s *Server) handleTestResponseStringUnixArrayRequest(args [0]string, w http
 	request, err := decodeTestResponseStringUnixArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixArray",
-			err,
+			Operation: "TestResponseStringUnixArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25099,8 +25099,8 @@ func (s *Server) handleTestResponseStringUnixArrayArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringUnixArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixArrayArray",
-			err,
+			Operation: "TestResponseStringUnixArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25144,8 +25144,8 @@ func (s *Server) handleTestResponseStringUnixMicroRequest(args [0]string, w http
 	request, err := decodeTestResponseStringUnixMicroRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicro",
-			err,
+			Operation: "TestResponseStringUnixMicro",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25189,8 +25189,8 @@ func (s *Server) handleTestResponseStringUnixMicroArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringUnixMicroArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicroArray",
-			err,
+			Operation: "TestResponseStringUnixMicroArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25234,8 +25234,8 @@ func (s *Server) handleTestResponseStringUnixMicroArrayArrayRequest(args [0]stri
 	request, err := decodeTestResponseStringUnixMicroArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicroArrayArray",
-			err,
+			Operation: "TestResponseStringUnixMicroArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25279,8 +25279,8 @@ func (s *Server) handleTestResponseStringUnixMicroNullableRequest(args [0]string
 	request, err := decodeTestResponseStringUnixMicroNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicroNullable",
-			err,
+			Operation: "TestResponseStringUnixMicroNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25324,8 +25324,8 @@ func (s *Server) handleTestResponseStringUnixMicroNullableArrayRequest(args [0]s
 	request, err := decodeTestResponseStringUnixMicroNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicroNullableArray",
-			err,
+			Operation: "TestResponseStringUnixMicroNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25369,8 +25369,8 @@ func (s *Server) handleTestResponseStringUnixMicroNullableArrayArrayRequest(args
 	request, err := decodeTestResponseStringUnixMicroNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMicroNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUnixMicroNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25414,8 +25414,8 @@ func (s *Server) handleTestResponseStringUnixMilliRequest(args [0]string, w http
 	request, err := decodeTestResponseStringUnixMilliRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilli",
-			err,
+			Operation: "TestResponseStringUnixMilli",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25459,8 +25459,8 @@ func (s *Server) handleTestResponseStringUnixMilliArrayRequest(args [0]string, w
 	request, err := decodeTestResponseStringUnixMilliArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilliArray",
-			err,
+			Operation: "TestResponseStringUnixMilliArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25504,8 +25504,8 @@ func (s *Server) handleTestResponseStringUnixMilliArrayArrayRequest(args [0]stri
 	request, err := decodeTestResponseStringUnixMilliArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilliArrayArray",
-			err,
+			Operation: "TestResponseStringUnixMilliArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25549,8 +25549,8 @@ func (s *Server) handleTestResponseStringUnixMilliNullableRequest(args [0]string
 	request, err := decodeTestResponseStringUnixMilliNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilliNullable",
-			err,
+			Operation: "TestResponseStringUnixMilliNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25594,8 +25594,8 @@ func (s *Server) handleTestResponseStringUnixMilliNullableArrayRequest(args [0]s
 	request, err := decodeTestResponseStringUnixMilliNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilliNullableArray",
-			err,
+			Operation: "TestResponseStringUnixMilliNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25639,8 +25639,8 @@ func (s *Server) handleTestResponseStringUnixMilliNullableArrayArrayRequest(args
 	request, err := decodeTestResponseStringUnixMilliNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixMilliNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUnixMilliNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25684,8 +25684,8 @@ func (s *Server) handleTestResponseStringUnixNanoRequest(args [0]string, w http.
 	request, err := decodeTestResponseStringUnixNanoRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNano",
-			err,
+			Operation: "TestResponseStringUnixNano",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25729,8 +25729,8 @@ func (s *Server) handleTestResponseStringUnixNanoArrayRequest(args [0]string, w 
 	request, err := decodeTestResponseStringUnixNanoArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNanoArray",
-			err,
+			Operation: "TestResponseStringUnixNanoArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25774,8 +25774,8 @@ func (s *Server) handleTestResponseStringUnixNanoArrayArrayRequest(args [0]strin
 	request, err := decodeTestResponseStringUnixNanoArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNanoArrayArray",
-			err,
+			Operation: "TestResponseStringUnixNanoArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25819,8 +25819,8 @@ func (s *Server) handleTestResponseStringUnixNanoNullableRequest(args [0]string,
 	request, err := decodeTestResponseStringUnixNanoNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNanoNullable",
-			err,
+			Operation: "TestResponseStringUnixNanoNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25864,8 +25864,8 @@ func (s *Server) handleTestResponseStringUnixNanoNullableArrayRequest(args [0]st
 	request, err := decodeTestResponseStringUnixNanoNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNanoNullableArray",
-			err,
+			Operation: "TestResponseStringUnixNanoNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25909,8 +25909,8 @@ func (s *Server) handleTestResponseStringUnixNanoNullableArrayArrayRequest(args 
 	request, err := decodeTestResponseStringUnixNanoNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNanoNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUnixNanoNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25954,8 +25954,8 @@ func (s *Server) handleTestResponseStringUnixNullableRequest(args [0]string, w h
 	request, err := decodeTestResponseStringUnixNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNullable",
-			err,
+			Operation: "TestResponseStringUnixNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -25999,8 +25999,8 @@ func (s *Server) handleTestResponseStringUnixNullableArrayRequest(args [0]string
 	request, err := decodeTestResponseStringUnixNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNullableArray",
-			err,
+			Operation: "TestResponseStringUnixNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26044,8 +26044,8 @@ func (s *Server) handleTestResponseStringUnixNullableArrayArrayRequest(args [0]s
 	request, err := decodeTestResponseStringUnixNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUnixNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26089,8 +26089,8 @@ func (s *Server) handleTestResponseStringUnixSecondsRequest(args [0]string, w ht
 	request, err := decodeTestResponseStringUnixSecondsRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSeconds",
-			err,
+			Operation: "TestResponseStringUnixSeconds",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26134,8 +26134,8 @@ func (s *Server) handleTestResponseStringUnixSecondsArrayRequest(args [0]string,
 	request, err := decodeTestResponseStringUnixSecondsArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSecondsArray",
-			err,
+			Operation: "TestResponseStringUnixSecondsArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26179,8 +26179,8 @@ func (s *Server) handleTestResponseStringUnixSecondsArrayArrayRequest(args [0]st
 	request, err := decodeTestResponseStringUnixSecondsArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSecondsArrayArray",
-			err,
+			Operation: "TestResponseStringUnixSecondsArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26224,8 +26224,8 @@ func (s *Server) handleTestResponseStringUnixSecondsNullableRequest(args [0]stri
 	request, err := decodeTestResponseStringUnixSecondsNullableRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSecondsNullable",
-			err,
+			Operation: "TestResponseStringUnixSecondsNullable",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26269,8 +26269,8 @@ func (s *Server) handleTestResponseStringUnixSecondsNullableArrayRequest(args [0
 	request, err := decodeTestResponseStringUnixSecondsNullableArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSecondsNullableArray",
-			err,
+			Operation: "TestResponseStringUnixSecondsNullableArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -26314,8 +26314,8 @@ func (s *Server) handleTestResponseStringUnixSecondsNullableArrayArrayRequest(ar
 	request, err := decodeTestResponseStringUnixSecondsNullableArrayArrayRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestResponseStringUnixSecondsNullableArrayArray",
-			err,
+			Operation: "TestResponseStringUnixSecondsNullableArrayArray",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_test_format/oas_req_dec_gen.go
+++ b/examples/ex_test_format/oas_req_dec_gen.go
@@ -195,7 +195,7 @@ func decodeTestRequestBooleanArrayArrayRequest(r *http.Request, span trace.Span)
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -206,7 +206,7 @@ func decodeTestRequestBooleanArrayArrayRequest(r *http.Request, span trace.Span)
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestBooleanArrayArray request")
 		}
@@ -354,7 +354,7 @@ func decodeTestRequestBooleanNullableArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -365,7 +365,7 @@ func decodeTestRequestBooleanNullableArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestBooleanNullableArrayArray request")
 		}
@@ -451,13 +451,13 @@ func decodeTestRequestFormatTestRequest(r *http.Request, span trace.Span) (req O
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestFormatTest request")
 		}
@@ -605,7 +605,7 @@ func decodeTestRequestIntegerArrayArrayRequest(r *http.Request, span trace.Span)
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -616,7 +616,7 @@ func decodeTestRequestIntegerArrayArrayRequest(r *http.Request, span trace.Span)
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerArrayArray request")
 		}
@@ -764,7 +764,7 @@ func decodeTestRequestIntegerInt32ArrayArrayRequest(r *http.Request, span trace.
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -775,7 +775,7 @@ func decodeTestRequestIntegerInt32ArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerInt32ArrayArray request")
 		}
@@ -923,7 +923,7 @@ func decodeTestRequestIntegerInt32NullableArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -934,7 +934,7 @@ func decodeTestRequestIntegerInt32NullableArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerInt32NullableArrayArray request")
 		}
@@ -1082,7 +1082,7 @@ func decodeTestRequestIntegerInt64ArrayArrayRequest(r *http.Request, span trace.
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1093,7 +1093,7 @@ func decodeTestRequestIntegerInt64ArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerInt64ArrayArray request")
 		}
@@ -1241,7 +1241,7 @@ func decodeTestRequestIntegerInt64NullableArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1252,7 +1252,7 @@ func decodeTestRequestIntegerInt64NullableArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerInt64NullableArrayArray request")
 		}
@@ -1400,7 +1400,7 @@ func decodeTestRequestIntegerNullableArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1411,7 +1411,7 @@ func decodeTestRequestIntegerNullableArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestIntegerNullableArrayArray request")
 		}
@@ -1555,7 +1555,7 @@ func decodeTestRequestNullArrayArrayRequest(r *http.Request, span trace.Span) (r
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1566,7 +1566,7 @@ func decodeTestRequestNullArrayArrayRequest(r *http.Request, span trace.Span) (r
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNullArrayArray request")
 		}
@@ -1710,7 +1710,7 @@ func decodeTestRequestNullNullableArrayArrayRequest(r *http.Request, span trace.
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1721,7 +1721,7 @@ func decodeTestRequestNullNullableArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNullNullableArrayArray request")
 		}
@@ -1768,13 +1768,13 @@ func decodeTestRequestNumberRequest(r *http.Request, span trace.Span) (req OptFl
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumber request")
 		}
@@ -1831,7 +1831,7 @@ func decodeTestRequestNumberArrayRequest(r *http.Request, span trace.Span) (req 
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1842,7 +1842,7 @@ func decodeTestRequestNumberArrayRequest(r *http.Request, span trace.Span) (req 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberArray request")
 		}
@@ -1913,7 +1913,7 @@ func decodeTestRequestNumberArrayArrayRequest(r *http.Request, span trace.Span) 
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -1924,7 +1924,7 @@ func decodeTestRequestNumberArrayArrayRequest(r *http.Request, span trace.Span) 
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -1935,7 +1935,7 @@ func decodeTestRequestNumberArrayArrayRequest(r *http.Request, span trace.Span) 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberArrayArray request")
 		}
@@ -1982,13 +1982,13 @@ func decodeTestRequestNumberDoubleRequest(r *http.Request, span trace.Span) (req
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDouble request")
 		}
@@ -2045,7 +2045,7 @@ func decodeTestRequestNumberDoubleArrayRequest(r *http.Request, span trace.Span)
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2056,7 +2056,7 @@ func decodeTestRequestNumberDoubleArrayRequest(r *http.Request, span trace.Span)
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDoubleArray request")
 		}
@@ -2127,7 +2127,7 @@ func decodeTestRequestNumberDoubleArrayArrayRequest(r *http.Request, span trace.
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -2138,7 +2138,7 @@ func decodeTestRequestNumberDoubleArrayArrayRequest(r *http.Request, span trace.
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2149,7 +2149,7 @@ func decodeTestRequestNumberDoubleArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDoubleArrayArray request")
 		}
@@ -2196,13 +2196,13 @@ func decodeTestRequestNumberDoubleNullableRequest(r *http.Request, span trace.Sp
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDoubleNullable request")
 		}
@@ -2259,7 +2259,7 @@ func decodeTestRequestNumberDoubleNullableArrayRequest(r *http.Request, span tra
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2270,7 +2270,7 @@ func decodeTestRequestNumberDoubleNullableArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDoubleNullableArray request")
 		}
@@ -2341,7 +2341,7 @@ func decodeTestRequestNumberDoubleNullableArrayArrayRequest(r *http.Request, spa
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -2352,7 +2352,7 @@ func decodeTestRequestNumberDoubleNullableArrayArrayRequest(r *http.Request, spa
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2363,7 +2363,7 @@ func decodeTestRequestNumberDoubleNullableArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberDoubleNullableArrayArray request")
 		}
@@ -2410,13 +2410,13 @@ func decodeTestRequestNumberFloatRequest(r *http.Request, span trace.Span) (req 
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloat request")
 		}
@@ -2473,7 +2473,7 @@ func decodeTestRequestNumberFloatArrayRequest(r *http.Request, span trace.Span) 
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2484,7 +2484,7 @@ func decodeTestRequestNumberFloatArrayRequest(r *http.Request, span trace.Span) 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloatArray request")
 		}
@@ -2555,7 +2555,7 @@ func decodeTestRequestNumberFloatArrayArrayRequest(r *http.Request, span trace.S
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -2566,7 +2566,7 @@ func decodeTestRequestNumberFloatArrayArrayRequest(r *http.Request, span trace.S
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2577,7 +2577,7 @@ func decodeTestRequestNumberFloatArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloatArrayArray request")
 		}
@@ -2624,13 +2624,13 @@ func decodeTestRequestNumberFloatNullableRequest(r *http.Request, span trace.Spa
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloatNullable request")
 		}
@@ -2687,7 +2687,7 @@ func decodeTestRequestNumberFloatNullableArrayRequest(r *http.Request, span trac
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2698,7 +2698,7 @@ func decodeTestRequestNumberFloatNullableArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloatNullableArray request")
 		}
@@ -2769,7 +2769,7 @@ func decodeTestRequestNumberFloatNullableArrayArrayRequest(r *http.Request, span
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -2780,7 +2780,7 @@ func decodeTestRequestNumberFloatNullableArrayArrayRequest(r *http.Request, span
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2791,7 +2791,7 @@ func decodeTestRequestNumberFloatNullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberFloatNullableArrayArray request")
 		}
@@ -2939,7 +2939,7 @@ func decodeTestRequestNumberInt32ArrayArrayRequest(r *http.Request, span trace.S
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -2950,7 +2950,7 @@ func decodeTestRequestNumberInt32ArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberInt32ArrayArray request")
 		}
@@ -3098,7 +3098,7 @@ func decodeTestRequestNumberInt32NullableArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3109,7 +3109,7 @@ func decodeTestRequestNumberInt32NullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberInt32NullableArrayArray request")
 		}
@@ -3257,7 +3257,7 @@ func decodeTestRequestNumberInt64ArrayArrayRequest(r *http.Request, span trace.S
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3268,7 +3268,7 @@ func decodeTestRequestNumberInt64ArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberInt64ArrayArray request")
 		}
@@ -3416,7 +3416,7 @@ func decodeTestRequestNumberInt64NullableArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3427,7 +3427,7 @@ func decodeTestRequestNumberInt64NullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberInt64NullableArrayArray request")
 		}
@@ -3474,13 +3474,13 @@ func decodeTestRequestNumberNullableRequest(r *http.Request, span trace.Span) (r
 					if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberNullable request")
 		}
@@ -3537,7 +3537,7 @@ func decodeTestRequestNumberNullableArrayRequest(r *http.Request, span trace.Spa
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3548,7 +3548,7 @@ func decodeTestRequestNumberNullableArrayRequest(r *http.Request, span trace.Spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberNullableArray request")
 		}
@@ -3619,7 +3619,7 @@ func decodeTestRequestNumberNullableArrayArrayRequest(r *http.Request, span trac
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -3630,7 +3630,7 @@ func decodeTestRequestNumberNullableArrayArrayRequest(r *http.Request, span trac
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3641,7 +3641,7 @@ func decodeTestRequestNumberNullableArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestNumberNullableArrayArray request")
 		}
@@ -3771,7 +3771,7 @@ func decodeTestRequestRequiredBooleanArrayRequest(r *http.Request, span trace.Sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredBooleanArray request")
 		}
@@ -3839,7 +3839,7 @@ func decodeTestRequestRequiredBooleanArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -3850,7 +3850,7 @@ func decodeTestRequestRequiredBooleanArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredBooleanArrayArray request")
 		}
@@ -3940,7 +3940,7 @@ func decodeTestRequestRequiredBooleanNullableArrayRequest(r *http.Request, span 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredBooleanNullableArray request")
 		}
@@ -4008,7 +4008,7 @@ func decodeTestRequestRequiredBooleanNullableArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4019,7 +4019,7 @@ func decodeTestRequestRequiredBooleanNullableArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredBooleanNullableArrayArray request")
 		}
@@ -4099,7 +4099,7 @@ func decodeTestRequestRequiredFormatTestRequest(r *http.Request, span trace.Span
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredFormatTest request")
 		}
@@ -4191,7 +4191,7 @@ func decodeTestRequestRequiredIntegerArrayRequest(r *http.Request, span trace.Sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerArray request")
 		}
@@ -4259,7 +4259,7 @@ func decodeTestRequestRequiredIntegerArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4270,7 +4270,7 @@ func decodeTestRequestRequiredIntegerArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerArrayArray request")
 		}
@@ -4362,7 +4362,7 @@ func decodeTestRequestRequiredIntegerInt32ArrayRequest(r *http.Request, span tra
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt32Array request")
 		}
@@ -4430,7 +4430,7 @@ func decodeTestRequestRequiredIntegerInt32ArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4441,7 +4441,7 @@ func decodeTestRequestRequiredIntegerInt32ArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt32ArrayArray request")
 		}
@@ -4531,7 +4531,7 @@ func decodeTestRequestRequiredIntegerInt32NullableArrayRequest(r *http.Request, 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt32NullableArray request")
 		}
@@ -4599,7 +4599,7 @@ func decodeTestRequestRequiredIntegerInt32NullableArrayArrayRequest(r *http.Requ
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4610,7 +4610,7 @@ func decodeTestRequestRequiredIntegerInt32NullableArrayArrayRequest(r *http.Requ
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt32NullableArrayArray request")
 		}
@@ -4702,7 +4702,7 @@ func decodeTestRequestRequiredIntegerInt64ArrayRequest(r *http.Request, span tra
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt64Array request")
 		}
@@ -4770,7 +4770,7 @@ func decodeTestRequestRequiredIntegerInt64ArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4781,7 +4781,7 @@ func decodeTestRequestRequiredIntegerInt64ArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt64ArrayArray request")
 		}
@@ -4871,7 +4871,7 @@ func decodeTestRequestRequiredIntegerInt64NullableArrayRequest(r *http.Request, 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt64NullableArray request")
 		}
@@ -4939,7 +4939,7 @@ func decodeTestRequestRequiredIntegerInt64NullableArrayArrayRequest(r *http.Requ
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -4950,7 +4950,7 @@ func decodeTestRequestRequiredIntegerInt64NullableArrayArrayRequest(r *http.Requ
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerInt64NullableArrayArray request")
 		}
@@ -5040,7 +5040,7 @@ func decodeTestRequestRequiredIntegerNullableArrayRequest(r *http.Request, span 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerNullableArray request")
 		}
@@ -5108,7 +5108,7 @@ func decodeTestRequestRequiredIntegerNullableArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5119,7 +5119,7 @@ func decodeTestRequestRequiredIntegerNullableArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredIntegerNullableArrayArray request")
 		}
@@ -5207,7 +5207,7 @@ func decodeTestRequestRequiredNullArrayRequest(r *http.Request, span trace.Span)
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNullArray request")
 		}
@@ -5273,7 +5273,7 @@ func decodeTestRequestRequiredNullArrayArrayRequest(r *http.Request, span trace.
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5284,7 +5284,7 @@ func decodeTestRequestRequiredNullArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNullArrayArray request")
 		}
@@ -5372,7 +5372,7 @@ func decodeTestRequestRequiredNullNullableArrayRequest(r *http.Request, span tra
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNullNullableArray request")
 		}
@@ -5438,7 +5438,7 @@ func decodeTestRequestRequiredNullNullableArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5449,7 +5449,7 @@ func decodeTestRequestRequiredNullNullableArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNullNullableArrayArray request")
 		}
@@ -5495,7 +5495,7 @@ func decodeTestRequestRequiredNumberRequest(r *http.Request, span trace.Span) (r
 			if err := (validate.Float{}).Validate(float64(request)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumber request")
 		}
@@ -5555,7 +5555,7 @@ func decodeTestRequestRequiredNumberArrayRequest(r *http.Request, span trace.Spa
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5566,7 +5566,7 @@ func decodeTestRequestRequiredNumberArrayRequest(r *http.Request, span trace.Spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberArray request")
 		}
@@ -5640,7 +5640,7 @@ func decodeTestRequestRequiredNumberArrayArrayRequest(r *http.Request, span trac
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -5651,7 +5651,7 @@ func decodeTestRequestRequiredNumberArrayArrayRequest(r *http.Request, span trac
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5662,7 +5662,7 @@ func decodeTestRequestRequiredNumberArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberArrayArray request")
 		}
@@ -5708,7 +5708,7 @@ func decodeTestRequestRequiredNumberDoubleRequest(r *http.Request, span trace.Sp
 			if err := (validate.Float{}).Validate(float64(request)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDouble request")
 		}
@@ -5768,7 +5768,7 @@ func decodeTestRequestRequiredNumberDoubleArrayRequest(r *http.Request, span tra
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5779,7 +5779,7 @@ func decodeTestRequestRequiredNumberDoubleArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDoubleArray request")
 		}
@@ -5853,7 +5853,7 @@ func decodeTestRequestRequiredNumberDoubleArrayArrayRequest(r *http.Request, spa
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -5864,7 +5864,7 @@ func decodeTestRequestRequiredNumberDoubleArrayArrayRequest(r *http.Request, spa
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5875,7 +5875,7 @@ func decodeTestRequestRequiredNumberDoubleArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDoubleArrayArray request")
 		}
@@ -5919,8 +5919,8 @@ func decodeTestRequestRequiredNumberDoubleNullableRequest(r *http.Request, span 
 			if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDoubleNullable request")
 		}
@@ -5980,7 +5980,7 @@ func decodeTestRequestRequiredNumberDoubleNullableArrayRequest(r *http.Request, 
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -5991,7 +5991,7 @@ func decodeTestRequestRequiredNumberDoubleNullableArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDoubleNullableArray request")
 		}
@@ -6065,7 +6065,7 @@ func decodeTestRequestRequiredNumberDoubleNullableArrayArrayRequest(r *http.Requ
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -6076,7 +6076,7 @@ func decodeTestRequestRequiredNumberDoubleNullableArrayArrayRequest(r *http.Requ
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6087,7 +6087,7 @@ func decodeTestRequestRequiredNumberDoubleNullableArrayArrayRequest(r *http.Requ
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberDoubleNullableArrayArray request")
 		}
@@ -6133,7 +6133,7 @@ func decodeTestRequestRequiredNumberFloatRequest(r *http.Request, span trace.Spa
 			if err := (validate.Float{}).Validate(float64(request)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloat request")
 		}
@@ -6193,7 +6193,7 @@ func decodeTestRequestRequiredNumberFloatArrayRequest(r *http.Request, span trac
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6204,7 +6204,7 @@ func decodeTestRequestRequiredNumberFloatArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloatArray request")
 		}
@@ -6278,7 +6278,7 @@ func decodeTestRequestRequiredNumberFloatArrayArrayRequest(r *http.Request, span
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -6289,7 +6289,7 @@ func decodeTestRequestRequiredNumberFloatArrayArrayRequest(r *http.Request, span
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6300,7 +6300,7 @@ func decodeTestRequestRequiredNumberFloatArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloatArrayArray request")
 		}
@@ -6344,8 +6344,8 @@ func decodeTestRequestRequiredNumberFloatNullableRequest(r *http.Request, span t
 			if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloatNullable request")
 		}
@@ -6405,7 +6405,7 @@ func decodeTestRequestRequiredNumberFloatNullableArrayRequest(r *http.Request, s
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6416,7 +6416,7 @@ func decodeTestRequestRequiredNumberFloatNullableArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloatNullableArray request")
 		}
@@ -6490,7 +6490,7 @@ func decodeTestRequestRequiredNumberFloatNullableArrayArrayRequest(r *http.Reque
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -6501,7 +6501,7 @@ func decodeTestRequestRequiredNumberFloatNullableArrayArrayRequest(r *http.Reque
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6512,7 +6512,7 @@ func decodeTestRequestRequiredNumberFloatNullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberFloatNullableArrayArray request")
 		}
@@ -6604,7 +6604,7 @@ func decodeTestRequestRequiredNumberInt32ArrayRequest(r *http.Request, span trac
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt32Array request")
 		}
@@ -6672,7 +6672,7 @@ func decodeTestRequestRequiredNumberInt32ArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6683,7 +6683,7 @@ func decodeTestRequestRequiredNumberInt32ArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt32ArrayArray request")
 		}
@@ -6773,7 +6773,7 @@ func decodeTestRequestRequiredNumberInt32NullableArrayRequest(r *http.Request, s
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt32NullableArray request")
 		}
@@ -6841,7 +6841,7 @@ func decodeTestRequestRequiredNumberInt32NullableArrayArrayRequest(r *http.Reque
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -6852,7 +6852,7 @@ func decodeTestRequestRequiredNumberInt32NullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt32NullableArrayArray request")
 		}
@@ -6944,7 +6944,7 @@ func decodeTestRequestRequiredNumberInt64ArrayRequest(r *http.Request, span trac
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt64Array request")
 		}
@@ -7012,7 +7012,7 @@ func decodeTestRequestRequiredNumberInt64ArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7023,7 +7023,7 @@ func decodeTestRequestRequiredNumberInt64ArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt64ArrayArray request")
 		}
@@ -7113,7 +7113,7 @@ func decodeTestRequestRequiredNumberInt64NullableArrayRequest(r *http.Request, s
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt64NullableArray request")
 		}
@@ -7181,7 +7181,7 @@ func decodeTestRequestRequiredNumberInt64NullableArrayArrayRequest(r *http.Reque
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7192,7 +7192,7 @@ func decodeTestRequestRequiredNumberInt64NullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberInt64NullableArrayArray request")
 		}
@@ -7236,8 +7236,8 @@ func decodeTestRequestRequiredNumberNullableRequest(r *http.Request, span trace.
 			if err := (validate.Float{}).Validate(float64(request.Value)); err != nil {
 				return errors.Wrap(err, "float")
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberNullable request")
 		}
@@ -7297,7 +7297,7 @@ func decodeTestRequestRequiredNumberNullableArrayRequest(r *http.Request, span t
 					if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 						return errors.Wrap(err, "float")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7308,7 +7308,7 @@ func decodeTestRequestRequiredNumberNullableArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberNullableArray request")
 		}
@@ -7382,7 +7382,7 @@ func decodeTestRequestRequiredNumberNullableArrayArrayRequest(r *http.Request, s
 							if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 								return errors.Wrap(err, "float")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -7393,7 +7393,7 @@ func decodeTestRequestRequiredNumberNullableArrayArrayRequest(r *http.Request, s
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7404,7 +7404,7 @@ func decodeTestRequestRequiredNumberNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredNumberNullableArrayArray request")
 		}
@@ -7496,7 +7496,7 @@ func decodeTestRequestRequiredStringArrayRequest(r *http.Request, span trace.Spa
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringArray request")
 		}
@@ -7564,7 +7564,7 @@ func decodeTestRequestRequiredStringArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7575,7 +7575,7 @@ func decodeTestRequestRequiredStringArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringArrayArray request")
 		}
@@ -7667,7 +7667,7 @@ func decodeTestRequestRequiredStringBinaryArrayRequest(r *http.Request, span tra
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringBinaryArray request")
 		}
@@ -7735,7 +7735,7 @@ func decodeTestRequestRequiredStringBinaryArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7746,7 +7746,7 @@ func decodeTestRequestRequiredStringBinaryArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringBinaryArrayArray request")
 		}
@@ -7836,7 +7836,7 @@ func decodeTestRequestRequiredStringBinaryNullableArrayRequest(r *http.Request, 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringBinaryNullableArray request")
 		}
@@ -7904,7 +7904,7 @@ func decodeTestRequestRequiredStringBinaryNullableArrayArrayRequest(r *http.Requ
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -7915,7 +7915,7 @@ func decodeTestRequestRequiredStringBinaryNullableArrayArrayRequest(r *http.Requ
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringBinaryNullableArrayArray request")
 		}
@@ -8007,7 +8007,7 @@ func decodeTestRequestRequiredStringByteArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringByteArray request")
 		}
@@ -8075,7 +8075,7 @@ func decodeTestRequestRequiredStringByteArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8086,7 +8086,7 @@ func decodeTestRequestRequiredStringByteArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringByteArrayArray request")
 		}
@@ -8178,7 +8178,7 @@ func decodeTestRequestRequiredStringByteNullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringByteNullableArray request")
 		}
@@ -8246,7 +8246,7 @@ func decodeTestRequestRequiredStringByteNullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8257,7 +8257,7 @@ func decodeTestRequestRequiredStringByteNullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringByteNullableArrayArray request")
 		}
@@ -8349,7 +8349,7 @@ func decodeTestRequestRequiredStringDateArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateArray request")
 		}
@@ -8417,7 +8417,7 @@ func decodeTestRequestRequiredStringDateArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8428,7 +8428,7 @@ func decodeTestRequestRequiredStringDateArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateArrayArray request")
 		}
@@ -8518,7 +8518,7 @@ func decodeTestRequestRequiredStringDateNullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateNullableArray request")
 		}
@@ -8586,7 +8586,7 @@ func decodeTestRequestRequiredStringDateNullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8597,7 +8597,7 @@ func decodeTestRequestRequiredStringDateNullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateNullableArrayArray request")
 		}
@@ -8689,7 +8689,7 @@ func decodeTestRequestRequiredStringDateTimeArrayRequest(r *http.Request, span t
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateTimeArray request")
 		}
@@ -8757,7 +8757,7 @@ func decodeTestRequestRequiredStringDateTimeArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8768,7 +8768,7 @@ func decodeTestRequestRequiredStringDateTimeArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateTimeArrayArray request")
 		}
@@ -8858,7 +8858,7 @@ func decodeTestRequestRequiredStringDateTimeNullableArrayRequest(r *http.Request
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateTimeNullableArray request")
 		}
@@ -8926,7 +8926,7 @@ func decodeTestRequestRequiredStringDateTimeNullableArrayArrayRequest(r *http.Re
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -8937,7 +8937,7 @@ func decodeTestRequestRequiredStringDateTimeNullableArrayArrayRequest(r *http.Re
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDateTimeNullableArrayArray request")
 		}
@@ -9029,7 +9029,7 @@ func decodeTestRequestRequiredStringDurationArrayRequest(r *http.Request, span t
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDurationArray request")
 		}
@@ -9097,7 +9097,7 @@ func decodeTestRequestRequiredStringDurationArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9108,7 +9108,7 @@ func decodeTestRequestRequiredStringDurationArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDurationArrayArray request")
 		}
@@ -9198,7 +9198,7 @@ func decodeTestRequestRequiredStringDurationNullableArrayRequest(r *http.Request
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDurationNullableArray request")
 		}
@@ -9266,7 +9266,7 @@ func decodeTestRequestRequiredStringDurationNullableArrayArrayRequest(r *http.Re
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9277,7 +9277,7 @@ func decodeTestRequestRequiredStringDurationNullableArrayArrayRequest(r *http.Re
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringDurationNullableArrayArray request")
 		}
@@ -9331,7 +9331,7 @@ func decodeTestRequestRequiredStringEmailRequest(r *http.Request, span trace.Spa
 			}).Validate(string(request)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmail request")
 		}
@@ -9399,7 +9399,7 @@ func decodeTestRequestRequiredStringEmailArrayRequest(r *http.Request, span trac
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9410,7 +9410,7 @@ func decodeTestRequestRequiredStringEmailArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmailArray request")
 		}
@@ -9492,7 +9492,7 @@ func decodeTestRequestRequiredStringEmailArrayArrayRequest(r *http.Request, span
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -9503,7 +9503,7 @@ func decodeTestRequestRequiredStringEmailArrayArrayRequest(r *http.Request, span
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9514,7 +9514,7 @@ func decodeTestRequestRequiredStringEmailArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmailArrayArray request")
 		}
@@ -9566,8 +9566,8 @@ func decodeTestRequestRequiredStringEmailNullableRequest(r *http.Request, span t
 			}).Validate(string(request.Value)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmailNullable request")
 		}
@@ -9635,7 +9635,7 @@ func decodeTestRequestRequiredStringEmailNullableArrayRequest(r *http.Request, s
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9646,7 +9646,7 @@ func decodeTestRequestRequiredStringEmailNullableArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmailNullableArray request")
 		}
@@ -9728,7 +9728,7 @@ func decodeTestRequestRequiredStringEmailNullableArrayArrayRequest(r *http.Reque
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -9739,7 +9739,7 @@ func decodeTestRequestRequiredStringEmailNullableArrayArrayRequest(r *http.Reque
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9750,7 +9750,7 @@ func decodeTestRequestRequiredStringEmailNullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringEmailNullableArrayArray request")
 		}
@@ -9804,7 +9804,7 @@ func decodeTestRequestRequiredStringHostnameRequest(r *http.Request, span trace.
 			}).Validate(string(request)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostname request")
 		}
@@ -9872,7 +9872,7 @@ func decodeTestRequestRequiredStringHostnameArrayRequest(r *http.Request, span t
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9883,7 +9883,7 @@ func decodeTestRequestRequiredStringHostnameArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostnameArray request")
 		}
@@ -9965,7 +9965,7 @@ func decodeTestRequestRequiredStringHostnameArrayArrayRequest(r *http.Request, s
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -9976,7 +9976,7 @@ func decodeTestRequestRequiredStringHostnameArrayArrayRequest(r *http.Request, s
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -9987,7 +9987,7 @@ func decodeTestRequestRequiredStringHostnameArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostnameArrayArray request")
 		}
@@ -10039,8 +10039,8 @@ func decodeTestRequestRequiredStringHostnameNullableRequest(r *http.Request, spa
 			}).Validate(string(request.Value)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
-			return nil
+			return nil // return 1
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostnameNullable request")
 		}
@@ -10108,7 +10108,7 @@ func decodeTestRequestRequiredStringHostnameNullableArrayRequest(r *http.Request
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10119,7 +10119,7 @@ func decodeTestRequestRequiredStringHostnameNullableArrayRequest(r *http.Request
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostnameNullableArray request")
 		}
@@ -10201,7 +10201,7 @@ func decodeTestRequestRequiredStringHostnameNullableArrayArrayRequest(r *http.Re
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -10212,7 +10212,7 @@ func decodeTestRequestRequiredStringHostnameNullableArrayArrayRequest(r *http.Re
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10223,7 +10223,7 @@ func decodeTestRequestRequiredStringHostnameNullableArrayArrayRequest(r *http.Re
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringHostnameNullableArrayArray request")
 		}
@@ -10315,7 +10315,7 @@ func decodeTestRequestRequiredStringIPArrayRequest(r *http.Request, span trace.S
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIPArray request")
 		}
@@ -10383,7 +10383,7 @@ func decodeTestRequestRequiredStringIPArrayArrayRequest(r *http.Request, span tr
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10394,7 +10394,7 @@ func decodeTestRequestRequiredStringIPArrayArrayRequest(r *http.Request, span tr
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIPArrayArray request")
 		}
@@ -10484,7 +10484,7 @@ func decodeTestRequestRequiredStringIPNullableArrayRequest(r *http.Request, span
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIPNullableArray request")
 		}
@@ -10552,7 +10552,7 @@ func decodeTestRequestRequiredStringIPNullableArrayArrayRequest(r *http.Request,
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10563,7 +10563,7 @@ func decodeTestRequestRequiredStringIPNullableArrayArrayRequest(r *http.Request,
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIPNullableArrayArray request")
 		}
@@ -10655,7 +10655,7 @@ func decodeTestRequestRequiredStringInt32ArrayRequest(r *http.Request, span trac
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt32Array request")
 		}
@@ -10723,7 +10723,7 @@ func decodeTestRequestRequiredStringInt32ArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10734,7 +10734,7 @@ func decodeTestRequestRequiredStringInt32ArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt32ArrayArray request")
 		}
@@ -10824,7 +10824,7 @@ func decodeTestRequestRequiredStringInt32NullableArrayRequest(r *http.Request, s
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt32NullableArray request")
 		}
@@ -10892,7 +10892,7 @@ func decodeTestRequestRequiredStringInt32NullableArrayArrayRequest(r *http.Reque
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -10903,7 +10903,7 @@ func decodeTestRequestRequiredStringInt32NullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt32NullableArrayArray request")
 		}
@@ -10995,7 +10995,7 @@ func decodeTestRequestRequiredStringInt64ArrayRequest(r *http.Request, span trac
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt64Array request")
 		}
@@ -11063,7 +11063,7 @@ func decodeTestRequestRequiredStringInt64ArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11074,7 +11074,7 @@ func decodeTestRequestRequiredStringInt64ArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt64ArrayArray request")
 		}
@@ -11164,7 +11164,7 @@ func decodeTestRequestRequiredStringInt64NullableArrayRequest(r *http.Request, s
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt64NullableArray request")
 		}
@@ -11232,7 +11232,7 @@ func decodeTestRequestRequiredStringInt64NullableArrayArrayRequest(r *http.Reque
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11243,7 +11243,7 @@ func decodeTestRequestRequiredStringInt64NullableArrayArrayRequest(r *http.Reque
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringInt64NullableArrayArray request")
 		}
@@ -11335,7 +11335,7 @@ func decodeTestRequestRequiredStringIpv4ArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv4Array request")
 		}
@@ -11403,7 +11403,7 @@ func decodeTestRequestRequiredStringIpv4ArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11414,7 +11414,7 @@ func decodeTestRequestRequiredStringIpv4ArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv4ArrayArray request")
 		}
@@ -11504,7 +11504,7 @@ func decodeTestRequestRequiredStringIpv4NullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv4NullableArray request")
 		}
@@ -11572,7 +11572,7 @@ func decodeTestRequestRequiredStringIpv4NullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11583,7 +11583,7 @@ func decodeTestRequestRequiredStringIpv4NullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv4NullableArrayArray request")
 		}
@@ -11675,7 +11675,7 @@ func decodeTestRequestRequiredStringIpv6ArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv6Array request")
 		}
@@ -11743,7 +11743,7 @@ func decodeTestRequestRequiredStringIpv6ArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11754,7 +11754,7 @@ func decodeTestRequestRequiredStringIpv6ArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv6ArrayArray request")
 		}
@@ -11844,7 +11844,7 @@ func decodeTestRequestRequiredStringIpv6NullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv6NullableArray request")
 		}
@@ -11912,7 +11912,7 @@ func decodeTestRequestRequiredStringIpv6NullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -11923,7 +11923,7 @@ func decodeTestRequestRequiredStringIpv6NullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringIpv6NullableArrayArray request")
 		}
@@ -12013,7 +12013,7 @@ func decodeTestRequestRequiredStringNullableArrayRequest(r *http.Request, span t
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringNullableArray request")
 		}
@@ -12081,7 +12081,7 @@ func decodeTestRequestRequiredStringNullableArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12092,7 +12092,7 @@ func decodeTestRequestRequiredStringNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringNullableArrayArray request")
 		}
@@ -12184,7 +12184,7 @@ func decodeTestRequestRequiredStringPasswordArrayRequest(r *http.Request, span t
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringPasswordArray request")
 		}
@@ -12252,7 +12252,7 @@ func decodeTestRequestRequiredStringPasswordArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12263,7 +12263,7 @@ func decodeTestRequestRequiredStringPasswordArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringPasswordArrayArray request")
 		}
@@ -12353,7 +12353,7 @@ func decodeTestRequestRequiredStringPasswordNullableArrayRequest(r *http.Request
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringPasswordNullableArray request")
 		}
@@ -12421,7 +12421,7 @@ func decodeTestRequestRequiredStringPasswordNullableArrayArrayRequest(r *http.Re
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12432,7 +12432,7 @@ func decodeTestRequestRequiredStringPasswordNullableArrayArrayRequest(r *http.Re
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringPasswordNullableArrayArray request")
 		}
@@ -12524,7 +12524,7 @@ func decodeTestRequestRequiredStringTimeArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringTimeArray request")
 		}
@@ -12592,7 +12592,7 @@ func decodeTestRequestRequiredStringTimeArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12603,7 +12603,7 @@ func decodeTestRequestRequiredStringTimeArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringTimeArrayArray request")
 		}
@@ -12693,7 +12693,7 @@ func decodeTestRequestRequiredStringTimeNullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringTimeNullableArray request")
 		}
@@ -12761,7 +12761,7 @@ func decodeTestRequestRequiredStringTimeNullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12772,7 +12772,7 @@ func decodeTestRequestRequiredStringTimeNullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringTimeNullableArrayArray request")
 		}
@@ -12864,7 +12864,7 @@ func decodeTestRequestRequiredStringURIArrayRequest(r *http.Request, span trace.
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringURIArray request")
 		}
@@ -12932,7 +12932,7 @@ func decodeTestRequestRequiredStringURIArrayArrayRequest(r *http.Request, span t
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -12943,7 +12943,7 @@ func decodeTestRequestRequiredStringURIArrayArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringURIArrayArray request")
 		}
@@ -13033,7 +13033,7 @@ func decodeTestRequestRequiredStringURINullableArrayRequest(r *http.Request, spa
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringURINullableArray request")
 		}
@@ -13101,7 +13101,7 @@ func decodeTestRequestRequiredStringURINullableArrayArrayRequest(r *http.Request
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13112,7 +13112,7 @@ func decodeTestRequestRequiredStringURINullableArrayArrayRequest(r *http.Request
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringURINullableArrayArray request")
 		}
@@ -13204,7 +13204,7 @@ func decodeTestRequestRequiredStringUUIDArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUUIDArray request")
 		}
@@ -13272,7 +13272,7 @@ func decodeTestRequestRequiredStringUUIDArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13283,7 +13283,7 @@ func decodeTestRequestRequiredStringUUIDArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUUIDArrayArray request")
 		}
@@ -13373,7 +13373,7 @@ func decodeTestRequestRequiredStringUUIDNullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUUIDNullableArray request")
 		}
@@ -13441,7 +13441,7 @@ func decodeTestRequestRequiredStringUUIDNullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13452,7 +13452,7 @@ func decodeTestRequestRequiredStringUUIDNullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUUIDNullableArrayArray request")
 		}
@@ -13544,7 +13544,7 @@ func decodeTestRequestRequiredStringUnixArrayRequest(r *http.Request, span trace
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixArray request")
 		}
@@ -13612,7 +13612,7 @@ func decodeTestRequestRequiredStringUnixArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13623,7 +13623,7 @@ func decodeTestRequestRequiredStringUnixArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixArrayArray request")
 		}
@@ -13715,7 +13715,7 @@ func decodeTestRequestRequiredStringUnixMicroArrayRequest(r *http.Request, span 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMicroArray request")
 		}
@@ -13783,7 +13783,7 @@ func decodeTestRequestRequiredStringUnixMicroArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13794,7 +13794,7 @@ func decodeTestRequestRequiredStringUnixMicroArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMicroArrayArray request")
 		}
@@ -13884,7 +13884,7 @@ func decodeTestRequestRequiredStringUnixMicroNullableArrayRequest(r *http.Reques
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMicroNullableArray request")
 		}
@@ -13952,7 +13952,7 @@ func decodeTestRequestRequiredStringUnixMicroNullableArrayArrayRequest(r *http.R
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -13963,7 +13963,7 @@ func decodeTestRequestRequiredStringUnixMicroNullableArrayArrayRequest(r *http.R
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMicroNullableArrayArray request")
 		}
@@ -14055,7 +14055,7 @@ func decodeTestRequestRequiredStringUnixMilliArrayRequest(r *http.Request, span 
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMilliArray request")
 		}
@@ -14123,7 +14123,7 @@ func decodeTestRequestRequiredStringUnixMilliArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14134,7 +14134,7 @@ func decodeTestRequestRequiredStringUnixMilliArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMilliArrayArray request")
 		}
@@ -14224,7 +14224,7 @@ func decodeTestRequestRequiredStringUnixMilliNullableArrayRequest(r *http.Reques
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMilliNullableArray request")
 		}
@@ -14292,7 +14292,7 @@ func decodeTestRequestRequiredStringUnixMilliNullableArrayArrayRequest(r *http.R
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14303,7 +14303,7 @@ func decodeTestRequestRequiredStringUnixMilliNullableArrayArrayRequest(r *http.R
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixMilliNullableArrayArray request")
 		}
@@ -14395,7 +14395,7 @@ func decodeTestRequestRequiredStringUnixNanoArrayRequest(r *http.Request, span t
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNanoArray request")
 		}
@@ -14463,7 +14463,7 @@ func decodeTestRequestRequiredStringUnixNanoArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14474,7 +14474,7 @@ func decodeTestRequestRequiredStringUnixNanoArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNanoArrayArray request")
 		}
@@ -14564,7 +14564,7 @@ func decodeTestRequestRequiredStringUnixNanoNullableArrayRequest(r *http.Request
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNanoNullableArray request")
 		}
@@ -14632,7 +14632,7 @@ func decodeTestRequestRequiredStringUnixNanoNullableArrayArrayRequest(r *http.Re
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14643,7 +14643,7 @@ func decodeTestRequestRequiredStringUnixNanoNullableArrayArrayRequest(r *http.Re
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNanoNullableArrayArray request")
 		}
@@ -14733,7 +14733,7 @@ func decodeTestRequestRequiredStringUnixNullableArrayRequest(r *http.Request, sp
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNullableArray request")
 		}
@@ -14801,7 +14801,7 @@ func decodeTestRequestRequiredStringUnixNullableArrayArrayRequest(r *http.Reques
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14812,7 +14812,7 @@ func decodeTestRequestRequiredStringUnixNullableArrayArrayRequest(r *http.Reques
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixNullableArrayArray request")
 		}
@@ -14904,7 +14904,7 @@ func decodeTestRequestRequiredStringUnixSecondsArrayRequest(r *http.Request, spa
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixSecondsArray request")
 		}
@@ -14972,7 +14972,7 @@ func decodeTestRequestRequiredStringUnixSecondsArrayArrayRequest(r *http.Request
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -14983,7 +14983,7 @@ func decodeTestRequestRequiredStringUnixSecondsArrayArrayRequest(r *http.Request
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixSecondsArrayArray request")
 		}
@@ -15073,7 +15073,7 @@ func decodeTestRequestRequiredStringUnixSecondsNullableArrayRequest(r *http.Requ
 			if request == nil {
 				return errors.New("nil is invalid value")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixSecondsNullableArray request")
 		}
@@ -15141,7 +15141,7 @@ func decodeTestRequestRequiredStringUnixSecondsNullableArrayArrayRequest(r *http
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15152,7 +15152,7 @@ func decodeTestRequestRequiredStringUnixSecondsNullableArrayArrayRequest(r *http
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestRequiredStringUnixSecondsNullableArrayArray request")
 		}
@@ -15300,7 +15300,7 @@ func decodeTestRequestStringArrayArrayRequest(r *http.Request, span trace.Span) 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15311,7 +15311,7 @@ func decodeTestRequestStringArrayArrayRequest(r *http.Request, span trace.Span) 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringArrayArray request")
 		}
@@ -15459,7 +15459,7 @@ func decodeTestRequestStringBinaryArrayArrayRequest(r *http.Request, span trace.
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15470,7 +15470,7 @@ func decodeTestRequestStringBinaryArrayArrayRequest(r *http.Request, span trace.
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringBinaryArrayArray request")
 		}
@@ -15618,7 +15618,7 @@ func decodeTestRequestStringBinaryNullableArrayArrayRequest(r *http.Request, spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15629,7 +15629,7 @@ func decodeTestRequestStringBinaryNullableArrayArrayRequest(r *http.Request, spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringBinaryNullableArrayArray request")
 		}
@@ -15778,7 +15778,7 @@ func decodeTestRequestStringByteArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15789,7 +15789,7 @@ func decodeTestRequestStringByteArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringByteArrayArray request")
 		}
@@ -15937,7 +15937,7 @@ func decodeTestRequestStringByteNullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -15948,7 +15948,7 @@ func decodeTestRequestStringByteNullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringByteNullableArrayArray request")
 		}
@@ -16096,7 +16096,7 @@ func decodeTestRequestStringDateArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16107,7 +16107,7 @@ func decodeTestRequestStringDateArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDateArrayArray request")
 		}
@@ -16255,7 +16255,7 @@ func decodeTestRequestStringDateNullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16266,7 +16266,7 @@ func decodeTestRequestStringDateNullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDateNullableArrayArray request")
 		}
@@ -16414,7 +16414,7 @@ func decodeTestRequestStringDateTimeArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16425,7 +16425,7 @@ func decodeTestRequestStringDateTimeArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDateTimeArrayArray request")
 		}
@@ -16573,7 +16573,7 @@ func decodeTestRequestStringDateTimeNullableArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16584,7 +16584,7 @@ func decodeTestRequestStringDateTimeNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDateTimeNullableArrayArray request")
 		}
@@ -16732,7 +16732,7 @@ func decodeTestRequestStringDurationArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16743,7 +16743,7 @@ func decodeTestRequestStringDurationArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDurationArrayArray request")
 		}
@@ -16891,7 +16891,7 @@ func decodeTestRequestStringDurationNullableArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -16902,7 +16902,7 @@ func decodeTestRequestStringDurationNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringDurationNullableArrayArray request")
 		}
@@ -16957,13 +16957,13 @@ func decodeTestRequestStringEmailRequest(r *http.Request, span trace.Span) (req 
 					}).Validate(string(request.Value)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmail request")
 		}
@@ -17028,7 +17028,7 @@ func decodeTestRequestStringEmailArrayRequest(r *http.Request, span trace.Span) 
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17039,7 +17039,7 @@ func decodeTestRequestStringEmailArrayRequest(r *http.Request, span trace.Span) 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmailArray request")
 		}
@@ -17118,7 +17118,7 @@ func decodeTestRequestStringEmailArrayArrayRequest(r *http.Request, span trace.S
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -17129,7 +17129,7 @@ func decodeTestRequestStringEmailArrayArrayRequest(r *http.Request, span trace.S
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17140,7 +17140,7 @@ func decodeTestRequestStringEmailArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmailArrayArray request")
 		}
@@ -17195,13 +17195,13 @@ func decodeTestRequestStringEmailNullableRequest(r *http.Request, span trace.Spa
 					}).Validate(string(request.Value)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmailNullable request")
 		}
@@ -17266,7 +17266,7 @@ func decodeTestRequestStringEmailNullableArrayRequest(r *http.Request, span trac
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17277,7 +17277,7 @@ func decodeTestRequestStringEmailNullableArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmailNullableArray request")
 		}
@@ -17356,7 +17356,7 @@ func decodeTestRequestStringEmailNullableArrayArrayRequest(r *http.Request, span
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -17367,7 +17367,7 @@ func decodeTestRequestStringEmailNullableArrayArrayRequest(r *http.Request, span
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17378,7 +17378,7 @@ func decodeTestRequestStringEmailNullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringEmailNullableArrayArray request")
 		}
@@ -17433,13 +17433,13 @@ func decodeTestRequestStringHostnameRequest(r *http.Request, span trace.Span) (r
 					}).Validate(string(request.Value)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostname request")
 		}
@@ -17504,7 +17504,7 @@ func decodeTestRequestStringHostnameArrayRequest(r *http.Request, span trace.Spa
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17515,7 +17515,7 @@ func decodeTestRequestStringHostnameArrayRequest(r *http.Request, span trace.Spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostnameArray request")
 		}
@@ -17594,7 +17594,7 @@ func decodeTestRequestStringHostnameArrayArrayRequest(r *http.Request, span trac
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -17605,7 +17605,7 @@ func decodeTestRequestStringHostnameArrayArrayRequest(r *http.Request, span trac
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17616,7 +17616,7 @@ func decodeTestRequestStringHostnameArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostnameArrayArray request")
 		}
@@ -17671,13 +17671,13 @@ func decodeTestRequestStringHostnameNullableRequest(r *http.Request, span trace.
 					}).Validate(string(request.Value)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostnameNullable request")
 		}
@@ -17742,7 +17742,7 @@ func decodeTestRequestStringHostnameNullableArrayRequest(r *http.Request, span t
 					}).Validate(string(elem)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17753,7 +17753,7 @@ func decodeTestRequestStringHostnameNullableArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostnameNullableArray request")
 		}
@@ -17832,7 +17832,7 @@ func decodeTestRequestStringHostnameNullableArrayArrayRequest(r *http.Request, s
 							}).Validate(string(elem)); err != nil {
 								return errors.Wrap(err, "string")
 							}
-							return nil
+							return nil // return 1
 						}(); err != nil {
 							failures = append(failures, validate.FieldError{
 								Name:  fmt.Sprintf("[%d]", i),
@@ -17843,7 +17843,7 @@ func decodeTestRequestStringHostnameNullableArrayArrayRequest(r *http.Request, s
 					if len(failures) > 0 {
 						return &validate.Error{Fields: failures}
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -17854,7 +17854,7 @@ func decodeTestRequestStringHostnameNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringHostnameNullableArrayArray request")
 		}
@@ -18002,7 +18002,7 @@ func decodeTestRequestStringIPArrayArrayRequest(r *http.Request, span trace.Span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18013,7 +18013,7 @@ func decodeTestRequestStringIPArrayArrayRequest(r *http.Request, span trace.Span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIPArrayArray request")
 		}
@@ -18161,7 +18161,7 @@ func decodeTestRequestStringIPNullableArrayArrayRequest(r *http.Request, span tr
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18172,7 +18172,7 @@ func decodeTestRequestStringIPNullableArrayArrayRequest(r *http.Request, span tr
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIPNullableArrayArray request")
 		}
@@ -18320,7 +18320,7 @@ func decodeTestRequestStringInt32ArrayArrayRequest(r *http.Request, span trace.S
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18331,7 +18331,7 @@ func decodeTestRequestStringInt32ArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringInt32ArrayArray request")
 		}
@@ -18479,7 +18479,7 @@ func decodeTestRequestStringInt32NullableArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18490,7 +18490,7 @@ func decodeTestRequestStringInt32NullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringInt32NullableArrayArray request")
 		}
@@ -18638,7 +18638,7 @@ func decodeTestRequestStringInt64ArrayArrayRequest(r *http.Request, span trace.S
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18649,7 +18649,7 @@ func decodeTestRequestStringInt64ArrayArrayRequest(r *http.Request, span trace.S
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringInt64ArrayArray request")
 		}
@@ -18797,7 +18797,7 @@ func decodeTestRequestStringInt64NullableArrayArrayRequest(r *http.Request, span
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18808,7 +18808,7 @@ func decodeTestRequestStringInt64NullableArrayArrayRequest(r *http.Request, span
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringInt64NullableArrayArray request")
 		}
@@ -18956,7 +18956,7 @@ func decodeTestRequestStringIpv4ArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -18967,7 +18967,7 @@ func decodeTestRequestStringIpv4ArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIpv4ArrayArray request")
 		}
@@ -19115,7 +19115,7 @@ func decodeTestRequestStringIpv4NullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19126,7 +19126,7 @@ func decodeTestRequestStringIpv4NullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIpv4NullableArrayArray request")
 		}
@@ -19274,7 +19274,7 @@ func decodeTestRequestStringIpv6ArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19285,7 +19285,7 @@ func decodeTestRequestStringIpv6ArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIpv6ArrayArray request")
 		}
@@ -19433,7 +19433,7 @@ func decodeTestRequestStringIpv6NullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19444,7 +19444,7 @@ func decodeTestRequestStringIpv6NullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringIpv6NullableArrayArray request")
 		}
@@ -19592,7 +19592,7 @@ func decodeTestRequestStringNullableArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19603,7 +19603,7 @@ func decodeTestRequestStringNullableArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringNullableArrayArray request")
 		}
@@ -19751,7 +19751,7 @@ func decodeTestRequestStringPasswordArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19762,7 +19762,7 @@ func decodeTestRequestStringPasswordArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringPasswordArrayArray request")
 		}
@@ -19910,7 +19910,7 @@ func decodeTestRequestStringPasswordNullableArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -19921,7 +19921,7 @@ func decodeTestRequestStringPasswordNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringPasswordNullableArrayArray request")
 		}
@@ -20069,7 +20069,7 @@ func decodeTestRequestStringTimeArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20080,7 +20080,7 @@ func decodeTestRequestStringTimeArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringTimeArrayArray request")
 		}
@@ -20228,7 +20228,7 @@ func decodeTestRequestStringTimeNullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20239,7 +20239,7 @@ func decodeTestRequestStringTimeNullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringTimeNullableArrayArray request")
 		}
@@ -20387,7 +20387,7 @@ func decodeTestRequestStringURIArrayArrayRequest(r *http.Request, span trace.Spa
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20398,7 +20398,7 @@ func decodeTestRequestStringURIArrayArrayRequest(r *http.Request, span trace.Spa
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringURIArrayArray request")
 		}
@@ -20546,7 +20546,7 @@ func decodeTestRequestStringURINullableArrayArrayRequest(r *http.Request, span t
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20557,7 +20557,7 @@ func decodeTestRequestStringURINullableArrayArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringURINullableArrayArray request")
 		}
@@ -20705,7 +20705,7 @@ func decodeTestRequestStringUUIDArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20716,7 +20716,7 @@ func decodeTestRequestStringUUIDArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUUIDArrayArray request")
 		}
@@ -20864,7 +20864,7 @@ func decodeTestRequestStringUUIDNullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -20875,7 +20875,7 @@ func decodeTestRequestStringUUIDNullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUUIDNullableArrayArray request")
 		}
@@ -21023,7 +21023,7 @@ func decodeTestRequestStringUnixArrayArrayRequest(r *http.Request, span trace.Sp
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21034,7 +21034,7 @@ func decodeTestRequestStringUnixArrayArrayRequest(r *http.Request, span trace.Sp
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixArrayArray request")
 		}
@@ -21182,7 +21182,7 @@ func decodeTestRequestStringUnixMicroArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21193,7 +21193,7 @@ func decodeTestRequestStringUnixMicroArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixMicroArrayArray request")
 		}
@@ -21341,7 +21341,7 @@ func decodeTestRequestStringUnixMicroNullableArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21352,7 +21352,7 @@ func decodeTestRequestStringUnixMicroNullableArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixMicroNullableArrayArray request")
 		}
@@ -21500,7 +21500,7 @@ func decodeTestRequestStringUnixMilliArrayArrayRequest(r *http.Request, span tra
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21511,7 +21511,7 @@ func decodeTestRequestStringUnixMilliArrayArrayRequest(r *http.Request, span tra
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixMilliArrayArray request")
 		}
@@ -21659,7 +21659,7 @@ func decodeTestRequestStringUnixMilliNullableArrayArrayRequest(r *http.Request, 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21670,7 +21670,7 @@ func decodeTestRequestStringUnixMilliNullableArrayArrayRequest(r *http.Request, 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixMilliNullableArrayArray request")
 		}
@@ -21818,7 +21818,7 @@ func decodeTestRequestStringUnixNanoArrayArrayRequest(r *http.Request, span trac
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21829,7 +21829,7 @@ func decodeTestRequestStringUnixNanoArrayArrayRequest(r *http.Request, span trac
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixNanoArrayArray request")
 		}
@@ -21977,7 +21977,7 @@ func decodeTestRequestStringUnixNanoNullableArrayArrayRequest(r *http.Request, s
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -21988,7 +21988,7 @@ func decodeTestRequestStringUnixNanoNullableArrayArrayRequest(r *http.Request, s
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixNanoNullableArrayArray request")
 		}
@@ -22136,7 +22136,7 @@ func decodeTestRequestStringUnixNullableArrayArrayRequest(r *http.Request, span 
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -22147,7 +22147,7 @@ func decodeTestRequestStringUnixNullableArrayArrayRequest(r *http.Request, span 
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixNullableArrayArray request")
 		}
@@ -22295,7 +22295,7 @@ func decodeTestRequestStringUnixSecondsArrayArrayRequest(r *http.Request, span t
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -22306,7 +22306,7 @@ func decodeTestRequestStringUnixSecondsArrayArrayRequest(r *http.Request, span t
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixSecondsArrayArray request")
 		}
@@ -22454,7 +22454,7 @@ func decodeTestRequestStringUnixSecondsNullableArrayArrayRequest(r *http.Request
 					if elem == nil {
 						return errors.New("nil is invalid value")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					failures = append(failures, validate.FieldError{
 						Name:  fmt.Sprintf("[%d]", i),
@@ -22465,7 +22465,7 @@ func decodeTestRequestStringUnixSecondsNullableArrayArrayRequest(r *http.Request
 			if len(failures) > 0 {
 				return &validate.Error{Fields: failures}
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestRequestStringUnixSecondsNullableArrayArray request")
 		}

--- a/examples/ex_test_format/oas_validators_gen.go
+++ b/examples/ex_test_format/oas_validators_gen.go
@@ -16,7 +16,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayAny == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_any",
@@ -27,7 +27,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayBoolean == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_boolean",
@@ -38,7 +38,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayInteger == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer",
@@ -49,7 +49,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayIntegerInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int32",
@@ -60,7 +60,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayIntegerInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int64",
@@ -71,7 +71,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayNull == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_null",
@@ -88,7 +88,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -99,7 +99,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number",
@@ -116,7 +116,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -127,7 +127,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_double",
@@ -144,7 +144,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -155,7 +155,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_float",
@@ -166,7 +166,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayNumberInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int32",
@@ -177,7 +177,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayNumberInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int64",
@@ -188,7 +188,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayString == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string",
@@ -199,7 +199,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringBinary == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_binary",
@@ -210,7 +210,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringByte == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_byte",
@@ -221,7 +221,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDate == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date",
@@ -232,7 +232,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDateMinusTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date-time",
@@ -243,7 +243,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDuration == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_duration",
@@ -268,7 +268,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -279,7 +279,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_email",
@@ -304,7 +304,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -315,7 +315,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_hostname",
@@ -326,7 +326,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int32",
@@ -337,7 +337,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int64",
@@ -348,7 +348,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIP == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ip",
@@ -359,7 +359,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIpv4 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv4",
@@ -370,7 +370,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIpv6 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv6",
@@ -381,7 +381,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_password",
@@ -392,7 +392,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_time",
@@ -403,7 +403,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnix == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix",
@@ -414,7 +414,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusMicro == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-micro",
@@ -425,7 +425,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusMilli == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-milli",
@@ -436,7 +436,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusNano == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-nano",
@@ -447,7 +447,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusSeconds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-seconds",
@@ -458,7 +458,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringURI == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uri",
@@ -469,7 +469,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUUID == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uuid",
@@ -486,7 +486,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -497,7 +497,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_any",
@@ -514,7 +514,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -525,7 +525,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_boolean",
@@ -542,7 +542,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -553,7 +553,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer",
@@ -570,7 +570,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -581,7 +581,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int32",
@@ -598,7 +598,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -609,7 +609,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int64",
@@ -626,7 +626,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -637,7 +637,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_null",
@@ -660,7 +660,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -671,7 +671,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -682,7 +682,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number",
@@ -705,7 +705,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -716,7 +716,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -727,7 +727,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_double",
@@ -750,7 +750,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -761,7 +761,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -772,7 +772,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_float",
@@ -789,7 +789,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -800,7 +800,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int32",
@@ -817,7 +817,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -828,7 +828,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int64",
@@ -845,7 +845,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -856,7 +856,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string",
@@ -873,7 +873,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -884,7 +884,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_binary",
@@ -901,7 +901,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -912,7 +912,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_byte",
@@ -929,7 +929,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -940,7 +940,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date",
@@ -957,7 +957,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -968,7 +968,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date-time",
@@ -985,7 +985,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -996,7 +996,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_duration",
@@ -1027,7 +1027,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1038,7 +1038,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1049,7 +1049,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_email",
@@ -1080,7 +1080,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1091,7 +1091,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1102,7 +1102,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_hostname",
@@ -1119,7 +1119,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1130,7 +1130,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int32",
@@ -1147,7 +1147,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1158,7 +1158,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int64",
@@ -1175,7 +1175,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1186,7 +1186,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ip",
@@ -1203,7 +1203,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1214,7 +1214,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv4",
@@ -1231,7 +1231,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1242,7 +1242,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
@@ -1259,7 +1259,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1270,7 +1270,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_password",
@@ -1287,7 +1287,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1298,7 +1298,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_time",
@@ -1315,7 +1315,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1326,7 +1326,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix",
@@ -1343,7 +1343,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1354,7 +1354,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-micro",
@@ -1371,7 +1371,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1382,7 +1382,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-milli",
@@ -1399,7 +1399,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1410,7 +1410,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-nano",
@@ -1427,7 +1427,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1438,7 +1438,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-seconds",
@@ -1455,7 +1455,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1466,7 +1466,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uri",
@@ -1483,7 +1483,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1494,7 +1494,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uuid",
@@ -1505,7 +1505,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumber)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number",
@@ -1516,7 +1516,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberDouble)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_double",
@@ -1527,7 +1527,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberFloat)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_float",
@@ -1546,7 +1546,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_email",
@@ -1565,7 +1565,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_hostname",
@@ -1579,7 +1579,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1590,7 +1590,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number",
@@ -1604,7 +1604,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1615,7 +1615,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_double",
@@ -1629,7 +1629,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1640,7 +1640,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_float",
@@ -1662,7 +1662,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1673,7 +1673,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_email",
@@ -1695,7 +1695,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1706,7 +1706,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_hostname",
@@ -1720,7 +1720,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1731,7 +1731,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_any",
@@ -1745,7 +1745,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1756,7 +1756,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_boolean",
@@ -1770,7 +1770,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1781,7 +1781,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer",
@@ -1795,7 +1795,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1806,7 +1806,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int32",
@@ -1820,7 +1820,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1831,7 +1831,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int64",
@@ -1845,7 +1845,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1856,7 +1856,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_null",
@@ -1876,7 +1876,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1887,7 +1887,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1898,7 +1898,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number",
@@ -1918,7 +1918,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1929,7 +1929,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1940,7 +1940,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_double",
@@ -1960,7 +1960,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -1971,7 +1971,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1982,7 +1982,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_float",
@@ -1996,7 +1996,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2007,7 +2007,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int32",
@@ -2021,7 +2021,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2032,7 +2032,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int64",
@@ -2046,7 +2046,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2057,7 +2057,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string",
@@ -2071,7 +2071,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2082,7 +2082,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_binary",
@@ -2096,7 +2096,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2107,7 +2107,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_byte",
@@ -2121,7 +2121,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2132,7 +2132,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date",
@@ -2146,7 +2146,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2157,7 +2157,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date-time",
@@ -2171,7 +2171,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2182,7 +2182,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_duration",
@@ -2210,7 +2210,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -2221,7 +2221,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2232,7 +2232,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_email",
@@ -2260,7 +2260,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -2271,7 +2271,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2282,7 +2282,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_hostname",
@@ -2296,7 +2296,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2307,7 +2307,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int32",
@@ -2321,7 +2321,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2332,7 +2332,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int64",
@@ -2346,7 +2346,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2357,7 +2357,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ip",
@@ -2371,7 +2371,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2382,7 +2382,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv4",
@@ -2396,7 +2396,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2407,7 +2407,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
@@ -2421,7 +2421,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2432,7 +2432,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_password",
@@ -2446,7 +2446,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2457,7 +2457,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_time",
@@ -2471,7 +2471,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2482,7 +2482,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix",
@@ -2496,7 +2496,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2507,7 +2507,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-micro",
@@ -2521,7 +2521,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2532,7 +2532,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-milli",
@@ -2546,7 +2546,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2557,7 +2557,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-nano",
@@ -2571,7 +2571,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2582,7 +2582,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-seconds",
@@ -2596,7 +2596,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2607,7 +2607,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uri",
@@ -2621,7 +2621,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2632,7 +2632,7 @@ func (s TestRequestFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uuid",
@@ -2645,13 +2645,13 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumber.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number",
@@ -2664,13 +2664,13 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberDouble.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_double",
@@ -2683,13 +2683,13 @@ func (s TestRequestFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberFloat.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_float",
@@ -2710,13 +2710,13 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(s.OptionalStringEmail.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_email",
@@ -2737,13 +2737,13 @@ func (s TestRequestFormatTestReq) Validate() error {
 				}).Validate(string(s.OptionalStringHostname.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_hostname",
@@ -2761,7 +2761,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayAny == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_any",
@@ -2772,7 +2772,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayBoolean == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_boolean",
@@ -2783,7 +2783,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayInteger == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer",
@@ -2794,7 +2794,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayIntegerInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int32",
@@ -2805,7 +2805,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayIntegerInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int64",
@@ -2816,7 +2816,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayNull == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_null",
@@ -2833,7 +2833,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2844,7 +2844,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number",
@@ -2861,7 +2861,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2872,7 +2872,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_double",
@@ -2889,7 +2889,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -2900,7 +2900,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_float",
@@ -2911,7 +2911,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayNumberInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int32",
@@ -2922,7 +2922,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayNumberInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int64",
@@ -2933,7 +2933,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayString == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string",
@@ -2944,7 +2944,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringBinary == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_binary",
@@ -2955,7 +2955,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringByte == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_byte",
@@ -2966,7 +2966,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDate == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date",
@@ -2977,7 +2977,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDateMinusTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date-time",
@@ -2988,7 +2988,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringDuration == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_duration",
@@ -3013,7 +3013,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3024,7 +3024,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_email",
@@ -3049,7 +3049,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3060,7 +3060,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_hostname",
@@ -3071,7 +3071,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int32",
@@ -3082,7 +3082,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int64",
@@ -3093,7 +3093,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIP == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ip",
@@ -3104,7 +3104,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIpv4 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv4",
@@ -3115,7 +3115,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringIpv6 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv6",
@@ -3126,7 +3126,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_password",
@@ -3137,7 +3137,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_time",
@@ -3148,7 +3148,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnix == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix",
@@ -3159,7 +3159,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusMicro == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-micro",
@@ -3170,7 +3170,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusMilli == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-milli",
@@ -3181,7 +3181,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusNano == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-nano",
@@ -3192,7 +3192,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUnixMinusSeconds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-seconds",
@@ -3203,7 +3203,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringURI == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uri",
@@ -3214,7 +3214,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if s.RequiredArrayStringUUID == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uuid",
@@ -3231,7 +3231,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3242,7 +3242,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_any",
@@ -3259,7 +3259,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3270,7 +3270,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_boolean",
@@ -3287,7 +3287,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3298,7 +3298,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer",
@@ -3315,7 +3315,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3326,7 +3326,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int32",
@@ -3343,7 +3343,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3354,7 +3354,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int64",
@@ -3371,7 +3371,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3382,7 +3382,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_null",
@@ -3405,7 +3405,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3416,7 +3416,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3427,7 +3427,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number",
@@ -3450,7 +3450,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3461,7 +3461,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3472,7 +3472,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_double",
@@ -3495,7 +3495,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3506,7 +3506,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3517,7 +3517,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_float",
@@ -3534,7 +3534,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3545,7 +3545,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int32",
@@ -3562,7 +3562,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3573,7 +3573,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int64",
@@ -3590,7 +3590,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3601,7 +3601,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string",
@@ -3618,7 +3618,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3629,7 +3629,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_binary",
@@ -3646,7 +3646,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3657,7 +3657,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_byte",
@@ -3674,7 +3674,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3685,7 +3685,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date",
@@ -3702,7 +3702,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3713,7 +3713,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date-time",
@@ -3730,7 +3730,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3741,7 +3741,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_duration",
@@ -3772,7 +3772,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3783,7 +3783,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3794,7 +3794,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_email",
@@ -3825,7 +3825,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -3836,7 +3836,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3847,7 +3847,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_hostname",
@@ -3864,7 +3864,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3875,7 +3875,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int32",
@@ -3892,7 +3892,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3903,7 +3903,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int64",
@@ -3920,7 +3920,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3931,7 +3931,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ip",
@@ -3948,7 +3948,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3959,7 +3959,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv4",
@@ -3976,7 +3976,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -3987,7 +3987,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
@@ -4004,7 +4004,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4015,7 +4015,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_password",
@@ -4032,7 +4032,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4043,7 +4043,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_time",
@@ -4060,7 +4060,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4071,7 +4071,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix",
@@ -4088,7 +4088,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4099,7 +4099,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-micro",
@@ -4116,7 +4116,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4127,7 +4127,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-milli",
@@ -4144,7 +4144,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4155,7 +4155,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-nano",
@@ -4172,7 +4172,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4183,7 +4183,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-seconds",
@@ -4200,7 +4200,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4211,7 +4211,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uri",
@@ -4228,7 +4228,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4239,7 +4239,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uuid",
@@ -4250,7 +4250,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumber)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number",
@@ -4261,7 +4261,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberDouble)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_double",
@@ -4272,7 +4272,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberFloat)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_float",
@@ -4291,7 +4291,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_email",
@@ -4310,7 +4310,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_hostname",
@@ -4324,7 +4324,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4335,7 +4335,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number",
@@ -4349,7 +4349,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4360,7 +4360,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_double",
@@ -4374,7 +4374,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4385,7 +4385,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_float",
@@ -4407,7 +4407,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4418,7 +4418,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_email",
@@ -4440,7 +4440,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4451,7 +4451,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_hostname",
@@ -4465,7 +4465,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4476,7 +4476,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_any",
@@ -4490,7 +4490,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4501,7 +4501,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_boolean",
@@ -4515,7 +4515,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4526,7 +4526,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer",
@@ -4540,7 +4540,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4551,7 +4551,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int32",
@@ -4565,7 +4565,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4576,7 +4576,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int64",
@@ -4590,7 +4590,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4601,7 +4601,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_null",
@@ -4621,7 +4621,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4632,7 +4632,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4643,7 +4643,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number",
@@ -4663,7 +4663,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4674,7 +4674,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4685,7 +4685,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_double",
@@ -4705,7 +4705,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4716,7 +4716,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4727,7 +4727,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_float",
@@ -4741,7 +4741,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4752,7 +4752,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int32",
@@ -4766,7 +4766,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4777,7 +4777,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int64",
@@ -4791,7 +4791,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4802,7 +4802,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string",
@@ -4816,7 +4816,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4827,7 +4827,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_binary",
@@ -4841,7 +4841,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4852,7 +4852,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_byte",
@@ -4866,7 +4866,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4877,7 +4877,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date",
@@ -4891,7 +4891,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4902,7 +4902,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date-time",
@@ -4916,7 +4916,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4927,7 +4927,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_duration",
@@ -4955,7 +4955,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -4966,7 +4966,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -4977,7 +4977,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_email",
@@ -5005,7 +5005,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -5016,7 +5016,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5027,7 +5027,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_hostname",
@@ -5041,7 +5041,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5052,7 +5052,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int32",
@@ -5066,7 +5066,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5077,7 +5077,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int64",
@@ -5091,7 +5091,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5102,7 +5102,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ip",
@@ -5116,7 +5116,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5127,7 +5127,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv4",
@@ -5141,7 +5141,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5152,7 +5152,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
@@ -5166,7 +5166,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5177,7 +5177,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_password",
@@ -5191,7 +5191,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5202,7 +5202,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_time",
@@ -5216,7 +5216,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5227,7 +5227,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix",
@@ -5241,7 +5241,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5252,7 +5252,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-micro",
@@ -5266,7 +5266,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5277,7 +5277,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-milli",
@@ -5291,7 +5291,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5302,7 +5302,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-nano",
@@ -5316,7 +5316,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5327,7 +5327,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-seconds",
@@ -5341,7 +5341,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5352,7 +5352,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uri",
@@ -5366,7 +5366,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5377,7 +5377,7 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uuid",
@@ -5390,13 +5390,13 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumber.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number",
@@ -5409,13 +5409,13 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberDouble.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_double",
@@ -5428,13 +5428,13 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberFloat.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_float",
@@ -5455,13 +5455,13 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(s.OptionalStringEmail.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_email",
@@ -5482,13 +5482,13 @@ func (s TestRequestRequiredFormatTestReq) Validate() error {
 				}).Validate(string(s.OptionalStringHostname.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_hostname",
@@ -5506,7 +5506,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayAny == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_any",
@@ -5517,7 +5517,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayBoolean == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_boolean",
@@ -5528,7 +5528,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayInteger == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer",
@@ -5539,7 +5539,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayIntegerInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int32",
@@ -5550,7 +5550,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayIntegerInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_integer_int64",
@@ -5561,7 +5561,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayNull == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_null",
@@ -5578,7 +5578,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5589,7 +5589,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number",
@@ -5606,7 +5606,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5617,7 +5617,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_double",
@@ -5634,7 +5634,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5645,7 +5645,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_float",
@@ -5656,7 +5656,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayNumberInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int32",
@@ -5667,7 +5667,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayNumberInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_number_int64",
@@ -5678,7 +5678,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayString == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string",
@@ -5689,7 +5689,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringBinary == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_binary",
@@ -5700,7 +5700,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringByte == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_byte",
@@ -5711,7 +5711,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringDate == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date",
@@ -5722,7 +5722,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringDateMinusTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_date-time",
@@ -5733,7 +5733,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringDuration == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_duration",
@@ -5758,7 +5758,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5769,7 +5769,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_email",
@@ -5794,7 +5794,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5805,7 +5805,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_hostname",
@@ -5816,7 +5816,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringInt32 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int32",
@@ -5827,7 +5827,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringInt64 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_int64",
@@ -5838,7 +5838,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringIP == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ip",
@@ -5849,7 +5849,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringIpv4 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv4",
@@ -5860,7 +5860,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringIpv6 == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_ipv6",
@@ -5871,7 +5871,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_password",
@@ -5882,7 +5882,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringTime == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_time",
@@ -5893,7 +5893,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUnix == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix",
@@ -5904,7 +5904,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUnixMinusMicro == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-micro",
@@ -5915,7 +5915,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUnixMinusMilli == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-milli",
@@ -5926,7 +5926,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUnixMinusNano == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-nano",
@@ -5937,7 +5937,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUnixMinusSeconds == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_unix-seconds",
@@ -5948,7 +5948,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringURI == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uri",
@@ -5959,7 +5959,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if s.RequiredArrayStringUUID == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_array_string_uuid",
@@ -5976,7 +5976,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -5987,7 +5987,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_any",
@@ -6004,7 +6004,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6015,7 +6015,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_boolean",
@@ -6032,7 +6032,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6043,7 +6043,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer",
@@ -6060,7 +6060,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6071,7 +6071,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int32",
@@ -6088,7 +6088,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6099,7 +6099,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_integer_int64",
@@ -6116,7 +6116,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6127,7 +6127,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_null",
@@ -6150,7 +6150,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6161,7 +6161,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6172,7 +6172,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number",
@@ -6195,7 +6195,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6206,7 +6206,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6217,7 +6217,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_double",
@@ -6240,7 +6240,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6251,7 +6251,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6262,7 +6262,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_float",
@@ -6279,7 +6279,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6290,7 +6290,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int32",
@@ -6307,7 +6307,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6318,7 +6318,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_number_int64",
@@ -6335,7 +6335,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6346,7 +6346,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string",
@@ -6363,7 +6363,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6374,7 +6374,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_binary",
@@ -6391,7 +6391,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6402,7 +6402,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_byte",
@@ -6419,7 +6419,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6430,7 +6430,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date",
@@ -6447,7 +6447,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6458,7 +6458,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_date-time",
@@ -6475,7 +6475,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6486,7 +6486,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_duration",
@@ -6517,7 +6517,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6528,7 +6528,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6539,7 +6539,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_email",
@@ -6570,7 +6570,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -6581,7 +6581,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6592,7 +6592,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_hostname",
@@ -6609,7 +6609,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6620,7 +6620,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int32",
@@ -6637,7 +6637,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6648,7 +6648,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_int64",
@@ -6665,7 +6665,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6676,7 +6676,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ip",
@@ -6693,7 +6693,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6704,7 +6704,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv4",
@@ -6721,7 +6721,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6732,7 +6732,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
@@ -6749,7 +6749,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6760,7 +6760,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_password",
@@ -6777,7 +6777,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6788,7 +6788,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_time",
@@ -6805,7 +6805,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6816,7 +6816,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix",
@@ -6833,7 +6833,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6844,7 +6844,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-micro",
@@ -6861,7 +6861,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6872,7 +6872,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-milli",
@@ -6889,7 +6889,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6900,7 +6900,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-nano",
@@ -6917,7 +6917,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6928,7 +6928,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_unix-seconds",
@@ -6945,7 +6945,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6956,7 +6956,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uri",
@@ -6973,7 +6973,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -6984,7 +6984,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_uuid",
@@ -6995,7 +6995,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumber)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number",
@@ -7006,7 +7006,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberDouble)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_double",
@@ -7017,7 +7017,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.RequiredNumberFloat)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_number_float",
@@ -7036,7 +7036,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_email",
@@ -7055,7 +7055,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_string_hostname",
@@ -7069,7 +7069,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7080,7 +7080,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number",
@@ -7094,7 +7094,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7105,7 +7105,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_double",
@@ -7119,7 +7119,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7130,7 +7130,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_number_float",
@@ -7152,7 +7152,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7163,7 +7163,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_email",
@@ -7185,7 +7185,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(elem)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7196,7 +7196,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_array_string_hostname",
@@ -7210,7 +7210,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7221,7 +7221,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_any",
@@ -7235,7 +7235,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7246,7 +7246,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_boolean",
@@ -7260,7 +7260,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7271,7 +7271,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer",
@@ -7285,7 +7285,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7296,7 +7296,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int32",
@@ -7310,7 +7310,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7321,7 +7321,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_integer_int64",
@@ -7335,7 +7335,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7346,7 +7346,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_null",
@@ -7366,7 +7366,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7377,7 +7377,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7388,7 +7388,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number",
@@ -7408,7 +7408,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7419,7 +7419,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7430,7 +7430,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_double",
@@ -7450,7 +7450,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						if err := (validate.Float{}).Validate(float64(elem)); err != nil {
 							return errors.Wrap(err, "float")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7461,7 +7461,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7472,7 +7472,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_float",
@@ -7486,7 +7486,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7497,7 +7497,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int32",
@@ -7511,7 +7511,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7522,7 +7522,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_number_int64",
@@ -7536,7 +7536,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7547,7 +7547,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string",
@@ -7561,7 +7561,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7572,7 +7572,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_binary",
@@ -7586,7 +7586,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7597,7 +7597,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_byte",
@@ -7611,7 +7611,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7622,7 +7622,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date",
@@ -7636,7 +7636,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7647,7 +7647,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_date-time",
@@ -7661,7 +7661,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7672,7 +7672,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_duration",
@@ -7700,7 +7700,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7711,7 +7711,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7722,7 +7722,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_email",
@@ -7750,7 +7750,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -7761,7 +7761,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7772,7 +7772,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_hostname",
@@ -7786,7 +7786,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7797,7 +7797,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int32",
@@ -7811,7 +7811,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7822,7 +7822,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_int64",
@@ -7836,7 +7836,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7847,7 +7847,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ip",
@@ -7861,7 +7861,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7872,7 +7872,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv4",
@@ -7886,7 +7886,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7897,7 +7897,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
@@ -7911,7 +7911,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7922,7 +7922,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_password",
@@ -7936,7 +7936,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7947,7 +7947,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_time",
@@ -7961,7 +7961,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7972,7 +7972,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix",
@@ -7986,7 +7986,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -7997,7 +7997,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-micro",
@@ -8011,7 +8011,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8022,7 +8022,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-milli",
@@ -8036,7 +8036,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8047,7 +8047,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-nano",
@@ -8061,7 +8061,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8072,7 +8072,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_unix-seconds",
@@ -8086,7 +8086,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8097,7 +8097,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uri",
@@ -8111,7 +8111,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if elem == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -8122,7 +8122,7 @@ func (s TestResponseFormatTestOK) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_uuid",
@@ -8135,13 +8135,13 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumber.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number",
@@ -8154,13 +8154,13 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberDouble.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_double",
@@ -8173,13 +8173,13 @@ func (s TestResponseFormatTestOK) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.OptionalNumberFloat.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_number_float",
@@ -8200,13 +8200,13 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(s.OptionalStringEmail.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_email",
@@ -8227,13 +8227,13 @@ func (s TestResponseFormatTestOK) Validate() error {
 				}).Validate(string(s.OptionalStringHostname.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_string_hostname",

--- a/examples/ex_tinkoff/oas_client_gen.go
+++ b/examples/ex_tinkoff/oas_client_gen.go
@@ -785,7 +785,7 @@ func (c *Client) OrdersLimitOrderPost(ctx context.Context, request LimitOrderReq
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -884,7 +884,7 @@ func (c *Client) OrdersMarketOrderPost(ctx context.Context, request MarketOrderR
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1177,7 +1177,7 @@ func (c *Client) SandboxCurrenciesBalancePost(ctx context.Context, request Sandb
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1263,7 +1263,7 @@ func (c *Client) SandboxPositionsBalancePost(ctx context.Context, request Sandbo
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1353,13 +1353,13 @@ func (c *Client) SandboxRegisterPost(ctx context.Context, request OptSandboxRegi
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/examples/ex_tinkoff/oas_handlers_gen.go
+++ b/examples/ex_tinkoff/oas_handlers_gen.go
@@ -85,8 +85,8 @@ func (s *Server) handleMarketCandlesGetRequest(args [0]string, w http.ResponseWr
 	params, err := decodeMarketCandlesGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MarketCandlesGet",
-			err,
+			Operation: "MarketCandlesGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -226,8 +226,8 @@ func (s *Server) handleMarketOrderbookGetRequest(args [0]string, w http.Response
 	params, err := decodeMarketOrderbookGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MarketOrderbookGet",
-			err,
+			Operation: "MarketOrderbookGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -279,8 +279,8 @@ func (s *Server) handleMarketSearchByFigiGetRequest(args [0]string, w http.Respo
 	params, err := decodeMarketSearchByFigiGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MarketSearchByFigiGet",
-			err,
+			Operation: "MarketSearchByFigiGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -332,8 +332,8 @@ func (s *Server) handleMarketSearchByTickerGetRequest(args [0]string, w http.Res
 	params, err := decodeMarketSearchByTickerGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"MarketSearchByTickerGet",
-			err,
+			Operation: "MarketSearchByTickerGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -429,8 +429,8 @@ func (s *Server) handleOperationsGetRequest(args [0]string, w http.ResponseWrite
 	params, err := decodeOperationsGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OperationsGet",
-			err,
+			Operation: "OperationsGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -482,8 +482,8 @@ func (s *Server) handleOrdersCancelPostRequest(args [0]string, w http.ResponseWr
 	params, err := decodeOrdersCancelPostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrdersCancelPost",
-			err,
+			Operation: "OrdersCancelPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -535,8 +535,8 @@ func (s *Server) handleOrdersGetRequest(args [0]string, w http.ResponseWriter, r
 	params, err := decodeOrdersGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrdersGet",
-			err,
+			Operation: "OrdersGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -588,8 +588,8 @@ func (s *Server) handleOrdersLimitOrderPostRequest(args [0]string, w http.Respon
 	params, err := decodeOrdersLimitOrderPostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrdersLimitOrderPost",
-			err,
+			Operation: "OrdersLimitOrderPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -597,8 +597,8 @@ func (s *Server) handleOrdersLimitOrderPostRequest(args [0]string, w http.Respon
 	request, err := decodeOrdersLimitOrderPostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrdersLimitOrderPost",
-			err,
+			Operation: "OrdersLimitOrderPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -650,8 +650,8 @@ func (s *Server) handleOrdersMarketOrderPostRequest(args [0]string, w http.Respo
 	params, err := decodeOrdersMarketOrderPostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"OrdersMarketOrderPost",
-			err,
+			Operation: "OrdersMarketOrderPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -659,8 +659,8 @@ func (s *Server) handleOrdersMarketOrderPostRequest(args [0]string, w http.Respo
 	request, err := decodeOrdersMarketOrderPostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OrdersMarketOrderPost",
-			err,
+			Operation: "OrdersMarketOrderPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -712,8 +712,8 @@ func (s *Server) handlePortfolioCurrenciesGetRequest(args [0]string, w http.Resp
 	params, err := decodePortfolioCurrenciesGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PortfolioCurrenciesGet",
-			err,
+			Operation: "PortfolioCurrenciesGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -765,8 +765,8 @@ func (s *Server) handlePortfolioGetRequest(args [0]string, w http.ResponseWriter
 	params, err := decodePortfolioGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PortfolioGet",
-			err,
+			Operation: "PortfolioGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -818,8 +818,8 @@ func (s *Server) handleSandboxClearPostRequest(args [0]string, w http.ResponseWr
 	params, err := decodeSandboxClearPostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SandboxClearPost",
-			err,
+			Operation: "SandboxClearPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -871,8 +871,8 @@ func (s *Server) handleSandboxCurrenciesBalancePostRequest(args [0]string, w htt
 	params, err := decodeSandboxCurrenciesBalancePostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SandboxCurrenciesBalancePost",
-			err,
+			Operation: "SandboxCurrenciesBalancePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -880,8 +880,8 @@ func (s *Server) handleSandboxCurrenciesBalancePostRequest(args [0]string, w htt
 	request, err := decodeSandboxCurrenciesBalancePostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SandboxCurrenciesBalancePost",
-			err,
+			Operation: "SandboxCurrenciesBalancePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -933,8 +933,8 @@ func (s *Server) handleSandboxPositionsBalancePostRequest(args [0]string, w http
 	params, err := decodeSandboxPositionsBalancePostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SandboxPositionsBalancePost",
-			err,
+			Operation: "SandboxPositionsBalancePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -942,8 +942,8 @@ func (s *Server) handleSandboxPositionsBalancePostRequest(args [0]string, w http
 	request, err := decodeSandboxPositionsBalancePostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SandboxPositionsBalancePost",
-			err,
+			Operation: "SandboxPositionsBalancePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -995,8 +995,8 @@ func (s *Server) handleSandboxRegisterPostRequest(args [0]string, w http.Respons
 	request, err := decodeSandboxRegisterPostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"SandboxRegisterPost",
-			err,
+			Operation: "SandboxRegisterPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1048,8 +1048,8 @@ func (s *Server) handleSandboxRemovePostRequest(args [0]string, w http.ResponseW
 	params, err := decodeSandboxRemovePostParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"SandboxRemovePost",
-			err,
+			Operation: "SandboxRemovePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/examples/ex_tinkoff/oas_param_dec_gen.go
+++ b/examples/ex_tinkoff/oas_param_dec_gen.go
@@ -136,7 +136,7 @@ func decodeMarketCandlesGetParams(args [0]string, r *http.Request) (MarketCandle
 				if err := params.Interval.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: interval: invalid")
 			}

--- a/examples/ex_tinkoff/oas_req_dec_gen.go
+++ b/examples/ex_tinkoff/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeOrdersLimitOrderPostRequest(r *http.Request, span trace.Span) (req Li
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrdersLimitOrderPost request")
 		}
@@ -91,7 +91,7 @@ func decodeOrdersMarketOrderPostRequest(r *http.Request, span trace.Span) (req M
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OrdersMarketOrderPost request")
 		}
@@ -135,7 +135,7 @@ func decodeSandboxCurrenciesBalancePostRequest(r *http.Request, span trace.Span)
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SandboxCurrenciesBalancePost request")
 		}
@@ -179,7 +179,7 @@ func decodeSandboxPositionsBalancePostRequest(r *http.Request, span trace.Span) 
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SandboxPositionsBalancePost request")
 		}
@@ -226,13 +226,13 @@ func decodeSandboxRegisterPostRequest(r *http.Request, span trace.Span) (req Opt
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate SandboxRegisterPost request")
 		}

--- a/examples/ex_tinkoff/oas_validators_gen.go
+++ b/examples/ex_tinkoff/oas_validators_gen.go
@@ -26,7 +26,7 @@ func (s Candle) Validate() error {
 		if err := s.Interval.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "interval",
@@ -37,7 +37,7 @@ func (s Candle) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.O)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "o",
@@ -48,7 +48,7 @@ func (s Candle) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.C)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "c",
@@ -59,7 +59,7 @@ func (s Candle) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.H)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "h",
@@ -70,7 +70,7 @@ func (s Candle) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.L)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "l",
@@ -116,7 +116,7 @@ func (s Candles) Validate() error {
 		if err := s.Interval.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "interval",
@@ -133,7 +133,7 @@ func (s Candles) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -144,7 +144,7 @@ func (s Candles) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "candles",
@@ -162,7 +162,7 @@ func (s CandlesResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -186,7 +186,7 @@ func (s Currencies) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -197,7 +197,7 @@ func (s Currencies) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currencies",
@@ -239,7 +239,7 @@ func (s CurrencyPosition) Validate() error {
 		if err := s.Currency.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -250,7 +250,7 @@ func (s CurrencyPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Balance)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "balance",
@@ -263,13 +263,13 @@ func (s CurrencyPosition) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.Blocked.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "blocked",
@@ -301,7 +301,7 @@ func (s LimitOrderRequest) Validate() error {
 		if err := s.Operation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operation",
@@ -312,7 +312,7 @@ func (s LimitOrderRequest) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Price)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "price",
@@ -330,7 +330,7 @@ func (s LimitOrderResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -350,13 +350,13 @@ func (s MarketInstrument) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.MinPriceIncrement.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minPriceIncrement",
@@ -369,13 +369,13 @@ func (s MarketInstrument) Validate() error {
 				if err := s.Currency.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -386,7 +386,7 @@ func (s MarketInstrument) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -410,7 +410,7 @@ func (s MarketInstrumentList) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -421,7 +421,7 @@ func (s MarketInstrumentList) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "instruments",
@@ -439,7 +439,7 @@ func (s MarketInstrumentListResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -457,7 +457,7 @@ func (s MarketOrderRequest) Validate() error {
 		if err := s.Operation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operation",
@@ -475,7 +475,7 @@ func (s MarketOrderResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -493,7 +493,7 @@ func (s MoneyAmount) Validate() error {
 		if err := s.Currency.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -504,7 +504,7 @@ func (s MoneyAmount) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Value)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "value",
@@ -522,7 +522,7 @@ func (s Operation) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -536,7 +536,7 @@ func (s Operation) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -547,7 +547,7 @@ func (s Operation) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "trades",
@@ -560,13 +560,13 @@ func (s Operation) Validate() error {
 				if err := s.Commission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commission",
@@ -577,7 +577,7 @@ func (s Operation) Validate() error {
 		if err := s.Currency.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -588,7 +588,7 @@ func (s Operation) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Payment)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payment",
@@ -601,13 +601,13 @@ func (s Operation) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.Price.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "price",
@@ -620,13 +620,13 @@ func (s Operation) Validate() error {
 				if err := s.InstrumentType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "instrumentType",
@@ -639,13 +639,13 @@ func (s Operation) Validate() error {
 				if err := s.OperationType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operationType",
@@ -675,7 +675,7 @@ func (s OperationTrade) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Price)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "price",
@@ -757,7 +757,7 @@ func (s Operations) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -768,7 +768,7 @@ func (s Operations) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operations",
@@ -786,7 +786,7 @@ func (s OperationsResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -805,7 +805,7 @@ func (s Order) Validate() error {
 		if err := s.Operation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operation",
@@ -816,7 +816,7 @@ func (s Order) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -827,7 +827,7 @@ func (s Order) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -838,7 +838,7 @@ func (s Order) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Price)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "price",
@@ -856,7 +856,7 @@ func (s OrderResponse) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Price)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "price",
@@ -914,7 +914,7 @@ func (s Orderbook) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -925,7 +925,7 @@ func (s Orderbook) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "bids",
@@ -942,7 +942,7 @@ func (s Orderbook) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -953,7 +953,7 @@ func (s Orderbook) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "asks",
@@ -964,7 +964,7 @@ func (s Orderbook) Validate() error {
 		if err := s.TradeStatus.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tradeStatus",
@@ -975,7 +975,7 @@ func (s Orderbook) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.MinPriceIncrement)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minPriceIncrement",
@@ -988,13 +988,13 @@ func (s Orderbook) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.FaceValue.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "faceValue",
@@ -1007,13 +1007,13 @@ func (s Orderbook) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.LastPrice.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "lastPrice",
@@ -1026,13 +1026,13 @@ func (s Orderbook) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.ClosePrice.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "closePrice",
@@ -1045,13 +1045,13 @@ func (s Orderbook) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.LimitUp.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limitUp",
@@ -1064,13 +1064,13 @@ func (s Orderbook) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.LimitDown.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "limitDown",
@@ -1088,7 +1088,7 @@ func (s OrderbookResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1112,7 +1112,7 @@ func (s OrdersResponse) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1123,7 +1123,7 @@ func (s OrdersResponse) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1141,7 +1141,7 @@ func (s PlacedLimitOrder) Validate() error {
 		if err := s.Operation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operation",
@@ -1152,7 +1152,7 @@ func (s PlacedLimitOrder) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -1165,13 +1165,13 @@ func (s PlacedLimitOrder) Validate() error {
 				if err := s.Commission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commission",
@@ -1189,7 +1189,7 @@ func (s PlacedMarketOrder) Validate() error {
 		if err := s.Operation.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "operation",
@@ -1200,7 +1200,7 @@ func (s PlacedMarketOrder) Validate() error {
 		if err := s.Status.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
@@ -1213,13 +1213,13 @@ func (s PlacedMarketOrder) Validate() error {
 				if err := s.Commission.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "commission",
@@ -1243,7 +1243,7 @@ func (s Portfolio) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1254,7 +1254,7 @@ func (s Portfolio) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "positions",
@@ -1272,7 +1272,7 @@ func (s PortfolioCurrenciesResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1290,7 +1290,7 @@ func (s PortfolioPosition) Validate() error {
 		if err := s.InstrumentType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "instrumentType",
@@ -1301,7 +1301,7 @@ func (s PortfolioPosition) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Balance)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "balance",
@@ -1314,13 +1314,13 @@ func (s PortfolioPosition) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.Blocked.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "blocked",
@@ -1333,13 +1333,13 @@ func (s PortfolioPosition) Validate() error {
 				if err := s.ExpectedYield.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "expectedYield",
@@ -1352,13 +1352,13 @@ func (s PortfolioPosition) Validate() error {
 				if err := s.AveragePositionPrice.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "averagePositionPrice",
@@ -1371,13 +1371,13 @@ func (s PortfolioPosition) Validate() error {
 				if err := s.AveragePositionPriceNoNkd.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "averagePositionPriceNoNkd",
@@ -1395,7 +1395,7 @@ func (s PortfolioResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1413,7 +1413,7 @@ func (s SandboxAccount) Validate() error {
 		if err := s.BrokerAccountType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "brokerAccountType",
@@ -1457,13 +1457,13 @@ func (s SandboxRegisterRequest) Validate() error {
 				if err := s.BrokerAccountType.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "brokerAccountType",
@@ -1481,7 +1481,7 @@ func (s SandboxRegisterResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1499,7 +1499,7 @@ func (s SandboxSetCurrencyBalanceRequest) Validate() error {
 		if err := s.Currency.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -1510,7 +1510,7 @@ func (s SandboxSetCurrencyBalanceRequest) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Balance)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "balance",
@@ -1528,7 +1528,7 @@ func (s SandboxSetPositionBalanceRequest) Validate() error {
 		if err := (validate.Float{}).Validate(float64(s.Balance)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "balance",
@@ -1548,13 +1548,13 @@ func (s SearchMarketInstrument) Validate() error {
 				if err := (validate.Float{}).Validate(float64(s.MinPriceIncrement.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minPriceIncrement",
@@ -1567,13 +1567,13 @@ func (s SearchMarketInstrument) Validate() error {
 				if err := s.Currency.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "currency",
@@ -1584,7 +1584,7 @@ func (s SearchMarketInstrument) Validate() error {
 		if err := s.Type.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -1602,7 +1602,7 @@ func (s SearchMarketInstrumentResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",
@@ -1630,7 +1630,7 @@ func (s UserAccount) Validate() error {
 		if err := s.BrokerAccountType.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "brokerAccountType",
@@ -1654,7 +1654,7 @@ func (s UserAccounts) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -1665,7 +1665,7 @@ func (s UserAccounts) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "accounts",
@@ -1683,7 +1683,7 @@ func (s UserAccountsResponse) Validate() error {
 		if err := s.Payload.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "payload",

--- a/gen/_template/handlers.tmpl
+++ b/gen/_template/handlers.tmpl
@@ -52,8 +52,8 @@ func (s *Server) handle{{ $op.Name }}Request(args [{{ $op.PathParamsCount }}]str
 	request, err := decode{{ $op.Name }}Request(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			{{ quote $op.Name }},
-			err,
+			Operation: {{ quote $op.Name }},
+			Err: err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/gen/_template/handlers.tmpl
+++ b/gen/_template/handlers.tmpl
@@ -40,8 +40,8 @@ func (s *Server) handle{{ $op.Name }}Request(args [{{ $op.PathParamsCount }}]str
 	params, err := decode{{ $op.Name }}Params(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			{{ quote $op.Name }},
-			err,
+			Operation: {{ quote $op.Name }},
+			Err: err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/gen/_template/validators.tmpl
+++ b/gen/_template/validators.tmpl
@@ -18,8 +18,8 @@
 				}(); err != nil {
 					return err
 				}
-			}
-			return nil
+			}      
+			return nil // return 2
         {{- else }}
             {{- template "validate" elem $t.GenericOf (printf "%s.Value" $.Var) }}
         {{- end }}
@@ -130,7 +130,7 @@
 	{{- if not $validated }}
 	{{ errorf "validation expected %s" $t }}
 	{{- end }}
-	return nil
+	return nil // return 1
 {{- end }}
 
 {{ define "validators/body" }}

--- a/internal/sample_api/oas_client_gen.go
+++ b/internal/sample_api/oas_client_gen.go
@@ -182,7 +182,7 @@ func (c *Client) DefaultTest(ctx context.Context, request DefaultTest, params De
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -389,13 +389,13 @@ func (c *Client) FoobarPost(ctx context.Context, request OptPet) (res FoobarPost
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -646,7 +646,7 @@ func (c *Client) OneofBug(ctx context.Context, request OneOfBugs) (res OneofBugO
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -756,13 +756,13 @@ func (c *Client) PetCreate(ctx context.Context, request OptPet) (res Pet, err er
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1246,13 +1246,13 @@ func (c *Client) PetUpdateNameAliasPost(ctx context.Context, request OptPetName)
 				if err := request.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1325,13 +1325,13 @@ func (c *Client) PetUpdateNamePost(ctx context.Context, request OptString) (res 
 				}).Validate(string(request.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}
@@ -1638,7 +1638,7 @@ func (c *Client) TestFloatValidation(ctx context.Context, request TestFloatValid
 		if err := request.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		return res, errors.Wrap(err, "validate")
 	}

--- a/internal/sample_api/oas_handlers_gen.go
+++ b/internal/sample_api/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleDataGetFormatRequest(args [5]string, w http.ResponseWrite
 	params, err := decodeDataGetFormatParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DataGetFormat",
-			err,
+			Operation: "DataGetFormat",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -79,8 +79,8 @@ func (s *Server) handleDefaultTestRequest(args [0]string, w http.ResponseWriter,
 	params, err := decodeDefaultTestParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"DefaultTest",
-			err,
+			Operation: "DefaultTest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -88,8 +88,8 @@ func (s *Server) handleDefaultTestRequest(args [0]string, w http.ResponseWriter,
 	request, err := decodeDefaultTestRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DefaultTest",
-			err,
+			Operation: "DefaultTest",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -169,8 +169,8 @@ func (s *Server) handleFoobarGetRequest(args [0]string, w http.ResponseWriter, r
 	params, err := decodeFoobarGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"FoobarGet",
-			err,
+			Operation: "FoobarGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -214,8 +214,8 @@ func (s *Server) handleFoobarPostRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeFoobarPostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"FoobarPost",
-			err,
+			Operation: "FoobarPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -293,8 +293,8 @@ func (s *Server) handleGetHeaderRequest(args [0]string, w http.ResponseWriter, r
 	params, err := decodeGetHeaderParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"GetHeader",
-			err,
+			Operation: "GetHeader",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -410,8 +410,8 @@ func (s *Server) handleOneofBugRequest(args [0]string, w http.ResponseWriter, r 
 	request, err := decodeOneofBugRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"OneofBug",
-			err,
+			Operation: "OneofBug",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -489,8 +489,8 @@ func (s *Server) handlePetCreateRequest(args [0]string, w http.ResponseWriter, r
 	request, err := decodePetCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PetCreate",
-			err,
+			Operation: "PetCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -534,8 +534,8 @@ func (s *Server) handlePetFriendsNamesByIDRequest(args [1]string, w http.Respons
 	params, err := decodePetFriendsNamesByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetFriendsNamesByID",
-			err,
+			Operation: "PetFriendsNamesByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -579,8 +579,8 @@ func (s *Server) handlePetGetRequest(args [0]string, w http.ResponseWriter, r *h
 	params, err := decodePetGetParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetGet",
-			err,
+			Operation: "PetGet",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -624,8 +624,8 @@ func (s *Server) handlePetGetAvatarByIDRequest(args [0]string, w http.ResponseWr
 	params, err := decodePetGetAvatarByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetGetAvatarByID",
-			err,
+			Operation: "PetGetAvatarByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -669,8 +669,8 @@ func (s *Server) handlePetGetAvatarByNameRequest(args [1]string, w http.Response
 	params, err := decodePetGetAvatarByNameParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetGetAvatarByName",
-			err,
+			Operation: "PetGetAvatarByName",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -714,8 +714,8 @@ func (s *Server) handlePetGetByNameRequest(args [1]string, w http.ResponseWriter
 	params, err := decodePetGetByNameParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetGetByName",
-			err,
+			Operation: "PetGetByName",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -759,8 +759,8 @@ func (s *Server) handlePetNameByIDRequest(args [1]string, w http.ResponseWriter,
 	params, err := decodePetNameByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetNameByID",
-			err,
+			Operation: "PetNameByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -802,8 +802,8 @@ func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, w http.Resp
 	request, err := decodePetUpdateNameAliasPostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PetUpdateNameAliasPost",
-			err,
+			Operation: "PetUpdateNameAliasPost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -845,8 +845,8 @@ func (s *Server) handlePetUpdateNamePostRequest(args [0]string, w http.ResponseW
 	request, err := decodePetUpdateNamePostRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PetUpdateNamePost",
-			err,
+			Operation: "PetUpdateNamePost",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -890,8 +890,8 @@ func (s *Server) handlePetUploadAvatarByIDRequest(args [0]string, w http.Respons
 	params, err := decodePetUploadAvatarByIDParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"PetUploadAvatarByID",
-			err,
+			Operation: "PetUploadAvatarByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -899,8 +899,8 @@ func (s *Server) handlePetUploadAvatarByIDRequest(args [0]string, w http.Respons
 	request, err := decodePetUploadAvatarByIDRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"PetUploadAvatarByID",
-			err,
+			Operation: "PetUploadAvatarByID",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1092,8 +1092,8 @@ func (s *Server) handleTestFloatValidationRequest(args [0]string, w http.Respons
 	request, err := decodeTestFloatValidationRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"TestFloatValidation",
-			err,
+			Operation: "TestFloatValidation",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -1137,8 +1137,8 @@ func (s *Server) handleTestObjectQueryParameterRequest(args [0]string, w http.Re
 	params, err := decodeTestObjectQueryParameterParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"TestObjectQueryParameter",
-			err,
+			Operation: "TestObjectQueryParameter",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/internal/sample_api/oas_param_dec_gen.go
+++ b/internal/sample_api/oas_param_dec_gen.go
@@ -409,7 +409,7 @@ func decodePetGetParams(args [0]string, r *http.Request) (PetGetParams, error) {
 				}).Validate(int64(params.PetID)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: petID: invalid")
 			}

--- a/internal/sample_api/oas_req_dec_gen.go
+++ b/internal/sample_api/oas_req_dec_gen.go
@@ -47,7 +47,7 @@ func decodeDefaultTestRequest(r *http.Request, span trace.Span) (req DefaultTest
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate DefaultTest request")
 		}
@@ -94,13 +94,13 @@ func decodeFoobarPostRequest(r *http.Request, span trace.Span) (req OptPet, err 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate FoobarPost request")
 		}
@@ -144,7 +144,7 @@ func decodeOneofBugRequest(r *http.Request, span trace.Span) (req OneOfBugs, err
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate OneofBug request")
 		}
@@ -191,13 +191,13 @@ func decodePetCreateRequest(r *http.Request, span trace.Span) (req OptPet, err e
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PetCreate request")
 		}
@@ -244,13 +244,13 @@ func decodePetUpdateNameAliasPostRequest(r *http.Request, span trace.Span) (req 
 					if err := request.Value.Validate(); err != nil {
 						return err
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PetUpdateNameAliasPost request")
 		}
@@ -305,13 +305,13 @@ func decodePetUpdateNamePostRequest(r *http.Request, span trace.Span) (req OptSt
 					}).Validate(string(request.Value)); err != nil {
 						return errors.Wrap(err, "string")
 					}
-					return nil
+					return nil // return 1
 				}(); err != nil {
 					return err
 				}
 			}
-			return nil
-			return nil
+			return nil // return 2
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate PetUpdateNamePost request")
 		}
@@ -364,7 +364,7 @@ func decodeTestFloatValidationRequest(r *http.Request, span trace.Span) (req Tes
 			if err := request.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return req, errors.Wrap(err, "validate TestFloatValidation request")
 		}

--- a/internal/sample_api/oas_validators_gen.go
+++ b/internal/sample_api/oas_validators_gen.go
@@ -16,7 +16,7 @@ func (s AnyOfTest) Validate() error {
 		if err := s.SizeLimit.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sizeLimit",
@@ -44,7 +44,7 @@ func (s AnyOfTestSizeLimit) Validate() error {
 		}).Validate(string(s.String)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -56,7 +56,7 @@ func (s ArrayTest) Validate() error {
 		if s.Required == nil {
 			return errors.New("nil is invalid value")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required",
@@ -69,13 +69,13 @@ func (s ArrayTest) Validate() error {
 				if s.NullableOptional.Value == nil {
 					return errors.New("nil is invalid value")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nullable_optional",
@@ -101,7 +101,7 @@ func (s Data) Validate() error {
 		}).Validate(string(s.Email)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -120,7 +120,7 @@ func (s Data) Validate() error {
 		}).Validate(string(s.Hostname)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "hostname",
@@ -139,7 +139,7 @@ func (s Data) Validate() error {
 		}).Validate(string(s.Format)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "format",
@@ -152,13 +152,13 @@ func (s Data) Validate() error {
 				if err := s.NullableEnum.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "nullable_enum",
@@ -178,13 +178,13 @@ func (s DefaultTest) Validate() error {
 				if err := s.Enum.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "enum",
@@ -205,13 +205,13 @@ func (s DefaultTest) Validate() error {
 				}).Validate(string(s.Email.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "email",
@@ -232,13 +232,13 @@ func (s DefaultTest) Validate() error {
 				}).Validate(string(s.Hostname.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "hostname",
@@ -259,13 +259,13 @@ func (s DefaultTest) Validate() error {
 				}).Validate(string(s.Format.Value)); err != nil {
 					return errors.Wrap(err, "string")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "format",
@@ -301,7 +301,7 @@ func (s Hash) Validate() error {
 		}).Validate(string(s.Hex)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "hex",
@@ -321,13 +321,13 @@ func (s MapWithProperties) Validate() error {
 				if err := s.SubMap.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "sub_map",
@@ -340,13 +340,13 @@ func (s MapWithProperties) Validate() error {
 				if err := s.MapValidation.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "map_validation",
@@ -365,8 +365,8 @@ func (s NullableEnums) Validate() error {
 		if err := s.OnlyNullable.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "only_nullable",
@@ -377,8 +377,8 @@ func (s NullableEnums) Validate() error {
 		if err := s.OnlyNullValue.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "only_null_value",
@@ -389,8 +389,8 @@ func (s NullableEnums) Validate() error {
 		if err := s.Both.Value.Validate(); err != nil {
 			return err
 		}
-		return nil
-		return nil
+		return nil // return 1
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "both",
@@ -440,13 +440,13 @@ func (s OneOfBugs) Validate() error {
 				if err := s.OneOfMinusUUIDMinusIntMinusEnum.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "oneOf-uuid-int-enum",
@@ -466,7 +466,7 @@ func (s OneOfUUIDAndIntEnum) Validate() error {
 		if err := s.OneOfUUIDAndIntEnum1.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -493,11 +493,11 @@ func (s Pet) Validate() error {
 			if err := s.Primary.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			return errors.Wrap(err, "pointer")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "primary",
@@ -517,7 +517,7 @@ func (s Pet) Validate() error {
 		}).Validate(int64(s.ID)); err != nil {
 			return errors.Wrap(err, "int")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "id",
@@ -536,7 +536,7 @@ func (s Pet) Validate() error {
 		}).Validate(string(s.Name)); err != nil {
 			return errors.Wrap(err, "string")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "name",
@@ -549,13 +549,13 @@ func (s Pet) Validate() error {
 				if err := s.Type.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "type",
@@ -566,7 +566,7 @@ func (s Pet) Validate() error {
 		if err := s.Kind.Validate(); err != nil {
 			return err
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "kind",
@@ -588,7 +588,7 @@ func (s Pet) Validate() error {
 				if err := elem.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -599,7 +599,7 @@ func (s Pet) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "friends",
@@ -612,13 +612,13 @@ func (s Pet) Validate() error {
 				if err := s.Next.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "next",
@@ -640,13 +640,13 @@ func (s Pet) Validate() error {
 				}).Validate(int64(s.TestInteger1.Value)); err != nil {
 					return errors.Wrap(err, "int")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testInteger1",
@@ -668,13 +668,13 @@ func (s Pet) Validate() error {
 				}).Validate(float64(s.TestFloat1.Value)); err != nil {
 					return errors.Wrap(err, "float")
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testFloat1",
@@ -710,7 +710,7 @@ func (s Pet) Validate() error {
 						}).Validate(string(elem)); err != nil {
 							return errors.Wrap(err, "string")
 						}
-						return nil
+						return nil // return 1
 					}(); err != nil {
 						failures = append(failures, validate.FieldError{
 							Name:  fmt.Sprintf("[%d]", i),
@@ -721,7 +721,7 @@ func (s Pet) Validate() error {
 				if len(failures) > 0 {
 					return &validate.Error{Fields: failures}
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				failures = append(failures, validate.FieldError{
 					Name:  fmt.Sprintf("[%d]", i),
@@ -732,7 +732,7 @@ func (s Pet) Validate() error {
 		if len(failures) > 0 {
 			return &validate.Error{Fields: failures}
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testArray1",
@@ -745,13 +745,13 @@ func (s Pet) Validate() error {
 				if err := s.TestArray2.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testArray2",
@@ -764,13 +764,13 @@ func (s Pet) Validate() error {
 				if err := s.TestMap.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testMap",
@@ -783,13 +783,13 @@ func (s Pet) Validate() error {
 				if err := s.TestMapWithProps.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testMapWithProps",
@@ -802,13 +802,13 @@ func (s Pet) Validate() error {
 				if err := s.TestAnyOf.Value.Validate(); err != nil {
 					return err
 				}
-				return nil
+				return nil // return 1
 			}(); err != nil {
 				return err
 			}
 		}
-		return nil
-		return nil
+		return nil // return 2
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "testAnyOf",
@@ -842,7 +842,7 @@ func (s PetName) Validate() error {
 	}).Validate(string(s)); err != nil {
 		return errors.Wrap(err, "string")
 	}
-	return nil
+	return nil // return 1
 }
 func (s PetType) Validate() error {
 	switch s {
@@ -864,7 +864,7 @@ func (s RecursiveArray) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  fmt.Sprintf("[%d]", i),
@@ -875,7 +875,7 @@ func (s RecursiveArray) Validate() error {
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
-	return nil
+	return nil // return 1
 }
 func (s StringMap) Validate() error {
 	var failures []validate.FieldError
@@ -892,7 +892,7 @@ func (s StringMap) Validate() error {
 			}).Validate(string(elem)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -913,7 +913,7 @@ func (s StringStringMap) Validate() error {
 			if err := elem.Validate(); err != nil {
 				return err
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,
@@ -942,7 +942,7 @@ func (s TestFloatValidation) Validate() error {
 		}).Validate(float64(s.Minmax)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "minmax",
@@ -962,7 +962,7 @@ func (s TestFloatValidation) Validate() error {
 		}).Validate(float64(s.MultipleOf)); err != nil {
 			return errors.Wrap(err, "float")
 		}
-		return nil
+		return nil // return 1
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "multipleOf",
@@ -989,7 +989,7 @@ func (s ValidationStringMap) Validate() error {
 			}).Validate(string(elem)); err != nil {
 				return errors.Wrap(err, "string")
 			}
-			return nil
+			return nil // return 1
 		}(); err != nil {
 			failures = append(failures, validate.FieldError{
 				Name:  key,

--- a/internal/sample_err/oas_handlers_gen.go
+++ b/internal/sample_err/oas_handlers_gen.go
@@ -36,8 +36,8 @@ func (s *Server) handleDataCreateRequest(args [0]string, w http.ResponseWriter, 
 	request, err := decodeDataCreateRequest(r, span)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
-			"DataCreate",
-			err,
+			Operation: "DataCreate",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/internal/techempower/oas_handlers_gen.go
+++ b/internal/techempower/oas_handlers_gen.go
@@ -34,8 +34,8 @@ func (s *Server) handleCachingRequest(args [0]string, w http.ResponseWriter, r *
 	params, err := decodeCachingParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"Caching",
-			err,
+			Operation: "Caching",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -151,8 +151,8 @@ func (s *Server) handleQueriesRequest(args [0]string, w http.ResponseWriter, r *
 	params, err := decodeQueriesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"Queries",
-			err,
+			Operation: "Queries",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return
@@ -196,8 +196,8 @@ func (s *Server) handleUpdatesRequest(args [0]string, w http.ResponseWriter, r *
 	params, err := decodeUpdatesParams(args, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
-			"Updates",
-			err,
+			Operation: "Updates",
+			Err:       err,
 		}
 		s.badRequest(ctx, w, r, span, otelAttrs, err)
 		return

--- a/internal/techempower/oas_validators_gen.go
+++ b/internal/techempower/oas_validators_gen.go
@@ -10,5 +10,5 @@ func (s WorldObjects) Validate() error {
 	if s == nil {
 		return errors.New("nil is invalid value")
 	}
-	return nil
+	return nil // return 1
 }


### PR DESCRIPTION
This PR fixes issue #328 