### PR TITLE
fix(gen): use mapping key for discriminator const

### DIFF
--- a/examples/ex_gotd/oas_schemas_gen.go
+++ b/examples/ex_gotd/oas_schemas_gen.go
@@ -792,13 +792,13 @@ type BotCommandScopeType string
 
 // Possible values for BotCommandScopeType.
 const (
-	BotCommandScopeDefaultBotCommandScope               BotCommandScopeType = "BotCommandScopeDefault"
-	BotCommandScopeAllPrivateChatsBotCommandScope       BotCommandScopeType = "BotCommandScopeAllPrivateChats"
-	BotCommandScopeAllGroupChatsBotCommandScope         BotCommandScopeType = "BotCommandScopeAllGroupChats"
-	BotCommandScopeAllChatAdministratorsBotCommandScope BotCommandScopeType = "BotCommandScopeAllChatAdministrators"
-	BotCommandScopeChatBotCommandScope                  BotCommandScopeType = "BotCommandScopeChat"
-	BotCommandScopeChatAdministratorsBotCommandScope    BotCommandScopeType = "BotCommandScopeChatAdministrators"
-	BotCommandScopeChatMemberBotCommandScope            BotCommandScopeType = "BotCommandScopeChatMember"
+	BotCommandScopeDefaultBotCommandScope               BotCommandScopeType = "default"
+	BotCommandScopeAllPrivateChatsBotCommandScope       BotCommandScopeType = "all_private_chats"
+	BotCommandScopeAllGroupChatsBotCommandScope         BotCommandScopeType = "all_group_chats"
+	BotCommandScopeAllChatAdministratorsBotCommandScope BotCommandScopeType = "all_chat_administrators"
+	BotCommandScopeChatBotCommandScope                  BotCommandScopeType = "chat"
+	BotCommandScopeChatAdministratorsBotCommandScope    BotCommandScopeType = "chat_administrators"
+	BotCommandScopeChatMemberBotCommandScope            BotCommandScopeType = "chat_member"
 )
 
 // IsBotCommandScopeDefault reports whether BotCommandScope is BotCommandScopeDefault.
@@ -5267,21 +5267,21 @@ const (
 	InlineQueryResultCachedGifInlineQueryResult      InlineQueryResultType = "InlineQueryResultCachedGif"
 	InlineQueryResultCachedMpeg4GifInlineQueryResult InlineQueryResultType = "InlineQueryResultCachedMpeg4Gif"
 	InlineQueryResultCachedPhotoInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedPhoto"
-	InlineQueryResultCachedStickerInlineQueryResult  InlineQueryResultType = "InlineQueryResultCachedSticker"
+	InlineQueryResultCachedStickerInlineQueryResult  InlineQueryResultType = "sticker"
 	InlineQueryResultCachedVideoInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedVideo"
 	InlineQueryResultCachedVoiceInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedVoice"
-	InlineQueryResultArticleInlineQueryResult        InlineQueryResultType = "InlineQueryResultArticle"
-	InlineQueryResultAudioInlineQueryResult          InlineQueryResultType = "InlineQueryResultAudio"
-	InlineQueryResultContactInlineQueryResult        InlineQueryResultType = "InlineQueryResultContact"
-	InlineQueryResultGameInlineQueryResult           InlineQueryResultType = "InlineQueryResultGame"
-	InlineQueryResultDocumentInlineQueryResult       InlineQueryResultType = "InlineQueryResultDocument"
-	InlineQueryResultGifInlineQueryResult            InlineQueryResultType = "InlineQueryResultGif"
-	InlineQueryResultLocationInlineQueryResult       InlineQueryResultType = "InlineQueryResultLocation"
-	InlineQueryResultMpeg4GifInlineQueryResult       InlineQueryResultType = "InlineQueryResultMpeg4Gif"
-	InlineQueryResultPhotoInlineQueryResult          InlineQueryResultType = "InlineQueryResultPhoto"
-	InlineQueryResultVenueInlineQueryResult          InlineQueryResultType = "InlineQueryResultVenue"
-	InlineQueryResultVideoInlineQueryResult          InlineQueryResultType = "InlineQueryResultVideo"
-	InlineQueryResultVoiceInlineQueryResult          InlineQueryResultType = "InlineQueryResultVoice"
+	InlineQueryResultArticleInlineQueryResult        InlineQueryResultType = "article"
+	InlineQueryResultAudioInlineQueryResult          InlineQueryResultType = "audio"
+	InlineQueryResultContactInlineQueryResult        InlineQueryResultType = "contact"
+	InlineQueryResultGameInlineQueryResult           InlineQueryResultType = "game"
+	InlineQueryResultDocumentInlineQueryResult       InlineQueryResultType = "document"
+	InlineQueryResultGifInlineQueryResult            InlineQueryResultType = "gif"
+	InlineQueryResultLocationInlineQueryResult       InlineQueryResultType = "location"
+	InlineQueryResultMpeg4GifInlineQueryResult       InlineQueryResultType = "mpeg4_gif"
+	InlineQueryResultPhotoInlineQueryResult          InlineQueryResultType = "photo"
+	InlineQueryResultVenueInlineQueryResult          InlineQueryResultType = "venue"
+	InlineQueryResultVideoInlineQueryResult          InlineQueryResultType = "video"
+	InlineQueryResultVoiceInlineQueryResult          InlineQueryResultType = "voice"
 )
 
 // IsInlineQueryResultCachedAudio reports whether InlineQueryResult is InlineQueryResultCachedAudio.
@@ -8745,11 +8745,11 @@ type InputMediaType string
 
 // Possible values for InputMediaType.
 const (
-	InputMediaAnimationInputMedia InputMediaType = "InputMediaAnimation"
-	InputMediaDocumentInputMedia  InputMediaType = "InputMediaDocument"
-	InputMediaAudioInputMedia     InputMediaType = "InputMediaAudio"
-	InputMediaPhotoInputMedia     InputMediaType = "InputMediaPhoto"
-	InputMediaVideoInputMedia     InputMediaType = "InputMediaVideo"
+	InputMediaAnimationInputMedia InputMediaType = "animation"
+	InputMediaDocumentInputMedia  InputMediaType = "document"
+	InputMediaAudioInputMedia     InputMediaType = "audio"
+	InputMediaPhotoInputMedia     InputMediaType = "photo"
+	InputMediaVideoInputMedia     InputMediaType = "video"
 )
 
 // IsInputMediaAnimation reports whether InputMedia is InputMediaAnimation.
@@ -10145,9 +10145,9 @@ type MenuButtonType string
 
 // Possible values for MenuButtonType.
 const (
-	MenuButtonCommandsMenuButton MenuButtonType = "MenuButtonCommands"
-	MenuButtonWebAppMenuButton   MenuButtonType = "MenuButtonWebApp"
-	MenuButtonDefaultMenuButton  MenuButtonType = "MenuButtonDefault"
+	MenuButtonCommandsMenuButton MenuButtonType = "commands"
+	MenuButtonWebAppMenuButton   MenuButtonType = "web_app"
+	MenuButtonDefaultMenuButton  MenuButtonType = "default"
 )
 
 // IsMenuButtonCommands reports whether MenuButton is MenuButtonCommands.
@@ -14735,15 +14735,15 @@ type PassportElementErrorType string
 
 // Possible values for PassportElementErrorType.
 const (
-	PassportElementErrorDataFieldPassportElementError        PassportElementErrorType = "PassportElementErrorDataField"
-	PassportElementErrorFrontSidePassportElementError        PassportElementErrorType = "PassportElementErrorFrontSide"
-	PassportElementErrorReverseSidePassportElementError      PassportElementErrorType = "PassportElementErrorReverseSide"
-	PassportElementErrorSelfiePassportElementError           PassportElementErrorType = "PassportElementErrorSelfie"
-	PassportElementErrorFilePassportElementError             PassportElementErrorType = "PassportElementErrorFile"
-	PassportElementErrorFilesPassportElementError            PassportElementErrorType = "PassportElementErrorFiles"
-	PassportElementErrorTranslationFilePassportElementError  PassportElementErrorType = "PassportElementErrorTranslationFile"
-	PassportElementErrorTranslationFilesPassportElementError PassportElementErrorType = "PassportElementErrorTranslationFiles"
-	PassportElementErrorUnspecifiedPassportElementError      PassportElementErrorType = "PassportElementErrorUnspecified"
+	PassportElementErrorDataFieldPassportElementError        PassportElementErrorType = "data"
+	PassportElementErrorFrontSidePassportElementError        PassportElementErrorType = "front_side"
+	PassportElementErrorReverseSidePassportElementError      PassportElementErrorType = "reverse_side"
+	PassportElementErrorSelfiePassportElementError           PassportElementErrorType = "selfie"
+	PassportElementErrorFilePassportElementError             PassportElementErrorType = "file"
+	PassportElementErrorFilesPassportElementError            PassportElementErrorType = "files"
+	PassportElementErrorTranslationFilePassportElementError  PassportElementErrorType = "translation_file"
+	PassportElementErrorTranslationFilesPassportElementError PassportElementErrorType = "translation_files"
+	PassportElementErrorUnspecifiedPassportElementError      PassportElementErrorType = "unspecified"
 )
 
 // IsPassportElementErrorDataField reports whether PassportElementError is PassportElementErrorDataField.
@@ -18784,10 +18784,10 @@ type SendMediaGroupMediaItemType string
 
 // Possible values for SendMediaGroupMediaItemType.
 const (
-	InputMediaAudioSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaAudio"
-	InputMediaDocumentSendMediaGroupMediaItem SendMediaGroupMediaItemType = "InputMediaDocument"
-	InputMediaPhotoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaPhoto"
-	InputMediaVideoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaVideo"
+	InputMediaAudioSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "audio"
+	InputMediaDocumentSendMediaGroupMediaItem SendMediaGroupMediaItemType = "document"
+	InputMediaPhotoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "photo"
+	InputMediaVideoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "video"
 )
 
 // IsInputMediaAudio reports whether SendMediaGroupMediaItem is InputMediaAudio.

--- a/examples/ex_telegram/oas_schemas_gen.go
+++ b/examples/ex_telegram/oas_schemas_gen.go
@@ -752,13 +752,13 @@ type BotCommandScopeType string
 
 // Possible values for BotCommandScopeType.
 const (
-	BotCommandScopeDefaultBotCommandScope               BotCommandScopeType = "BotCommandScopeDefault"
-	BotCommandScopeAllPrivateChatsBotCommandScope       BotCommandScopeType = "BotCommandScopeAllPrivateChats"
-	BotCommandScopeAllGroupChatsBotCommandScope         BotCommandScopeType = "BotCommandScopeAllGroupChats"
-	BotCommandScopeAllChatAdministratorsBotCommandScope BotCommandScopeType = "BotCommandScopeAllChatAdministrators"
-	BotCommandScopeChatBotCommandScope                  BotCommandScopeType = "BotCommandScopeChat"
-	BotCommandScopeChatAdministratorsBotCommandScope    BotCommandScopeType = "BotCommandScopeChatAdministrators"
-	BotCommandScopeChatMemberBotCommandScope            BotCommandScopeType = "BotCommandScopeChatMember"
+	BotCommandScopeDefaultBotCommandScope               BotCommandScopeType = "default"
+	BotCommandScopeAllPrivateChatsBotCommandScope       BotCommandScopeType = "all_private_chats"
+	BotCommandScopeAllGroupChatsBotCommandScope         BotCommandScopeType = "all_group_chats"
+	BotCommandScopeAllChatAdministratorsBotCommandScope BotCommandScopeType = "all_chat_administrators"
+	BotCommandScopeChatBotCommandScope                  BotCommandScopeType = "chat"
+	BotCommandScopeChatAdministratorsBotCommandScope    BotCommandScopeType = "chat_administrators"
+	BotCommandScopeChatMemberBotCommandScope            BotCommandScopeType = "chat_member"
 )
 
 // IsBotCommandScopeDefault reports whether BotCommandScope is BotCommandScopeDefault.
@@ -5124,21 +5124,21 @@ const (
 	InlineQueryResultCachedGifInlineQueryResult      InlineQueryResultType = "InlineQueryResultCachedGif"
 	InlineQueryResultCachedMpeg4GifInlineQueryResult InlineQueryResultType = "InlineQueryResultCachedMpeg4Gif"
 	InlineQueryResultCachedPhotoInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedPhoto"
-	InlineQueryResultCachedStickerInlineQueryResult  InlineQueryResultType = "InlineQueryResultCachedSticker"
+	InlineQueryResultCachedStickerInlineQueryResult  InlineQueryResultType = "sticker"
 	InlineQueryResultCachedVideoInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedVideo"
 	InlineQueryResultCachedVoiceInlineQueryResult    InlineQueryResultType = "InlineQueryResultCachedVoice"
-	InlineQueryResultArticleInlineQueryResult        InlineQueryResultType = "InlineQueryResultArticle"
-	InlineQueryResultAudioInlineQueryResult          InlineQueryResultType = "InlineQueryResultAudio"
-	InlineQueryResultContactInlineQueryResult        InlineQueryResultType = "InlineQueryResultContact"
-	InlineQueryResultGameInlineQueryResult           InlineQueryResultType = "InlineQueryResultGame"
-	InlineQueryResultDocumentInlineQueryResult       InlineQueryResultType = "InlineQueryResultDocument"
-	InlineQueryResultGifInlineQueryResult            InlineQueryResultType = "InlineQueryResultGif"
-	InlineQueryResultLocationInlineQueryResult       InlineQueryResultType = "InlineQueryResultLocation"
-	InlineQueryResultMpeg4GifInlineQueryResult       InlineQueryResultType = "InlineQueryResultMpeg4Gif"
-	InlineQueryResultPhotoInlineQueryResult          InlineQueryResultType = "InlineQueryResultPhoto"
-	InlineQueryResultVenueInlineQueryResult          InlineQueryResultType = "InlineQueryResultVenue"
-	InlineQueryResultVideoInlineQueryResult          InlineQueryResultType = "InlineQueryResultVideo"
-	InlineQueryResultVoiceInlineQueryResult          InlineQueryResultType = "InlineQueryResultVoice"
+	InlineQueryResultArticleInlineQueryResult        InlineQueryResultType = "article"
+	InlineQueryResultAudioInlineQueryResult          InlineQueryResultType = "audio"
+	InlineQueryResultContactInlineQueryResult        InlineQueryResultType = "contact"
+	InlineQueryResultGameInlineQueryResult           InlineQueryResultType = "game"
+	InlineQueryResultDocumentInlineQueryResult       InlineQueryResultType = "document"
+	InlineQueryResultGifInlineQueryResult            InlineQueryResultType = "gif"
+	InlineQueryResultLocationInlineQueryResult       InlineQueryResultType = "location"
+	InlineQueryResultMpeg4GifInlineQueryResult       InlineQueryResultType = "mpeg4_gif"
+	InlineQueryResultPhotoInlineQueryResult          InlineQueryResultType = "photo"
+	InlineQueryResultVenueInlineQueryResult          InlineQueryResultType = "venue"
+	InlineQueryResultVideoInlineQueryResult          InlineQueryResultType = "video"
+	InlineQueryResultVoiceInlineQueryResult          InlineQueryResultType = "voice"
 )
 
 // IsInlineQueryResultCachedAudio reports whether InlineQueryResult is InlineQueryResultCachedAudio.
@@ -8602,11 +8602,11 @@ type InputMediaType string
 
 // Possible values for InputMediaType.
 const (
-	InputMediaAnimationInputMedia InputMediaType = "InputMediaAnimation"
-	InputMediaDocumentInputMedia  InputMediaType = "InputMediaDocument"
-	InputMediaAudioInputMedia     InputMediaType = "InputMediaAudio"
-	InputMediaPhotoInputMedia     InputMediaType = "InputMediaPhoto"
-	InputMediaVideoInputMedia     InputMediaType = "InputMediaVideo"
+	InputMediaAnimationInputMedia InputMediaType = "animation"
+	InputMediaDocumentInputMedia  InputMediaType = "document"
+	InputMediaAudioInputMedia     InputMediaType = "audio"
+	InputMediaPhotoInputMedia     InputMediaType = "photo"
+	InputMediaVideoInputMedia     InputMediaType = "video"
 )
 
 // IsInputMediaAnimation reports whether InputMedia is InputMediaAnimation.
@@ -14632,15 +14632,15 @@ type PassportElementErrorType string
 
 // Possible values for PassportElementErrorType.
 const (
-	PassportElementErrorDataFieldPassportElementError        PassportElementErrorType = "PassportElementErrorDataField"
-	PassportElementErrorFrontSidePassportElementError        PassportElementErrorType = "PassportElementErrorFrontSide"
-	PassportElementErrorReverseSidePassportElementError      PassportElementErrorType = "PassportElementErrorReverseSide"
-	PassportElementErrorSelfiePassportElementError           PassportElementErrorType = "PassportElementErrorSelfie"
-	PassportElementErrorFilePassportElementError             PassportElementErrorType = "PassportElementErrorFile"
-	PassportElementErrorFilesPassportElementError            PassportElementErrorType = "PassportElementErrorFiles"
-	PassportElementErrorTranslationFilePassportElementError  PassportElementErrorType = "PassportElementErrorTranslationFile"
-	PassportElementErrorTranslationFilesPassportElementError PassportElementErrorType = "PassportElementErrorTranslationFiles"
-	PassportElementErrorUnspecifiedPassportElementError      PassportElementErrorType = "PassportElementErrorUnspecified"
+	PassportElementErrorDataFieldPassportElementError        PassportElementErrorType = "data"
+	PassportElementErrorFrontSidePassportElementError        PassportElementErrorType = "front_side"
+	PassportElementErrorReverseSidePassportElementError      PassportElementErrorType = "reverse_side"
+	PassportElementErrorSelfiePassportElementError           PassportElementErrorType = "selfie"
+	PassportElementErrorFilePassportElementError             PassportElementErrorType = "file"
+	PassportElementErrorFilesPassportElementError            PassportElementErrorType = "files"
+	PassportElementErrorTranslationFilePassportElementError  PassportElementErrorType = "translation_file"
+	PassportElementErrorTranslationFilesPassportElementError PassportElementErrorType = "translation_files"
+	PassportElementErrorUnspecifiedPassportElementError      PassportElementErrorType = "unspecified"
 )
 
 // IsPassportElementErrorDataField reports whether PassportElementError is PassportElementErrorDataField.
@@ -19221,10 +19221,10 @@ type SendMediaGroupMediaItemType string
 
 // Possible values for SendMediaGroupMediaItemType.
 const (
-	InputMediaAudioSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaAudio"
-	InputMediaDocumentSendMediaGroupMediaItem SendMediaGroupMediaItemType = "InputMediaDocument"
-	InputMediaPhotoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaPhoto"
-	InputMediaVideoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "InputMediaVideo"
+	InputMediaAudioSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "audio"
+	InputMediaDocumentSendMediaGroupMediaItem SendMediaGroupMediaItemType = "document"
+	InputMediaPhotoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "photo"
+	InputMediaVideoSendMediaGroupMediaItem    SendMediaGroupMediaItemType = "video"
 )
 
 // IsInputMediaAudio reports whether SendMediaGroupMediaItem is InputMediaAudio.

--- a/gen/_template/schema/sum.tmpl
+++ b/gen/_template/schema/sum.tmpl
@@ -15,7 +15,7 @@ type {{ $.Name }}Type string
 const (
 	{{- range $s := $.SumOf }}
 	{{- $m := $.SumSpec.PickMappingEntryFor $s }}
-	{{- if ne $m nil }}
+	{{- if $m }}
 	{{- /* try to use mapping key if the entry for $s is defined */}}
 	{{ $s.Name }}{{ $.Name }} {{ $.Name }}Type = {{ quote $m.Key }}
 	{{- else }}

--- a/gen/_template/schema/sum.tmpl
+++ b/gen/_template/schema/sum.tmpl
@@ -14,7 +14,14 @@ type {{ $.Name }}Type string
 // Possible values for {{ $.Name }}Type.
 const (
 	{{- range $s := $.SumOf }}
-		{{ $s.Name }}{{ $.Name }} {{ $.Name }}Type = {{ quote $s.Go }}
+	{{- $m := $.SumSpec.PickMappingEntryFor $s }}
+	{{- if ne $m nil }}
+	{{- /* try to use mapping key if the entry for $s is defined */}}
+	{{ $s.Name }}{{ $.Name }} {{ $.Name }}Type = {{ quote $m.Key }}
+	{{- else }}
+	{{- /* otherwise fallback to SumOf Type name */}}
+	{{ $s.Name }}{{ $.Name }} {{ $.Name }}Type = {{ quote $s.Go }}
+	{{- end }}
 	{{- end }}
 )
 

--- a/gen/ir/type.go
+++ b/gen/ir/type.go
@@ -48,6 +48,20 @@ type SumSpec struct {
 	TypeDiscriminator bool
 }
 
+// PickMappingEntryFor returns mapping entry for given type if exists.
+func (s SumSpec) PickMappingEntryFor(t *Type) *SumSpecMap {
+	if s.Discriminator == "" {
+		return nil
+	}
+
+	for _, m := range s.Mapping {
+		if m.Type == t {
+			return &m
+		}
+	}
+	return nil
+}
+
 type Type struct {
 	Doc                 string              // ogen documentation
 	Kind                Kind                // kind

--- a/internal/integration/sample_api/oas_schemas_gen.go
+++ b/internal/integration/sample_api/oas_schemas_gen.go
@@ -938,9 +938,9 @@ type Issue943Type string
 
 // Possible values for Issue943Type.
 const (
-	Issue943Variant1Issue943 Issue943Type = "Issue943Variant1"
-	Issue943Variant2Issue943 Issue943Type = "Issue943Variant2"
-	Issue943MapIssue943      Issue943Type = "Issue943Map"
+	Issue943Variant1Issue943 Issue943Type = "variant1"
+	Issue943Variant2Issue943 Issue943Type = "variant2"
+	Issue943MapIssue943      Issue943Type = "variant3"
 )
 
 // IsIssue943Variant1 reports whether Issue943 is Issue943Variant1.
@@ -1794,8 +1794,8 @@ type OneOfMappingReferenceType string
 
 // Possible values for OneOfMappingReferenceType.
 const (
-	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceA"
-	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceB"
+	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "simple"
+	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "extended"
 )
 
 // IsOneOfMappingReferenceA reports whether OneOfMappingReference is OneOfMappingReferenceA.

--- a/internal/integration/sample_api_nc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nc/oas_schemas_gen.go
@@ -938,9 +938,9 @@ type Issue943Type string
 
 // Possible values for Issue943Type.
 const (
-	Issue943Variant1Issue943 Issue943Type = "Issue943Variant1"
-	Issue943Variant2Issue943 Issue943Type = "Issue943Variant2"
-	Issue943MapIssue943      Issue943Type = "Issue943Map"
+	Issue943Variant1Issue943 Issue943Type = "variant1"
+	Issue943Variant2Issue943 Issue943Type = "variant2"
+	Issue943MapIssue943      Issue943Type = "variant3"
 )
 
 // IsIssue943Variant1 reports whether Issue943 is Issue943Variant1.
@@ -1794,8 +1794,8 @@ type OneOfMappingReferenceType string
 
 // Possible values for OneOfMappingReferenceType.
 const (
-	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceA"
-	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceB"
+	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "simple"
+	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "extended"
 )
 
 // IsOneOfMappingReferenceA reports whether OneOfMappingReference is OneOfMappingReferenceA.

--- a/internal/integration/sample_api_ns/oas_schemas_gen.go
+++ b/internal/integration/sample_api_ns/oas_schemas_gen.go
@@ -938,9 +938,9 @@ type Issue943Type string
 
 // Possible values for Issue943Type.
 const (
-	Issue943Variant1Issue943 Issue943Type = "Issue943Variant1"
-	Issue943Variant2Issue943 Issue943Type = "Issue943Variant2"
-	Issue943MapIssue943      Issue943Type = "Issue943Map"
+	Issue943Variant1Issue943 Issue943Type = "variant1"
+	Issue943Variant2Issue943 Issue943Type = "variant2"
+	Issue943MapIssue943      Issue943Type = "variant3"
 )
 
 // IsIssue943Variant1 reports whether Issue943 is Issue943Variant1.
@@ -1794,8 +1794,8 @@ type OneOfMappingReferenceType string
 
 // Possible values for OneOfMappingReferenceType.
 const (
-	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceA"
-	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceB"
+	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "simple"
+	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "extended"
 )
 
 // IsOneOfMappingReferenceA reports whether OneOfMappingReference is OneOfMappingReferenceA.

--- a/internal/integration/sample_api_nsnc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_schemas_gen.go
@@ -938,9 +938,9 @@ type Issue943Type string
 
 // Possible values for Issue943Type.
 const (
-	Issue943Variant1Issue943 Issue943Type = "Issue943Variant1"
-	Issue943Variant2Issue943 Issue943Type = "Issue943Variant2"
-	Issue943MapIssue943      Issue943Type = "Issue943Map"
+	Issue943Variant1Issue943 Issue943Type = "variant1"
+	Issue943Variant2Issue943 Issue943Type = "variant2"
+	Issue943MapIssue943      Issue943Type = "variant3"
 )
 
 // IsIssue943Variant1 reports whether Issue943 is Issue943Variant1.
@@ -1794,8 +1794,8 @@ type OneOfMappingReferenceType string
 
 // Possible values for OneOfMappingReferenceType.
 const (
-	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceA"
-	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "OneOfMappingReferenceB"
+	OneOfMappingReferenceAOneOfMappingReference OneOfMappingReferenceType = "simple"
+	OneOfMappingReferenceBOneOfMappingReference OneOfMappingReferenceType = "extended"
 )
 
 // IsOneOfMappingReferenceA reports whether OneOfMappingReference is OneOfMappingReferenceA.


### PR DESCRIPTION
Closes: https://github.com/ogen-go/ogen/issues/967

Just changing the generated string constant
This won't allow us to use the same value as was stated in https://github.com/ogen-go/ogen/issues/967#issue-1787529410.

Please tell me if any changes to be made are missing.