### PR TITLE
make `MutipartFile.File` be `io.ReadSeeker`

### DIFF
--- a/http/multipart_file.go
+++ b/http/multipart_file.go
@@ -13,7 +13,7 @@ import (
 // MultipartFile is multipart form file.
 type MultipartFile struct {
 	Name   string
-	File   io.Reader
+	File   io.ReadSeeker
 	Header textproto.MIMEHeader
 }
 


### PR DESCRIPTION
- multipart.File has more capability than io.Reader: https://pkg.go.dev/mime/multipart#File
- `Close()` is handled in ogen generated logic, so would be ideal to pick an interface that covers the rest (Reader, ReaderAt, Seeker)
- there's no such builtin interface, so using [ReadSeeker](https://pkg.go.dev/io#ReadSeeker) for now