### PR TITLE
fix: do not fold Set-Cookie values into a single header, per RFC6265

### DIFF
--- a/uri/header_param_encoder.go
+++ b/uri/header_param_encoder.go
@@ -20,13 +20,26 @@ func (e *headerParamEncoder) serialize() error {
 		e.header.Set(e.paramName, e.val)
 		return nil
 	case typeArray:
-		const sep = ","
-		for _, val := range e.items {
-			if err := checkNotContains(val, sep); err != nil {
-				return err
+		if strings.EqualFold(e.paramName, "set-cookie") {
+			// As per RFC6265:
+			//
+			// Origin servers SHOULD NOT fold multiple Set-Cookie header fields into
+			// a single header field. The usual mechanism for folding HTTP headers
+			// fields (i.e., as defined in RFC2616) might change the semantics of
+			// the Set-Cookie header field because the %x2C (",") character is used
+			// by Set-Cookie in a way that conflicts with such folding.
+			for _, val := range e.items {
+				e.header.Add(e.paramName, val)
 			}
+		} else {
+			const sep = ","
+			for _, val := range e.items {
+				if err := checkNotContains(val, sep); err != nil {
+					return err
+				}
+			}
+			e.header.Set(e.paramName, strings.Join(e.items, sep))
 		}
-		e.header.Set(e.paramName, strings.Join(e.items, sep))
 		return nil
 	case typeObject:
 		var kvSep, fieldSep byte = ',', ','

--- a/uri/header_param_encoder_test.go
+++ b/uri/header_param_encoder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,27 @@ func TestHeaderParamEncoder(t *testing.T) {
 				Explode:    true,
 				Expect: http.Header{
 					"X-Myheader": []string{"3,4,5"},
+				},
+			},
+			{
+				HeaderName: "Set-Cookie",
+				Input: []string{
+					(&http.Cookie{
+						Name:  "key1",
+						Value: "value1",
+					}).String(),
+					(&http.Cookie{
+						Name:    "key2",
+						Value:   "value2",
+						Expires: time.Date(2023, 9, 6, 10, 11, 12, 0, time.UTC),
+					}).String(),
+				},
+				Explode: true,
+				Expect: http.Header{
+					"Set-Cookie": []string{
+						"key1=value1",
+						"key2=value2; Expires=Wed, 06 Sep 2023 10:11:12 GMT",
+					},
 				},
 			},
 		}


### PR DESCRIPTION
This PR adds a special case for encoding `Set-Cookie` headers in responses. Specifically, it prevents `headerParamEncoder` from folding multiple header values into a single header value using a comma separator, as per [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265):

>   Origin servers SHOULD NOT fold multiple `Set-Cookie` header fields into a single header field.  The usual mechanism for folding HTTP headers fields (i.e., as defined in [RFC2616 section 4.2](https://www.rfc-editor.org/rfc/rfc2616#section-4.2)) might change the semantics of the `Set-Cookie` header field because the `%x2C` (`,`) character is used by `Set-Cookie` in a way that conflicts with such folding.

The comma mentioned by the RFC appears when using a cookie with an expiry timestamp, because the recommended timestamp format (see [RFC2616 section 3.3.1](https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1)) uses a comma after the day-of-week.

/cc @ezzatron