### PR TITLE
fix(gen): avoid faulty warnings for `number` and `integer` types

### DIFF
--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -314,7 +314,16 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 			}
 			if t.Validators.Int.Set() {
 				switch t.Primitive {
-				case ir.String, ir.ByteSlice:
+				case ir.Int,
+					ir.Int8,
+					ir.Int16,
+					ir.Int32,
+					ir.Int64,
+					ir.Uint,
+					ir.Uint8,
+					ir.Uint16,
+					ir.Uint32,
+					ir.Uint64:
 				default:
 					g.log.Warn("Int validator cannot be applied to generated type and will be ignored", fields...)
 				}
@@ -325,7 +334,7 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 			}
 			if t.Validators.Float.Set() {
 				switch t.Primitive {
-				case ir.String, ir.ByteSlice:
+				case ir.Float32, ir.Float64:
 				default:
 					g.log.Warn("Float validator cannot be applied to generated type and will be ignored", fields...)
 				}


### PR DESCRIPTION
This PR fixes faulty generator warnings when generating the code for `number` and `integer` types declared in the input YAML.

The example of input YAML: 
```yaml

  ... 
            ratio:
                description: The ratio of something.
                type: number
                minimum: 0
                maximum: 1
            total:
                description: The total of something.
                type: integer
                minimum: 0
   ...
```

results in the following warnings:
```
WARN	schemagen	Float validator cannot be applied to generated type and will be ignored	{"at": "file:///somefile.yml:xx:xx", "type": "number", "format": "", "go_type": "float64"}
WARN	schemagen	Int validator cannot be applied to generated type and will be ignored	{"at": "file:///somefile.yaml:xx:xx", "type": "integer", "format": "", "go_type": "int"}
```