### PR TITLE
Fix logic for decoding valueless query parameter into an array

### DIFF
--- a/uri/query_param_decoder.go
+++ b/uri/query_param_decoder.go
@@ -59,6 +59,11 @@ func (d *queryParamDecoder) DecodeArray(f func(d Decoder) error) error {
 			return errors.New("invalid value")
 		}
 
+		// do not decode `?param=` as `[""]` and leave the parameter as whatever zero value it has
+		if values[0] == "" {
+			return nil
+		}
+
 		for _, item := range strings.Split(values[0], ",") {
 			if err := f(&constval{item}); err != nil {
 				return err

--- a/uri/query_param_decoder_test.go
+++ b/uri/query_param_decoder_test.go
@@ -72,6 +72,20 @@ func TestQueryParamDecoder(t *testing.T) {
 			},
 			{
 				Param:   "id",
+				Input:   "id=",
+				Expect:  []string{""},
+				Style:   QueryStyleForm,
+				Explode: true,
+			},
+			{
+				Param:   "id",
+				Input:   "id=",
+				Expect:  []string(nil),
+				Style:   QueryStyleForm,
+				Explode: false,
+			},
+			{
+				Param:   "id",
 				Input:   "id=3&id=4&id=5",
 				Expect:  []string{"3", "4", "5"},
 				Style:   QueryStyleSpaceDelimited,

--- a/uri/query_param_encoder_test.go
+++ b/uri/query_param_encoder_test.go
@@ -71,6 +71,20 @@ func TestQueryParamEncoder(t *testing.T) {
 			},
 			{
 				Param:   "id",
+				Input:   []string{},
+				Expect:  "",
+				Style:   QueryStyleForm,
+				Explode: true,
+			},
+			{
+				Param:   "id",
+				Input:   []string{},
+				Expect:  "id=",
+				Style:   QueryStyleForm,
+				Explode: false,
+			},
+			{
+				Param:   "id",
 				Input:   []string{"3", "4", "5"},
 				Expect:  "id=3&id=4&id=5",
 				Style:   QueryStyleSpaceDelimited,


### PR DESCRIPTION
Given the schema below,

```yaml
/resource:
  get:
  parameters:
    - name: my_enums
      in: query
      required: true
      type: array
      items:
        type: string
        enum:
          - a
          - b
```

hitting the generated ogen server API using the generated ogen client with an empty array raises validation error, because the client encodes `[]MyEnums{}` into `/resource?my_eums=` then the server tries to enum-validate against the net/url decoded value `[]string{""}`.

This PR attempts to fix this by making array decoder not call the child decoder for `[]string{""}`.

Seems to me like the spec doesn't clearly state about this empty array case:
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#style-examples

found a stackoverflow question without answer:
https://stackoverflow.com/questions/74589019/openapi-empty-array-object-query-parameter-serializing

Unless I'm missing something, the framework needs decide what to do with valueless array parameter.

<img width="424" alt="image" src="https://github.com/ogen-go/ogen/assets/1630378/e49e901d-94b1-42b0-9596-1ddc4497ec27">
