### PR TITLE
fix(gen): allow xml property for arrays and objects

### DIFF
--- a/jsonschema/parser.go
+++ b/jsonschema/parser.go
@@ -309,12 +309,14 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 				"patternProperties": {},
 				"minProperties":     {},
 				"maxProperties":     {},
+				"xml":               {},
 			},
 			"array": {
 				"items":       {},
 				"maxItems":    {},
 				"minItems":    {},
 				"uniqueItems": {},
+				"xml":         {},
 			},
 			"string": {
 				"maxLength": {},


### PR DESCRIPTION
This appears to be an openapi extension to jsonschema, but without this the parsing fails unnecessarily.
 https://swagger.io/docs/specification/data-models/representing-xml/