### PR TITLE
fix(gen): generate files with read permissions for all users

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,9 @@
 linters-settings:
+  gosec:
+    config:
+      # Maximum allowed permissions mode file creation
+      # Default: "0600"
+      G306: "0644"
   gocyclo:
     min-complexity: 15
   maligned:

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -58,7 +58,7 @@ func expandSpec(api *openapi.API, p string) (err error) {
 		return errors.Wrap(err, "marshal")
 	}
 
-	if err := os.WriteFile(p, data, 0o600); err != nil {
+	if err := os.WriteFile(p, data, 0o644); err != nil {
 		return errors.Wrap(err, "write")
 	}
 

--- a/gen/genfs/genfs.go
+++ b/gen/genfs/genfs.go
@@ -23,5 +23,5 @@ func (t FormattedSource) WriteFile(name string, content []byte) error {
 		}
 		out = buf
 	}
-	return os.WriteFile(filepath.Join(t.Root, name), out, 0600)
+	return os.WriteFile(filepath.Join(t.Root, name), out, 0644)
 }

--- a/gen/write.go
+++ b/gen/write.go
@@ -199,7 +199,7 @@ func (w *writer) Generate(templateName, fileName string, cfg TemplateConfig) (re
 	generated := buf.Bytes()
 	defer func() {
 		if rerr != nil {
-			_ = os.WriteFile(fileName+".dump", generated, 0o600)
+			_ = os.WriteFile(fileName+".dump", generated, 0o644)
 		}
 	}()
 

--- a/tools/mkformattest/main.go
+++ b/tools/mkformattest/main.go
@@ -249,7 +249,7 @@ func run() error {
 		return errors.Wrap(err, "marshal spec")
 	}
 
-	return os.WriteFile(*output, data, 0o600)
+	return os.WriteFile(*output, data, 0o644)
 }
 
 func main() {


### PR DESCRIPTION
This commit updates the file permissions in the various `os.WriteFile` calls from `600` -> `644`, as there isn't a good reason to make the files readable only to the user who generates them. This change requires updating the G306 rule in the gosec linter, which seems to be restrictive as a way to prevent leaking secrets in files that are created by Go code. As the code being generated won't contain secrets (by design), this isn't an issue and it should be safe to allow all users to read the generated files by default.

Note that this change will not alter the generated code in any way. It only affects the permissions on the files containing the generated code.