### PR TITLE
fix(gen): remove unreachable code

### DIFF
--- a/examples/ex_firecracker/oas_json_gen.go
+++ b/examples/ex_firecracker/oas_json_gen.go
@@ -2168,7 +2168,6 @@ func (s *MmdsGetOK) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode MmdsGetOK")
 	}
@@ -2213,7 +2212,6 @@ func (s *MmdsPatchReq) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode MmdsPatchReq")
 	}
@@ -2258,7 +2256,6 @@ func (s *MmdsPutReq) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode MmdsPutReq")
 	}

--- a/examples/ex_github/oas_json_gen.go
+++ b/examples/ex_github/oas_json_gen.go
@@ -537,7 +537,6 @@ func (s *Accepted) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Accepted")
 	}
@@ -900,7 +899,6 @@ func (s *ActionsCancelWorkflowRunAccepted) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ActionsCancelWorkflowRunAccepted")
 	}
@@ -1258,7 +1256,6 @@ func (s *ActionsCreateOrUpdateRepoSecretCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ActionsCreateOrUpdateRepoSecretCreated")
 	}
@@ -3955,7 +3952,6 @@ func (s *ActionsReRunWorkflowCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ActionsReRunWorkflowCreated")
 	}
@@ -4128,7 +4124,6 @@ func (s *ActionsRetryWorkflowCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ActionsRetryWorkflowCreated")
 	}
@@ -10510,7 +10505,6 @@ func (s *AppsCreateFromManifestReq) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode AppsCreateFromManifestReq")
 	}
@@ -13798,7 +13792,6 @@ func (s *AuthenticationTokenPermissions) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode AuthenticationTokenPermissions")
 	}
@@ -20921,7 +20914,6 @@ func (s *ChecksRerequestSuiteCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ChecksRerequestSuiteCreated")
 	}
@@ -33527,7 +33519,6 @@ func (s *EmptyObject) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode EmptyObject")
 	}
@@ -36769,7 +36760,6 @@ func (s *EnterpriseAdminUpdateAttributeForEnterpriseGroupReqOperationsItemValue1
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode EnterpriseAdminUpdateAttributeForEnterpriseGroupReqOperationsItemValue1")
 	}
@@ -36949,7 +36939,6 @@ func (s *EnterpriseAdminUpdateAttributeForEnterpriseUserReqOperationsItem) Decod
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode EnterpriseAdminUpdateAttributeForEnterpriseUserReqOperationsItem")
 	}
@@ -44094,7 +44083,6 @@ func (s *GistsCheckIsStarredNotFound) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode GistsCheckIsStarredNotFound")
 	}
@@ -96107,7 +96095,6 @@ func (s *OrgsConvertMemberToOutsideCollaboratorAccepted) Decode(d *jx.Decoder) e
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OrgsConvertMemberToOutsideCollaboratorAccepted")
 	}
@@ -108209,7 +108196,6 @@ func (s *ProjectsMoveCardCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ProjectsMoveCardCreated")
 	}
@@ -108794,7 +108780,6 @@ func (s *ProjectsMoveColumnCreated) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ProjectsMoveColumnCreated")
 	}

--- a/examples/ex_gotd/oas_json_gen.go
+++ b/examples/ex_gotd/oas_json_gen.go
@@ -2106,7 +2106,6 @@ func (s *BotCommandScopeAllChatAdministrators) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllChatAdministrators")
 	}
@@ -2153,7 +2152,6 @@ func (s *BotCommandScopeAllGroupChats) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllGroupChats")
 	}
@@ -2200,7 +2198,6 @@ func (s *BotCommandScopeAllPrivateChats) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllPrivateChats")
 	}
@@ -2552,7 +2549,6 @@ func (s *BotCommandScopeDefault) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeDefault")
 	}
@@ -2597,7 +2593,6 @@ func (s *CallbackGame) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CallbackGame")
 	}
@@ -21576,7 +21571,6 @@ func (s *MenuButtonCommands) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode MenuButtonCommands")
 	}
@@ -21623,7 +21617,6 @@ func (s *MenuButtonDefault) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode MenuButtonDefault")
 	}
@@ -42592,7 +42585,6 @@ func (s *VideoChatStarted) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode VideoChatStarted")
 	}

--- a/examples/ex_k8s/oas_json_gen.go
+++ b/examples/ex_k8s/oas_json_gen.go
@@ -2235,7 +2235,6 @@ func (s *IoK8sAPIApiserverinternalV1alpha1StorageVersionSpec) Decode(d *jx.Decod
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sAPIApiserverinternalV1alpha1StorageVersionSpec")
 	}
@@ -70484,7 +70483,6 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceSubresou
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceSubresourceStatus")
 	}
@@ -70754,7 +70752,6 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSON) Decode(d *jx.Dec
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSON")
 	}
@@ -71766,7 +71763,6 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrArray
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrArray")
 	}
@@ -71811,7 +71807,6 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrBool)
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrBool")
 	}
@@ -71856,7 +71851,6 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrStrin
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApiextensionsApiserverPkgApisApiextensionsV1JSONSchemaPropsOrStringArray")
 	}
@@ -73552,7 +73546,6 @@ func (s *IoK8sApimachineryPkgApisMetaV1FieldsV1) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApimachineryPkgApisMetaV1FieldsV1")
 	}
@@ -75231,7 +75224,6 @@ func (s *IoK8sApimachineryPkgRuntimeRawExtension) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode IoK8sApimachineryPkgRuntimeRawExtension")
 	}

--- a/examples/ex_openai/oas_json_gen.go
+++ b/examples/ex_openai/oas_json_gen.go
@@ -771,7 +771,6 @@ func (s *CreateAnswerRequestLogitBias) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateAnswerRequestLogitBias")
 	}
@@ -1425,7 +1424,6 @@ func (s *CreateChatCompletionRequestLogitBias) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateChatCompletionRequestLogitBias")
 	}
@@ -2269,7 +2267,6 @@ func (s *CreateClassificationRequestLogitBias) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateClassificationRequestLogitBias")
 	}
@@ -2923,7 +2920,6 @@ func (s *CreateCompletionRequestLogitBias) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateCompletionRequestLogitBias")
 	}
@@ -3569,7 +3565,6 @@ func (s *CreateCompletionResponseChoicesItemLogprobsTopLogprobsItem) Decode(d *j
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateCompletionResponseChoicesItemLogprobsTopLogprobsItem")
 	}
@@ -4359,7 +4354,6 @@ func (s *CreateEditResponseChoicesItemLogprobsTopLogprobsItem) Decode(d *jx.Deco
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateEditResponseChoicesItemLogprobsTopLogprobsItem")
 	}

--- a/examples/ex_openapi/output.gen.go
+++ b/examples/ex_openapi/output.gen.go
@@ -6035,7 +6035,6 @@ func (s *Callback) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Callback")
 	}
@@ -13088,7 +13087,6 @@ func (s *Paths) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Paths")
 	}

--- a/examples/ex_telegram/oas_json_gen.go
+++ b/examples/ex_telegram/oas_json_gen.go
@@ -1979,7 +1979,6 @@ func (s *BotCommandScopeAllChatAdministrators) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllChatAdministrators")
 	}
@@ -2026,7 +2025,6 @@ func (s *BotCommandScopeAllGroupChats) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllGroupChats")
 	}
@@ -2073,7 +2071,6 @@ func (s *BotCommandScopeAllPrivateChats) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeAllPrivateChats")
 	}
@@ -2425,7 +2422,6 @@ func (s *BotCommandScopeDefault) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode BotCommandScopeDefault")
 	}
@@ -2470,7 +2466,6 @@ func (s *CallbackGame) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CallbackGame")
 	}
@@ -42815,7 +42810,6 @@ func (s *VoiceChatStarted) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode VoiceChatStarted")
 	}

--- a/examples/ex_test_format/oas_json_gen.go
+++ b/examples/ex_test_format/oas_json_gen.go
@@ -4594,7 +4594,6 @@ func (s *TestRequestEmptyStructReq) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode TestRequestEmptyStructReq")
 	}
@@ -14619,7 +14618,6 @@ func (s *TestRequestRequiredEmptyStructReq) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode TestRequestRequiredEmptyStructReq")
 	}
@@ -24644,7 +24642,6 @@ func (s *TestResponseEmptyStructOK) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode TestResponseEmptyStructOK")
 	}

--- a/examples/ex_tinkoff/oas_json_gen.go
+++ b/examples/ex_tinkoff/oas_json_gen.go
@@ -1032,7 +1032,6 @@ func (s *EmptyPayload) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode EmptyPayload")
 	}

--- a/gen/_template/json/encoders_struct.tmpl
+++ b/gen/_template/json/encoders_struct.tmpl
@@ -177,7 +177,9 @@ func (s *{{ $.Name }}) Decode(d *jx.Decoder) error {
 			return d.Skip()
 			{{- end }}
 		}
+		{{- if or (ne (len $fields) 0) $additional }}
 		return nil
+		{{- end }}
 	}); err != nil {
 		return errors.Wrap(err, {{ printf "decode %s" $.Name | quote }})
 	}

--- a/internal/integration/sample_api/oas_json_gen.go
+++ b/internal/integration/sample_api/oas_json_gen.go
@@ -2210,7 +2210,6 @@ func (s *Issue943Map) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Issue943Map")
 	}
@@ -4044,7 +4043,6 @@ func (s *OneOfMappingReferenceBData) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OneOfMappingReferenceBData")
 	}
@@ -4769,7 +4767,6 @@ func (s *OnlyEmptyObject) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OnlyEmptyObject")
 	}

--- a/internal/integration/sample_api_nc/oas_json_gen.go
+++ b/internal/integration/sample_api_nc/oas_json_gen.go
@@ -2210,7 +2210,6 @@ func (s *Issue943Map) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Issue943Map")
 	}
@@ -4044,7 +4043,6 @@ func (s *OneOfMappingReferenceBData) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OneOfMappingReferenceBData")
 	}
@@ -4769,7 +4767,6 @@ func (s *OnlyEmptyObject) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OnlyEmptyObject")
 	}

--- a/internal/integration/sample_api_ns/oas_json_gen.go
+++ b/internal/integration/sample_api_ns/oas_json_gen.go
@@ -2210,7 +2210,6 @@ func (s *Issue943Map) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Issue943Map")
 	}
@@ -4044,7 +4043,6 @@ func (s *OneOfMappingReferenceBData) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OneOfMappingReferenceBData")
 	}
@@ -4769,7 +4767,6 @@ func (s *OnlyEmptyObject) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OnlyEmptyObject")
 	}

--- a/internal/integration/sample_api_nsnc/oas_json_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_json_gen.go
@@ -2210,7 +2210,6 @@ func (s *Issue943Map) Decode(d *jx.Decoder) error {
 			}
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode Issue943Map")
 	}
@@ -4044,7 +4043,6 @@ func (s *OneOfMappingReferenceBData) Decode(d *jx.Decoder) error {
 		default:
 			return d.Skip()
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OneOfMappingReferenceBData")
 	}
@@ -4769,7 +4767,6 @@ func (s *OnlyEmptyObject) Decode(d *jx.Decoder) error {
 		default:
 			return errors.Errorf("unexpected field %q", k)
 		}
-		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode OnlyEmptyObject")
 	}


### PR DESCRIPTION
Fixes #955 
With this change, the following complaint when running `go vet` will be resolved.
```
# github.com/ogen-go/ogen/internal/integration/sample_api_nsnc                                     <
internal/integration/sample_api_nsnc/oas_json_gen.go:2213:3: unreachable code                      <
internal/integration/sample_api_nsnc/oas_json_gen.go:4047:3: unreachable code                      <
internal/integration/sample_api_nsnc/oas_json_gen.go:4772:3: unreachable code                      <
# github.com/ogen-go/ogen/internal/integration/sample_api_nc                                       <
internal/integration/sample_api_nc/oas_json_gen.go:2213:3: unreachable code                        <
internal/integration/sample_api_nc/oas_json_gen.go:4047:3: unreachable code                        <
internal/integration/sample_api_nc/oas_json_gen.go:4772:3: unreachable code                        <
# github.com/ogen-go/ogen/internal/integration/sample_api_ns                                       <
internal/integration/sample_api_ns/oas_json_gen.go:2213:3: unreachable code                        <
internal/integration/sample_api_ns/oas_json_gen.go:4047:3: unreachable code                        <
internal/integration/sample_api_ns/oas_json_gen.go:4772:3: unreachable code                        <
# github.com/ogen-go/ogen/internal/integration/sample_api                                          <
internal/integration/sample_api/oas_json_gen.go:2213:3: unreachable code                           <
internal/integration/sample_api/oas_json_gen.go:4047:3: unreachable code                           <
internal/integration/sample_api/oas_json_gen.go:4772:3: unreachable code                           <
```