### PR TITLE
perf(gen): run generation in parallel

### DIFF
--- a/gen/gen_schema.go
+++ b/gen/gen_schema.go
@@ -1,7 +1,6 @@
 package gen
 
 import (
-	"bytes"
 	"os"
 	"strings"
 
@@ -132,10 +131,8 @@ func GenerateSchema(schema *jsonschema.Schema, fs FileSystem, opts GenerateSchem
 	}
 
 	w := &writer{
-		fs:    fs,
-		t:     vendoredTemplates(),
-		buf:   new(bytes.Buffer),
-		wrote: map[string]bool{},
+		fs: fs,
+		t:  vendoredTemplates(),
 	}
 	if err := w.Generate("jsonschema", opts.FileName, TemplateConfig{
 		Package: opts.PkgName,


### PR DESCRIPTION
Benchstat:
```
name                        old time/op    new time/op    delta
Generator/api.github.com-4     7.41s ± 1%     4.29s ± 2%  -42.16%  (p=0.000 n=24+22)
Generator/gotd_bot_api-4       1.24s ± 2%     0.86s ± 5%  -30.10%  (p=0.000 n=22+25)
Generator/tinkoff-4            258ms ± 3%     153ms ± 3%  -40.57%  (p=0.000 n=24+24)
Generator/manga-4             77.7ms ± 3%    39.6ms ± 4%  -49.04%  (p=0.000 n=25+24)

name                        old alloc/op   new alloc/op   delta
Generator/api.github.com-4    1.22GB ± 0%    1.24GB ± 0%   +1.72%  (p=0.000 n=24+23)
Generator/gotd_bot_api-4       191MB ± 0%     193MB ± 0%   +0.95%  (p=0.000 n=23+25)
Generator/tinkoff-4           35.3MB ± 0%    36.5MB ± 4%   +3.24%  (p=0.000 n=25+25)
Generator/manga-4             9.19MB ± 0%    9.45MB ± 3%   +2.81%  (p=0.000 n=24+25)

name                        old allocs/op  new allocs/op  delta
Generator/api.github.com-4     32.0M ± 0%     32.0M ± 0%     ~     (p=0.283 n=24+23)
Generator/gotd_bot_api-4       5.32M ± 0%     5.32M ± 0%     ~     (p=0.051 n=23+23)
Generator/tinkoff-4            1.01M ± 0%     1.01M ± 0%   +0.00%  (p=0.000 n=25+25)
Generator/manga-4               263k ± 0%      263k ± 0%   +0.00%  (p=0.000 n=25+25)
```