### PR TITLE
perf(middleware): reduce chain allocation

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -42,9 +42,10 @@ func ChainMiddlewares(m ...Middleware) Middleware {
 			return next(req)
 		}
 	}
+	tail := ChainMiddlewares(m[1:]...)
 	return func(req Request, next Next) (Response, error) {
 		return m[0](req, func(req Request) (Response, error) {
-			return ChainMiddlewares(m[1:]...)(req, next)
+			return tail(req, next)
 		})
 	}
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -36,19 +36,24 @@ func TestChainMiddlewares(t *testing.T) {
 	)
 	a := require.New(t)
 
-	req := Request{
-		Context: context.Background(),
-		Body:    []string{},
-		Params:  map[string]any{},
+	for i := range [2]struct{}{} {
+		req := Request{
+			Context: context.Background(),
+			Body:    []string{},
+			Params: map[string]any{
+				"call": i,
+			},
+		}
+		resp, err := chain(req, func(req Request) (Response, error) {
+			a.Equal([]string{"first", "second", "third"}, req.Body)
+			a.Equal("bar", req.Params["second"])
+			a.Equal("baz", req.Context.Value(testKey{}))
+			a.Equal(i, req.Params["call"])
+			return Response{Type: "ok"}, nil
+		})
+		a.NoError(err)
+		a.Equal("ok", resp.Type)
 	}
-	resp, err := chain(req, func(req Request) (Response, error) {
-		a.Equal([]string{"first", "second", "third"}, req.Body)
-		a.Equal("bar", req.Params["second"])
-		a.Equal("baz", req.Context.Value(testKey{}))
-		return Response{Type: "ok"}, nil
-	})
-	a.NoError(err)
-	a.Equal("ok", resp.Type)
 }
 
 func BenchmarkChainMiddlewares(b *testing.B) {


### PR DESCRIPTION
Benchstat:
```
name                old time/op    new time/op    delta
ChainMiddlewares-4    2.69µs ± 2%    1.29µs ± 2%  -52.01%  (p=0.000 n=13+15)

name                old alloc/op   new alloc/op   delta
ChainMiddlewares-4    1.57kB ± 0%    0.48kB ± 0%  -69.39%  (p=0.000 n=15+15)

name                old allocs/op  new allocs/op  delta
ChainMiddlewares-4      39.0 ± 0%      20.0 ± 0%  -48.72%  (p=0.000 n=15+15)
```
