### PR TITLE
perf(gen): add mime packages to header

### DIFF
--- a/gen/_template/header.tmpl
+++ b/gen/_template/header.tmpl
@@ -33,6 +33,8 @@ import (
 	"math"
 	"math/big"
 	"math/bits"
+	"mime"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/netip"


### PR DESCRIPTION
Benchstat result of `manga.json` generation:
```
name         old time/op    new time/op    delta
Generator-4     135ms ± 3%      74ms ± 3%  -45.22%  (p=0.000 n=14+15)

name         old alloc/op   new alloc/op   delta
Generator-4    10.1MB ± 0%     9.2MB ± 0%   -9.45%  (p=0.000 n=14+15)

name         old allocs/op  new allocs/op  delta
Generator-4      281k ± 0%      262k ± 0%   -6.55%  (p=0.000 n=15+15)
```