### PR TITLE
fix(gen): pass HTTP attributes, even if `operationId` is not set

### DIFF
--- a/examples/ex_2ch/oas_client_gen.go
+++ b/examples/ex_2ch/oas_client_gen.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
 	ht "github.com/ogen-go/ogen/http"
@@ -78,7 +80,10 @@ func (c *Client) APICaptcha2chcaptchaIDGet(ctx context.Context, params APICaptch
 }
 
 func (c *Client) sendAPICaptcha2chcaptchaIDGet(ctx context.Context, params APICaptcha2chcaptchaIDGetParams) (res *Captcha, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/2chcaptcha/id"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -93,6 +98,7 @@ func (c *Client) sendAPICaptcha2chcaptchaIDGet(ctx context.Context, params APICa
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptcha2chcaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -184,7 +190,10 @@ func (c *Client) APICaptcha2chcaptchaShowGet(ctx context.Context, params APICapt
 }
 
 func (c *Client) sendAPICaptcha2chcaptchaShowGet(ctx context.Context, params APICaptcha2chcaptchaShowGetParams) (res APICaptcha2chcaptchaShowGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/2chcaptcha/show"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -199,6 +208,7 @@ func (c *Client) sendAPICaptcha2chcaptchaShowGet(ctx context.Context, params API
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptcha2chcaptchaShowGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -274,7 +284,10 @@ func (c *Client) APICaptchaAppIDPublicKeyGet(ctx context.Context, params APICapt
 }
 
 func (c *Client) sendAPICaptchaAppIDPublicKeyGet(ctx context.Context, params APICaptchaAppIDPublicKeyGetParams) (res *Captcha, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/app/id/{public_key}"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -289,6 +302,7 @@ func (c *Client) sendAPICaptchaAppIDPublicKeyGet(ctx context.Context, params API
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptchaAppIDPublicKeyGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -398,7 +412,10 @@ func (c *Client) APICaptchaInvisibleRecaptchaIDGet(ctx context.Context, params A
 }
 
 func (c *Client) sendAPICaptchaInvisibleRecaptchaIDGet(ctx context.Context, params APICaptchaInvisibleRecaptchaIDGetParams) (res *Captcha, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/invisible_recaptcha/id"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -413,6 +430,7 @@ func (c *Client) sendAPICaptchaInvisibleRecaptchaIDGet(ctx context.Context, para
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptchaInvisibleRecaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -504,7 +522,10 @@ func (c *Client) APICaptchaInvisibleRecaptchaMobileGet(ctx context.Context) erro
 }
 
 func (c *Client) sendAPICaptchaInvisibleRecaptchaMobileGet(ctx context.Context) (res *APICaptchaInvisibleRecaptchaMobileGetOK, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/invisible_recaptcha/mobile"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -519,6 +540,7 @@ func (c *Client) sendAPICaptchaInvisibleRecaptchaMobileGet(ctx context.Context) 
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptchaInvisibleRecaptchaMobileGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -572,7 +594,10 @@ func (c *Client) APICaptchaRecaptchaIDGet(ctx context.Context, params APICaptcha
 }
 
 func (c *Client) sendAPICaptchaRecaptchaIDGet(ctx context.Context, params APICaptchaRecaptchaIDGetParams) (res *Captcha, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/recaptcha/id"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -587,6 +612,7 @@ func (c *Client) sendAPICaptchaRecaptchaIDGet(ctx context.Context, params APICap
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptchaRecaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -678,7 +704,10 @@ func (c *Client) APICaptchaRecaptchaMobileGet(ctx context.Context) error {
 }
 
 func (c *Client) sendAPICaptchaRecaptchaMobileGet(ctx context.Context) (res *APICaptchaRecaptchaMobileGetOK, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/recaptcha/mobile"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -693,6 +722,7 @@ func (c *Client) sendAPICaptchaRecaptchaMobileGet(ctx context.Context) (res *API
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APICaptchaRecaptchaMobileGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -746,7 +776,10 @@ func (c *Client) APIDislikeGet(ctx context.Context, params APIDislikeGetParams) 
 }
 
 func (c *Client) sendAPIDislikeGet(ctx context.Context, params APIDislikeGetParams) (res *Like, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/dislike"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -761,6 +794,7 @@ func (c *Client) sendAPIDislikeGet(ctx context.Context, params APIDislikeGetPara
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APIDislikeGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -846,7 +880,10 @@ func (c *Client) APILikeGet(ctx context.Context, params APILikeGetParams) (*Like
 }
 
 func (c *Client) sendAPILikeGet(ctx context.Context, params APILikeGetParams) (res *Like, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/like"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -861,6 +898,7 @@ func (c *Client) sendAPILikeGet(ctx context.Context, params APILikeGetParams) (r
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APILikeGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -948,7 +986,10 @@ func (c *Client) APIMobileV2AfterBoardThreadNumGet(ctx context.Context, params A
 }
 
 func (c *Client) sendAPIMobileV2AfterBoardThreadNumGet(ctx context.Context, params APIMobileV2AfterBoardThreadNumGetParams) (res *MobileThreadPostsAfter, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/after/{board}/{thread}/{num}"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -963,6 +1004,7 @@ func (c *Client) sendAPIMobileV2AfterBoardThreadNumGet(ctx context.Context, para
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APIMobileV2AfterBoardThreadNumGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1072,7 +1114,10 @@ func (c *Client) APIMobileV2BoardsGet(ctx context.Context) (Boards, error) {
 }
 
 func (c *Client) sendAPIMobileV2BoardsGet(ctx context.Context) (res Boards, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/boards"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1087,6 +1132,7 @@ func (c *Client) sendAPIMobileV2BoardsGet(ctx context.Context) (res Boards, err 
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APIMobileV2BoardsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1140,7 +1186,10 @@ func (c *Client) APIMobileV2InfoBoardThreadGet(ctx context.Context, params APIMo
 }
 
 func (c *Client) sendAPIMobileV2InfoBoardThreadGet(ctx context.Context, params APIMobileV2InfoBoardThreadGetParams) (res *MobileThreadLastInfo, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/info/{board}/{thread}"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1155,6 +1204,7 @@ func (c *Client) sendAPIMobileV2InfoBoardThreadGet(ctx context.Context, params A
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APIMobileV2InfoBoardThreadGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1245,7 +1295,10 @@ func (c *Client) APIMobileV2PostBoardNumGet(ctx context.Context, params APIMobil
 }
 
 func (c *Client) sendAPIMobileV2PostBoardNumGet(ctx context.Context, params APIMobileV2PostBoardNumGetParams) (res *MobilePost, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/post/{board}/{num}"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1260,6 +1313,7 @@ func (c *Client) sendAPIMobileV2PostBoardNumGet(ctx context.Context, params APIM
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "APIMobileV2PostBoardNumGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1350,7 +1404,10 @@ func (c *Client) UserPassloginPost(ctx context.Context, request OptUserPasslogin
 }
 
 func (c *Client) sendUserPassloginPost(ctx context.Context, request OptUserPassloginPostReq, params UserPassloginPostParams) (res *Passcode, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/passlogin"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1365,6 +1422,7 @@ func (c *Client) sendUserPassloginPost(ctx context.Context, request OptUserPassl
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "UserPassloginPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1439,7 +1497,10 @@ func (c *Client) UserPostingPost(ctx context.Context, request OptUserPostingPost
 }
 
 func (c *Client) sendUserPostingPost(ctx context.Context, request OptUserPostingPostReq) (res UserPostingPostOK, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/posting"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -1470,6 +1531,7 @@ func (c *Client) sendUserPostingPost(ctx context.Context, request OptUserPosting
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "UserPostingPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1526,7 +1588,10 @@ func (c *Client) UserReportPost(ctx context.Context, request OptUserReportPostRe
 }
 
 func (c *Client) sendUserReportPost(ctx context.Context, request OptUserReportPostReq) (res *Report, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/report"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1541,6 +1606,7 @@ func (c *Client) sendUserReportPost(ctx context.Context, request OptUserReportPo
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "UserReportPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.

--- a/examples/ex_2ch/oas_handlers_gen.go
+++ b/examples/ex_2ch/oas_handlers_gen.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -21,10 +23,14 @@ import (
 //
 // GET /api/captcha/2chcaptcha/id
 func (s *Server) handleAPICaptcha2chcaptchaIDGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/2chcaptcha/id"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptcha2chcaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -123,10 +129,14 @@ func (s *Server) handleAPICaptcha2chcaptchaIDGetRequest(args [0]string, argsEsca
 //
 // GET /api/captcha/2chcaptcha/show
 func (s *Server) handleAPICaptcha2chcaptchaShowGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/2chcaptcha/show"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptcha2chcaptchaShowGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -225,10 +235,14 @@ func (s *Server) handleAPICaptcha2chcaptchaShowGetRequest(args [0]string, argsEs
 //
 // GET /api/captcha/app/id/{public_key}
 func (s *Server) handleAPICaptchaAppIDPublicKeyGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/app/id/{public_key}"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptchaAppIDPublicKeyGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -331,10 +345,14 @@ func (s *Server) handleAPICaptchaAppIDPublicKeyGetRequest(args [1]string, argsEs
 //
 // GET /api/captcha/invisible_recaptcha/id
 func (s *Server) handleAPICaptchaInvisibleRecaptchaIDGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/invisible_recaptcha/id"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptchaInvisibleRecaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -433,10 +451,14 @@ func (s *Server) handleAPICaptchaInvisibleRecaptchaIDGetRequest(args [0]string, 
 //
 // GET /api/captcha/invisible_recaptcha/mobile
 func (s *Server) handleAPICaptchaInvisibleRecaptchaMobileGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/invisible_recaptcha/mobile"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptchaInvisibleRecaptchaMobileGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -512,10 +534,14 @@ func (s *Server) handleAPICaptchaInvisibleRecaptchaMobileGetRequest(args [0]stri
 //
 // GET /api/captcha/recaptcha/id
 func (s *Server) handleAPICaptchaRecaptchaIDGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/recaptcha/id"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptchaRecaptchaIDGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -614,10 +640,14 @@ func (s *Server) handleAPICaptchaRecaptchaIDGetRequest(args [0]string, argsEscap
 //
 // GET /api/captcha/recaptcha/mobile
 func (s *Server) handleAPICaptchaRecaptchaMobileGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/captcha/recaptcha/mobile"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APICaptchaRecaptchaMobileGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -693,10 +723,14 @@ func (s *Server) handleAPICaptchaRecaptchaMobileGetRequest(args [0]string, argsE
 //
 // GET /api/dislike
 func (s *Server) handleAPIDislikeGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/dislike"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APIDislikeGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -795,10 +829,14 @@ func (s *Server) handleAPIDislikeGetRequest(args [0]string, argsEscaped bool, w 
 //
 // GET /api/like
 func (s *Server) handleAPILikeGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/like"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APILikeGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -899,10 +937,14 @@ func (s *Server) handleAPILikeGetRequest(args [0]string, argsEscaped bool, w htt
 //
 // GET /api/mobile/v2/after/{board}/{thread}/{num}
 func (s *Server) handleAPIMobileV2AfterBoardThreadNumGetRequest(args [3]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/after/{board}/{thread}/{num}"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APIMobileV2AfterBoardThreadNumGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1005,10 +1047,14 @@ func (s *Server) handleAPIMobileV2AfterBoardThreadNumGetRequest(args [3]string, 
 //
 // GET /api/mobile/v2/boards
 func (s *Server) handleAPIMobileV2BoardsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/boards"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APIMobileV2BoardsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1084,10 +1130,14 @@ func (s *Server) handleAPIMobileV2BoardsGetRequest(args [0]string, argsEscaped b
 //
 // GET /api/mobile/v2/info/{board}/{thread}
 func (s *Server) handleAPIMobileV2InfoBoardThreadGetRequest(args [2]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/info/{board}/{thread}"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APIMobileV2InfoBoardThreadGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1186,10 +1236,14 @@ func (s *Server) handleAPIMobileV2InfoBoardThreadGetRequest(args [2]string, args
 //
 // GET /api/mobile/v2/post/{board}/{num}
 func (s *Server) handleAPIMobileV2PostBoardNumGetRequest(args [2]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/mobile/v2/post/{board}/{num}"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "APIMobileV2PostBoardNumGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1288,10 +1342,14 @@ func (s *Server) handleAPIMobileV2PostBoardNumGetRequest(args [2]string, argsEsc
 //
 // POST /user/passlogin
 func (s *Server) handleUserPassloginPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/passlogin"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "UserPassloginPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1401,10 +1459,14 @@ func (s *Server) handleUserPassloginPostRequest(args [0]string, argsEscaped bool
 //
 // POST /user/posting
 func (s *Server) handleUserPostingPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/posting"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "UserPostingPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1499,10 +1561,14 @@ func (s *Server) handleUserPostingPostRequest(args [0]string, argsEscaped bool, 
 //
 // POST /user/report
 func (s *Server) handleUserReportPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/report"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "UserReportPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/examples/ex_ent/oas_client_gen.go
+++ b/examples/ex_ent/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -82,6 +83,8 @@ func (c *Client) CreatePet(ctx context.Context, request *CreatePetReq) (CreatePe
 func (c *Client) sendCreatePet(ctx context.Context, request *CreatePetReq) (res CreatePetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createPet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.
@@ -156,6 +159,8 @@ func (c *Client) CreatePetCategories(ctx context.Context, request *CreatePetCate
 func (c *Client) sendCreatePetCategories(ctx context.Context, request *CreatePetCategoriesReq, params CreatePetCategoriesParams) (res CreatePetCategoriesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createPetCategories"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets/{id}/categories"),
 	}
 
 	// Run stopwatch.
@@ -249,6 +254,8 @@ func (c *Client) CreatePetFriends(ctx context.Context, request *CreatePetFriends
 func (c *Client) sendCreatePetFriends(ctx context.Context, request *CreatePetFriendsReq, params CreatePetFriendsParams) (res CreatePetFriendsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createPetFriends"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets/{id}/friends"),
 	}
 
 	// Run stopwatch.
@@ -342,6 +349,8 @@ func (c *Client) CreatePetOwner(ctx context.Context, request *CreatePetOwnerReq,
 func (c *Client) sendCreatePetOwner(ctx context.Context, request *CreatePetOwnerReq, params CreatePetOwnerParams) (res CreatePetOwnerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createPetOwner"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets/{id}/owner"),
 	}
 
 	// Run stopwatch.
@@ -435,6 +444,8 @@ func (c *Client) DeletePet(ctx context.Context, params DeletePetParams) (DeleteP
 func (c *Client) sendDeletePet(ctx context.Context, params DeletePetParams) (res DeletePetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deletePet"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/pets/{id}"),
 	}
 
 	// Run stopwatch.
@@ -524,6 +535,8 @@ func (c *Client) DeletePetOwner(ctx context.Context, params DeletePetOwnerParams
 func (c *Client) sendDeletePetOwner(ctx context.Context, params DeletePetOwnerParams) (res DeletePetOwnerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deletePetOwner"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/pets/{id}/owner"),
 	}
 
 	// Run stopwatch.
@@ -614,6 +627,8 @@ func (c *Client) ListPet(ctx context.Context, params ListPetParams) (ListPetRes,
 func (c *Client) sendListPet(ctx context.Context, params ListPetParams) (res ListPetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.
@@ -723,6 +738,8 @@ func (c *Client) ListPetCategories(ctx context.Context, params ListPetCategories
 func (c *Client) sendListPetCategories(ctx context.Context, params ListPetCategoriesParams) (res ListPetCategoriesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPetCategories"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{id}/categories"),
 	}
 
 	// Run stopwatch.
@@ -851,6 +868,8 @@ func (c *Client) ListPetFriends(ctx context.Context, params ListPetFriendsParams
 func (c *Client) sendListPetFriends(ctx context.Context, params ListPetFriendsParams) (res ListPetFriendsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPetFriends"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{id}/friends"),
 	}
 
 	// Run stopwatch.
@@ -979,6 +998,8 @@ func (c *Client) ReadPet(ctx context.Context, params ReadPetParams) (ReadPetRes,
 func (c *Client) sendReadPet(ctx context.Context, params ReadPetParams) (res ReadPetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{id}"),
 	}
 
 	// Run stopwatch.
@@ -1068,6 +1089,8 @@ func (c *Client) ReadPetOwner(ctx context.Context, params ReadPetOwnerParams) (R
 func (c *Client) sendReadPetOwner(ctx context.Context, params ReadPetOwnerParams) (res ReadPetOwnerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPetOwner"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{id}/owner"),
 	}
 
 	// Run stopwatch.
@@ -1158,6 +1181,8 @@ func (c *Client) UpdatePet(ctx context.Context, request *UpdatePetReq, params Up
 func (c *Client) sendUpdatePet(ctx context.Context, request *UpdatePetReq, params UpdatePetParams) (res UpdatePetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("updatePet"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/pets/{id}"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_firecracker/oas_client_gen.go
+++ b/examples/ex_firecracker/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -86,6 +87,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, request *SnapshotCreatePara
 func (c *Client) sendCreateSnapshot(ctx context.Context, request *SnapshotCreateParams) (res CreateSnapshotRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createSnapshot"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/snapshot/create"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -169,6 +172,8 @@ func (c *Client) CreateSyncAction(ctx context.Context, request *InstanceActionIn
 func (c *Client) sendCreateSyncAction(ctx context.Context, request *InstanceActionInfo) (res CreateSyncActionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createSyncAction"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/actions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -252,6 +257,8 @@ func (c *Client) DescribeBalloonConfig(ctx context.Context) (DescribeBalloonConf
 func (c *Client) sendDescribeBalloonConfig(ctx context.Context) (res DescribeBalloonConfigRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("describeBalloonConfig"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/balloon"),
 	}
 
 	// Run stopwatch.
@@ -323,6 +330,8 @@ func (c *Client) DescribeBalloonStats(ctx context.Context) (DescribeBalloonStats
 func (c *Client) sendDescribeBalloonStats(ctx context.Context) (res DescribeBalloonStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("describeBalloonStats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/balloon/statistics"),
 	}
 
 	// Run stopwatch.
@@ -394,6 +403,8 @@ func (c *Client) DescribeInstance(ctx context.Context) (*InstanceInfo, error) {
 func (c *Client) sendDescribeInstance(ctx context.Context) (res *InstanceInfo, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("describeInstance"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/"),
 	}
 
 	// Run stopwatch.
@@ -465,6 +476,8 @@ func (c *Client) GetExportVmConfig(ctx context.Context) (*FullVmConfiguration, e
 func (c *Client) sendGetExportVmConfig(ctx context.Context) (res *FullVmConfiguration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getExportVmConfig"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/vm/config"),
 	}
 
 	// Run stopwatch.
@@ -538,6 +551,8 @@ func (c *Client) GetMachineConfiguration(ctx context.Context) (*MachineConfigura
 func (c *Client) sendGetMachineConfiguration(ctx context.Context) (res *MachineConfiguration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMachineConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/machine-config"),
 	}
 
 	// Run stopwatch.
@@ -610,6 +625,8 @@ func (c *Client) LoadSnapshot(ctx context.Context, request *SnapshotLoadParams) 
 func (c *Client) sendLoadSnapshot(ctx context.Context, request *SnapshotLoadParams) (res LoadSnapshotRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("loadSnapshot"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/snapshot/load"),
 	}
 
 	// Run stopwatch.
@@ -682,7 +699,10 @@ func (c *Client) MmdsConfigPut(ctx context.Context, request *MmdsConfig) (MmdsCo
 }
 
 func (c *Client) sendMmdsConfigPut(ctx context.Context, request *MmdsConfig) (res MmdsConfigPutRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/mmds/config"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -697,6 +717,7 @@ func (c *Client) sendMmdsConfigPut(ctx context.Context, request *MmdsConfig) (re
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MmdsConfigPut",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -753,7 +774,10 @@ func (c *Client) MmdsGet(ctx context.Context) (MmdsGetRes, error) {
 }
 
 func (c *Client) sendMmdsGet(ctx context.Context) (res MmdsGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -768,6 +792,7 @@ func (c *Client) sendMmdsGet(ctx context.Context) (res MmdsGetRes, err error) {
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MmdsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -821,7 +846,10 @@ func (c *Client) MmdsPatch(ctx context.Context, request *MmdsPatchReq) (MmdsPatc
 }
 
 func (c *Client) sendMmdsPatch(ctx context.Context, request *MmdsPatchReq) (res MmdsPatchRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -836,6 +864,7 @@ func (c *Client) sendMmdsPatch(ctx context.Context, request *MmdsPatchReq) (res 
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MmdsPatch",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -892,7 +921,10 @@ func (c *Client) MmdsPut(ctx context.Context, request *MmdsPutReq) (MmdsPutRes, 
 }
 
 func (c *Client) sendMmdsPut(ctx context.Context, request *MmdsPutReq) (res MmdsPutRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -907,6 +939,7 @@ func (c *Client) sendMmdsPut(ctx context.Context, request *MmdsPutReq) (res Mmds
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MmdsPut",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -966,6 +999,8 @@ func (c *Client) PatchBalloon(ctx context.Context, request *BalloonUpdate) (Patc
 func (c *Client) sendPatchBalloon(ctx context.Context, request *BalloonUpdate) (res PatchBalloonRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchBalloon"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/balloon"),
 	}
 
 	// Run stopwatch.
@@ -1041,6 +1076,8 @@ func (c *Client) PatchBalloonStatsInterval(ctx context.Context, request *Balloon
 func (c *Client) sendPatchBalloonStatsInterval(ctx context.Context, request *BalloonStatsUpdate) (res PatchBalloonStatsIntervalRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchBalloonStatsInterval"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/balloon/statistics"),
 	}
 
 	// Run stopwatch.
@@ -1116,6 +1153,8 @@ func (c *Client) PatchGuestDriveByID(ctx context.Context, request *PartialDrive,
 func (c *Client) sendPatchGuestDriveByID(ctx context.Context, request *PartialDrive, params PatchGuestDriveByIDParams) (res PatchGuestDriveByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchGuestDriveByID"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/drives/{drive_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1217,6 +1256,8 @@ func (c *Client) PatchGuestNetworkInterfaceByID(ctx context.Context, request *Pa
 func (c *Client) sendPatchGuestNetworkInterfaceByID(ctx context.Context, request *PartialNetworkInterface, params PatchGuestNetworkInterfaceByIDParams) (res PatchGuestNetworkInterfaceByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchGuestNetworkInterfaceByID"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/network-interfaces/{iface_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1319,6 +1360,8 @@ func (c *Client) PatchMachineConfiguration(ctx context.Context, request OptMachi
 func (c *Client) sendPatchMachineConfiguration(ctx context.Context, request OptMachineConfiguration) (res PatchMachineConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchMachineConfiguration"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/machine-config"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1409,6 +1452,8 @@ func (c *Client) PatchVm(ctx context.Context, request *VM) (PatchVmRes, error) {
 func (c *Client) sendPatchVm(ctx context.Context, request *VM) (res PatchVmRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("patchVm"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/vm"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1493,6 +1538,8 @@ func (c *Client) PutBalloon(ctx context.Context, request *Balloon) (PutBalloonRe
 func (c *Client) sendPutBalloon(ctx context.Context, request *Balloon) (res PutBalloonRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putBalloon"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/balloon"),
 	}
 
 	// Run stopwatch.
@@ -1568,6 +1615,8 @@ func (c *Client) PutGuestBootSource(ctx context.Context, request *BootSource) (P
 func (c *Client) sendPutGuestBootSource(ctx context.Context, request *BootSource) (res PutGuestBootSourceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putGuestBootSource"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/boot-source"),
 	}
 
 	// Run stopwatch.
@@ -1643,6 +1692,8 @@ func (c *Client) PutGuestDriveByID(ctx context.Context, request *Drive, params P
 func (c *Client) sendPutGuestDriveByID(ctx context.Context, request *Drive, params PutGuestDriveByIDParams) (res PutGuestDriveByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putGuestDriveByID"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/drives/{drive_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1744,6 +1795,8 @@ func (c *Client) PutGuestNetworkInterfaceByID(ctx context.Context, request *Netw
 func (c *Client) sendPutGuestNetworkInterfaceByID(ctx context.Context, request *NetworkInterface, params PutGuestNetworkInterfaceByIDParams) (res PutGuestNetworkInterfaceByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putGuestNetworkInterfaceByID"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/network-interfaces/{iface_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1846,6 +1899,8 @@ func (c *Client) PutGuestVsock(ctx context.Context, request *Vsock) (PutGuestVso
 func (c *Client) sendPutGuestVsock(ctx context.Context, request *Vsock) (res PutGuestVsockRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putGuestVsock"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/vsock"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1929,6 +1984,8 @@ func (c *Client) PutLogger(ctx context.Context, request *Logger) (PutLoggerRes, 
 func (c *Client) sendPutLogger(ctx context.Context, request *Logger) (res PutLoggerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putLogger"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/logger"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2015,6 +2072,8 @@ func (c *Client) PutMachineConfiguration(ctx context.Context, request OptMachine
 func (c *Client) sendPutMachineConfiguration(ctx context.Context, request OptMachineConfiguration) (res PutMachineConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putMachineConfiguration"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/machine-config"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2105,6 +2164,8 @@ func (c *Client) PutMetrics(ctx context.Context, request *Metrics) (PutMetricsRe
 func (c *Client) sendPutMetrics(ctx context.Context, request *Metrics) (res PutMetricsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("putMetrics"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/metrics"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_firecracker/oas_handlers_gen.go
+++ b/examples/ex_firecracker/oas_handlers_gen.go
@@ -822,10 +822,14 @@ func (s *Server) handleLoadSnapshotRequest(args [0]string, argsEscaped bool, w h
 //
 // PUT /mmds/config
 func (s *Server) handleMmdsConfigPutRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/mmds/config"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MmdsConfigPut",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -928,10 +932,14 @@ func (s *Server) handleMmdsConfigPutRequest(args [0]string, argsEscaped bool, w 
 //
 // GET /mmds
 func (s *Server) handleMmdsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MmdsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1015,10 +1023,14 @@ func (s *Server) handleMmdsGetRequest(args [0]string, argsEscaped bool, w http.R
 //
 // PATCH /mmds
 func (s *Server) handleMmdsPatchRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MmdsPatch",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1121,10 +1133,14 @@ func (s *Server) handleMmdsPatchRequest(args [0]string, argsEscaped bool, w http
 //
 // PUT /mmds
 func (s *Server) handleMmdsPutRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/mmds"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MmdsPut",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/examples/ex_github/oas_client_gen.go
+++ b/examples/ex_github/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -90,6 +91,8 @@ func (c *Client) ActionsAddRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Co
 func (c *Client) sendActionsAddRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Context, params ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgParams) (res *ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/add-repo-access-to-self-hosted-runner-group-in-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -221,6 +224,8 @@ func (c *Client) ActionsAddSelectedRepoToOrgSecret(ctx context.Context, params A
 func (c *Client) sendActionsAddSelectedRepoToOrgSecret(ctx context.Context, params ActionsAddSelectedRepoToOrgSecretParams) (res ActionsAddSelectedRepoToOrgSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/add-selected-repo-to-org-secret"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -353,6 +358,8 @@ func (c *Client) ActionsAddSelfHostedRunnerToGroupForOrg(ctx context.Context, pa
 func (c *Client) sendActionsAddSelfHostedRunnerToGroupForOrg(ctx context.Context, params ActionsAddSelfHostedRunnerToGroupForOrgParams) (res *ActionsAddSelfHostedRunnerToGroupForOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/add-self-hosted-runner-to-group-for-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -484,6 +491,8 @@ func (c *Client) ActionsApproveWorkflowRun(ctx context.Context, params ActionsAp
 func (c *Client) sendActionsApproveWorkflowRun(ctx context.Context, params ActionsApproveWorkflowRunParams) (res ActionsApproveWorkflowRunRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/approve-workflow-run"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/approve"),
 	}
 
 	// Run stopwatch.
@@ -614,6 +623,8 @@ func (c *Client) ActionsCancelWorkflowRun(ctx context.Context, params ActionsCan
 func (c *Client) sendActionsCancelWorkflowRun(ctx context.Context, params ActionsCancelWorkflowRunParams) (res *ActionsCancelWorkflowRunAccepted, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/cancel-workflow-run"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/cancel"),
 	}
 
 	// Run stopwatch.
@@ -795,6 +806,8 @@ func (c *Client) ActionsCreateOrUpdateEnvironmentSecret(ctx context.Context, req
 func (c *Client) sendActionsCreateOrUpdateEnvironmentSecret(ctx context.Context, request *ActionsCreateOrUpdateEnvironmentSecretReq, params ActionsCreateOrUpdateEnvironmentSecretParams) (res ActionsCreateOrUpdateEnvironmentSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-or-update-environment-secret"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -987,6 +1000,8 @@ func (c *Client) ActionsCreateOrUpdateOrgSecret(ctx context.Context, request *Ac
 func (c *Client) sendActionsCreateOrUpdateOrgSecret(ctx context.Context, request *ActionsCreateOrUpdateOrgSecretReq, params ActionsCreateOrUpdateOrgSecretParams) (res ActionsCreateOrUpdateOrgSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-or-update-org-secret"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1160,6 +1175,8 @@ func (c *Client) ActionsCreateOrUpdateRepoSecret(ctx context.Context, request *A
 func (c *Client) sendActionsCreateOrUpdateRepoSecret(ctx context.Context, request *ActionsCreateOrUpdateRepoSecretReq, params ActionsCreateOrUpdateRepoSecretParams) (res ActionsCreateOrUpdateRepoSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-or-update-repo-secret"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/secrets/{secret_name}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1306,6 +1323,8 @@ func (c *Client) ActionsCreateRegistrationTokenForOrg(ctx context.Context, param
 func (c *Client) sendActionsCreateRegistrationTokenForOrg(ctx context.Context, params ActionsCreateRegistrationTokenForOrgParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-registration-token-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners/registration-token"),
 	}
 
 	// Run stopwatch.
@@ -1404,6 +1423,8 @@ func (c *Client) ActionsCreateRegistrationTokenForRepo(ctx context.Context, para
 func (c *Client) sendActionsCreateRegistrationTokenForRepo(ctx context.Context, params ActionsCreateRegistrationTokenForRepoParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-registration-token-for-repo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners/registration-token"),
 	}
 
 	// Run stopwatch.
@@ -1522,6 +1543,8 @@ func (c *Client) ActionsCreateRemoveTokenForOrg(ctx context.Context, params Acti
 func (c *Client) sendActionsCreateRemoveTokenForOrg(ctx context.Context, params ActionsCreateRemoveTokenForOrgParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-remove-token-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners/remove-token"),
 	}
 
 	// Run stopwatch.
@@ -1620,6 +1643,8 @@ func (c *Client) ActionsCreateRemoveTokenForRepo(ctx context.Context, params Act
 func (c *Client) sendActionsCreateRemoveTokenForRepo(ctx context.Context, params ActionsCreateRemoveTokenForRepoParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-remove-token-for-repo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners/remove-token"),
 	}
 
 	// Run stopwatch.
@@ -1733,6 +1758,8 @@ func (c *Client) ActionsCreateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 func (c *Client) sendActionsCreateSelfHostedRunnerGroupForOrg(ctx context.Context, request *ActionsCreateSelfHostedRunnerGroupForOrgReq, params ActionsCreateSelfHostedRunnerGroupForOrgParams) (res *RunnerGroupsOrg, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/create-self-hosted-runner-group-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1837,6 +1864,8 @@ func (c *Client) ActionsDeleteArtifact(ctx context.Context, params ActionsDelete
 func (c *Client) sendActionsDeleteArtifact(ctx context.Context, params ActionsDeleteArtifactParams) (res *ActionsDeleteArtifactNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-artifact"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/artifacts/{artifact_id}"),
 	}
 
 	// Run stopwatch.
@@ -1966,6 +1995,8 @@ func (c *Client) ActionsDeleteEnvironmentSecret(ctx context.Context, params Acti
 func (c *Client) sendActionsDeleteEnvironmentSecret(ctx context.Context, params ActionsDeleteEnvironmentSecretParams) (res *ActionsDeleteEnvironmentSecretNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-environment-secret"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -2095,6 +2126,8 @@ func (c *Client) ActionsDeleteOrgSecret(ctx context.Context, params ActionsDelet
 func (c *Client) sendActionsDeleteOrgSecret(ctx context.Context, params ActionsDeleteOrgSecretParams) (res *ActionsDeleteOrgSecretNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-org-secret"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -2205,6 +2238,8 @@ func (c *Client) ActionsDeleteRepoSecret(ctx context.Context, params ActionsDele
 func (c *Client) sendActionsDeleteRepoSecret(ctx context.Context, params ActionsDeleteRepoSecretParams) (res *ActionsDeleteRepoSecretNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-repo-secret"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -2334,6 +2369,8 @@ func (c *Client) ActionsDeleteSelfHostedRunnerFromOrg(ctx context.Context, param
 func (c *Client) sendActionsDeleteSelfHostedRunnerFromOrg(ctx context.Context, params ActionsDeleteSelfHostedRunnerFromOrgParams) (res *ActionsDeleteSelfHostedRunnerFromOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-self-hosted-runner-from-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -2445,6 +2482,8 @@ func (c *Client) ActionsDeleteSelfHostedRunnerFromRepo(ctx context.Context, para
 func (c *Client) sendActionsDeleteSelfHostedRunnerFromRepo(ctx context.Context, params ActionsDeleteSelfHostedRunnerFromRepoParams) (res *ActionsDeleteSelfHostedRunnerFromRepoNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-self-hosted-runner-from-repo"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -2576,6 +2615,8 @@ func (c *Client) ActionsDeleteSelfHostedRunnerGroupFromOrg(ctx context.Context, 
 func (c *Client) sendActionsDeleteSelfHostedRunnerGroupFromOrg(ctx context.Context, params ActionsDeleteSelfHostedRunnerGroupFromOrgParams) (res *ActionsDeleteSelfHostedRunnerGroupFromOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-self-hosted-runner-group-from-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -2688,6 +2729,8 @@ func (c *Client) ActionsDeleteWorkflowRun(ctx context.Context, params ActionsDel
 func (c *Client) sendActionsDeleteWorkflowRun(ctx context.Context, params ActionsDeleteWorkflowRunParams) (res *ActionsDeleteWorkflowRunNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-workflow-run"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}"),
 	}
 
 	// Run stopwatch.
@@ -2817,6 +2860,8 @@ func (c *Client) ActionsDeleteWorkflowRunLogs(ctx context.Context, params Action
 func (c *Client) sendActionsDeleteWorkflowRunLogs(ctx context.Context, params ActionsDeleteWorkflowRunLogsParams) (res *ActionsDeleteWorkflowRunLogsNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/delete-workflow-run-logs"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/logs"),
 	}
 
 	// Run stopwatch.
@@ -2950,6 +2995,8 @@ func (c *Client) ActionsDisableSelectedRepositoryGithubActionsOrganization(ctx c
 func (c *Client) sendActionsDisableSelectedRepositoryGithubActionsOrganization(ctx context.Context, params ActionsDisableSelectedRepositoryGithubActionsOrganizationParams) (res *ActionsDisableSelectedRepositoryGithubActionsOrganizationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/disable-selected-repository-github-actions-organization"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -3064,6 +3111,8 @@ func (c *Client) ActionsDownloadArtifact(ctx context.Context, params ActionsDown
 func (c *Client) sendActionsDownloadArtifact(ctx context.Context, params ActionsDownloadArtifactParams) (res *ActionsDownloadArtifactFound, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/download-artifact"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"),
 	}
 
 	// Run stopwatch.
@@ -3218,6 +3267,8 @@ func (c *Client) ActionsDownloadJobLogsForWorkflowRun(ctx context.Context, param
 func (c *Client) sendActionsDownloadJobLogsForWorkflowRun(ctx context.Context, params ActionsDownloadJobLogsForWorkflowRunParams) (res *ActionsDownloadJobLogsForWorkflowRunFound, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/download-job-logs-for-workflow-run"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs"),
 	}
 
 	// Run stopwatch.
@@ -3352,6 +3403,8 @@ func (c *Client) ActionsDownloadWorkflowRunLogs(ctx context.Context, params Acti
 func (c *Client) sendActionsDownloadWorkflowRunLogs(ctx context.Context, params ActionsDownloadWorkflowRunLogsParams) (res *ActionsDownloadWorkflowRunLogsFound, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/download-workflow-run-logs"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/logs"),
 	}
 
 	// Run stopwatch.
@@ -3485,6 +3538,8 @@ func (c *Client) ActionsEnableSelectedRepositoryGithubActionsOrganization(ctx co
 func (c *Client) sendActionsEnableSelectedRepositoryGithubActionsOrganization(ctx context.Context, params ActionsEnableSelectedRepositoryGithubActionsOrganizationParams) (res *ActionsEnableSelectedRepositoryGithubActionsOrganizationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/enable-selected-repository-github-actions-organization"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -3598,6 +3653,8 @@ func (c *Client) ActionsGetAllowedActionsOrganization(ctx context.Context, param
 func (c *Client) sendActionsGetAllowedActionsOrganization(ctx context.Context, params ActionsGetAllowedActionsOrganizationParams) (res *SelectedActions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-allowed-actions-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -3693,6 +3750,8 @@ func (c *Client) ActionsGetAllowedActionsRepository(ctx context.Context, params 
 func (c *Client) sendActionsGetAllowedActionsRepository(ctx context.Context, params ActionsGetAllowedActionsRepositoryParams) (res *SelectedActions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-allowed-actions-repository"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -3804,6 +3863,8 @@ func (c *Client) ActionsGetArtifact(ctx context.Context, params ActionsGetArtifa
 func (c *Client) sendActionsGetArtifact(ctx context.Context, params ActionsGetArtifactParams) (res *Artifact, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-artifact"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/artifacts/{artifact_id}"),
 	}
 
 	// Run stopwatch.
@@ -3934,6 +3995,8 @@ func (c *Client) ActionsGetEnvironmentPublicKey(ctx context.Context, params Acti
 func (c *Client) sendActionsGetEnvironmentPublicKey(ctx context.Context, params ActionsGetEnvironmentPublicKeyParams) (res *ActionsPublicKey, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-environment-public-key"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repositories/{repository_id}/environments/{environment_name}/secrets/public-key"),
 	}
 
 	// Run stopwatch.
@@ -4045,6 +4108,8 @@ func (c *Client) ActionsGetEnvironmentSecret(ctx context.Context, params Actions
 func (c *Client) sendActionsGetEnvironmentSecret(ctx context.Context, params ActionsGetEnvironmentSecretParams) (res *ActionsSecret, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-environment-secret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -4174,6 +4239,8 @@ func (c *Client) ActionsGetGithubActionsPermissionsOrganization(ctx context.Cont
 func (c *Client) sendActionsGetGithubActionsPermissionsOrganization(ctx context.Context, params ActionsGetGithubActionsPermissionsOrganizationParams) (res *ActionsOrganizationPermissions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-github-actions-permissions-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions"),
 	}
 
 	// Run stopwatch.
@@ -4267,6 +4334,8 @@ func (c *Client) ActionsGetGithubActionsPermissionsRepository(ctx context.Contex
 func (c *Client) sendActionsGetGithubActionsPermissionsRepository(ctx context.Context, params ActionsGetGithubActionsPermissionsRepositoryParams) (res *ActionsRepositoryPermissions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-github-actions-permissions-repository"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/permissions"),
 	}
 
 	// Run stopwatch.
@@ -4378,6 +4447,8 @@ func (c *Client) ActionsGetJobForWorkflowRun(ctx context.Context, params Actions
 func (c *Client) sendActionsGetJobForWorkflowRun(ctx context.Context, params ActionsGetJobForWorkflowRunParams) (res *Job, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-job-for-workflow-run"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/jobs/{job_id}"),
 	}
 
 	// Run stopwatch.
@@ -4508,6 +4579,8 @@ func (c *Client) ActionsGetOrgPublicKey(ctx context.Context, params ActionsGetOr
 func (c *Client) sendActionsGetOrgPublicKey(ctx context.Context, params ActionsGetOrgPublicKeyParams) (res *ActionsPublicKey, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-org-public-key"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/public-key"),
 	}
 
 	// Run stopwatch.
@@ -4600,6 +4673,8 @@ func (c *Client) ActionsGetOrgSecret(ctx context.Context, params ActionsGetOrgSe
 func (c *Client) sendActionsGetOrgSecret(ctx context.Context, params ActionsGetOrgSecretParams) (res *OrganizationActionsSecret, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-org-secret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -4711,6 +4786,8 @@ func (c *Client) ActionsGetRepoPublicKey(ctx context.Context, params ActionsGetR
 func (c *Client) sendActionsGetRepoPublicKey(ctx context.Context, params ActionsGetRepoPublicKeyParams) (res *ActionsPublicKey, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-repo-public-key"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/secrets/public-key"),
 	}
 
 	// Run stopwatch.
@@ -4822,6 +4899,8 @@ func (c *Client) ActionsGetRepoSecret(ctx context.Context, params ActionsGetRepo
 func (c *Client) sendActionsGetRepoSecret(ctx context.Context, params ActionsGetRepoSecretParams) (res *ActionsSecret, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-repo-secret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/secrets/{secret_name}"),
 	}
 
 	// Run stopwatch.
@@ -4951,6 +5030,8 @@ func (c *Client) ActionsGetReviewsForRun(ctx context.Context, params ActionsGetR
 func (c *Client) sendActionsGetReviewsForRun(ctx context.Context, params ActionsGetReviewsForRunParams) (res []EnvironmentApprovals, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-reviews-for-run"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/approvals"),
 	}
 
 	// Run stopwatch.
@@ -5080,6 +5161,8 @@ func (c *Client) ActionsGetSelfHostedRunnerForOrg(ctx context.Context, params Ac
 func (c *Client) sendActionsGetSelfHostedRunnerForOrg(ctx context.Context, params ActionsGetSelfHostedRunnerForOrgParams) (res *Runner, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-self-hosted-runner-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -5190,6 +5273,8 @@ func (c *Client) ActionsGetSelfHostedRunnerForRepo(ctx context.Context, params A
 func (c *Client) sendActionsGetSelfHostedRunnerForRepo(ctx context.Context, params ActionsGetSelfHostedRunnerForRepoParams) (res *Runner, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-self-hosted-runner-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -5321,6 +5406,8 @@ func (c *Client) ActionsGetSelfHostedRunnerGroupForOrg(ctx context.Context, para
 func (c *Client) sendActionsGetSelfHostedRunnerGroupForOrg(ctx context.Context, params ActionsGetSelfHostedRunnerGroupForOrgParams) (res *RunnerGroupsOrg, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-self-hosted-runner-group-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -5431,6 +5518,8 @@ func (c *Client) ActionsGetWorkflowRun(ctx context.Context, params ActionsGetWor
 func (c *Client) sendActionsGetWorkflowRun(ctx context.Context, params ActionsGetWorkflowRunParams) (res *WorkflowRun, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-workflow-run"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}"),
 	}
 
 	// Run stopwatch.
@@ -5567,6 +5656,8 @@ func (c *Client) ActionsGetWorkflowRunUsage(ctx context.Context, params ActionsG
 func (c *Client) sendActionsGetWorkflowRunUsage(ctx context.Context, params ActionsGetWorkflowRunUsageParams) (res *WorkflowRunUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/get-workflow-run-usage"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/timing"),
 	}
 
 	// Run stopwatch.
@@ -5697,6 +5788,8 @@ func (c *Client) ActionsListArtifactsForRepo(ctx context.Context, params Actions
 func (c *Client) sendActionsListArtifactsForRepo(ctx context.Context, params ActionsListArtifactsForRepoParams) (res *ActionsListArtifactsForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-artifacts-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/artifacts"),
 	}
 
 	// Run stopwatch.
@@ -5846,6 +5939,8 @@ func (c *Client) ActionsListEnvironmentSecrets(ctx context.Context, params Actio
 func (c *Client) sendActionsListEnvironmentSecrets(ctx context.Context, params ActionsListEnvironmentSecretsParams) (res *ActionsListEnvironmentSecretsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-environment-secrets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repositories/{repository_id}/environments/{environment_name}/secrets"),
 	}
 
 	// Run stopwatch.
@@ -5997,6 +6092,8 @@ func (c *Client) ActionsListJobsForWorkflowRun(ctx context.Context, params Actio
 func (c *Client) sendActionsListJobsForWorkflowRun(ctx context.Context, params ActionsListJobsForWorkflowRunParams) (res *ActionsListJobsForWorkflowRunOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-jobs-for-workflow-run"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/jobs"),
 	}
 
 	// Run stopwatch.
@@ -6182,6 +6279,8 @@ func (c *Client) ActionsListOrgSecrets(ctx context.Context, params ActionsListOr
 func (c *Client) sendActionsListOrgSecrets(ctx context.Context, params ActionsListOrgSecretsParams) (res *ActionsListOrgSecretsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-org-secrets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets"),
 	}
 
 	// Run stopwatch.
@@ -6314,6 +6413,8 @@ func (c *Client) ActionsListRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.C
 func (c *Client) sendActionsListRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Context, params ActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams) (res *ActionsListRepoAccessToSelfHostedRunnerGroupInOrgOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-repo-access-to-self-hosted-runner-group-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories"),
 	}
 
 	// Run stopwatch.
@@ -6463,6 +6564,8 @@ func (c *Client) ActionsListRepoSecrets(ctx context.Context, params ActionsListR
 func (c *Client) sendActionsListRepoSecrets(ctx context.Context, params ActionsListRepoSecretsParams) (res *ActionsListRepoSecretsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-repo-secrets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/secrets"),
 	}
 
 	// Run stopwatch.
@@ -6612,6 +6715,8 @@ func (c *Client) ActionsListRepoWorkflows(ctx context.Context, params ActionsLis
 func (c *Client) sendActionsListRepoWorkflows(ctx context.Context, params ActionsListRepoWorkflowsParams) (res *ActionsListRepoWorkflowsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-repo-workflows"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/workflows"),
 	}
 
 	// Run stopwatch.
@@ -6760,6 +6865,8 @@ func (c *Client) ActionsListRunnerApplicationsForOrg(ctx context.Context, params
 func (c *Client) sendActionsListRunnerApplicationsForOrg(ctx context.Context, params ActionsListRunnerApplicationsForOrgParams) (res []RunnerApplication, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-runner-applications-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners/downloads"),
 	}
 
 	// Run stopwatch.
@@ -6851,6 +6958,8 @@ func (c *Client) ActionsListRunnerApplicationsForRepo(ctx context.Context, param
 func (c *Client) sendActionsListRunnerApplicationsForRepo(ctx context.Context, params ActionsListRunnerApplicationsForRepoParams) (res []RunnerApplication, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-runner-applications-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners/downloads"),
 	}
 
 	// Run stopwatch.
@@ -6963,6 +7072,8 @@ func (c *Client) ActionsListSelectedReposForOrgSecret(ctx context.Context, param
 func (c *Client) sendActionsListSelectedReposForOrgSecret(ctx context.Context, params ActionsListSelectedReposForOrgSecretParams) (res *ActionsListSelectedReposForOrgSecretOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-selected-repos-for-org-secret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}/repositories"),
 	}
 
 	// Run stopwatch.
@@ -7115,6 +7226,8 @@ func (c *Client) ActionsListSelectedRepositoriesEnabledGithubActionsOrganization
 func (c *Client) sendActionsListSelectedRepositoriesEnabledGithubActionsOrganization(ctx context.Context, params ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams) (res *ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-selected-repositories-enabled-github-actions-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/repositories"),
 	}
 
 	// Run stopwatch.
@@ -7247,6 +7360,8 @@ func (c *Client) ActionsListSelfHostedRunnerGroupsForOrg(ctx context.Context, pa
 func (c *Client) sendActionsListSelfHostedRunnerGroupsForOrg(ctx context.Context, params ActionsListSelfHostedRunnerGroupsForOrgParams) (res *ActionsListSelfHostedRunnerGroupsForOrgOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-self-hosted-runner-groups-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups"),
 	}
 
 	// Run stopwatch.
@@ -7376,6 +7491,8 @@ func (c *Client) ActionsListSelfHostedRunnersForOrg(ctx context.Context, params 
 func (c *Client) sendActionsListSelfHostedRunnersForOrg(ctx context.Context, params ActionsListSelfHostedRunnersForOrgParams) (res *ActionsListSelfHostedRunnersForOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-self-hosted-runners-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runners"),
 	}
 
 	// Run stopwatch.
@@ -7505,6 +7622,8 @@ func (c *Client) ActionsListSelfHostedRunnersForRepo(ctx context.Context, params
 func (c *Client) sendActionsListSelfHostedRunnersForRepo(ctx context.Context, params ActionsListSelfHostedRunnersForRepoParams) (res *ActionsListSelfHostedRunnersForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-self-hosted-runners-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runners"),
 	}
 
 	// Run stopwatch.
@@ -7656,6 +7775,8 @@ func (c *Client) ActionsListSelfHostedRunnersInGroupForOrg(ctx context.Context, 
 func (c *Client) sendActionsListSelfHostedRunnersInGroupForOrg(ctx context.Context, params ActionsListSelfHostedRunnersInGroupForOrgParams) (res *ActionsListSelfHostedRunnersInGroupForOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-self-hosted-runners-in-group-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/runners"),
 	}
 
 	// Run stopwatch.
@@ -7805,6 +7926,8 @@ func (c *Client) ActionsListWorkflowRunArtifacts(ctx context.Context, params Act
 func (c *Client) sendActionsListWorkflowRunArtifacts(ctx context.Context, params ActionsListWorkflowRunArtifactsParams) (res *ActionsListWorkflowRunArtifactsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-workflow-run-artifacts"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"),
 	}
 
 	// Run stopwatch.
@@ -7976,6 +8099,8 @@ func (c *Client) ActionsListWorkflowRunsForRepo(ctx context.Context, params Acti
 func (c *Client) sendActionsListWorkflowRunsForRepo(ctx context.Context, params ActionsListWorkflowRunsForRepoParams) (res *ActionsListWorkflowRunsForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/list-workflow-runs-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs"),
 	}
 
 	// Run stopwatch.
@@ -8215,6 +8340,8 @@ func (c *Client) ActionsReRunWorkflow(ctx context.Context, params ActionsReRunWo
 func (c *Client) sendActionsReRunWorkflow(ctx context.Context, params ActionsReRunWorkflowParams) (res *ActionsReRunWorkflowCreated, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/re-run-workflow"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/rerun"),
 	}
 
 	// Run stopwatch.
@@ -8350,6 +8477,8 @@ func (c *Client) ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg(ctx context
 func (c *Client) sendActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Context, params ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgParams) (res *ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/remove-repo-access-to-self-hosted-runner-group-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -8481,6 +8610,8 @@ func (c *Client) ActionsRemoveSelectedRepoFromOrgSecret(ctx context.Context, par
 func (c *Client) sendActionsRemoveSelectedRepoFromOrgSecret(ctx context.Context, params ActionsRemoveSelectedRepoFromOrgSecretParams) (res ActionsRemoveSelectedRepoFromOrgSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/remove-selected-repo-from-org-secret"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -8613,6 +8744,8 @@ func (c *Client) ActionsRemoveSelfHostedRunnerFromGroupForOrg(ctx context.Contex
 func (c *Client) sendActionsRemoveSelfHostedRunnerFromGroupForOrg(ctx context.Context, params ActionsRemoveSelfHostedRunnerFromGroupForOrgParams) (res *ActionsRemoveSelfHostedRunnerFromGroupForOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/remove-self-hosted-runner-from-group-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -8742,6 +8875,8 @@ func (c *Client) ActionsRetryWorkflow(ctx context.Context, params ActionsRetryWo
 func (c *Client) sendActionsRetryWorkflow(ctx context.Context, params ActionsRetryWorkflowParams) (res *ActionsRetryWorkflowCreated, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/retry-workflow"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/retry"),
 	}
 
 	// Run stopwatch.
@@ -8871,6 +9006,8 @@ func (c *Client) ActionsReviewPendingDeploymentsForRun(ctx context.Context, requ
 func (c *Client) sendActionsReviewPendingDeploymentsForRun(ctx context.Context, request *ActionsReviewPendingDeploymentsForRunReq, params ActionsReviewPendingDeploymentsForRunParams) (res []Deployment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/review-pending-deployments-for-run"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9021,6 +9158,8 @@ func (c *Client) ActionsSetAllowedActionsOrganization(ctx context.Context, reque
 func (c *Client) sendActionsSetAllowedActionsOrganization(ctx context.Context, request OptSelectedActions, params ActionsSetAllowedActionsOrganizationParams) (res *ActionsSetAllowedActionsOrganizationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-allowed-actions-organization"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -9123,6 +9262,8 @@ func (c *Client) ActionsSetAllowedActionsRepository(ctx context.Context, request
 func (c *Client) sendActionsSetAllowedActionsRepository(ctx context.Context, request OptSelectedActions, params ActionsSetAllowedActionsRepositoryParams) (res *ActionsSetAllowedActionsRepositoryNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-allowed-actions-repository"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -9240,6 +9381,8 @@ func (c *Client) ActionsSetGithubActionsPermissionsOrganization(ctx context.Cont
 func (c *Client) sendActionsSetGithubActionsPermissionsOrganization(ctx context.Context, request *ActionsSetGithubActionsPermissionsOrganizationReq, params ActionsSetGithubActionsPermissionsOrganizationParams) (res *ActionsSetGithubActionsPermissionsOrganizationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-github-actions-permissions-organization"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9348,6 +9491,8 @@ func (c *Client) ActionsSetGithubActionsPermissionsRepository(ctx context.Contex
 func (c *Client) sendActionsSetGithubActionsPermissionsRepository(ctx context.Context, request *ActionsSetGithubActionsPermissionsRepositoryReq, params ActionsSetGithubActionsPermissionsRepositoryParams) (res *ActionsSetGithubActionsPermissionsRepositoryNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-github-actions-permissions-repository"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/actions/permissions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9474,6 +9619,8 @@ func (c *Client) ActionsSetRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Co
 func (c *Client) sendActionsSetRepoAccessToSelfHostedRunnerGroupInOrg(ctx context.Context, request *ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgReq, params ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgParams) (res *ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-repo-access-to-self-hosted-runner-group-in-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9599,6 +9746,8 @@ func (c *Client) ActionsSetSelectedReposForOrgSecret(ctx context.Context, reques
 func (c *Client) sendActionsSetSelectedReposForOrgSecret(ctx context.Context, request *ActionsSetSelectedReposForOrgSecretReq, params ActionsSetSelectedReposForOrgSecretParams) (res *ActionsSetSelectedReposForOrgSecretNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-selected-repos-for-org-secret"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/secrets/{secret_name}/repositories"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9725,6 +9874,8 @@ func (c *Client) ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
 func (c *Client) sendActionsSetSelectedRepositoriesEnabledGithubActionsOrganization(ctx context.Context, request *ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationReq, params ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParams) (res *ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-selected-repositories-enabled-github-actions-organization"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/permissions/repositories"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9831,6 +9982,8 @@ func (c *Client) ActionsSetSelfHostedRunnersInGroupForOrg(ctx context.Context, r
 func (c *Client) sendActionsSetSelfHostedRunnersInGroupForOrg(ctx context.Context, request *ActionsSetSelfHostedRunnersInGroupForOrgReq, params ActionsSetSelfHostedRunnersInGroupForOrgParams) (res *ActionsSetSelfHostedRunnersInGroupForOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/set-self-hosted-runners-in-group-for-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}/runners"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9956,6 +10109,8 @@ func (c *Client) ActionsUpdateSelfHostedRunnerGroupForOrg(ctx context.Context, r
 func (c *Client) sendActionsUpdateSelfHostedRunnerGroupForOrg(ctx context.Context, request *ActionsUpdateSelfHostedRunnerGroupForOrgReq, params ActionsUpdateSelfHostedRunnerGroupForOrgParams) (res *RunnerGroupsOrg, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("actions/update-self-hosted-runner-group-for-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/actions/runner-groups/{runner_group_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10076,6 +10231,8 @@ func (c *Client) ActivityCheckRepoIsStarredByAuthenticatedUser(ctx context.Conte
 func (c *Client) sendActivityCheckRepoIsStarredByAuthenticatedUser(ctx context.Context, params ActivityCheckRepoIsStarredByAuthenticatedUserParams) (res ActivityCheckRepoIsStarredByAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/check-repo-is-starred-by-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/starred/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -10186,6 +10343,8 @@ func (c *Client) ActivityDeleteRepoSubscription(ctx context.Context, params Acti
 func (c *Client) sendActivityDeleteRepoSubscription(ctx context.Context, params ActivityDeleteRepoSubscriptionParams) (res *ActivityDeleteRepoSubscriptionNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/delete-repo-subscription"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -10299,6 +10458,8 @@ func (c *Client) ActivityDeleteThreadSubscription(ctx context.Context, params Ac
 func (c *Client) sendActivityDeleteThreadSubscription(ctx context.Context, params ActivityDeleteThreadSubscriptionParams) (res ActivityDeleteThreadSubscriptionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/delete-thread-subscription"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/notifications/threads/{thread_id}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -10403,6 +10564,8 @@ func (c *Client) ActivityGetFeeds(ctx context.Context) (*Feed, error) {
 func (c *Client) sendActivityGetFeeds(ctx context.Context) (res *Feed, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/get-feeds"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/feeds"),
 	}
 
 	// Run stopwatch.
@@ -10474,6 +10637,8 @@ func (c *Client) ActivityGetRepoSubscription(ctx context.Context, params Activit
 func (c *Client) sendActivityGetRepoSubscription(ctx context.Context, params ActivityGetRepoSubscriptionParams) (res ActivityGetRepoSubscriptionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/get-repo-subscription"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -10583,6 +10748,8 @@ func (c *Client) ActivityGetThread(ctx context.Context, params ActivityGetThread
 func (c *Client) sendActivityGetThread(ctx context.Context, params ActivityGetThreadParams) (res ActivityGetThreadRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/get-thread"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/notifications/threads/{thread_id}"),
 	}
 
 	// Run stopwatch.
@@ -10675,6 +10842,8 @@ func (c *Client) ActivityGetThreadSubscriptionForAuthenticatedUser(ctx context.C
 func (c *Client) sendActivityGetThreadSubscriptionForAuthenticatedUser(ctx context.Context, params ActivityGetThreadSubscriptionForAuthenticatedUserParams) (res ActivityGetThreadSubscriptionForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/get-thread-subscription-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/notifications/threads/{thread_id}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -10766,6 +10935,8 @@ func (c *Client) ActivityListEventsForAuthenticatedUser(ctx context.Context, par
 func (c *Client) sendActivityListEventsForAuthenticatedUser(ctx context.Context, params ActivityListEventsForAuthenticatedUserParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-events-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/events"),
 	}
 
 	// Run stopwatch.
@@ -10894,6 +11065,8 @@ func (c *Client) ActivityListNotificationsForAuthenticatedUser(ctx context.Conte
 func (c *Client) sendActivityListNotificationsForAuthenticatedUser(ctx context.Context, params ActivityListNotificationsForAuthenticatedUserParams) (res ActivityListNotificationsForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-notifications-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/notifications"),
 	}
 
 	// Run stopwatch.
@@ -11071,6 +11244,8 @@ func (c *Client) ActivityListOrgEventsForAuthenticatedUser(ctx context.Context, 
 func (c *Client) sendActivityListOrgEventsForAuthenticatedUser(ctx context.Context, params ActivityListOrgEventsForAuthenticatedUserParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-org-events-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/events/orgs/{org}"),
 	}
 
 	// Run stopwatch.
@@ -11218,6 +11393,8 @@ func (c *Client) ActivityListPublicEvents(ctx context.Context, params ActivityLi
 func (c *Client) sendActivityListPublicEvents(ctx context.Context, params ActivityListPublicEventsParams) (res ActivityListPublicEventsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-public-events"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/events"),
 	}
 
 	// Run stopwatch.
@@ -11327,6 +11504,8 @@ func (c *Client) ActivityListPublicEventsForRepoNetwork(ctx context.Context, par
 func (c *Client) sendActivityListPublicEventsForRepoNetwork(ctx context.Context, params ActivityListPublicEventsForRepoNetworkParams) (res ActivityListPublicEventsForRepoNetworkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-public-events-for-repo-network"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/networks/{owner}/{repo}/events"),
 	}
 
 	// Run stopwatch.
@@ -11474,6 +11653,8 @@ func (c *Client) ActivityListPublicEventsForUser(ctx context.Context, params Act
 func (c *Client) sendActivityListPublicEventsForUser(ctx context.Context, params ActivityListPublicEventsForUserParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-public-events-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/events/public"),
 	}
 
 	// Run stopwatch.
@@ -11602,6 +11783,8 @@ func (c *Client) ActivityListPublicOrgEvents(ctx context.Context, params Activit
 func (c *Client) sendActivityListPublicOrgEvents(ctx context.Context, params ActivityListPublicOrgEventsParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-public-org-events"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/events"),
 	}
 
 	// Run stopwatch.
@@ -11732,6 +11915,8 @@ func (c *Client) ActivityListReceivedEventsForUser(ctx context.Context, params A
 func (c *Client) sendActivityListReceivedEventsForUser(ctx context.Context, params ActivityListReceivedEventsForUserParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-received-events-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/received_events"),
 	}
 
 	// Run stopwatch.
@@ -11860,6 +12045,8 @@ func (c *Client) ActivityListReceivedPublicEventsForUser(ctx context.Context, pa
 func (c *Client) sendActivityListReceivedPublicEventsForUser(ctx context.Context, params ActivityListReceivedPublicEventsForUserParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-received-public-events-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/received_events/public"),
 	}
 
 	// Run stopwatch.
@@ -11988,6 +12175,8 @@ func (c *Client) ActivityListRepoEvents(ctx context.Context, params ActivityList
 func (c *Client) sendActivityListRepoEvents(ctx context.Context, params ActivityListRepoEventsParams) (res []Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-repo-events"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/events"),
 	}
 
 	// Run stopwatch.
@@ -12135,6 +12324,8 @@ func (c *Client) ActivityListRepoNotificationsForAuthenticatedUser(ctx context.C
 func (c *Client) sendActivityListRepoNotificationsForAuthenticatedUser(ctx context.Context, params ActivityListRepoNotificationsForAuthenticatedUserParams) (res *ActivityListRepoNotificationsForAuthenticatedUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-repo-notifications-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/notifications"),
 	}
 
 	// Run stopwatch.
@@ -12352,6 +12543,8 @@ func (c *Client) ActivityListReposStarredByAuthenticatedUser(ctx context.Context
 func (c *Client) sendActivityListReposStarredByAuthenticatedUser(ctx context.Context, params ActivityListReposStarredByAuthenticatedUserParams) (res ActivityListReposStarredByAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-repos-starred-by-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/starred"),
 	}
 
 	// Run stopwatch.
@@ -12495,6 +12688,8 @@ func (c *Client) ActivityListReposWatchedByUser(ctx context.Context, params Acti
 func (c *Client) sendActivityListReposWatchedByUser(ctx context.Context, params ActivityListReposWatchedByUserParams) (res *ActivityListReposWatchedByUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-repos-watched-by-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/subscriptions"),
 	}
 
 	// Run stopwatch.
@@ -12623,6 +12818,8 @@ func (c *Client) ActivityListWatchedReposForAuthenticatedUser(ctx context.Contex
 func (c *Client) sendActivityListWatchedReposForAuthenticatedUser(ctx context.Context, params ActivityListWatchedReposForAuthenticatedUserParams) (res ActivityListWatchedReposForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-watched-repos-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/subscriptions"),
 	}
 
 	// Run stopwatch.
@@ -12732,6 +12929,8 @@ func (c *Client) ActivityListWatchersForRepo(ctx context.Context, params Activit
 func (c *Client) sendActivityListWatchersForRepo(ctx context.Context, params ActivityListWatchersForRepoParams) (res *ActivityListWatchersForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/list-watchers-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/subscribers"),
 	}
 
 	// Run stopwatch.
@@ -12885,6 +13084,8 @@ func (c *Client) ActivityMarkNotificationsAsRead(ctx context.Context, request Op
 func (c *Client) sendActivityMarkNotificationsAsRead(ctx context.Context, request OptActivityMarkNotificationsAsReadReq) (res ActivityMarkNotificationsAsReadRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/mark-notifications-as-read"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/notifications"),
 	}
 
 	// Run stopwatch.
@@ -12965,6 +13166,8 @@ func (c *Client) ActivityMarkRepoNotificationsAsRead(ctx context.Context, reques
 func (c *Client) sendActivityMarkRepoNotificationsAsRead(ctx context.Context, request OptActivityMarkRepoNotificationsAsReadReq, params ActivityMarkRepoNotificationsAsReadParams) (res ActivityMarkRepoNotificationsAsReadRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/mark-repo-notifications-as-read"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/notifications"),
 	}
 
 	// Run stopwatch.
@@ -13077,6 +13280,8 @@ func (c *Client) ActivityMarkThreadAsRead(ctx context.Context, params ActivityMa
 func (c *Client) sendActivityMarkThreadAsRead(ctx context.Context, params ActivityMarkThreadAsReadParams) (res ActivityMarkThreadAsReadRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/mark-thread-as-read"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/notifications/threads/{thread_id}"),
 	}
 
 	// Run stopwatch.
@@ -13169,6 +13374,8 @@ func (c *Client) ActivitySetRepoSubscription(ctx context.Context, request OptAct
 func (c *Client) sendActivitySetRepoSubscription(ctx context.Context, request OptActivitySetRepoSubscriptionReq, params ActivitySetRepoSubscriptionParams) (res *RepositorySubscription, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/set-repo-subscription"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -13288,6 +13495,8 @@ func (c *Client) ActivitySetThreadSubscription(ctx context.Context, request OptA
 func (c *Client) sendActivitySetThreadSubscription(ctx context.Context, request OptActivitySetThreadSubscriptionReq, params ActivitySetThreadSubscriptionParams) (res ActivitySetThreadSubscriptionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/set-thread-subscription"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/notifications/threads/{thread_id}/subscription"),
 	}
 
 	// Run stopwatch.
@@ -13383,6 +13592,8 @@ func (c *Client) ActivityStarRepoForAuthenticatedUser(ctx context.Context, param
 func (c *Client) sendActivityStarRepoForAuthenticatedUser(ctx context.Context, params ActivityStarRepoForAuthenticatedUserParams) (res ActivityStarRepoForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/star-repo-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/user/starred/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -13491,6 +13702,8 @@ func (c *Client) ActivityUnstarRepoForAuthenticatedUser(ctx context.Context, par
 func (c *Client) sendActivityUnstarRepoForAuthenticatedUser(ctx context.Context, params ActivityUnstarRepoForAuthenticatedUserParams) (res ActivityUnstarRepoForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("activity/unstar-repo-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/starred/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -13604,6 +13817,8 @@ func (c *Client) AppsAddRepoToInstallation(ctx context.Context, params AppsAddRe
 func (c *Client) sendAppsAddRepoToInstallation(ctx context.Context, params AppsAddRepoToInstallationParams) (res AppsAddRepoToInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/add-repo-to-installation"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/user/installations/{installation_id}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -13717,6 +13932,8 @@ func (c *Client) AppsCheckToken(ctx context.Context, request *AppsCheckTokenReq,
 func (c *Client) sendAppsCheckToken(ctx context.Context, request *AppsCheckTokenReq, params AppsCheckTokenParams) (res AppsCheckTokenRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/check-token"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/applications/{client_id}/token"),
 	}
 
 	// Run stopwatch.
@@ -13819,6 +14036,8 @@ func (c *Client) AppsCreateContentAttachment(ctx context.Context, request *AppsC
 func (c *Client) sendAppsCreateContentAttachment(ctx context.Context, request *AppsCreateContentAttachmentReq, params AppsCreateContentAttachmentParams) (res AppsCreateContentAttachmentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/create-content-attachment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13962,6 +14181,8 @@ func (c *Client) AppsCreateFromManifest(ctx context.Context, request *AppsCreate
 func (c *Client) sendAppsCreateFromManifest(ctx context.Context, request *AppsCreateFromManifestReq, params AppsCreateFromManifestParams) (res AppsCreateFromManifestRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/create-from-manifest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/app-manifests/{code}/conversions"),
 	}
 
 	// Run stopwatch.
@@ -14064,6 +14285,8 @@ func (c *Client) AppsCreateInstallationAccessToken(ctx context.Context, request 
 func (c *Client) sendAppsCreateInstallationAccessToken(ctx context.Context, request OptAppsCreateInstallationAccessTokenReq, params AppsCreateInstallationAccessTokenParams) (res AppsCreateInstallationAccessTokenRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/create-installation-access-token"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/app/installations/{installation_id}/access_tokens"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14182,6 +14405,8 @@ func (c *Client) AppsDeleteAuthorization(ctx context.Context, request *AppsDelet
 func (c *Client) sendAppsDeleteAuthorization(ctx context.Context, request *AppsDeleteAuthorizationReq, params AppsDeleteAuthorizationParams) (res AppsDeleteAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/delete-authorization"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/applications/{client_id}/grant"),
 	}
 
 	// Run stopwatch.
@@ -14280,6 +14505,8 @@ func (c *Client) AppsDeleteInstallation(ctx context.Context, params AppsDeleteIn
 func (c *Client) sendAppsDeleteInstallation(ctx context.Context, params AppsDeleteInstallationParams) (res AppsDeleteInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/delete-installation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/app/installations/{installation_id}"),
 	}
 
 	// Run stopwatch.
@@ -14372,6 +14599,8 @@ func (c *Client) AppsDeleteToken(ctx context.Context, request *AppsDeleteTokenRe
 func (c *Client) sendAppsDeleteToken(ctx context.Context, request *AppsDeleteTokenReq, params AppsDeleteTokenParams) (res AppsDeleteTokenRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/delete-token"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/applications/{client_id}/token"),
 	}
 
 	// Run stopwatch.
@@ -14472,6 +14701,8 @@ func (c *Client) AppsGetAuthenticated(ctx context.Context) (*Integration, error)
 func (c *Client) sendAppsGetAuthenticated(ctx context.Context) (res *Integration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/app"),
 	}
 
 	// Run stopwatch.
@@ -14550,6 +14781,8 @@ func (c *Client) AppsGetBySlug(ctx context.Context, params AppsGetBySlugParams) 
 func (c *Client) sendAppsGetBySlug(ctx context.Context, params AppsGetBySlugParams) (res AppsGetBySlugRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-by-slug"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apps/{app_slug}"),
 	}
 
 	// Run stopwatch.
@@ -14646,6 +14879,8 @@ func (c *Client) AppsGetSubscriptionPlanForAccount(ctx context.Context, params A
 func (c *Client) sendAppsGetSubscriptionPlanForAccount(ctx context.Context, params AppsGetSubscriptionPlanForAccountParams) (res AppsGetSubscriptionPlanForAccountRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-subscription-plan-for-account"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/accounts/{account_id}"),
 	}
 
 	// Run stopwatch.
@@ -14742,6 +14977,8 @@ func (c *Client) AppsGetSubscriptionPlanForAccountStubbed(ctx context.Context, p
 func (c *Client) sendAppsGetSubscriptionPlanForAccountStubbed(ctx context.Context, params AppsGetSubscriptionPlanForAccountStubbedParams) (res AppsGetSubscriptionPlanForAccountStubbedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-subscription-plan-for-account-stubbed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/stubbed/accounts/{account_id}"),
 	}
 
 	// Run stopwatch.
@@ -14835,6 +15072,8 @@ func (c *Client) AppsGetWebhookConfigForApp(ctx context.Context) (*WebhookConfig
 func (c *Client) sendAppsGetWebhookConfigForApp(ctx context.Context) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-webhook-config-for-app"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/app/hook/config"),
 	}
 
 	// Run stopwatch.
@@ -14909,6 +15148,8 @@ func (c *Client) AppsGetWebhookDelivery(ctx context.Context, params AppsGetWebho
 func (c *Client) sendAppsGetWebhookDelivery(ctx context.Context, params AppsGetWebhookDeliveryParams) (res AppsGetWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/get-webhook-delivery"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/app/hook/deliveries/{delivery_id}"),
 	}
 
 	// Run stopwatch.
@@ -15006,6 +15247,8 @@ func (c *Client) AppsListAccountsForPlan(ctx context.Context, params AppsListAcc
 func (c *Client) sendAppsListAccountsForPlan(ctx context.Context, params AppsListAccountsForPlanParams) (res AppsListAccountsForPlanRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-accounts-for-plan"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/plans/{plan_id}/accounts"),
 	}
 
 	// Run stopwatch.
@@ -15176,6 +15419,8 @@ func (c *Client) AppsListAccountsForPlanStubbed(ctx context.Context, params Apps
 func (c *Client) sendAppsListAccountsForPlanStubbed(ctx context.Context, params AppsListAccountsForPlanStubbedParams) (res AppsListAccountsForPlanStubbedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-accounts-for-plan-stubbed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/stubbed/plans/{plan_id}/accounts"),
 	}
 
 	// Run stopwatch.
@@ -15344,6 +15589,8 @@ func (c *Client) AppsListInstallationReposForAuthenticatedUser(ctx context.Conte
 func (c *Client) sendAppsListInstallationReposForAuthenticatedUser(ctx context.Context, params AppsListInstallationReposForAuthenticatedUserParams) (res AppsListInstallationReposForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-installation-repos-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/installations/{installation_id}/repositories"),
 	}
 
 	// Run stopwatch.
@@ -15477,6 +15724,8 @@ func (c *Client) AppsListPlans(ctx context.Context, params AppsListPlansParams) 
 func (c *Client) sendAppsListPlans(ctx context.Context, params AppsListPlansParams) (res AppsListPlansRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-plans"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/plans"),
 	}
 
 	// Run stopwatch.
@@ -15591,6 +15840,8 @@ func (c *Client) AppsListPlansStubbed(ctx context.Context, params AppsListPlansS
 func (c *Client) sendAppsListPlansStubbed(ctx context.Context, params AppsListPlansStubbedParams) (res AppsListPlansStubbedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-plans-stubbed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/marketplace_listing/stubbed/plans"),
 	}
 
 	// Run stopwatch.
@@ -15703,6 +15954,8 @@ func (c *Client) AppsListReposAccessibleToInstallation(ctx context.Context, para
 func (c *Client) sendAppsListReposAccessibleToInstallation(ctx context.Context, params AppsListReposAccessibleToInstallationParams) (res AppsListReposAccessibleToInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-repos-accessible-to-installation"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/installation/repositories"),
 	}
 
 	// Run stopwatch.
@@ -15814,6 +16067,8 @@ func (c *Client) AppsListSubscriptionsForAuthenticatedUser(ctx context.Context, 
 func (c *Client) sendAppsListSubscriptionsForAuthenticatedUser(ctx context.Context, params AppsListSubscriptionsForAuthenticatedUserParams) (res AppsListSubscriptionsForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-subscriptions-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/marketplace_purchases"),
 	}
 
 	// Run stopwatch.
@@ -15925,6 +16180,8 @@ func (c *Client) AppsListSubscriptionsForAuthenticatedUserStubbed(ctx context.Co
 func (c *Client) sendAppsListSubscriptionsForAuthenticatedUserStubbed(ctx context.Context, params AppsListSubscriptionsForAuthenticatedUserStubbedParams) (res AppsListSubscriptionsForAuthenticatedUserStubbedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-subscriptions-for-authenticated-user-stubbed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/marketplace_purchases/stubbed"),
 	}
 
 	// Run stopwatch.
@@ -16037,6 +16294,8 @@ func (c *Client) AppsListWebhookDeliveries(ctx context.Context, params AppsListW
 func (c *Client) sendAppsListWebhookDeliveries(ctx context.Context, params AppsListWebhookDeliveriesParams) (res AppsListWebhookDeliveriesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/list-webhook-deliveries"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/app/hook/deliveries"),
 	}
 
 	// Run stopwatch.
@@ -16149,6 +16408,8 @@ func (c *Client) AppsRedeliverWebhookDelivery(ctx context.Context, params AppsRe
 func (c *Client) sendAppsRedeliverWebhookDelivery(ctx context.Context, params AppsRedeliverWebhookDeliveryParams) (res AppsRedeliverWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/redeliver-webhook-delivery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/app/hook/deliveries/{delivery_id}/attempts"),
 	}
 
 	// Run stopwatch.
@@ -16244,6 +16505,8 @@ func (c *Client) AppsRemoveRepoFromInstallation(ctx context.Context, params Apps
 func (c *Client) sendAppsRemoveRepoFromInstallation(ctx context.Context, params AppsRemoveRepoFromInstallationParams) (res AppsRemoveRepoFromInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/remove-repo-from-installation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/installations/{installation_id}/repositories/{repository_id}"),
 	}
 
 	// Run stopwatch.
@@ -16357,6 +16620,8 @@ func (c *Client) AppsResetToken(ctx context.Context, request *AppsResetTokenReq,
 func (c *Client) sendAppsResetToken(ctx context.Context, request *AppsResetTokenReq, params AppsResetTokenParams) (res AppsResetTokenRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/reset-token"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/applications/{client_id}/token"),
 	}
 
 	// Run stopwatch.
@@ -16459,6 +16724,8 @@ func (c *Client) AppsRevokeInstallationAccessToken(ctx context.Context) error {
 func (c *Client) sendAppsRevokeInstallationAccessToken(ctx context.Context) (res *AppsRevokeInstallationAccessTokenNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/revoke-installation-access-token"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/installation/token"),
 	}
 
 	// Run stopwatch.
@@ -16535,6 +16802,8 @@ func (c *Client) AppsScopeToken(ctx context.Context, request *AppsScopeTokenReq,
 func (c *Client) sendAppsScopeToken(ctx context.Context, request *AppsScopeTokenReq, params AppsScopeTokenParams) (res AppsScopeTokenRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/scope-token"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/applications/{client_id}/token/scoped"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16642,6 +16911,8 @@ func (c *Client) AppsSuspendInstallation(ctx context.Context, params AppsSuspend
 func (c *Client) sendAppsSuspendInstallation(ctx context.Context, params AppsSuspendInstallationParams) (res AppsSuspendInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/suspend-installation"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/app/installations/{installation_id}/suspended"),
 	}
 
 	// Run stopwatch.
@@ -16735,6 +17006,8 @@ func (c *Client) AppsUnsuspendInstallation(ctx context.Context, params AppsUnsus
 func (c *Client) sendAppsUnsuspendInstallation(ctx context.Context, params AppsUnsuspendInstallationParams) (res AppsUnsuspendInstallationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/unsuspend-installation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/app/installations/{installation_id}/suspended"),
 	}
 
 	// Run stopwatch.
@@ -16829,6 +17102,8 @@ func (c *Client) AppsUpdateWebhookConfigForApp(ctx context.Context, request OptA
 func (c *Client) sendAppsUpdateWebhookConfigForApp(ctx context.Context, request OptAppsUpdateWebhookConfigForAppReq) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("apps/update-webhook-config-for-app"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/app/hook/config"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16926,6 +17201,8 @@ func (c *Client) BillingGetGithubActionsBillingGhe(ctx context.Context, params B
 func (c *Client) sendBillingGetGithubActionsBillingGhe(ctx context.Context, params BillingGetGithubActionsBillingGheParams) (res *ActionsBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-actions-billing-ghe"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/settings/billing/actions"),
 	}
 
 	// Run stopwatch.
@@ -17023,6 +17300,8 @@ func (c *Client) BillingGetGithubActionsBillingOrg(ctx context.Context, params B
 func (c *Client) sendBillingGetGithubActionsBillingOrg(ctx context.Context, params BillingGetGithubActionsBillingOrgParams) (res *ActionsBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-actions-billing-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/settings/billing/actions"),
 	}
 
 	// Run stopwatch.
@@ -17120,6 +17399,8 @@ func (c *Client) BillingGetGithubActionsBillingUser(ctx context.Context, params 
 func (c *Client) sendBillingGetGithubActionsBillingUser(ctx context.Context, params BillingGetGithubActionsBillingUserParams) (res *ActionsBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-actions-billing-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/settings/billing/actions"),
 	}
 
 	// Run stopwatch.
@@ -17214,6 +17495,8 @@ func (c *Client) BillingGetGithubPackagesBillingGhe(ctx context.Context, params 
 func (c *Client) sendBillingGetGithubPackagesBillingGhe(ctx context.Context, params BillingGetGithubPackagesBillingGheParams) (res *PackagesBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-packages-billing-ghe"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/settings/billing/packages"),
 	}
 
 	// Run stopwatch.
@@ -17308,6 +17591,8 @@ func (c *Client) BillingGetGithubPackagesBillingOrg(ctx context.Context, params 
 func (c *Client) sendBillingGetGithubPackagesBillingOrg(ctx context.Context, params BillingGetGithubPackagesBillingOrgParams) (res *PackagesBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-packages-billing-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/settings/billing/packages"),
 	}
 
 	// Run stopwatch.
@@ -17402,6 +17687,8 @@ func (c *Client) BillingGetGithubPackagesBillingUser(ctx context.Context, params
 func (c *Client) sendBillingGetGithubPackagesBillingUser(ctx context.Context, params BillingGetGithubPackagesBillingUserParams) (res *PackagesBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-github-packages-billing-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/settings/billing/packages"),
 	}
 
 	// Run stopwatch.
@@ -17496,6 +17783,8 @@ func (c *Client) BillingGetSharedStorageBillingGhe(ctx context.Context, params B
 func (c *Client) sendBillingGetSharedStorageBillingGhe(ctx context.Context, params BillingGetSharedStorageBillingGheParams) (res *CombinedBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-shared-storage-billing-ghe"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/settings/billing/shared-storage"),
 	}
 
 	// Run stopwatch.
@@ -17590,6 +17879,8 @@ func (c *Client) BillingGetSharedStorageBillingOrg(ctx context.Context, params B
 func (c *Client) sendBillingGetSharedStorageBillingOrg(ctx context.Context, params BillingGetSharedStorageBillingOrgParams) (res *CombinedBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-shared-storage-billing-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/settings/billing/shared-storage"),
 	}
 
 	// Run stopwatch.
@@ -17684,6 +17975,8 @@ func (c *Client) BillingGetSharedStorageBillingUser(ctx context.Context, params 
 func (c *Client) sendBillingGetSharedStorageBillingUser(ctx context.Context, params BillingGetSharedStorageBillingUserParams) (res *CombinedBillingUsage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("billing/get-shared-storage-billing-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/settings/billing/shared-storage"),
 	}
 
 	// Run stopwatch.
@@ -17782,6 +18075,8 @@ func (c *Client) ChecksCreateSuite(ctx context.Context, request *ChecksCreateSui
 func (c *Client) sendChecksCreateSuite(ctx context.Context, request *ChecksCreateSuiteReq, params ChecksCreateSuiteParams) (res ChecksCreateSuiteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/create-suite"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-suites"),
 	}
 
 	// Run stopwatch.
@@ -17899,6 +18194,8 @@ func (c *Client) ChecksGet(ctx context.Context, params ChecksGetParams) (*CheckR
 func (c *Client) sendChecksGet(ctx context.Context, params ChecksGetParams) (res *CheckRun, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-runs/{check_run_id}"),
 	}
 
 	// Run stopwatch.
@@ -18031,6 +18328,8 @@ func (c *Client) ChecksGetSuite(ctx context.Context, params ChecksGetSuiteParams
 func (c *Client) sendChecksGetSuite(ctx context.Context, params ChecksGetSuiteParams) (res *CheckSuite, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/get-suite"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-suites/{check_suite_id}"),
 	}
 
 	// Run stopwatch.
@@ -18161,6 +18460,8 @@ func (c *Client) ChecksListAnnotations(ctx context.Context, params ChecksListAnn
 func (c *Client) sendChecksListAnnotations(ctx context.Context, params ChecksListAnnotationsParams) (res *ChecksListAnnotationsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/list-annotations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"),
 	}
 
 	// Run stopwatch.
@@ -18333,6 +18634,8 @@ func (c *Client) ChecksListForRef(ctx context.Context, params ChecksListForRefPa
 func (c *Client) sendChecksListForRef(ctx context.Context, params ChecksListForRefParams) (res *ChecksListForRefOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/list-for-ref"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{ref}/check-runs"),
 	}
 
 	// Run stopwatch.
@@ -18572,6 +18875,8 @@ func (c *Client) ChecksListForSuite(ctx context.Context, params ChecksListForSui
 func (c *Client) sendChecksListForSuite(ctx context.Context, params ChecksListForSuiteParams) (res *ChecksListForSuiteOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/list-for-suite"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"),
 	}
 
 	// Run stopwatch.
@@ -18795,6 +19100,8 @@ func (c *Client) ChecksListSuitesForRef(ctx context.Context, params ChecksListSu
 func (c *Client) sendChecksListSuitesForRef(ctx context.Context, params ChecksListSuitesForRefParams) (res *ChecksListSuitesForRefOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/list-suites-for-ref"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{ref}/check-suites"),
 	}
 
 	// Run stopwatch.
@@ -19000,6 +19307,8 @@ func (c *Client) ChecksRerequestSuite(ctx context.Context, params ChecksRereques
 func (c *Client) sendChecksRerequestSuite(ctx context.Context, params ChecksRerequestSuiteParams) (res *ChecksRerequestSuiteCreated, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/rerequest-suite"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"),
 	}
 
 	// Run stopwatch.
@@ -19132,6 +19441,8 @@ func (c *Client) ChecksSetSuitesPreferences(ctx context.Context, request *Checks
 func (c *Client) sendChecksSetSuitesPreferences(ctx context.Context, request *ChecksSetSuitesPreferencesReq, params ChecksSetSuitesPreferencesParams) (res *CheckSuitePreference, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("checks/set-suites-preferences"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/check-suites/preferences"),
 	}
 
 	// Run stopwatch.
@@ -19302,6 +19613,8 @@ func (c *Client) CodeScanningDeleteAnalysis(ctx context.Context, params CodeScan
 func (c *Client) sendCodeScanningDeleteAnalysis(ctx context.Context, params CodeScanningDeleteAnalysisParams) (res CodeScanningDeleteAnalysisRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/delete-analysis"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}"),
 	}
 
 	// Run stopwatch.
@@ -19456,6 +19769,8 @@ func (c *Client) CodeScanningGetAlert(ctx context.Context, params CodeScanningGe
 func (c *Client) sendCodeScanningGetAlert(ctx context.Context, params CodeScanningGetAlertParams) (res CodeScanningGetAlertRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/get-alert"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"),
 	}
 
 	// Run stopwatch.
@@ -19604,6 +19919,8 @@ func (c *Client) CodeScanningGetAnalysis(ctx context.Context, params CodeScannin
 func (c *Client) sendCodeScanningGetAnalysis(ctx context.Context, params CodeScanningGetAnalysisParams) (res CodeScanningGetAnalysisRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/get-analysis"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}"),
 	}
 
 	// Run stopwatch.
@@ -19736,6 +20053,8 @@ func (c *Client) CodeScanningGetSarif(ctx context.Context, params CodeScanningGe
 func (c *Client) sendCodeScanningGetSarif(ctx context.Context, params CodeScanningGetSarifParams) (res CodeScanningGetSarifRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/get-sarif"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}"),
 	}
 
 	// Run stopwatch.
@@ -19865,6 +20184,8 @@ func (c *Client) CodeScanningListAlertInstances(ctx context.Context, params Code
 func (c *Client) sendCodeScanningListAlertInstances(ctx context.Context, params CodeScanningListAlertInstancesParams) (res CodeScanningListAlertInstancesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/list-alert-instances"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances"),
 	}
 
 	// Run stopwatch.
@@ -20061,6 +20382,8 @@ func (c *Client) CodeScanningListAlertsForRepo(ctx context.Context, params CodeS
 func (c *Client) sendCodeScanningListAlertsForRepo(ctx context.Context, params CodeScanningListAlertsForRepoParams) (res CodeScanningListAlertsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/list-alerts-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/alerts"),
 	}
 
 	// Run stopwatch.
@@ -20299,6 +20622,8 @@ func (c *Client) CodeScanningListRecentAnalyses(ctx context.Context, params Code
 func (c *Client) sendCodeScanningListRecentAnalyses(ctx context.Context, params CodeScanningListRecentAnalysesParams) (res CodeScanningListRecentAnalysesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/list-recent-analyses"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/analyses"),
 	}
 
 	// Run stopwatch.
@@ -20528,6 +20853,8 @@ func (c *Client) CodeScanningUpdateAlert(ctx context.Context, request *CodeScann
 func (c *Client) sendCodeScanningUpdateAlert(ctx context.Context, request *CodeScanningUpdateAlertReq, params CodeScanningUpdateAlertParams) (res CodeScanningUpdateAlertRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/update-alert"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20696,6 +21023,8 @@ func (c *Client) CodeScanningUploadSarif(ctx context.Context, request *CodeScann
 func (c *Client) sendCodeScanningUploadSarif(ctx context.Context, request *CodeScanningUploadSarifReq, params CodeScanningUploadSarifParams) (res CodeScanningUploadSarifRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("code-scanning/upload-sarif"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/code-scanning/sarifs"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20817,6 +21146,8 @@ func (c *Client) CodesOfConductGetAllCodesOfConduct(ctx context.Context) (CodesO
 func (c *Client) sendCodesOfConductGetAllCodesOfConduct(ctx context.Context) (res CodesOfConductGetAllCodesOfConductRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("codes-of-conduct/get-all-codes-of-conduct"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/codes_of_conduct"),
 	}
 
 	// Run stopwatch.
@@ -20888,6 +21219,8 @@ func (c *Client) CodesOfConductGetConductCode(ctx context.Context, params CodesO
 func (c *Client) sendCodesOfConductGetConductCode(ctx context.Context, params CodesOfConductGetConductCodeParams) (res CodesOfConductGetConductCodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("codes-of-conduct/get-conduct-code"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/codes_of_conduct/{key}"),
 	}
 
 	// Run stopwatch.
@@ -20977,6 +21310,8 @@ func (c *Client) EmojisGet(ctx context.Context) (EmojisGetRes, error) {
 func (c *Client) sendEmojisGet(ctx context.Context) (res EmojisGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("emojis/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/emojis"),
 	}
 
 	// Run stopwatch.
@@ -21052,6 +21387,8 @@ func (c *Client) EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterprise(
 func (c *Client) sendEnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterprise(ctx context.Context, params EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseParams) (res *EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/add-org-access-to-self-hosted-runner-group-in-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}"),
 	}
 
 	// Run stopwatch.
@@ -21181,6 +21518,8 @@ func (c *Client) EnterpriseAdminAddSelfHostedRunnerToGroupForEnterprise(ctx cont
 func (c *Client) sendEnterpriseAdminAddSelfHostedRunnerToGroupForEnterprise(ctx context.Context, params EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseParams) (res *EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/add-self-hosted-runner-to-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -21315,6 +21654,8 @@ func (c *Client) EnterpriseAdminCreateRegistrationTokenForEnterprise(ctx context
 func (c *Client) sendEnterpriseAdminCreateRegistrationTokenForEnterprise(ctx context.Context, params EnterpriseAdminCreateRegistrationTokenForEnterpriseParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/create-registration-token-for-enterprise"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners/registration-token"),
 	}
 
 	// Run stopwatch.
@@ -21414,6 +21755,8 @@ func (c *Client) EnterpriseAdminCreateRemoveTokenForEnterprise(ctx context.Conte
 func (c *Client) sendEnterpriseAdminCreateRemoveTokenForEnterprise(ctx context.Context, params EnterpriseAdminCreateRemoveTokenForEnterpriseParams) (res *AuthenticationToken, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/create-remove-token-for-enterprise"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners/remove-token"),
 	}
 
 	// Run stopwatch.
@@ -21505,6 +21848,8 @@ func (c *Client) EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise(ctx con
 func (c *Client) sendEnterpriseAdminCreateSelfHostedRunnerGroupForEnterprise(ctx context.Context, request *EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseReq, params EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseParams) (res *RunnerGroupsEnterprise, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/create-self-hosted-runner-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21608,6 +21953,8 @@ func (c *Client) EnterpriseAdminDeleteScimGroupFromEnterprise(ctx context.Contex
 func (c *Client) sendEnterpriseAdminDeleteScimGroupFromEnterprise(ctx context.Context, params EnterpriseAdminDeleteScimGroupFromEnterpriseParams) (res *EnterpriseAdminDeleteScimGroupFromEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/delete-scim-group-from-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -21718,6 +22065,8 @@ func (c *Client) EnterpriseAdminDeleteSelfHostedRunnerFromEnterprise(ctx context
 func (c *Client) sendEnterpriseAdminDeleteSelfHostedRunnerFromEnterprise(ctx context.Context, params EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseParams) (res *EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/delete-self-hosted-runner-from-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -21827,6 +22176,8 @@ func (c *Client) EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterprise(ctx co
 func (c *Client) sendEnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterprise(ctx context.Context, params EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseParams) (res *EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/delete-self-hosted-runner-group-from-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -21936,6 +22287,8 @@ func (c *Client) EnterpriseAdminDeleteUserFromEnterprise(ctx context.Context, pa
 func (c *Client) sendEnterpriseAdminDeleteUserFromEnterprise(ctx context.Context, params EnterpriseAdminDeleteUserFromEnterpriseParams) (res *EnterpriseAdminDeleteUserFromEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/delete-user-from-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}"),
 	}
 
 	// Run stopwatch.
@@ -22048,6 +22401,8 @@ func (c *Client) EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpri
 func (c *Client) sendEnterpriseAdminDisableSelectedOrganizationGithubActionsEnterprise(ctx context.Context, params EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseParams) (res *EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/disable-selected-organization-github-actions-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/organizations/{org_id}"),
 	}
 
 	// Run stopwatch.
@@ -22160,6 +22515,8 @@ func (c *Client) EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpris
 func (c *Client) sendEnterpriseAdminEnableSelectedOrganizationGithubActionsEnterprise(ctx context.Context, params EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseParams) (res *EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/enable-selected-organization-github-actions-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/organizations/{org_id}"),
 	}
 
 	// Run stopwatch.
@@ -22272,6 +22629,8 @@ func (c *Client) EnterpriseAdminGetAllowedActionsEnterprise(ctx context.Context,
 func (c *Client) sendEnterpriseAdminGetAllowedActionsEnterprise(ctx context.Context, params EnterpriseAdminGetAllowedActionsEnterpriseParams) (res *SelectedActions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-allowed-actions-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -22363,6 +22722,8 @@ func (c *Client) EnterpriseAdminGetAuditLog(ctx context.Context, params Enterpri
 func (c *Client) sendEnterpriseAdminGetAuditLog(ctx context.Context, params EnterpriseAdminGetAuditLogParams) (res []AuditLogEvent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-audit-log"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/audit-log"),
 	}
 
 	// Run stopwatch.
@@ -22577,6 +22938,8 @@ func (c *Client) EnterpriseAdminGetGithubActionsPermissionsEnterprise(ctx contex
 func (c *Client) sendEnterpriseAdminGetGithubActionsPermissionsEnterprise(ctx context.Context, params EnterpriseAdminGetGithubActionsPermissionsEnterpriseParams) (res *ActionsEnterprisePermissions, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-github-actions-permissions-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions"),
 	}
 
 	// Run stopwatch.
@@ -22668,6 +23031,8 @@ func (c *Client) EnterpriseAdminGetProvisioningInformationForEnterpriseGroup(ctx
 func (c *Client) sendEnterpriseAdminGetProvisioningInformationForEnterpriseGroup(ctx context.Context, params EnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams) (res *ScimEnterpriseGroup, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-provisioning-information-for-enterprise-group"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -22798,6 +23163,8 @@ func (c *Client) EnterpriseAdminGetProvisioningInformationForEnterpriseUser(ctx 
 func (c *Client) sendEnterpriseAdminGetProvisioningInformationForEnterpriseUser(ctx context.Context, params EnterpriseAdminGetProvisioningInformationForEnterpriseUserParams) (res *ScimEnterpriseUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-provisioning-information-for-enterprise-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}"),
 	}
 
 	// Run stopwatch.
@@ -22907,6 +23274,8 @@ func (c *Client) EnterpriseAdminGetSelfHostedRunnerForEnterprise(ctx context.Con
 func (c *Client) sendEnterpriseAdminGetSelfHostedRunnerForEnterprise(ctx context.Context, params EnterpriseAdminGetSelfHostedRunnerForEnterpriseParams) (res *Runner, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-self-hosted-runner-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -23016,6 +23385,8 @@ func (c *Client) EnterpriseAdminGetSelfHostedRunnerGroupForEnterprise(ctx contex
 func (c *Client) sendEnterpriseAdminGetSelfHostedRunnerGroupForEnterprise(ctx context.Context, params EnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseParams) (res *RunnerGroupsEnterprise, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/get-self-hosted-runner-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}"),
 	}
 
 	// Run stopwatch.
@@ -23125,6 +23496,8 @@ func (c *Client) EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterprise
 func (c *Client) sendEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterprise(ctx context.Context, params EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseParams) (res *EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-org-access-to-self-hosted-runner-group-in-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations"),
 	}
 
 	// Run stopwatch.
@@ -23273,6 +23646,8 @@ func (c *Client) EnterpriseAdminListProvisionedGroupsEnterprise(ctx context.Cont
 func (c *Client) sendEnterpriseAdminListProvisionedGroupsEnterprise(ctx context.Context, params EnterpriseAdminListProvisionedGroupsEnterpriseParams) (res *ScimGroupListEnterprise, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-provisioned-groups-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups"),
 	}
 
 	// Run stopwatch.
@@ -23461,6 +23836,8 @@ func (c *Client) EnterpriseAdminListProvisionedIdentitiesEnterprise(ctx context.
 func (c *Client) sendEnterpriseAdminListProvisionedIdentitiesEnterprise(ctx context.Context, params EnterpriseAdminListProvisionedIdentitiesEnterpriseParams) (res *ScimUserListEnterprise, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-provisioned-identities-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users"),
 	}
 
 	// Run stopwatch.
@@ -23607,6 +23984,8 @@ func (c *Client) EnterpriseAdminListRunnerApplicationsForEnterprise(ctx context.
 func (c *Client) sendEnterpriseAdminListRunnerApplicationsForEnterprise(ctx context.Context, params EnterpriseAdminListRunnerApplicationsForEnterpriseParams) (res []RunnerApplication, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-runner-applications-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners/downloads"),
 	}
 
 	// Run stopwatch.
@@ -23701,6 +24080,8 @@ func (c *Client) EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnt
 func (c *Client) sendEnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterprise(ctx context.Context, params EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseParams) (res *EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-selected-organizations-enabled-github-actions-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/organizations"),
 	}
 
 	// Run stopwatch.
@@ -23830,6 +24211,8 @@ func (c *Client) EnterpriseAdminListSelfHostedRunnerGroupsForEnterprise(ctx cont
 func (c *Client) sendEnterpriseAdminListSelfHostedRunnerGroupsForEnterprise(ctx context.Context, params EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseParams) (res *EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-self-hosted-runner-groups-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups"),
 	}
 
 	// Run stopwatch.
@@ -23959,6 +24342,8 @@ func (c *Client) EnterpriseAdminListSelfHostedRunnersForEnterprise(ctx context.C
 func (c *Client) sendEnterpriseAdminListSelfHostedRunnersForEnterprise(ctx context.Context, params EnterpriseAdminListSelfHostedRunnersForEnterpriseParams) (res *EnterpriseAdminListSelfHostedRunnersForEnterpriseOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-self-hosted-runners-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runners"),
 	}
 
 	// Run stopwatch.
@@ -24088,6 +24473,8 @@ func (c *Client) EnterpriseAdminListSelfHostedRunnersInGroupForEnterprise(ctx co
 func (c *Client) sendEnterpriseAdminListSelfHostedRunnersInGroupForEnterprise(ctx context.Context, params EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams) (res *EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/list-self-hosted-runners-in-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners"),
 	}
 
 	// Run stopwatch.
@@ -24239,6 +24626,8 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseGroup(ctx context.Co
 func (c *Client) sendEnterpriseAdminProvisionAndInviteEnterpriseGroup(ctx context.Context, request *EnterpriseAdminProvisionAndInviteEnterpriseGroupReq, params EnterpriseAdminProvisionAndInviteEnterpriseGroupParams) (res *ScimEnterpriseGroup, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/provision-and-invite-enterprise-group"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24347,6 +24736,8 @@ func (c *Client) EnterpriseAdminProvisionAndInviteEnterpriseUser(ctx context.Con
 func (c *Client) sendEnterpriseAdminProvisionAndInviteEnterpriseUser(ctx context.Context, request *EnterpriseAdminProvisionAndInviteEnterpriseUserReq, params EnterpriseAdminProvisionAndInviteEnterpriseUserParams) (res *ScimEnterpriseUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/provision-and-invite-enterprise-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24453,6 +24844,8 @@ func (c *Client) EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpri
 func (c *Client) sendEnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterprise(ctx context.Context, params EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseParams) (res *EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/remove-org-access-to-self-hosted-runner-group-in-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}"),
 	}
 
 	// Run stopwatch.
@@ -24582,6 +24975,8 @@ func (c *Client) EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterprise(ctx
 func (c *Client) sendEnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterprise(ctx context.Context, params EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseParams) (res *EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/remove-self-hosted-runner-from-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}"),
 	}
 
 	// Run stopwatch.
@@ -24713,6 +25108,8 @@ func (c *Client) EnterpriseAdminSetAllowedActionsEnterprise(ctx context.Context,
 func (c *Client) sendEnterpriseAdminSetAllowedActionsEnterprise(ctx context.Context, request *SelectedActions, params EnterpriseAdminSetAllowedActionsEnterpriseParams) (res *EnterpriseAdminSetAllowedActionsEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-allowed-actions-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/selected-actions"),
 	}
 
 	// Run stopwatch.
@@ -24807,6 +25204,8 @@ func (c *Client) EnterpriseAdminSetGithubActionsPermissionsEnterprise(ctx contex
 func (c *Client) sendEnterpriseAdminSetGithubActionsPermissionsEnterprise(ctx context.Context, request *EnterpriseAdminSetGithubActionsPermissionsEnterpriseReq, params EnterpriseAdminSetGithubActionsPermissionsEnterpriseParams) (res *EnterpriseAdminSetGithubActionsPermissionsEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-github-actions-permissions-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24915,6 +25314,8 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseGroup(ctx 
 func (c *Client) sendEnterpriseAdminSetInformationForProvisionedEnterpriseGroup(ctx context.Context, request *EnterpriseAdminSetInformationForProvisionedEnterpriseGroupReq, params EnterpriseAdminSetInformationForProvisionedEnterpriseGroupParams) (res *ScimEnterpriseGroup, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-information-for-provisioned-enterprise-group"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25044,6 +25445,8 @@ func (c *Client) EnterpriseAdminSetInformationForProvisionedEnterpriseUser(ctx c
 func (c *Client) sendEnterpriseAdminSetInformationForProvisionedEnterpriseUser(ctx context.Context, request *EnterpriseAdminSetInformationForProvisionedEnterpriseUserReq, params EnterpriseAdminSetInformationForProvisionedEnterpriseUserParams) (res *ScimEnterpriseUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-information-for-provisioned-enterprise-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25166,6 +25569,8 @@ func (c *Client) EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise(
 func (c *Client) sendEnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise(ctx context.Context, request *EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseReq, params EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseParams) (res *EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-org-access-to-self-hosted-runner-group-in-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25291,6 +25696,8 @@ func (c *Client) EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnte
 func (c *Client) sendEnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise(ctx context.Context, request *EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseReq, params EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseParams) (res *EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-selected-organizations-enabled-github-actions-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/permissions/organizations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25394,6 +25801,8 @@ func (c *Client) EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise(ctx con
 func (c *Client) sendEnterpriseAdminSetSelfHostedRunnersInGroupForEnterprise(ctx context.Context, request *EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseReq, params EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseParams) (res *EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/set-self-hosted-runners-in-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25520,6 +25929,8 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseGroup(ctx context.Co
 func (c *Client) sendEnterpriseAdminUpdateAttributeForEnterpriseGroup(ctx context.Context, request *EnterpriseAdminUpdateAttributeForEnterpriseGroupReq, params EnterpriseAdminUpdateAttributeForEnterpriseGroupParams) (res *ScimEnterpriseGroup, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/update-attribute-for-enterprise-group"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25662,6 +26073,8 @@ func (c *Client) EnterpriseAdminUpdateAttributeForEnterpriseUser(ctx context.Con
 func (c *Client) sendEnterpriseAdminUpdateAttributeForEnterpriseUser(ctx context.Context, request *EnterpriseAdminUpdateAttributeForEnterpriseUserReq, params EnterpriseAdminUpdateAttributeForEnterpriseUserParams) (res *ScimEnterpriseUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/update-attribute-for-enterprise-user"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25783,6 +26196,8 @@ func (c *Client) EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise(ctx con
 func (c *Client) sendEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise(ctx context.Context, request OptEnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseReq, params EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseParams) (res *RunnerGroupsEnterprise, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("enterprise-admin/update-self-hosted-runner-group-for-enterprise"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25910,6 +26325,8 @@ func (c *Client) GistsCheckIsStarred(ctx context.Context, params GistsCheckIsSta
 func (c *Client) sendGistsCheckIsStarred(ctx context.Context, params GistsCheckIsStarredParams) (res GistsCheckIsStarredRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/check-is-starred"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/star"),
 	}
 
 	// Run stopwatch.
@@ -26002,6 +26419,8 @@ func (c *Client) GistsCreate(ctx context.Context, request *GistsCreateReq) (Gist
 func (c *Client) sendGistsCreate(ctx context.Context, request *GistsCreateReq) (res GistsCreateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/create"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/gists"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26085,6 +26504,8 @@ func (c *Client) GistsCreateComment(ctx context.Context, request *GistsCreateCom
 func (c *Client) sendGistsCreateComment(ctx context.Context, request *GistsCreateCommentReq, params GistsCreateCommentParams) (res GistsCreateCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/create-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/comments"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26187,6 +26608,8 @@ func (c *Client) GistsDelete(ctx context.Context, params GistsDeleteParams) (Gis
 func (c *Client) sendGistsDelete(ctx context.Context, params GistsDeleteParams) (res GistsDeleteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/delete"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}"),
 	}
 
 	// Run stopwatch.
@@ -26276,6 +26699,8 @@ func (c *Client) GistsDeleteComment(ctx context.Context, params GistsDeleteComme
 func (c *Client) sendGistsDeleteComment(ctx context.Context, params GistsDeleteCommentParams) (res GistsDeleteCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/delete-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -26384,6 +26809,8 @@ func (c *Client) GistsFork(ctx context.Context, params GistsForkParams) (GistsFo
 func (c *Client) sendGistsFork(ctx context.Context, params GistsForkParams) (res GistsForkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/fork"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/forks"),
 	}
 
 	// Run stopwatch.
@@ -26474,6 +26901,8 @@ func (c *Client) GistsGet(ctx context.Context, params GistsGetParams) (GistsGetR
 func (c *Client) sendGistsGet(ctx context.Context, params GistsGetParams) (res GistsGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}"),
 	}
 
 	// Run stopwatch.
@@ -26563,6 +26992,8 @@ func (c *Client) GistsGetComment(ctx context.Context, params GistsGetCommentPara
 func (c *Client) sendGistsGetComment(ctx context.Context, params GistsGetCommentParams) (res GistsGetCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/get-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -26671,6 +27102,8 @@ func (c *Client) GistsGetRevision(ctx context.Context, params GistsGetRevisionPa
 func (c *Client) sendGistsGetRevision(ctx context.Context, params GistsGetRevisionParams) (res GistsGetRevisionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/get-revision"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/{sha}"),
 	}
 
 	// Run stopwatch.
@@ -26780,6 +27213,8 @@ func (c *Client) GistsList(ctx context.Context, params GistsListParams) (GistsLi
 func (c *Client) sendGistsList(ctx context.Context, params GistsListParams) (res GistsListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists"),
 	}
 
 	// Run stopwatch.
@@ -26906,6 +27341,8 @@ func (c *Client) GistsListComments(ctx context.Context, params GistsListComments
 func (c *Client) sendGistsListComments(ctx context.Context, params GistsListCommentsParams) (res GistsListCommentsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-comments"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/comments"),
 	}
 
 	// Run stopwatch.
@@ -27034,6 +27471,8 @@ func (c *Client) GistsListCommits(ctx context.Context, params GistsListCommitsPa
 func (c *Client) sendGistsListCommits(ctx context.Context, params GistsListCommitsParams) (res GistsListCommitsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-commits"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/commits"),
 	}
 
 	// Run stopwatch.
@@ -27162,6 +27601,8 @@ func (c *Client) GistsListForUser(ctx context.Context, params GistsListForUserPa
 func (c *Client) sendGistsListForUser(ctx context.Context, params GistsListForUserParams) (res GistsListForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/gists"),
 	}
 
 	// Run stopwatch.
@@ -27307,6 +27748,8 @@ func (c *Client) GistsListForks(ctx context.Context, params GistsListForksParams
 func (c *Client) sendGistsListForks(ctx context.Context, params GistsListForksParams) (res GistsListForksRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-forks"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/forks"),
 	}
 
 	// Run stopwatch.
@@ -27438,6 +27881,8 @@ func (c *Client) GistsListPublic(ctx context.Context, params GistsListPublicPara
 func (c *Client) sendGistsListPublic(ctx context.Context, params GistsListPublicParams) (res GistsListPublicRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-public"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/public"),
 	}
 
 	// Run stopwatch.
@@ -27564,6 +28009,8 @@ func (c *Client) GistsListStarred(ctx context.Context, params GistsListStarredPa
 func (c *Client) sendGistsListStarred(ctx context.Context, params GistsListStarredParams) (res GistsListStarredRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/list-starred"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gists/starred"),
 	}
 
 	// Run stopwatch.
@@ -27692,6 +28139,8 @@ func (c *Client) GistsStar(ctx context.Context, params GistsStarParams) (GistsSt
 func (c *Client) sendGistsStar(ctx context.Context, params GistsStarParams) (res GistsStarRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/star"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/star"),
 	}
 
 	// Run stopwatch.
@@ -27782,6 +28231,8 @@ func (c *Client) GistsUnstar(ctx context.Context, params GistsUnstarParams) (Gis
 func (c *Client) sendGistsUnstar(ctx context.Context, params GistsUnstarParams) (res GistsUnstarRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/unstar"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/star"),
 	}
 
 	// Run stopwatch.
@@ -27872,6 +28323,8 @@ func (c *Client) GistsUpdateComment(ctx context.Context, request *GistsUpdateCom
 func (c *Client) sendGistsUpdateComment(ctx context.Context, request *GistsUpdateCommentReq, params GistsUpdateCommentParams) (res GistsUpdateCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gists/update-comment"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/gists/{gist_id}/comments/{comment_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27992,6 +28445,8 @@ func (c *Client) GitCreateBlob(ctx context.Context, request *GitCreateBlobReq, p
 func (c *Client) sendGitCreateBlob(ctx context.Context, request *GitCreateBlobReq, params GitCreateBlobParams) (res GitCreateBlobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/create-blob"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/blobs"),
 	}
 
 	// Run stopwatch.
@@ -28137,6 +28592,8 @@ func (c *Client) GitCreateCommit(ctx context.Context, request *GitCreateCommitRe
 func (c *Client) sendGitCreateCommit(ctx context.Context, request *GitCreateCommitReq, params GitCreateCommitParams) (res GitCreateCommitRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/create-commit"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/commits"),
 	}
 
 	// Run stopwatch.
@@ -28251,6 +28708,8 @@ func (c *Client) GitCreateRef(ctx context.Context, request *GitCreateRefReq, par
 func (c *Client) sendGitCreateRef(ctx context.Context, request *GitCreateRefReq, params GitCreateRefParams) (res GitCreateRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/create-ref"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/refs"),
 	}
 
 	// Run stopwatch.
@@ -28399,6 +28858,8 @@ func (c *Client) GitCreateTag(ctx context.Context, request *GitCreateTagReq, par
 func (c *Client) sendGitCreateTag(ctx context.Context, request *GitCreateTagReq, params GitCreateTagParams) (res GitCreateTagRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/create-tag"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/tags"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28526,6 +28987,8 @@ func (c *Client) GitCreateTree(ctx context.Context, request *GitCreateTreeReq, p
 func (c *Client) sendGitCreateTree(ctx context.Context, request *GitCreateTreeReq, params GitCreateTreeParams) (res GitCreateTreeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/create-tree"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/trees"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28647,6 +29110,8 @@ func (c *Client) GitDeleteRef(ctx context.Context, params GitDeleteRefParams) (G
 func (c *Client) sendGitDeleteRef(ctx context.Context, params GitDeleteRefParams) (res GitDeleteRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/delete-ref"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/refs/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -28775,6 +29240,8 @@ func (c *Client) GitGetBlob(ctx context.Context, params GitGetBlobParams) (GitGe
 func (c *Client) sendGitGetBlob(ctx context.Context, params GitGetBlobParams) (res GitGetBlobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/get-blob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/blobs/{file_sha}"),
 	}
 
 	// Run stopwatch.
@@ -28935,6 +29402,8 @@ func (c *Client) GitGetCommit(ctx context.Context, params GitGetCommitParams) (G
 func (c *Client) sendGitGetCommit(ctx context.Context, params GitGetCommitParams) (res GitGetCommitRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/get-commit"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/commits/{commit_sha}"),
 	}
 
 	// Run stopwatch.
@@ -29069,6 +29538,8 @@ func (c *Client) GitGetRef(ctx context.Context, params GitGetRefParams) (GitGetR
 func (c *Client) sendGitGetRef(ctx context.Context, params GitGetRefParams) (res GitGetRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/get-ref"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/ref/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -29227,6 +29698,8 @@ func (c *Client) GitGetTag(ctx context.Context, params GitGetTagParams) (GitGetT
 func (c *Client) sendGitGetTag(ctx context.Context, params GitGetTagParams) (res GitGetTagRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/get-tag"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/tags/{tag_sha}"),
 	}
 
 	// Run stopwatch.
@@ -29357,6 +29830,8 @@ func (c *Client) GitGetTree(ctx context.Context, params GitGetTreeParams) (GitGe
 func (c *Client) sendGitGetTree(ctx context.Context, params GitGetTreeParams) (res GitGetTreeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/get-tree"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/trees/{tree_sha}"),
 	}
 
 	// Run stopwatch.
@@ -29519,6 +29994,8 @@ func (c *Client) GitListMatchingRefs(ctx context.Context, params GitListMatching
 func (c *Client) sendGitListMatchingRefs(ctx context.Context, params GitListMatchingRefsParams) (res *GitListMatchingRefsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/list-matching-refs"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/matching-refs/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -29684,6 +30161,8 @@ func (c *Client) GitUpdateRef(ctx context.Context, request *GitUpdateRefReq, par
 func (c *Client) sendGitUpdateRef(ctx context.Context, request *GitUpdateRefReq, params GitUpdateRefParams) (res GitUpdateRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("git/update-ref"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/git/refs/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -29815,6 +30294,8 @@ func (c *Client) GitignoreGetAllTemplates(ctx context.Context) (GitignoreGetAllT
 func (c *Client) sendGitignoreGetAllTemplates(ctx context.Context) (res GitignoreGetAllTemplatesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gitignore/get-all-templates"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gitignore/templates"),
 	}
 
 	// Run stopwatch.
@@ -29888,6 +30369,8 @@ func (c *Client) GitignoreGetTemplate(ctx context.Context, params GitignoreGetTe
 func (c *Client) sendGitignoreGetTemplate(ctx context.Context, params GitignoreGetTemplateParams) (res GitignoreGetTemplateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("gitignore/get-template"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/gitignore/templates/{name}"),
 	}
 
 	// Run stopwatch.
@@ -29977,6 +30460,8 @@ func (c *Client) InteractionsRemoveRestrictionsForAuthenticatedUser(ctx context.
 func (c *Client) sendInteractionsRemoveRestrictionsForAuthenticatedUser(ctx context.Context) (res *InteractionsRemoveRestrictionsForAuthenticatedUserNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/remove-restrictions-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/interaction-limits"),
 	}
 
 	// Run stopwatch.
@@ -30049,6 +30534,8 @@ func (c *Client) InteractionsRemoveRestrictionsForOrg(ctx context.Context, param
 func (c *Client) sendInteractionsRemoveRestrictionsForOrg(ctx context.Context, params InteractionsRemoveRestrictionsForOrgParams) (res *InteractionsRemoveRestrictionsForOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/remove-restrictions-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/interaction-limits"),
 	}
 
 	// Run stopwatch.
@@ -30142,6 +30629,8 @@ func (c *Client) InteractionsRemoveRestrictionsForRepo(ctx context.Context, para
 func (c *Client) sendInteractionsRemoveRestrictionsForRepo(ctx context.Context, params InteractionsRemoveRestrictionsForRepoParams) (res InteractionsRemoveRestrictionsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/remove-restrictions-for-repo"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/interaction-limits"),
 	}
 
 	// Run stopwatch.
@@ -30253,6 +30742,8 @@ func (c *Client) InteractionsSetRestrictionsForAuthenticatedUser(ctx context.Con
 func (c *Client) sendInteractionsSetRestrictionsForAuthenticatedUser(ctx context.Context, request *InteractionLimit) (res InteractionsSetRestrictionsForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/set-restrictions-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/user/interaction-limits"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30339,6 +30830,8 @@ func (c *Client) InteractionsSetRestrictionsForOrg(ctx context.Context, request 
 func (c *Client) sendInteractionsSetRestrictionsForOrg(ctx context.Context, request *InteractionLimit, params InteractionsSetRestrictionsForOrgParams) (res InteractionsSetRestrictionsForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/set-restrictions-for-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/interaction-limits"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30444,6 +30937,8 @@ func (c *Client) InteractionsSetRestrictionsForRepo(ctx context.Context, request
 func (c *Client) sendInteractionsSetRestrictionsForRepo(ctx context.Context, request *InteractionLimit, params InteractionsSetRestrictionsForRepoParams) (res InteractionsSetRestrictionsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("interactions/set-restrictions-for-repo"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/interaction-limits"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30565,6 +31060,8 @@ func (c *Client) IssuesAddAssignees(ctx context.Context, request OptIssuesAddAss
 func (c *Client) sendIssuesAddAssignees(ctx context.Context, request OptIssuesAddAssigneesReq, params IssuesAddAssigneesParams) (res *IssueSimple, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/add-assignees"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/assignees"),
 	}
 
 	// Run stopwatch.
@@ -30699,6 +31196,8 @@ func (c *Client) IssuesCheckUserCanBeAssigned(ctx context.Context, params Issues
 func (c *Client) sendIssuesCheckUserCanBeAssigned(ctx context.Context, params IssuesCheckUserCanBeAssignedParams) (res IssuesCheckUserCanBeAssignedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/check-user-can-be-assigned"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/assignees/{assignee}"),
 	}
 
 	// Run stopwatch.
@@ -30835,6 +31334,8 @@ func (c *Client) IssuesCreate(ctx context.Context, request *IssuesCreateReq, par
 func (c *Client) sendIssuesCreate(ctx context.Context, request *IssuesCreateReq, params IssuesCreateParams) (res IssuesCreateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/create"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues"),
 	}
 
 	// Run stopwatch.
@@ -30953,6 +31454,8 @@ func (c *Client) IssuesCreateComment(ctx context.Context, request *IssuesCreateC
 func (c *Client) sendIssuesCreateComment(ctx context.Context, request *IssuesCreateCommentReq, params IssuesCreateCommentParams) (res IssuesCreateCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/create-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -31084,6 +31587,8 @@ func (c *Client) IssuesCreateLabel(ctx context.Context, request *IssuesCreateLab
 func (c *Client) sendIssuesCreateLabel(ctx context.Context, request *IssuesCreateLabelReq, params IssuesCreateLabelParams) (res IssuesCreateLabelRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/create-label"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/labels"),
 	}
 
 	// Run stopwatch.
@@ -31196,6 +31701,8 @@ func (c *Client) IssuesCreateMilestone(ctx context.Context, request *IssuesCreat
 func (c *Client) sendIssuesCreateMilestone(ctx context.Context, request *IssuesCreateMilestoneReq, params IssuesCreateMilestoneParams) (res IssuesCreateMilestoneRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/create-milestone"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31317,6 +31824,8 @@ func (c *Client) IssuesDeleteComment(ctx context.Context, params IssuesDeleteCom
 func (c *Client) sendIssuesDeleteComment(ctx context.Context, params IssuesDeleteCommentParams) (res *IssuesDeleteCommentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/delete-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -31444,6 +31953,8 @@ func (c *Client) IssuesDeleteLabel(ctx context.Context, params IssuesDeleteLabel
 func (c *Client) sendIssuesDeleteLabel(ctx context.Context, params IssuesDeleteLabelParams) (res *IssuesDeleteLabelNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/delete-label"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/labels/{name}"),
 	}
 
 	// Run stopwatch.
@@ -31571,6 +32082,8 @@ func (c *Client) IssuesDeleteMilestone(ctx context.Context, params IssuesDeleteM
 func (c *Client) sendIssuesDeleteMilestone(ctx context.Context, params IssuesDeleteMilestoneParams) (res IssuesDeleteMilestoneRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/delete-milestone"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones/{milestone_number}"),
 	}
 
 	// Run stopwatch.
@@ -31716,6 +32229,8 @@ func (c *Client) IssuesGet(ctx context.Context, params IssuesGetParams) (IssuesG
 func (c *Client) sendIssuesGet(ctx context.Context, params IssuesGetParams) (res IssuesGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}"),
 	}
 
 	// Run stopwatch.
@@ -31843,6 +32358,8 @@ func (c *Client) IssuesGetComment(ctx context.Context, params IssuesGetCommentPa
 func (c *Client) sendIssuesGetComment(ctx context.Context, params IssuesGetCommentParams) (res IssuesGetCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/get-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -31970,6 +32487,8 @@ func (c *Client) IssuesGetEvent(ctx context.Context, params IssuesGetEventParams
 func (c *Client) sendIssuesGetEvent(ctx context.Context, params IssuesGetEventParams) (res IssuesGetEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/get-event"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/events/{event_id}"),
 	}
 
 	// Run stopwatch.
@@ -32097,6 +32616,8 @@ func (c *Client) IssuesGetLabel(ctx context.Context, params IssuesGetLabelParams
 func (c *Client) sendIssuesGetLabel(ctx context.Context, params IssuesGetLabelParams) (res IssuesGetLabelRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/get-label"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/labels/{name}"),
 	}
 
 	// Run stopwatch.
@@ -32224,6 +32745,8 @@ func (c *Client) IssuesGetMilestone(ctx context.Context, params IssuesGetMilesto
 func (c *Client) sendIssuesGetMilestone(ctx context.Context, params IssuesGetMilestoneParams) (res IssuesGetMilestoneRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/get-milestone"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones/{milestone_number}"),
 	}
 
 	// Run stopwatch.
@@ -32363,6 +32886,8 @@ func (c *Client) IssuesList(ctx context.Context, params IssuesListParams) (Issue
 func (c *Client) sendIssuesList(ctx context.Context, params IssuesListParams) (res IssuesListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/issues"),
 	}
 
 	// Run stopwatch.
@@ -32643,6 +33168,8 @@ func (c *Client) IssuesListAssignees(ctx context.Context, params IssuesListAssig
 func (c *Client) sendIssuesListAssignees(ctx context.Context, params IssuesListAssigneesParams) (res IssuesListAssigneesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-assignees"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/assignees"),
 	}
 
 	// Run stopwatch.
@@ -32790,6 +33317,8 @@ func (c *Client) IssuesListComments(ctx context.Context, params IssuesListCommen
 func (c *Client) sendIssuesListComments(ctx context.Context, params IssuesListCommentsParams) (res IssuesListCommentsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-comments"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -32973,6 +33502,8 @@ func (c *Client) IssuesListCommentsForRepo(ctx context.Context, params IssuesLis
 func (c *Client) sendIssuesListCommentsForRepo(ctx context.Context, params IssuesListCommentsForRepoParams) (res IssuesListCommentsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-comments-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments"),
 	}
 
 	// Run stopwatch.
@@ -33171,6 +33702,8 @@ func (c *Client) IssuesListEventsForRepo(ctx context.Context, params IssuesListE
 func (c *Client) sendIssuesListEventsForRepo(ctx context.Context, params IssuesListEventsForRepoParams) (res IssuesListEventsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-events-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/events"),
 	}
 
 	// Run stopwatch.
@@ -33326,6 +33859,8 @@ func (c *Client) IssuesListForAuthenticatedUser(ctx context.Context, params Issu
 func (c *Client) sendIssuesListForAuthenticatedUser(ctx context.Context, params IssuesListForAuthenticatedUserParams) (res IssuesListForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/issues"),
 	}
 
 	// Run stopwatch.
@@ -33545,6 +34080,8 @@ func (c *Client) IssuesListForOrg(ctx context.Context, params IssuesListForOrgPa
 func (c *Client) sendIssuesListForOrg(ctx context.Context, params IssuesListForOrgParams) (res IssuesListForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/issues"),
 	}
 
 	// Run stopwatch.
@@ -33783,6 +34320,8 @@ func (c *Client) IssuesListForRepo(ctx context.Context, params IssuesListForRepo
 func (c *Client) sendIssuesListForRepo(ctx context.Context, params IssuesListForRepoParams) (res IssuesListForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues"),
 	}
 
 	// Run stopwatch.
@@ -34083,6 +34622,8 @@ func (c *Client) IssuesListLabelsForMilestone(ctx context.Context, params Issues
 func (c *Client) sendIssuesListLabelsForMilestone(ctx context.Context, params IssuesListLabelsForMilestoneParams) (res *IssuesListLabelsForMilestoneOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-labels-for-milestone"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones/{milestone_number}/labels"),
 	}
 
 	// Run stopwatch.
@@ -34249,6 +34790,8 @@ func (c *Client) IssuesListLabelsForRepo(ctx context.Context, params IssuesListL
 func (c *Client) sendIssuesListLabelsForRepo(ctx context.Context, params IssuesListLabelsForRepoParams) (res IssuesListLabelsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-labels-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/labels"),
 	}
 
 	// Run stopwatch.
@@ -34396,6 +34939,8 @@ func (c *Client) IssuesListLabelsOnIssue(ctx context.Context, params IssuesListL
 func (c *Client) sendIssuesListLabelsOnIssue(ctx context.Context, params IssuesListLabelsOnIssueParams) (res IssuesListLabelsOnIssueRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-labels-on-issue"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/labels"),
 	}
 
 	// Run stopwatch.
@@ -34562,6 +35107,8 @@ func (c *Client) IssuesListMilestones(ctx context.Context, params IssuesListMile
 func (c *Client) sendIssuesListMilestones(ctx context.Context, params IssuesListMilestonesParams) (res IssuesListMilestonesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/list-milestones"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones"),
 	}
 
 	// Run stopwatch.
@@ -34763,6 +35310,8 @@ func (c *Client) IssuesLock(ctx context.Context, request OptNilIssuesLockReq, pa
 func (c *Client) sendIssuesLock(ctx context.Context, request OptNilIssuesLockReq, params IssuesLockParams) (res IssuesLockRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/lock"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/lock"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34910,6 +35459,8 @@ func (c *Client) IssuesRemoveAllLabels(ctx context.Context, params IssuesRemoveA
 func (c *Client) sendIssuesRemoveAllLabels(ctx context.Context, params IssuesRemoveAllLabelsParams) (res IssuesRemoveAllLabelsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/remove-all-labels"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/labels"),
 	}
 
 	// Run stopwatch.
@@ -35038,6 +35589,8 @@ func (c *Client) IssuesRemoveAssignees(ctx context.Context, request OptIssuesRem
 func (c *Client) sendIssuesRemoveAssignees(ctx context.Context, request OptIssuesRemoveAssigneesReq, params IssuesRemoveAssigneesParams) (res *IssueSimple, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/remove-assignees"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/assignees"),
 	}
 
 	// Run stopwatch.
@@ -35170,6 +35723,8 @@ func (c *Client) IssuesRemoveLabel(ctx context.Context, params IssuesRemoveLabel
 func (c *Client) sendIssuesRemoveLabel(ctx context.Context, params IssuesRemoveLabelParams) (res IssuesRemoveLabelRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/remove-label"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"),
 	}
 
 	// Run stopwatch.
@@ -35316,6 +35871,8 @@ func (c *Client) IssuesUnlock(ctx context.Context, params IssuesUnlockParams) (I
 func (c *Client) sendIssuesUnlock(ctx context.Context, params IssuesUnlockParams) (res IssuesUnlockRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/unlock"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/lock"),
 	}
 
 	// Run stopwatch.
@@ -35444,6 +36001,8 @@ func (c *Client) IssuesUpdate(ctx context.Context, request OptIssuesUpdateReq, p
 func (c *Client) sendIssuesUpdate(ctx context.Context, request OptIssuesUpdateReq, params IssuesUpdateParams) (res IssuesUpdateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/update"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35590,6 +36149,8 @@ func (c *Client) IssuesUpdateComment(ctx context.Context, request *IssuesUpdateC
 func (c *Client) sendIssuesUpdateComment(ctx context.Context, request *IssuesUpdateCommentReq, params IssuesUpdateCommentParams) (res IssuesUpdateCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/update-comment"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -35720,6 +36281,8 @@ func (c *Client) IssuesUpdateLabel(ctx context.Context, request OptIssuesUpdateL
 func (c *Client) sendIssuesUpdateLabel(ctx context.Context, request OptIssuesUpdateLabelReq, params IssuesUpdateLabelParams) (res *Label, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/update-label"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/labels/{name}"),
 	}
 
 	// Run stopwatch.
@@ -35850,6 +36413,8 @@ func (c *Client) IssuesUpdateMilestone(ctx context.Context, request OptIssuesUpd
 func (c *Client) sendIssuesUpdateMilestone(ctx context.Context, request OptIssuesUpdateMilestoneReq, params IssuesUpdateMilestoneParams) (res *Milestone, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("issues/update-milestone"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/milestones/{milestone_number}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35996,6 +36561,8 @@ func (c *Client) LicensesGet(ctx context.Context, params LicensesGetParams) (Lic
 func (c *Client) sendLicensesGet(ctx context.Context, params LicensesGetParams) (res LicensesGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("licenses/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/licenses/{license}"),
 	}
 
 	// Run stopwatch.
@@ -36085,6 +36652,8 @@ func (c *Client) LicensesGetAllCommonlyUsed(ctx context.Context, params Licenses
 func (c *Client) sendLicensesGetAllCommonlyUsed(ctx context.Context, params LicensesGetAllCommonlyUsedParams) (res LicensesGetAllCommonlyUsedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("licenses/get-all-commonly-used"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/licenses"),
 	}
 
 	// Run stopwatch.
@@ -36215,6 +36784,8 @@ func (c *Client) LicensesGetForRepo(ctx context.Context, params LicensesGetForRe
 func (c *Client) sendLicensesGetForRepo(ctx context.Context, params LicensesGetForRepoParams) (res *LicenseContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("licenses/get-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/license"),
 	}
 
 	// Run stopwatch.
@@ -36324,6 +36895,8 @@ func (c *Client) MarkdownRender(ctx context.Context, request *MarkdownRenderReq)
 func (c *Client) sendMarkdownRender(ctx context.Context, request *MarkdownRenderReq) (res MarkdownRenderRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("markdown/render"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/markdown"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36410,6 +36983,8 @@ func (c *Client) MarkdownRenderRaw(ctx context.Context, request MarkdownRenderRa
 func (c *Client) sendMarkdownRenderRaw(ctx context.Context, request MarkdownRenderRawReq) (res MarkdownRenderRawRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("markdown/render-raw"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/markdown/raw"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {
@@ -36499,6 +37074,8 @@ func (c *Client) MetaGet(ctx context.Context) (MetaGetRes, error) {
 func (c *Client) sendMetaGet(ctx context.Context) (res MetaGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("meta/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/meta"),
 	}
 
 	// Run stopwatch.
@@ -36570,6 +37147,8 @@ func (c *Client) MetaGetOctocat(ctx context.Context, params MetaGetOctocatParams
 func (c *Client) sendMetaGetOctocat(ctx context.Context, params MetaGetOctocatParams) (res MetaGetOctocatOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("meta/get-octocat"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/octocat"),
 	}
 
 	// Run stopwatch.
@@ -36662,6 +37241,8 @@ func (c *Client) MetaGetZen(ctx context.Context) (MetaGetZenOK, error) {
 func (c *Client) sendMetaGetZen(ctx context.Context) (res MetaGetZenOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("meta/get-zen"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/zen"),
 	}
 
 	// Run stopwatch.
@@ -36733,6 +37314,8 @@ func (c *Client) MetaRoot(ctx context.Context) (*MetaRootOK, error) {
 func (c *Client) sendMetaRoot(ctx context.Context) (res *MetaRootOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("meta/root"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/"),
 	}
 
 	// Run stopwatch.
@@ -36804,6 +37387,8 @@ func (c *Client) MigrationsCancelImport(ctx context.Context, params MigrationsCa
 func (c *Client) sendMigrationsCancelImport(ctx context.Context, params MigrationsCancelImportParams) (res *MigrationsCancelImportNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/cancel-import"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import"),
 	}
 
 	// Run stopwatch.
@@ -36917,6 +37502,8 @@ func (c *Client) MigrationsDeleteArchiveForAuthenticatedUser(ctx context.Context
 func (c *Client) sendMigrationsDeleteArchiveForAuthenticatedUser(ctx context.Context, params MigrationsDeleteArchiveForAuthenticatedUserParams) (res MigrationsDeleteArchiveForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/delete-archive-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/migrations/{migration_id}/archive"),
 	}
 
 	// Run stopwatch.
@@ -37008,6 +37595,8 @@ func (c *Client) MigrationsDeleteArchiveForOrg(ctx context.Context, params Migra
 func (c *Client) sendMigrationsDeleteArchiveForOrg(ctx context.Context, params MigrationsDeleteArchiveForOrgParams) (res MigrationsDeleteArchiveForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/delete-archive-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations/{migration_id}/archive"),
 	}
 
 	// Run stopwatch.
@@ -37117,6 +37706,8 @@ func (c *Client) MigrationsDownloadArchiveForOrg(ctx context.Context, params Mig
 func (c *Client) sendMigrationsDownloadArchiveForOrg(ctx context.Context, params MigrationsDownloadArchiveForOrgParams) (res MigrationsDownloadArchiveForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/download-archive-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations/{migration_id}/archive"),
 	}
 
 	// Run stopwatch.
@@ -37246,6 +37837,8 @@ func (c *Client) MigrationsGetArchiveForAuthenticatedUser(ctx context.Context, p
 func (c *Client) sendMigrationsGetArchiveForAuthenticatedUser(ctx context.Context, params MigrationsGetArchiveForAuthenticatedUserParams) (res MigrationsGetArchiveForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-archive-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/migrations/{migration_id}/archive"),
 	}
 
 	// Run stopwatch.
@@ -37343,6 +37936,8 @@ func (c *Client) MigrationsGetCommitAuthors(ctx context.Context, params Migratio
 func (c *Client) sendMigrationsGetCommitAuthors(ctx context.Context, params MigrationsGetCommitAuthorsParams) (res MigrationsGetCommitAuthorsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-commit-authors"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import/authors"),
 	}
 
 	// Run stopwatch.
@@ -37525,6 +38120,8 @@ func (c *Client) MigrationsGetImportStatus(ctx context.Context, params Migration
 func (c *Client) sendMigrationsGetImportStatus(ctx context.Context, params MigrationsGetImportStatusParams) (res MigrationsGetImportStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-import-status"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import"),
 	}
 
 	// Run stopwatch.
@@ -37634,6 +38231,8 @@ func (c *Client) MigrationsGetLargeFiles(ctx context.Context, params MigrationsG
 func (c *Client) sendMigrationsGetLargeFiles(ctx context.Context, params MigrationsGetLargeFilesParams) (res []PorterLargeFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-large-files"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import/large_files"),
 	}
 
 	// Run stopwatch.
@@ -37750,6 +38349,8 @@ func (c *Client) MigrationsGetStatusForAuthenticatedUser(ctx context.Context, pa
 func (c *Client) sendMigrationsGetStatusForAuthenticatedUser(ctx context.Context, params MigrationsGetStatusForAuthenticatedUserParams) (res MigrationsGetStatusForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-status-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/migrations/{migration_id}"),
 	}
 
 	// Run stopwatch.
@@ -37871,6 +38472,8 @@ func (c *Client) MigrationsGetStatusForOrg(ctx context.Context, params Migration
 func (c *Client) sendMigrationsGetStatusForOrg(ctx context.Context, params MigrationsGetStatusForOrgParams) (res MigrationsGetStatusForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/get-status-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations/{migration_id}"),
 	}
 
 	// Run stopwatch.
@@ -38006,6 +38609,8 @@ func (c *Client) MigrationsListForAuthenticatedUser(ctx context.Context, params 
 func (c *Client) sendMigrationsListForAuthenticatedUser(ctx context.Context, params MigrationsListForAuthenticatedUserParams) (res MigrationsListForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/list-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/migrations"),
 	}
 
 	// Run stopwatch.
@@ -38115,6 +38720,8 @@ func (c *Client) MigrationsListForOrg(ctx context.Context, params MigrationsList
 func (c *Client) sendMigrationsListForOrg(ctx context.Context, params MigrationsListForOrgParams) (res *MigrationsListForOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/list-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations"),
 	}
 
 	// Run stopwatch.
@@ -38266,6 +38873,8 @@ func (c *Client) MigrationsListReposForOrg(ctx context.Context, params Migration
 func (c *Client) sendMigrationsListReposForOrg(ctx context.Context, params MigrationsListReposForOrgParams) (res MigrationsListReposForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/list-repos-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations/{migration_id}/repositories"),
 	}
 
 	// Run stopwatch.
@@ -38413,6 +39022,8 @@ func (c *Client) MigrationsListReposForUser(ctx context.Context, params Migratio
 func (c *Client) sendMigrationsListReposForUser(ctx context.Context, params MigrationsListReposForUserParams) (res MigrationsListReposForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/list-repos-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/migrations/{migration_id}/repositories"),
 	}
 
 	// Run stopwatch.
@@ -38542,6 +39153,8 @@ func (c *Client) MigrationsMapCommitAuthor(ctx context.Context, request OptMigra
 func (c *Client) sendMigrationsMapCommitAuthor(ctx context.Context, request OptMigrationsMapCommitAuthorReq, params MigrationsMapCommitAuthorParams) (res MigrationsMapCommitAuthorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/map-commit-author"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import/authors/{author_id}"),
 	}
 
 	// Run stopwatch.
@@ -38675,6 +39288,8 @@ func (c *Client) MigrationsSetLfsPreference(ctx context.Context, request *Migrat
 func (c *Client) sendMigrationsSetLfsPreference(ctx context.Context, request *MigrationsSetLfsPreferenceReq, params MigrationsSetLfsPreferenceParams) (res MigrationsSetLfsPreferenceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/set-lfs-preference"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import/lfs"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38796,6 +39411,8 @@ func (c *Client) MigrationsStartForAuthenticatedUser(ctx context.Context, reques
 func (c *Client) sendMigrationsStartForAuthenticatedUser(ctx context.Context, request *MigrationsStartForAuthenticatedUserReq) (res MigrationsStartForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/start-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/migrations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38879,6 +39496,8 @@ func (c *Client) MigrationsStartForOrg(ctx context.Context, request *MigrationsS
 func (c *Client) sendMigrationsStartForOrg(ctx context.Context, request *MigrationsStartForOrgReq, params MigrationsStartForOrgParams) (res MigrationsStartForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/start-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38981,6 +39600,8 @@ func (c *Client) MigrationsStartImport(ctx context.Context, request *MigrationsS
 func (c *Client) sendMigrationsStartImport(ctx context.Context, request *MigrationsStartImportReq, params MigrationsStartImportParams) (res MigrationsStartImportRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/start-import"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39106,6 +39727,8 @@ func (c *Client) MigrationsUnlockRepoForAuthenticatedUser(ctx context.Context, p
 func (c *Client) sendMigrationsUnlockRepoForAuthenticatedUser(ctx context.Context, params MigrationsUnlockRepoForAuthenticatedUserParams) (res MigrationsUnlockRepoForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/unlock-repo-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/migrations/{migration_id}/repos/{repo_name}/lock"),
 	}
 
 	// Run stopwatch.
@@ -39217,6 +39840,8 @@ func (c *Client) MigrationsUnlockRepoForOrg(ctx context.Context, params Migratio
 func (c *Client) sendMigrationsUnlockRepoForOrg(ctx context.Context, params MigrationsUnlockRepoForOrgParams) (res MigrationsUnlockRepoForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/unlock-repo-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock"),
 	}
 
 	// Run stopwatch.
@@ -39347,6 +39972,8 @@ func (c *Client) MigrationsUpdateImport(ctx context.Context, request OptNilMigra
 func (c *Client) sendMigrationsUpdateImport(ctx context.Context, request OptNilMigrationsUpdateImportReq, params MigrationsUpdateImportParams) (res *Import, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("migrations/update-import"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/import"),
 	}
 
 	// Run stopwatch.
@@ -39488,6 +40115,8 @@ func (c *Client) OAuthAuthorizationsCreateAuthorization(ctx context.Context, req
 func (c *Client) sendOAuthAuthorizationsCreateAuthorization(ctx context.Context, request OptOAuthAuthorizationsCreateAuthorizationReq) (res OAuthAuthorizationsCreateAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/create-authorization"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/authorizations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39587,6 +40216,8 @@ func (c *Client) OAuthAuthorizationsDeleteAuthorization(ctx context.Context, par
 func (c *Client) sendOAuthAuthorizationsDeleteAuthorization(ctx context.Context, params OAuthAuthorizationsDeleteAuthorizationParams) (res OAuthAuthorizationsDeleteAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/delete-authorization"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/authorizations/{authorization_id}"),
 	}
 
 	// Run stopwatch.
@@ -39688,6 +40319,8 @@ func (c *Client) OAuthAuthorizationsDeleteGrant(ctx context.Context, params OAut
 func (c *Client) sendOAuthAuthorizationsDeleteGrant(ctx context.Context, params OAuthAuthorizationsDeleteGrantParams) (res OAuthAuthorizationsDeleteGrantRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/delete-grant"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/applications/grants/{grant_id}"),
 	}
 
 	// Run stopwatch.
@@ -39786,6 +40419,8 @@ func (c *Client) OAuthAuthorizationsGetAuthorization(ctx context.Context, params
 func (c *Client) sendOAuthAuthorizationsGetAuthorization(ctx context.Context, params OAuthAuthorizationsGetAuthorizationParams) (res OAuthAuthorizationsGetAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/get-authorization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/authorizations/{authorization_id}"),
 	}
 
 	// Run stopwatch.
@@ -39884,6 +40519,8 @@ func (c *Client) OAuthAuthorizationsGetGrant(ctx context.Context, params OAuthAu
 func (c *Client) sendOAuthAuthorizationsGetGrant(ctx context.Context, params OAuthAuthorizationsGetGrantParams) (res OAuthAuthorizationsGetGrantRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/get-grant"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/applications/grants/{grant_id}"),
 	}
 
 	// Run stopwatch.
@@ -40001,6 +40638,8 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForApp(ctx context.C
 func (c *Client) sendOAuthAuthorizationsGetOrCreateAuthorizationForApp(ctx context.Context, request *OAuthAuthorizationsGetOrCreateAuthorizationForAppReq, params OAuthAuthorizationsGetOrCreateAuthorizationForAppParams) (res OAuthAuthorizationsGetOrCreateAuthorizationForAppRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/get-or-create-authorization-for-app"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/authorizations/clients/{client_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40125,6 +40764,8 @@ func (c *Client) OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
 func (c *Client) sendOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint(ctx context.Context, request *OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq, params OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintParams) (res OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/get-or-create-authorization-for-app-and-fingerprint"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/authorizations/clients/{client_id}/{fingerprint}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40254,6 +40895,8 @@ func (c *Client) OAuthAuthorizationsListAuthorizations(ctx context.Context, para
 func (c *Client) sendOAuthAuthorizationsListAuthorizations(ctx context.Context, params OAuthAuthorizationsListAuthorizationsParams) (res OAuthAuthorizationsListAuthorizationsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/list-authorizations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/authorizations"),
 	}
 
 	// Run stopwatch.
@@ -40400,6 +41043,8 @@ func (c *Client) OAuthAuthorizationsListGrants(ctx context.Context, params OAuth
 func (c *Client) sendOAuthAuthorizationsListGrants(ctx context.Context, params OAuthAuthorizationsListGrantsParams) (res OAuthAuthorizationsListGrantsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/list-grants"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/applications/grants"),
 	}
 
 	// Run stopwatch.
@@ -40539,6 +41184,8 @@ func (c *Client) OAuthAuthorizationsUpdateAuthorization(ctx context.Context, req
 func (c *Client) sendOAuthAuthorizationsUpdateAuthorization(ctx context.Context, request OptOAuthAuthorizationsUpdateAuthorizationReq, params OAuthAuthorizationsUpdateAuthorizationParams) (res OAuthAuthorizationsUpdateAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oauth-authorizations/update-authorization"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/authorizations/{authorization_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40647,6 +41294,8 @@ func (c *Client) OrgsBlockUser(ctx context.Context, params OrgsBlockUserParams) 
 func (c *Client) sendOrgsBlockUser(ctx context.Context, params OrgsBlockUserParams) (res OrgsBlockUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/block-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -40758,6 +41407,8 @@ func (c *Client) OrgsCancelInvitation(ctx context.Context, params OrgsCancelInvi
 func (c *Client) sendOrgsCancelInvitation(ctx context.Context, params OrgsCancelInvitationParams) (res OrgsCancelInvitationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/cancel-invitation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/invitations/{invitation_id}"),
 	}
 
 	// Run stopwatch.
@@ -40866,6 +41517,8 @@ func (c *Client) OrgsCheckBlockedUser(ctx context.Context, params OrgsCheckBlock
 func (c *Client) sendOrgsCheckBlockedUser(ctx context.Context, params OrgsCheckBlockedUserParams) (res OrgsCheckBlockedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/check-blocked-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -40974,6 +41627,8 @@ func (c *Client) OrgsCheckMembershipForUser(ctx context.Context, params OrgsChec
 func (c *Client) sendOrgsCheckMembershipForUser(ctx context.Context, params OrgsCheckMembershipForUserParams) (res OrgsCheckMembershipForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/check-membership-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -41082,6 +41737,8 @@ func (c *Client) OrgsCheckPublicMembershipForUser(ctx context.Context, params Or
 func (c *Client) sendOrgsCheckPublicMembershipForUser(ctx context.Context, params OrgsCheckPublicMembershipForUserParams) (res OrgsCheckPublicMembershipForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/check-public-membership-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/public_members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -41194,6 +41851,8 @@ func (c *Client) OrgsConvertMemberToOutsideCollaborator(ctx context.Context, par
 func (c *Client) sendOrgsConvertMemberToOutsideCollaborator(ctx context.Context, params OrgsConvertMemberToOutsideCollaboratorParams) (res OrgsConvertMemberToOutsideCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/convert-member-to-outside-collaborator"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/outside_collaborators/{username}"),
 	}
 
 	// Run stopwatch.
@@ -41310,6 +41969,8 @@ func (c *Client) OrgsCreateInvitation(ctx context.Context, request OptOrgsCreate
 func (c *Client) sendOrgsCreateInvitation(ctx context.Context, request OptOrgsCreateInvitationReq, params OrgsCreateInvitationParams) (res OrgsCreateInvitationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/create-invitation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/invitations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41419,6 +42080,8 @@ func (c *Client) OrgsCreateWebhook(ctx context.Context, request *OrgsCreateWebho
 func (c *Client) sendOrgsCreateWebhook(ctx context.Context, request *OrgsCreateWebhookReq, params OrgsCreateWebhookParams) (res OrgsCreateWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/create-webhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41521,6 +42184,8 @@ func (c *Client) OrgsDeleteWebhook(ctx context.Context, params OrgsDeleteWebhook
 func (c *Client) sendOrgsDeleteWebhook(ctx context.Context, params OrgsDeleteWebhookParams) (res OrgsDeleteWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/delete-webhook"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}"),
 	}
 
 	// Run stopwatch.
@@ -41637,6 +42302,8 @@ func (c *Client) OrgsGet(ctx context.Context, params OrgsGetParams) (OrgsGetRes,
 func (c *Client) sendOrgsGet(ctx context.Context, params OrgsGetParams) (res OrgsGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}"),
 	}
 
 	// Run stopwatch.
@@ -41731,6 +42398,8 @@ func (c *Client) OrgsGetAuditLog(ctx context.Context, params OrgsGetAuditLogPara
 func (c *Client) sendOrgsGetAuditLog(ctx context.Context, params OrgsGetAuditLogParams) (res []AuditLogEvent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-audit-log"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/audit-log"),
 	}
 
 	// Run stopwatch.
@@ -41944,6 +42613,8 @@ func (c *Client) OrgsGetMembershipForAuthenticatedUser(ctx context.Context, para
 func (c *Client) sendOrgsGetMembershipForAuthenticatedUser(ctx context.Context, params OrgsGetMembershipForAuthenticatedUserParams) (res OrgsGetMembershipForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-membership-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/memberships/orgs/{org}"),
 	}
 
 	// Run stopwatch.
@@ -42035,6 +42706,8 @@ func (c *Client) OrgsGetMembershipForUser(ctx context.Context, params OrgsGetMem
 func (c *Client) sendOrgsGetMembershipForUser(ctx context.Context, params OrgsGetMembershipForUserParams) (res OrgsGetMembershipForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-membership-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -42145,6 +42818,8 @@ func (c *Client) OrgsGetWebhook(ctx context.Context, params OrgsGetWebhookParams
 func (c *Client) sendOrgsGetWebhook(ctx context.Context, params OrgsGetWebhookParams) (res OrgsGetWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-webhook"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}"),
 	}
 
 	// Run stopwatch.
@@ -42257,6 +42932,8 @@ func (c *Client) OrgsGetWebhookConfigForOrg(ctx context.Context, params OrgsGetW
 func (c *Client) sendOrgsGetWebhookConfigForOrg(ctx context.Context, params OrgsGetWebhookConfigForOrgParams) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-webhook-config-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/config"),
 	}
 
 	// Run stopwatch.
@@ -42366,6 +43043,8 @@ func (c *Client) OrgsGetWebhookDelivery(ctx context.Context, params OrgsGetWebho
 func (c *Client) sendOrgsGetWebhookDelivery(ctx context.Context, params OrgsGetWebhookDeliveryParams) (res OrgsGetWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/get-webhook-delivery"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}"),
 	}
 
 	// Run stopwatch.
@@ -42496,6 +43175,8 @@ func (c *Client) OrgsList(ctx context.Context, params OrgsListParams) (OrgsListR
 func (c *Client) sendOrgsList(ctx context.Context, params OrgsListParams) (res OrgsListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/organizations"),
 	}
 
 	// Run stopwatch.
@@ -42605,6 +43286,8 @@ func (c *Client) OrgsListBlockedUsers(ctx context.Context, params OrgsListBlocke
 func (c *Client) sendOrgsListBlockedUsers(ctx context.Context, params OrgsListBlockedUsersParams) (res OrgsListBlockedUsersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-blocked-users"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/blocks"),
 	}
 
 	// Run stopwatch.
@@ -42696,6 +43379,8 @@ func (c *Client) OrgsListFailedInvitations(ctx context.Context, params OrgsListF
 func (c *Client) sendOrgsListFailedInvitations(ctx context.Context, params OrgsListFailedInvitationsParams) (res OrgsListFailedInvitationsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-failed-invitations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/failed_invitations"),
 	}
 
 	// Run stopwatch.
@@ -42829,6 +43514,8 @@ func (c *Client) OrgsListForAuthenticatedUser(ctx context.Context, params OrgsLi
 func (c *Client) sendOrgsListForAuthenticatedUser(ctx context.Context, params OrgsListForAuthenticatedUserParams) (res OrgsListForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/orgs"),
 	}
 
 	// Run stopwatch.
@@ -42943,6 +43630,8 @@ func (c *Client) OrgsListForUser(ctx context.Context, params OrgsListForUserPara
 func (c *Client) sendOrgsListForUser(ctx context.Context, params OrgsListForUserParams) (res *OrgsListForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/orgs"),
 	}
 
 	// Run stopwatch.
@@ -43072,6 +43761,8 @@ func (c *Client) OrgsListInvitationTeams(ctx context.Context, params OrgsListInv
 func (c *Client) sendOrgsListInvitationTeams(ctx context.Context, params OrgsListInvitationTeamsParams) (res OrgsListInvitationTeamsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-invitation-teams"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/invitations/{invitation_id}/teams"),
 	}
 
 	// Run stopwatch.
@@ -43220,6 +43911,8 @@ func (c *Client) OrgsListMembers(ctx context.Context, params OrgsListMembersPara
 func (c *Client) sendOrgsListMembers(ctx context.Context, params OrgsListMembersParams) (res OrgsListMembersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-members"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/members"),
 	}
 
 	// Run stopwatch.
@@ -43382,6 +44075,8 @@ func (c *Client) OrgsListMembershipsForAuthenticatedUser(ctx context.Context, pa
 func (c *Client) sendOrgsListMembershipsForAuthenticatedUser(ctx context.Context, params OrgsListMembershipsForAuthenticatedUserParams) (res OrgsListMembershipsForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-memberships-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/memberships/orgs"),
 	}
 
 	// Run stopwatch.
@@ -43508,6 +44203,8 @@ func (c *Client) OrgsListOutsideCollaborators(ctx context.Context, params OrgsLi
 func (c *Client) sendOrgsListOutsideCollaborators(ctx context.Context, params OrgsListOutsideCollaboratorsParams) (res *OrgsListOutsideCollaboratorsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-outside-collaborators"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/outside_collaborators"),
 	}
 
 	// Run stopwatch.
@@ -43656,6 +44353,8 @@ func (c *Client) OrgsListPendingInvitations(ctx context.Context, params OrgsList
 func (c *Client) sendOrgsListPendingInvitations(ctx context.Context, params OrgsListPendingInvitationsParams) (res OrgsListPendingInvitationsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-pending-invitations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/invitations"),
 	}
 
 	// Run stopwatch.
@@ -43784,6 +44483,8 @@ func (c *Client) OrgsListPublicMembers(ctx context.Context, params OrgsListPubli
 func (c *Client) sendOrgsListPublicMembers(ctx context.Context, params OrgsListPublicMembersParams) (res *OrgsListPublicMembersOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-public-members"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/public_members"),
 	}
 
 	// Run stopwatch.
@@ -43919,6 +44620,8 @@ func (c *Client) OrgsListSamlSSOAuthorizations(ctx context.Context, params OrgsL
 func (c *Client) sendOrgsListSamlSSOAuthorizations(ctx context.Context, params OrgsListSamlSSOAuthorizationsParams) (res []CredentialAuthorization, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-saml-sso-authorizations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/credential-authorizations"),
 	}
 
 	// Run stopwatch.
@@ -44009,6 +44712,8 @@ func (c *Client) OrgsListWebhookDeliveries(ctx context.Context, params OrgsListW
 func (c *Client) sendOrgsListWebhookDeliveries(ctx context.Context, params OrgsListWebhookDeliveriesParams) (res OrgsListWebhookDeliveriesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-webhook-deliveries"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/deliveries"),
 	}
 
 	// Run stopwatch.
@@ -44156,6 +44861,8 @@ func (c *Client) OrgsListWebhooks(ctx context.Context, params OrgsListWebhooksPa
 func (c *Client) sendOrgsListWebhooks(ctx context.Context, params OrgsListWebhooksParams) (res OrgsListWebhooksRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/list-webhooks"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks"),
 	}
 
 	// Run stopwatch.
@@ -44285,6 +44992,8 @@ func (c *Client) OrgsPingWebhook(ctx context.Context, params OrgsPingWebhookPara
 func (c *Client) sendOrgsPingWebhook(ctx context.Context, params OrgsPingWebhookParams) (res OrgsPingWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/ping-webhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/pings"),
 	}
 
 	// Run stopwatch.
@@ -44394,6 +45103,8 @@ func (c *Client) OrgsRedeliverWebhookDelivery(ctx context.Context, params OrgsRe
 func (c *Client) sendOrgsRedeliverWebhookDelivery(ctx context.Context, params OrgsRedeliverWebhookDeliveryParams) (res OrgsRedeliverWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/redeliver-webhook-delivery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts"),
 	}
 
 	// Run stopwatch.
@@ -44523,6 +45234,8 @@ func (c *Client) OrgsRemoveMember(ctx context.Context, params OrgsRemoveMemberPa
 func (c *Client) sendOrgsRemoveMember(ctx context.Context, params OrgsRemoveMemberParams) (res OrgsRemoveMemberRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/remove-member"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -44635,6 +45348,8 @@ func (c *Client) OrgsRemoveMembershipForUser(ctx context.Context, params OrgsRem
 func (c *Client) sendOrgsRemoveMembershipForUser(ctx context.Context, params OrgsRemoveMembershipForUserParams) (res OrgsRemoveMembershipForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/remove-membership-for-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -44743,6 +45458,8 @@ func (c *Client) OrgsRemoveOutsideCollaborator(ctx context.Context, params OrgsR
 func (c *Client) sendOrgsRemoveOutsideCollaborator(ctx context.Context, params OrgsRemoveOutsideCollaboratorParams) (res OrgsRemoveOutsideCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/remove-outside-collaborator"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/outside_collaborators/{username}"),
 	}
 
 	// Run stopwatch.
@@ -44851,6 +45568,8 @@ func (c *Client) OrgsRemovePublicMembershipForAuthenticatedUser(ctx context.Cont
 func (c *Client) sendOrgsRemovePublicMembershipForAuthenticatedUser(ctx context.Context, params OrgsRemovePublicMembershipForAuthenticatedUserParams) (res *OrgsRemovePublicMembershipForAuthenticatedUserNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/remove-public-membership-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/public_members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -44965,6 +45684,8 @@ func (c *Client) OrgsRemoveSamlSSOAuthorization(ctx context.Context, params Orgs
 func (c *Client) sendOrgsRemoveSamlSSOAuthorization(ctx context.Context, params OrgsRemoveSamlSSOAuthorizationParams) (res OrgsRemoveSamlSSOAuthorizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/remove-saml-sso-authorization"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/credential-authorizations/{credential_id}"),
 	}
 
 	// Run stopwatch.
@@ -45086,6 +45807,8 @@ func (c *Client) OrgsSetMembershipForUser(ctx context.Context, request OptOrgsSe
 func (c *Client) sendOrgsSetMembershipForUser(ctx context.Context, request OptOrgsSetMembershipForUserReq, params OrgsSetMembershipForUserParams) (res OrgsSetMembershipForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/set-membership-for-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/memberships/{username}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45217,6 +45940,8 @@ func (c *Client) OrgsSetPublicMembershipForAuthenticatedUser(ctx context.Context
 func (c *Client) sendOrgsSetPublicMembershipForAuthenticatedUser(ctx context.Context, params OrgsSetPublicMembershipForAuthenticatedUserParams) (res OrgsSetPublicMembershipForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/set-public-membership-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/public_members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -45325,6 +46050,8 @@ func (c *Client) OrgsUnblockUser(ctx context.Context, params OrgsUnblockUserPara
 func (c *Client) sendOrgsUnblockUser(ctx context.Context, params OrgsUnblockUserParams) (res *OrgsUnblockUserNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/unblock-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -45433,6 +46160,8 @@ func (c *Client) OrgsUpdateMembershipForAuthenticatedUser(ctx context.Context, r
 func (c *Client) sendOrgsUpdateMembershipForAuthenticatedUser(ctx context.Context, request *OrgsUpdateMembershipForAuthenticatedUserReq, params OrgsUpdateMembershipForAuthenticatedUserParams) (res OrgsUpdateMembershipForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/update-membership-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/user/memberships/orgs/{org}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45538,6 +46267,8 @@ func (c *Client) OrgsUpdateWebhook(ctx context.Context, request OptOrgsUpdateWeb
 func (c *Client) sendOrgsUpdateWebhook(ctx context.Context, request OptOrgsUpdateWebhookReq, params OrgsUpdateWebhookParams) (res OrgsUpdateWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/update-webhook"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45669,6 +46400,8 @@ func (c *Client) OrgsUpdateWebhookConfigForOrg(ctx context.Context, request OptO
 func (c *Client) sendOrgsUpdateWebhookConfigForOrg(ctx context.Context, request OptOrgsUpdateWebhookConfigForOrgReq, params OrgsUpdateWebhookConfigForOrgParams) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("orgs/update-webhook-config-for-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/hooks/{hook_id}/config"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45802,6 +46535,8 @@ func (c *Client) PackagesDeletePackageForAuthenticatedUser(ctx context.Context, 
 func (c *Client) sendPackagesDeletePackageForAuthenticatedUser(ctx context.Context, params PackagesDeletePackageForAuthenticatedUserParams) (res PackagesDeletePackageForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -45917,6 +46652,8 @@ func (c *Client) PackagesDeletePackageForOrg(ctx context.Context, params Package
 func (c *Client) sendPackagesDeletePackageForOrg(ctx context.Context, params PackagesDeletePackageForOrgParams) (res PackagesDeletePackageForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -46051,6 +46788,8 @@ func (c *Client) PackagesDeletePackageForUser(ctx context.Context, params Packag
 func (c *Client) sendPackagesDeletePackageForUser(ctx context.Context, params PackagesDeletePackageForUserParams) (res PackagesDeletePackageForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-for-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -46183,6 +46922,8 @@ func (c *Client) PackagesDeletePackageVersionForAuthenticatedUser(ctx context.Co
 func (c *Client) sendPackagesDeletePackageVersionForAuthenticatedUser(ctx context.Context, params PackagesDeletePackageVersionForAuthenticatedUserParams) (res PackagesDeletePackageVersionForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-version-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -46317,6 +47058,8 @@ func (c *Client) PackagesDeletePackageVersionForOrg(ctx context.Context, params 
 func (c *Client) sendPackagesDeletePackageVersionForOrg(ctx context.Context, params PackagesDeletePackageVersionForOrgParams) (res PackagesDeletePackageVersionForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-version-for-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -46470,6 +47213,8 @@ func (c *Client) PackagesDeletePackageVersionForUser(ctx context.Context, params
 func (c *Client) sendPackagesDeletePackageVersionForUser(ctx context.Context, params PackagesDeletePackageVersionForUserParams) (res PackagesDeletePackageVersionForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/delete-package-version-for-user"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -46618,6 +47363,8 @@ func (c *Client) PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser
 func (c *Client) sendPackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(ctx context.Context, params PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams) (res PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-all-package-versions-for-package-owned-by-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}/versions"),
 	}
 
 	// Run stopwatch.
@@ -46784,6 +47531,8 @@ func (c *Client) PackagesGetAllPackageVersionsForPackageOwnedByOrg(ctx context.C
 func (c *Client) sendPackagesGetAllPackageVersionsForPackageOwnedByOrg(ctx context.Context, params PackagesGetAllPackageVersionsForPackageOwnedByOrgParams) (res PackagesGetAllPackageVersionsForPackageOwnedByOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-all-package-versions-for-package-owned-by-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}/versions"),
 	}
 
 	// Run stopwatch.
@@ -46969,6 +47718,8 @@ func (c *Client) PackagesGetAllPackageVersionsForPackageOwnedByUser(ctx context.
 func (c *Client) sendPackagesGetAllPackageVersionsForPackageOwnedByUser(ctx context.Context, params PackagesGetAllPackageVersionsForPackageOwnedByUserParams) (res PackagesGetAllPackageVersionsForPackageOwnedByUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-all-package-versions-for-package-owned-by-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}/versions"),
 	}
 
 	// Run stopwatch.
@@ -47099,6 +47850,8 @@ func (c *Client) PackagesGetPackageForAuthenticatedUser(ctx context.Context, par
 func (c *Client) sendPackagesGetPackageForAuthenticatedUser(ctx context.Context, params PackagesGetPackageForAuthenticatedUserParams) (res *Package, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -47209,6 +47962,8 @@ func (c *Client) PackagesGetPackageForOrganization(ctx context.Context, params P
 func (c *Client) sendPackagesGetPackageForOrganization(ctx context.Context, params PackagesGetPackageForOrganizationParams) (res *Package, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-for-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -47338,6 +48093,8 @@ func (c *Client) PackagesGetPackageForUser(ctx context.Context, params PackagesG
 func (c *Client) sendPackagesGetPackageForUser(ctx context.Context, params PackagesGetPackageForUserParams) (res *Package, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}"),
 	}
 
 	// Run stopwatch.
@@ -47467,6 +48224,8 @@ func (c *Client) PackagesGetPackageVersionForAuthenticatedUser(ctx context.Conte
 func (c *Client) sendPackagesGetPackageVersionForAuthenticatedUser(ctx context.Context, params PackagesGetPackageVersionForAuthenticatedUserParams) (res *PackageVersion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-version-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -47596,6 +48355,8 @@ func (c *Client) PackagesGetPackageVersionForOrganization(ctx context.Context, p
 func (c *Client) sendPackagesGetPackageVersionForOrganization(ctx context.Context, params PackagesGetPackageVersionForOrganizationParams) (res *PackageVersion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-version-for-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -47745,6 +48506,8 @@ func (c *Client) PackagesGetPackageVersionForUser(ctx context.Context, params Pa
 func (c *Client) sendPackagesGetPackageVersionForUser(ctx context.Context, params PackagesGetPackageVersionForUserParams) (res *PackageVersion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/get-package-version-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}"),
 	}
 
 	// Run stopwatch.
@@ -47893,6 +48656,8 @@ func (c *Client) PackagesListPackagesForAuthenticatedUser(ctx context.Context, p
 func (c *Client) sendPackagesListPackagesForAuthenticatedUser(ctx context.Context, params PackagesListPackagesForAuthenticatedUserParams) (res []Package, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/list-packages-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/packages"),
 	}
 
 	// Run stopwatch.
@@ -48001,6 +48766,8 @@ func (c *Client) PackagesListPackagesForOrganization(ctx context.Context, params
 func (c *Client) sendPackagesListPackagesForOrganization(ctx context.Context, params PackagesListPackagesForOrganizationParams) (res PackagesListPackagesForOrganizationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/list-packages-for-organization"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages"),
 	}
 
 	// Run stopwatch.
@@ -48128,6 +48895,8 @@ func (c *Client) PackagesListPackagesForUser(ctx context.Context, params Package
 func (c *Client) sendPackagesListPackagesForUser(ctx context.Context, params PackagesListPackagesForUserParams) (res PackagesListPackagesForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/list-packages-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages"),
 	}
 
 	// Run stopwatch.
@@ -48262,6 +49031,8 @@ func (c *Client) PackagesRestorePackageForAuthenticatedUser(ctx context.Context,
 func (c *Client) sendPackagesRestorePackageForAuthenticatedUser(ctx context.Context, params PackagesRestorePackageForAuthenticatedUserParams) (res PackagesRestorePackageForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}/restore"),
 	}
 
 	// Run stopwatch.
@@ -48403,6 +49174,8 @@ func (c *Client) PackagesRestorePackageForOrg(ctx context.Context, params Packag
 func (c *Client) sendPackagesRestorePackageForOrg(ctx context.Context, params PackagesRestorePackageForOrgParams) (res PackagesRestorePackageForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}/restore"),
 	}
 
 	// Run stopwatch.
@@ -48563,6 +49336,8 @@ func (c *Client) PackagesRestorePackageForUser(ctx context.Context, params Packa
 func (c *Client) sendPackagesRestorePackageForUser(ctx context.Context, params PackagesRestorePackageForUserParams) (res PackagesRestorePackageForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-for-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}/restore"),
 	}
 
 	// Run stopwatch.
@@ -48721,6 +49496,8 @@ func (c *Client) PackagesRestorePackageVersionForAuthenticatedUser(ctx context.C
 func (c *Client) sendPackagesRestorePackageVersionForAuthenticatedUser(ctx context.Context, params PackagesRestorePackageVersionForAuthenticatedUserParams) (res PackagesRestorePackageVersionForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-version-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore"),
 	}
 
 	// Run stopwatch.
@@ -48860,6 +49637,8 @@ func (c *Client) PackagesRestorePackageVersionForOrg(ctx context.Context, params
 func (c *Client) sendPackagesRestorePackageVersionForOrg(ctx context.Context, params PackagesRestorePackageVersionForOrgParams) (res PackagesRestorePackageVersionForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-version-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore"),
 	}
 
 	// Run stopwatch.
@@ -49018,6 +49797,8 @@ func (c *Client) PackagesRestorePackageVersionForUser(ctx context.Context, param
 func (c *Client) sendPackagesRestorePackageVersionForUser(ctx context.Context, params PackagesRestorePackageVersionForUserParams) (res PackagesRestorePackageVersionForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("packages/restore-package-version-for-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore"),
 	}
 
 	// Run stopwatch.
@@ -49166,6 +49947,8 @@ func (c *Client) ProjectsAddCollaborator(ctx context.Context, request OptNilProj
 func (c *Client) sendProjectsAddCollaborator(ctx context.Context, request OptNilProjectsAddCollaboratorReq, params ProjectsAddCollaboratorParams) (res ProjectsAddCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/add-collaborator"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/collaborators/{username}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -49293,6 +50076,8 @@ func (c *Client) ProjectsCreateColumn(ctx context.Context, request *ProjectsCrea
 func (c *Client) sendProjectsCreateColumn(ctx context.Context, request *ProjectsCreateColumnReq, params ProjectsCreateColumnParams) (res ProjectsCreateColumnRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/create-column"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/columns"),
 	}
 
 	// Run stopwatch.
@@ -49386,6 +50171,8 @@ func (c *Client) ProjectsCreateForAuthenticatedUser(ctx context.Context, request
 func (c *Client) sendProjectsCreateForAuthenticatedUser(ctx context.Context, request *ProjectsCreateForAuthenticatedUserReq) (res ProjectsCreateForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/create-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/projects"),
 	}
 
 	// Run stopwatch.
@@ -49462,6 +50249,8 @@ func (c *Client) ProjectsCreateForOrg(ctx context.Context, request *ProjectsCrea
 func (c *Client) sendProjectsCreateForOrg(ctx context.Context, request *ProjectsCreateForOrgReq, params ProjectsCreateForOrgParams) (res ProjectsCreateForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/create-for-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/projects"),
 	}
 
 	// Run stopwatch.
@@ -49557,6 +50346,8 @@ func (c *Client) ProjectsCreateForRepo(ctx context.Context, request *ProjectsCre
 func (c *Client) sendProjectsCreateForRepo(ctx context.Context, request *ProjectsCreateForRepoReq, params ProjectsCreateForRepoParams) (res ProjectsCreateForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/create-for-repo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/projects"),
 	}
 
 	// Run stopwatch.
@@ -49669,6 +50460,8 @@ func (c *Client) ProjectsDelete(ctx context.Context, params ProjectsDeleteParams
 func (c *Client) sendProjectsDelete(ctx context.Context, params ProjectsDeleteParams) (res ProjectsDeleteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/delete"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -49758,6 +50551,8 @@ func (c *Client) ProjectsDeleteCard(ctx context.Context, params ProjectsDeleteCa
 func (c *Client) sendProjectsDeleteCard(ctx context.Context, params ProjectsDeleteCardParams) (res ProjectsDeleteCardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/delete-card"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/projects/columns/cards/{card_id}"),
 	}
 
 	// Run stopwatch.
@@ -49847,6 +50642,8 @@ func (c *Client) ProjectsDeleteColumn(ctx context.Context, params ProjectsDelete
 func (c *Client) sendProjectsDeleteColumn(ctx context.Context, params ProjectsDeleteColumnParams) (res ProjectsDeleteColumnRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/delete-column"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/projects/columns/{column_id}"),
 	}
 
 	// Run stopwatch.
@@ -49938,6 +50735,8 @@ func (c *Client) ProjectsGet(ctx context.Context, params ProjectsGetParams) (Pro
 func (c *Client) sendProjectsGet(ctx context.Context, params ProjectsGetParams) (res ProjectsGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -50027,6 +50826,8 @@ func (c *Client) ProjectsGetCard(ctx context.Context, params ProjectsGetCardPara
 func (c *Client) sendProjectsGetCard(ctx context.Context, params ProjectsGetCardParams) (res ProjectsGetCardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/get-card"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/columns/cards/{card_id}"),
 	}
 
 	// Run stopwatch.
@@ -50116,6 +50917,8 @@ func (c *Client) ProjectsGetColumn(ctx context.Context, params ProjectsGetColumn
 func (c *Client) sendProjectsGetColumn(ctx context.Context, params ProjectsGetColumnParams) (res ProjectsGetColumnRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/get-column"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/columns/{column_id}"),
 	}
 
 	// Run stopwatch.
@@ -50207,6 +51010,8 @@ func (c *Client) ProjectsGetPermissionForUser(ctx context.Context, params Projec
 func (c *Client) sendProjectsGetPermissionForUser(ctx context.Context, params ProjectsGetPermissionForUserParams) (res ProjectsGetPermissionForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/get-permission-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/collaborators/{username}/permission"),
 	}
 
 	// Run stopwatch.
@@ -50316,6 +51121,8 @@ func (c *Client) ProjectsListCards(ctx context.Context, params ProjectsListCards
 func (c *Client) sendProjectsListCards(ctx context.Context, params ProjectsListCardsParams) (res ProjectsListCardsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-cards"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/columns/{column_id}/cards"),
 	}
 
 	// Run stopwatch.
@@ -50465,6 +51272,8 @@ func (c *Client) ProjectsListCollaborators(ctx context.Context, params ProjectsL
 func (c *Client) sendProjectsListCollaborators(ctx context.Context, params ProjectsListCollaboratorsParams) (res ProjectsListCollaboratorsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-collaborators"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/collaborators"),
 	}
 
 	// Run stopwatch.
@@ -50610,6 +51419,8 @@ func (c *Client) ProjectsListColumns(ctx context.Context, params ProjectsListCol
 func (c *Client) sendProjectsListColumns(ctx context.Context, params ProjectsListColumnsParams) (res ProjectsListColumnsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-columns"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/columns"),
 	}
 
 	// Run stopwatch.
@@ -50740,6 +51551,8 @@ func (c *Client) ProjectsListForOrg(ctx context.Context, params ProjectsListForO
 func (c *Client) sendProjectsListForOrg(ctx context.Context, params ProjectsListForOrgParams) (res ProjectsListForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/projects"),
 	}
 
 	// Run stopwatch.
@@ -50887,6 +51700,8 @@ func (c *Client) ProjectsListForRepo(ctx context.Context, params ProjectsListFor
 func (c *Client) sendProjectsListForRepo(ctx context.Context, params ProjectsListForRepoParams) (res ProjectsListForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/projects"),
 	}
 
 	// Run stopwatch.
@@ -51051,6 +51866,8 @@ func (c *Client) ProjectsListForUser(ctx context.Context, params ProjectsListFor
 func (c *Client) sendProjectsListForUser(ctx context.Context, params ProjectsListForUserParams) (res ProjectsListForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/list-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/projects"),
 	}
 
 	// Run stopwatch.
@@ -51196,6 +52013,8 @@ func (c *Client) ProjectsMoveCard(ctx context.Context, request *ProjectsMoveCard
 func (c *Client) sendProjectsMoveCard(ctx context.Context, request *ProjectsMoveCardReq, params ProjectsMoveCardParams) (res ProjectsMoveCardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/move-card"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/projects/columns/cards/{card_id}/moves"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51298,6 +52117,8 @@ func (c *Client) ProjectsMoveColumn(ctx context.Context, request *ProjectsMoveCo
 func (c *Client) sendProjectsMoveColumn(ctx context.Context, request *ProjectsMoveColumnReq, params ProjectsMoveColumnParams) (res ProjectsMoveColumnRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/move-column"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/projects/columns/{column_id}/moves"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51401,6 +52222,8 @@ func (c *Client) ProjectsRemoveCollaborator(ctx context.Context, params Projects
 func (c *Client) sendProjectsRemoveCollaborator(ctx context.Context, params ProjectsRemoveCollaboratorParams) (res ProjectsRemoveCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/remove-collaborator"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}/collaborators/{username}"),
 	}
 
 	// Run stopwatch.
@@ -51511,6 +52334,8 @@ func (c *Client) ProjectsUpdate(ctx context.Context, request OptProjectsUpdateRe
 func (c *Client) sendProjectsUpdate(ctx context.Context, request OptProjectsUpdateReq, params ProjectsUpdateParams) (res ProjectsUpdateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/update"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/projects/{project_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51619,6 +52444,8 @@ func (c *Client) ProjectsUpdateCard(ctx context.Context, request OptProjectsUpda
 func (c *Client) sendProjectsUpdateCard(ctx context.Context, request OptProjectsUpdateCardReq, params ProjectsUpdateCardParams) (res ProjectsUpdateCardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/update-card"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/projects/columns/cards/{card_id}"),
 	}
 
 	// Run stopwatch.
@@ -51711,6 +52538,8 @@ func (c *Client) ProjectsUpdateColumn(ctx context.Context, request *ProjectsUpda
 func (c *Client) sendProjectsUpdateColumn(ctx context.Context, request *ProjectsUpdateColumnReq, params ProjectsUpdateColumnParams) (res ProjectsUpdateColumnRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("projects/update-column"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/projects/columns/{column_id}"),
 	}
 
 	// Run stopwatch.
@@ -51803,6 +52632,8 @@ func (c *Client) PullsCheckIfMerged(ctx context.Context, params PullsCheckIfMerg
 func (c *Client) sendPullsCheckIfMerged(ctx context.Context, params PullsCheckIfMergedParams) (res PullsCheckIfMergedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/check-if-merged"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/merge"),
 	}
 
 	// Run stopwatch.
@@ -51946,6 +52777,8 @@ func (c *Client) PullsCreate(ctx context.Context, request *PullsCreateReq, param
 func (c *Client) sendPullsCreate(ctx context.Context, request *PullsCreateReq, params PullsCreateParams) (res PullsCreateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/create"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls"),
 	}
 
 	// Run stopwatch.
@@ -52067,6 +52900,8 @@ func (c *Client) PullsCreateReplyForReviewComment(ctx context.Context, request *
 func (c *Client) sendPullsCreateReplyForReviewComment(ctx context.Context, request *PullsCreateReplyForReviewCommentReq, params PullsCreateReplyForReviewCommentParams) (res PullsCreateReplyForReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/create-reply-for-review-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"),
 	}
 
 	// Run stopwatch.
@@ -52235,6 +53070,8 @@ func (c *Client) PullsCreateReview(ctx context.Context, request OptPullsCreateRe
 func (c *Client) sendPullsCreateReview(ctx context.Context, request OptPullsCreateReviewReq, params PullsCreateReviewParams) (res PullsCreateReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/create-review"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52401,6 +53238,8 @@ func (c *Client) PullsCreateReviewComment(ctx context.Context, request *PullsCre
 func (c *Client) sendPullsCreateReviewComment(ctx context.Context, request *PullsCreateReviewCommentReq, params PullsCreateReviewCommentParams) (res PullsCreateReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/create-review-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/comments"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52541,6 +53380,8 @@ func (c *Client) PullsDeletePendingReview(ctx context.Context, params PullsDelet
 func (c *Client) sendPullsDeletePendingReview(ctx context.Context, params PullsDeletePendingReviewParams) (res PullsDeletePendingReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/delete-pending-review"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"),
 	}
 
 	// Run stopwatch.
@@ -52687,6 +53528,8 @@ func (c *Client) PullsDeleteReviewComment(ctx context.Context, params PullsDelet
 func (c *Client) sendPullsDeleteReviewComment(ctx context.Context, params PullsDeleteReviewCommentParams) (res PullsDeleteReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/delete-review-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -52816,6 +53659,8 @@ func (c *Client) PullsDismissReview(ctx context.Context, request *PullsDismissRe
 func (c *Client) sendPullsDismissReview(ctx context.Context, request *PullsDismissReviewReq, params PullsDismissReviewParams) (res PullsDismissReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/dismiss-review"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"),
 	}
 
 	// Run stopwatch.
@@ -52999,6 +53844,8 @@ func (c *Client) PullsGet(ctx context.Context, params PullsGetParams) (PullsGetR
 func (c *Client) sendPullsGet(ctx context.Context, params PullsGetParams) (res PullsGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}"),
 	}
 
 	// Run stopwatch.
@@ -53126,6 +53973,8 @@ func (c *Client) PullsGetReview(ctx context.Context, params PullsGetReviewParams
 func (c *Client) sendPullsGetReview(ctx context.Context, params PullsGetReviewParams) (res PullsGetReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/get-review"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"),
 	}
 
 	// Run stopwatch.
@@ -53272,6 +54121,8 @@ func (c *Client) PullsGetReviewComment(ctx context.Context, params PullsGetRevie
 func (c *Client) sendPullsGetReviewComment(ctx context.Context, params PullsGetReviewCommentParams) (res PullsGetReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/get-review-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -53403,6 +54254,8 @@ func (c *Client) PullsList(ctx context.Context, params PullsListParams) (PullsLi
 func (c *Client) sendPullsList(ctx context.Context, params PullsListParams) (res PullsListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls"),
 	}
 
 	// Run stopwatch.
@@ -53635,6 +54488,8 @@ func (c *Client) PullsListCommentsForReview(ctx context.Context, params PullsLis
 func (c *Client) sendPullsListCommentsForReview(ctx context.Context, params PullsListCommentsForReviewParams) (res PullsListCommentsForReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-comments-for-review"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"),
 	}
 
 	// Run stopwatch.
@@ -53822,6 +54677,8 @@ func (c *Client) PullsListCommits(ctx context.Context, params PullsListCommitsPa
 func (c *Client) sendPullsListCommits(ctx context.Context, params PullsListCommitsParams) (res *PullsListCommitsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-commits"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/commits"),
 	}
 
 	// Run stopwatch.
@@ -53989,6 +54846,8 @@ func (c *Client) PullsListFiles(ctx context.Context, params PullsListFilesParams
 func (c *Client) sendPullsListFiles(ctx context.Context, params PullsListFilesParams) (res PullsListFilesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-files"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/files"),
 	}
 
 	// Run stopwatch.
@@ -54155,6 +55014,8 @@ func (c *Client) PullsListRequestedReviewers(ctx context.Context, params PullsLi
 func (c *Client) sendPullsListRequestedReviewers(ctx context.Context, params PullsListRequestedReviewersParams) (res *PullRequestReviewRequestHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-requested-reviewers"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"),
 	}
 
 	// Run stopwatch.
@@ -54322,6 +55183,8 @@ func (c *Client) PullsListReviewComments(ctx context.Context, params PullsListRe
 func (c *Client) sendPullsListReviewComments(ctx context.Context, params PullsListReviewCommentsParams) (res *PullsListReviewCommentsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-review-comments"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -54540,6 +55403,8 @@ func (c *Client) PullsListReviewCommentsForRepo(ctx context.Context, params Pull
 func (c *Client) sendPullsListReviewCommentsForRepo(ctx context.Context, params PullsListReviewCommentsForRepoParams) (res *PullsListReviewCommentsForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-review-comments-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments"),
 	}
 
 	// Run stopwatch.
@@ -54738,6 +55603,8 @@ func (c *Client) PullsListReviews(ctx context.Context, params PullsListReviewsPa
 func (c *Client) sendPullsListReviews(ctx context.Context, params PullsListReviewsParams) (res *PullsListReviewsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/list-reviews"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews"),
 	}
 
 	// Run stopwatch.
@@ -54910,6 +55777,8 @@ func (c *Client) PullsMerge(ctx context.Context, request OptNilPullsMergeReq, pa
 func (c *Client) sendPullsMerge(ctx context.Context, request OptNilPullsMergeReq, params PullsMergeParams) (res PullsMergeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/merge"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/merge"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55057,6 +55926,8 @@ func (c *Client) PullsRemoveRequestedReviewers(ctx context.Context, request *Pul
 func (c *Client) sendPullsRemoveRequestedReviewers(ctx context.Context, request *PullsRemoveRequestedReviewersReq, params PullsRemoveRequestedReviewersParams) (res PullsRemoveRequestedReviewersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/remove-requested-reviewers"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55197,6 +56068,8 @@ func (c *Client) PullsSubmitReview(ctx context.Context, request *PullsSubmitRevi
 func (c *Client) sendPullsSubmitReview(ctx context.Context, request *PullsSubmitReviewReq, params PullsSubmitReviewParams) (res PullsSubmitReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/submit-review"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55363,6 +56236,8 @@ func (c *Client) PullsUpdate(ctx context.Context, request OptPullsUpdateReq, par
 func (c *Client) sendPullsUpdate(ctx context.Context, request OptPullsUpdateReq, params PullsUpdateParams) (res PullsUpdateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/update"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55510,6 +56385,8 @@ func (c *Client) PullsUpdateBranch(ctx context.Context, request OptNilPullsUpdat
 func (c *Client) sendPullsUpdateBranch(ctx context.Context, request OptNilPullsUpdateBranchReq, params PullsUpdateBranchParams) (res PullsUpdateBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/update-branch"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/update-branch"),
 	}
 
 	// Run stopwatch.
@@ -55641,6 +56518,8 @@ func (c *Client) PullsUpdateReview(ctx context.Context, request *PullsUpdateRevi
 func (c *Client) sendPullsUpdateReview(ctx context.Context, request *PullsUpdateReviewReq, params PullsUpdateReviewParams) (res PullsUpdateReviewRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/update-review"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"),
 	}
 
 	// Run stopwatch.
@@ -55790,6 +56669,8 @@ func (c *Client) PullsUpdateReviewComment(ctx context.Context, request *PullsUpd
 func (c *Client) sendPullsUpdateReviewComment(ctx context.Context, request *PullsUpdateReviewCommentReq, params PullsUpdateReviewCommentParams) (res *PullRequestReviewComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pulls/update-review-comment"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -55923,6 +56804,8 @@ func (c *Client) RateLimitGet(ctx context.Context) (RateLimitGetRes, error) {
 func (c *Client) sendRateLimitGet(ctx context.Context) (res RateLimitGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("rate-limit/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/rate_limit"),
 	}
 
 	// Run stopwatch.
@@ -55996,6 +56879,8 @@ func (c *Client) ReactionsCreateForCommitComment(ctx context.Context, request *R
 func (c *Client) sendReactionsCreateForCommitComment(ctx context.Context, request *ReactionsCreateForCommitCommentReq, params ReactionsCreateForCommitCommentParams) (res ReactionsCreateForCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-commit-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56137,6 +57022,8 @@ func (c *Client) ReactionsCreateForIssue(ctx context.Context, request *Reactions
 func (c *Client) sendReactionsCreateForIssue(ctx context.Context, request *ReactionsCreateForIssueReq, params ReactionsCreateForIssueParams) (res ReactionsCreateForIssueRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-issue"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56279,6 +57166,8 @@ func (c *Client) ReactionsCreateForIssueComment(ctx context.Context, request *Re
 func (c *Client) sendReactionsCreateForIssueComment(ctx context.Context, request *ReactionsCreateForIssueCommentReq, params ReactionsCreateForIssueCommentParams) (res ReactionsCreateForIssueCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-issue-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56421,6 +57310,8 @@ func (c *Client) ReactionsCreateForPullRequestReviewComment(ctx context.Context,
 func (c *Client) sendReactionsCreateForPullRequestReviewComment(ctx context.Context, request *ReactionsCreateForPullRequestReviewCommentReq, params ReactionsCreateForPullRequestReviewCommentParams) (res ReactionsCreateForPullRequestReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-pull-request-review-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56562,6 +57453,8 @@ func (c *Client) ReactionsCreateForRelease(ctx context.Context, request *Reactio
 func (c *Client) sendReactionsCreateForRelease(ctx context.Context, request *ReactionsCreateForReleaseReq, params ReactionsCreateForReleaseParams) (res ReactionsCreateForReleaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-release"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56708,6 +57601,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentInOrg(ctx context.Contex
 func (c *Client) sendReactionsCreateForTeamDiscussionCommentInOrg(ctx context.Context, request *ReactionsCreateForTeamDiscussionCommentInOrgReq, params ReactionsCreateForTeamDiscussionCommentInOrgParams) (res ReactionsCreateForTeamDiscussionCommentInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-team-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56877,6 +57772,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionCommentLegacy(ctx context.Conte
 func (c *Client) sendReactionsCreateForTeamDiscussionCommentLegacy(ctx context.Context, request *ReactionsCreateForTeamDiscussionCommentLegacyReq, params ReactionsCreateForTeamDiscussionCommentLegacyParams) (res *Reaction, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-team-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57024,6 +57921,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionInOrg(ctx context.Context, requ
 func (c *Client) sendReactionsCreateForTeamDiscussionInOrg(ctx context.Context, request *ReactionsCreateForTeamDiscussionInOrgReq, params ReactionsCreateForTeamDiscussionInOrgParams) (res ReactionsCreateForTeamDiscussionInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-team-discussion-in-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57175,6 +58074,8 @@ func (c *Client) ReactionsCreateForTeamDiscussionLegacy(ctx context.Context, req
 func (c *Client) sendReactionsCreateForTeamDiscussionLegacy(ctx context.Context, request *ReactionsCreateForTeamDiscussionLegacyReq, params ReactionsCreateForTeamDiscussionLegacyParams) (res *Reaction, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/create-for-team-discussion-legacy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/reactions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57298,6 +58199,8 @@ func (c *Client) ReactionsDeleteForCommitComment(ctx context.Context, params Rea
 func (c *Client) sendReactionsDeleteForCommitComment(ctx context.Context, params ReactionsDeleteForCommitCommentParams) (res *ReactionsDeleteForCommitCommentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-commit-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -57446,6 +58349,8 @@ func (c *Client) ReactionsDeleteForIssue(ctx context.Context, params ReactionsDe
 func (c *Client) sendReactionsDeleteForIssue(ctx context.Context, params ReactionsDeleteForIssueParams) (res *ReactionsDeleteForIssueNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-issue"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -57594,6 +58499,8 @@ func (c *Client) ReactionsDeleteForIssueComment(ctx context.Context, params Reac
 func (c *Client) sendReactionsDeleteForIssueComment(ctx context.Context, params ReactionsDeleteForIssueCommentParams) (res *ReactionsDeleteForIssueCommentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-issue-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -57743,6 +58650,8 @@ func (c *Client) ReactionsDeleteForPullRequestComment(ctx context.Context, param
 func (c *Client) sendReactionsDeleteForPullRequestComment(ctx context.Context, params ReactionsDeleteForPullRequestCommentParams) (res *ReactionsDeleteForPullRequestCommentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-pull-request-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -57896,6 +58805,8 @@ func (c *Client) ReactionsDeleteForTeamDiscussion(ctx context.Context, params Re
 func (c *Client) sendReactionsDeleteForTeamDiscussion(ctx context.Context, params ReactionsDeleteForTeamDiscussionParams) (res *ReactionsDeleteForTeamDiscussionNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-team-discussion"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -58047,6 +58958,8 @@ func (c *Client) ReactionsDeleteForTeamDiscussionComment(ctx context.Context, pa
 func (c *Client) sendReactionsDeleteForTeamDiscussionComment(ctx context.Context, params ReactionsDeleteForTeamDiscussionCommentParams) (res *ReactionsDeleteForTeamDiscussionCommentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-for-team-discussion-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -58221,6 +59134,8 @@ func (c *Client) ReactionsDeleteLegacy(ctx context.Context, params ReactionsDele
 func (c *Client) sendReactionsDeleteLegacy(ctx context.Context, params ReactionsDeleteLegacyParams) (res ReactionsDeleteLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/delete-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/reactions/{reaction_id}"),
 	}
 
 	// Run stopwatch.
@@ -58310,6 +59225,8 @@ func (c *Client) ReactionsListForCommitComment(ctx context.Context, params React
 func (c *Client) sendReactionsListForCommitComment(ctx context.Context, params ReactionsListForCommitCommentParams) (res ReactionsListForCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-commit-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -58493,6 +59410,8 @@ func (c *Client) ReactionsListForIssue(ctx context.Context, params ReactionsList
 func (c *Client) sendReactionsListForIssue(ctx context.Context, params ReactionsListForIssueParams) (res ReactionsListForIssueRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-issue"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/{issue_number}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -58676,6 +59595,8 @@ func (c *Client) ReactionsListForIssueComment(ctx context.Context, params Reacti
 func (c *Client) sendReactionsListForIssueComment(ctx context.Context, params ReactionsListForIssueCommentParams) (res ReactionsListForIssueCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-issue-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -58860,6 +59781,8 @@ func (c *Client) ReactionsListForPullRequestReviewComment(ctx context.Context, p
 func (c *Client) sendReactionsListForPullRequestReviewComment(ctx context.Context, params ReactionsListForPullRequestReviewCommentParams) (res ReactionsListForPullRequestReviewCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-pull-request-review-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -59047,6 +59970,8 @@ func (c *Client) ReactionsListForTeamDiscussionCommentInOrg(ctx context.Context,
 func (c *Client) sendReactionsListForTeamDiscussionCommentInOrg(ctx context.Context, params ReactionsListForTeamDiscussionCommentInOrgParams) (res *ReactionsListForTeamDiscussionCommentInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-team-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -59257,6 +60182,8 @@ func (c *Client) ReactionsListForTeamDiscussionCommentLegacy(ctx context.Context
 func (c *Client) sendReactionsListForTeamDiscussionCommentLegacy(ctx context.Context, params ReactionsListForTeamDiscussionCommentLegacyParams) (res *ReactionsListForTeamDiscussionCommentLegacyOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-team-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -59444,6 +60371,8 @@ func (c *Client) ReactionsListForTeamDiscussionInOrg(ctx context.Context, params
 func (c *Client) sendReactionsListForTeamDiscussionInOrg(ctx context.Context, params ReactionsListForTeamDiscussionInOrgParams) (res *ReactionsListForTeamDiscussionInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-team-discussion-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -59635,6 +60564,8 @@ func (c *Client) ReactionsListForTeamDiscussionLegacy(ctx context.Context, param
 func (c *Client) sendReactionsListForTeamDiscussionLegacy(ctx context.Context, params ReactionsListForTeamDiscussionLegacyParams) (res *ReactionsListForTeamDiscussionLegacyOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("reactions/list-for-team-discussion-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/reactions"),
 	}
 
 	// Run stopwatch.
@@ -59799,6 +60730,8 @@ func (c *Client) ReposAcceptInvitation(ctx context.Context, params ReposAcceptIn
 func (c *Client) sendReposAcceptInvitation(ctx context.Context, params ReposAcceptInvitationParams) (res ReposAcceptInvitationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/accept-invitation"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/user/repository_invitations/{invitation_id}"),
 	}
 
 	// Run stopwatch.
@@ -59902,6 +60835,8 @@ func (c *Client) ReposAddAppAccessRestrictions(ctx context.Context, request OptR
 func (c *Client) sendReposAddAppAccessRestrictions(ctx context.Context, request OptReposAddAppAccessRestrictionsReq, params ReposAddAppAccessRestrictionsParams) (res ReposAddAppAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/add-app-access-restrictions"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -60068,6 +61003,8 @@ func (c *Client) ReposAddCollaborator(ctx context.Context, request OptReposAddCo
 func (c *Client) sendReposAddCollaborator(ctx context.Context, request OptReposAddCollaboratorReq, params ReposAddCollaboratorParams) (res ReposAddCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/add-collaborator"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/collaborators/{username}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -60218,6 +61155,8 @@ func (c *Client) ReposAddStatusCheckContexts(ctx context.Context, request OptRep
 func (c *Client) sendReposAddStatusCheckContexts(ctx context.Context, request OptReposAddStatusCheckContextsReq, params ReposAddStatusCheckContextsParams) (res ReposAddStatusCheckContextsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/add-status-check-contexts"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -60379,6 +61318,8 @@ func (c *Client) ReposAddTeamAccessRestrictions(ctx context.Context, request Opt
 func (c *Client) sendReposAddTeamAccessRestrictions(ctx context.Context, request OptReposAddTeamAccessRestrictionsReq, params ReposAddTeamAccessRestrictionsParams) (res ReposAddTeamAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/add-team-access-restrictions"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -60539,6 +61480,8 @@ func (c *Client) ReposAddUserAccessRestrictions(ctx context.Context, request Opt
 func (c *Client) sendReposAddUserAccessRestrictions(ctx context.Context, request OptReposAddUserAccessRestrictionsReq, params ReposAddUserAccessRestrictionsParams) (res ReposAddUserAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/add-user-access-restrictions"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -60690,6 +61633,8 @@ func (c *Client) ReposCheckCollaborator(ctx context.Context, params ReposCheckCo
 func (c *Client) sendReposCheckCollaborator(ctx context.Context, params ReposCheckCollaboratorParams) (res ReposCheckCollaboratorRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/check-collaborator"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/collaborators/{username}"),
 	}
 
 	// Run stopwatch.
@@ -60820,6 +61765,8 @@ func (c *Client) ReposCheckVulnerabilityAlerts(ctx context.Context, params Repos
 func (c *Client) sendReposCheckVulnerabilityAlerts(ctx context.Context, params ReposCheckVulnerabilityAlertsParams) (res ReposCheckVulnerabilityAlertsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/check-vulnerability-alerts"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/vulnerability-alerts"),
 	}
 
 	// Run stopwatch.
@@ -60983,6 +61930,8 @@ func (c *Client) ReposCompareCommits(ctx context.Context, params ReposCompareCom
 func (c *Client) sendReposCompareCommits(ctx context.Context, params ReposCompareCommitsParams) (res ReposCompareCommitsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/compare-commits"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/compare/{basehead}"),
 	}
 
 	// Run stopwatch.
@@ -61148,6 +62097,8 @@ func (c *Client) ReposCreateAutolink(ctx context.Context, request *ReposCreateAu
 func (c *Client) sendReposCreateAutolink(ctx context.Context, request *ReposCreateAutolinkReq, params ReposCreateAutolinkParams) (res ReposCreateAutolinkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-autolink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/autolinks"),
 	}
 
 	// Run stopwatch.
@@ -61267,6 +62218,8 @@ func (c *Client) ReposCreateCommitComment(ctx context.Context, request *ReposCre
 func (c *Client) sendReposCreateCommitComment(ctx context.Context, request *ReposCreateCommitCommentReq, params ReposCreateCommitCommentParams) (res ReposCreateCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-commit-comment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{commit_sha}/comments"),
 	}
 
 	// Run stopwatch.
@@ -61404,6 +62357,8 @@ func (c *Client) ReposCreateCommitSignatureProtection(ctx context.Context, param
 func (c *Client) sendReposCreateCommitSignatureProtection(ctx context.Context, params ReposCreateCommitSignatureProtectionParams) (res ReposCreateCommitSignatureProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-commit-signature-protection"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"),
 	}
 
 	// Run stopwatch.
@@ -61534,6 +62489,8 @@ func (c *Client) ReposCreateCommitStatus(ctx context.Context, request *ReposCrea
 func (c *Client) sendReposCreateCommitStatus(ctx context.Context, request *ReposCreateCommitStatusReq, params ReposCreateCommitStatusParams) (res *StatusHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-commit-status"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/statuses/{sha}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -61673,6 +62630,8 @@ func (c *Client) ReposCreateDeployKey(ctx context.Context, request *ReposCreateD
 func (c *Client) sendReposCreateDeployKey(ctx context.Context, request *ReposCreateDeployKeyReq, params ReposCreateDeployKeyParams) (res ReposCreateDeployKeyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-deploy-key"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/keys"),
 	}
 
 	// Run stopwatch.
@@ -61840,6 +62799,8 @@ func (c *Client) ReposCreateDeployment(ctx context.Context, request *ReposCreate
 func (c *Client) sendReposCreateDeployment(ctx context.Context, request *ReposCreateDeploymentReq, params ReposCreateDeploymentParams) (res ReposCreateDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-deployment"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments"),
 	}
 
 	// Run stopwatch.
@@ -61954,6 +62915,8 @@ func (c *Client) ReposCreateDeploymentStatus(ctx context.Context, request *Repos
 func (c *Client) sendReposCreateDeploymentStatus(ctx context.Context, request *ReposCreateDeploymentStatusReq, params ReposCreateDeploymentStatusParams) (res ReposCreateDeploymentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-deployment-status"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments/{deployment_id}/statuses"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -62113,6 +63076,8 @@ func (c *Client) ReposCreateDispatchEvent(ctx context.Context, request *ReposCre
 func (c *Client) sendReposCreateDispatchEvent(ctx context.Context, request *ReposCreateDispatchEventReq, params ReposCreateDispatchEventParams) (res ReposCreateDispatchEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-dispatch-event"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/dispatches"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -62240,6 +63205,8 @@ func (c *Client) ReposCreateForAuthenticatedUser(ctx context.Context, request *R
 func (c *Client) sendReposCreateForAuthenticatedUser(ctx context.Context, request *ReposCreateForAuthenticatedUserReq) (res ReposCreateForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/repos"),
 	}
 
 	// Run stopwatch.
@@ -62317,6 +63284,8 @@ func (c *Client) ReposCreateFork(ctx context.Context, request OptNilReposCreateF
 func (c *Client) sendReposCreateFork(ctx context.Context, request OptNilReposCreateForkReq, params ReposCreateForkParams) (res ReposCreateForkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-fork"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/forks"),
 	}
 
 	// Run stopwatch.
@@ -62436,6 +63405,8 @@ func (c *Client) ReposCreateInOrg(ctx context.Context, request *ReposCreateInOrg
 func (c *Client) sendReposCreateInOrg(ctx context.Context, request *ReposCreateInOrgReq, params ReposCreateInOrgParams) (res ReposCreateInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-in-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/repos"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -62538,6 +63509,8 @@ func (c *Client) ReposCreateOrUpdateFileContents(ctx context.Context, request *R
 func (c *Client) sendReposCreateOrUpdateFileContents(ctx context.Context, request *ReposCreateOrUpdateFileContentsReq, params ReposCreateOrUpdateFileContentsParams) (res ReposCreateOrUpdateFileContentsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-or-update-file-contents"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/contents/{path}"),
 	}
 
 	// Run stopwatch.
@@ -62669,6 +63642,8 @@ func (c *Client) ReposCreatePagesSite(ctx context.Context, request NilReposCreat
 func (c *Client) sendReposCreatePagesSite(ctx context.Context, request NilReposCreatePagesSiteReq, params ReposCreatePagesSiteParams) (res ReposCreatePagesSiteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-pages-site"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -62804,6 +63779,8 @@ func (c *Client) ReposCreateRelease(ctx context.Context, request *ReposCreateRel
 func (c *Client) sendReposCreateRelease(ctx context.Context, request *ReposCreateReleaseReq, params ReposCreateReleaseParams) (res ReposCreateReleaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-release"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases"),
 	}
 
 	// Run stopwatch.
@@ -62927,6 +63904,8 @@ func (c *Client) ReposCreateUsingTemplate(ctx context.Context, request *ReposCre
 func (c *Client) sendReposCreateUsingTemplate(ctx context.Context, request *ReposCreateUsingTemplateReq, params ReposCreateUsingTemplateParams) (res *RepositoryHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-using-template"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{template_owner}/{template_repo}/generate"),
 	}
 
 	// Run stopwatch.
@@ -63041,6 +64020,8 @@ func (c *Client) ReposCreateWebhook(ctx context.Context, request OptNilReposCrea
 func (c *Client) sendReposCreateWebhook(ctx context.Context, request OptNilReposCreateWebhookReq, params ReposCreateWebhookParams) (res ReposCreateWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/create-webhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -63169,6 +64150,8 @@ func (c *Client) ReposDeclineInvitation(ctx context.Context, params ReposDecline
 func (c *Client) sendReposDeclineInvitation(ctx context.Context, params ReposDeclineInvitationParams) (res ReposDeclineInvitationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/decline-invitation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/repository_invitations/{invitation_id}"),
 	}
 
 	// Run stopwatch.
@@ -63261,6 +64244,8 @@ func (c *Client) ReposDelete(ctx context.Context, params ReposDeleteParams) (Rep
 func (c *Client) sendReposDelete(ctx context.Context, params ReposDeleteParams) (res ReposDeleteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -63374,6 +64359,8 @@ func (c *Client) ReposDeleteAccessRestrictions(ctx context.Context, params Repos
 func (c *Client) sendReposDeleteAccessRestrictions(ctx context.Context, params ReposDeleteAccessRestrictionsParams) (res *ReposDeleteAccessRestrictionsNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-access-restrictions"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions"),
 	}
 
 	// Run stopwatch.
@@ -63508,6 +64495,8 @@ func (c *Client) ReposDeleteAdminBranchProtection(ctx context.Context, params Re
 func (c *Client) sendReposDeleteAdminBranchProtection(ctx context.Context, params ReposDeleteAdminBranchProtectionParams) (res ReposDeleteAdminBranchProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-admin-branch-protection"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"),
 	}
 
 	// Run stopwatch.
@@ -63636,6 +64625,8 @@ func (c *Client) ReposDeleteAnEnvironment(ctx context.Context, params ReposDelet
 func (c *Client) sendReposDeleteAnEnvironment(ctx context.Context, params ReposDeleteAnEnvironmentParams) (res *ReposDeleteAnEnvironmentNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-an-environment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/environments/{environment_name}"),
 	}
 
 	// Run stopwatch.
@@ -63764,6 +64755,8 @@ func (c *Client) ReposDeleteAutolink(ctx context.Context, params ReposDeleteAuto
 func (c *Client) sendReposDeleteAutolink(ctx context.Context, params ReposDeleteAutolinkParams) (res ReposDeleteAutolinkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-autolink"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/autolinks/{autolink_id}"),
 	}
 
 	// Run stopwatch.
@@ -63895,6 +64888,8 @@ func (c *Client) ReposDeleteBranchProtection(ctx context.Context, params ReposDe
 func (c *Client) sendReposDeleteBranchProtection(ctx context.Context, params ReposDeleteBranchProtectionParams) (res ReposDeleteBranchProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-branch-protection"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection"),
 	}
 
 	// Run stopwatch.
@@ -64023,6 +65018,8 @@ func (c *Client) ReposDeleteCommitComment(ctx context.Context, params ReposDelet
 func (c *Client) sendReposDeleteCommitComment(ctx context.Context, params ReposDeleteCommitCommentParams) (res ReposDeleteCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-commit-comment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -64157,6 +65154,8 @@ func (c *Client) ReposDeleteCommitSignatureProtection(ctx context.Context, param
 func (c *Client) sendReposDeleteCommitSignatureProtection(ctx context.Context, params ReposDeleteCommitSignatureProtectionParams) (res ReposDeleteCommitSignatureProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-commit-signature-protection"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"),
 	}
 
 	// Run stopwatch.
@@ -64286,6 +65285,8 @@ func (c *Client) ReposDeleteDeployKey(ctx context.Context, params ReposDeleteDep
 func (c *Client) sendReposDeleteDeployKey(ctx context.Context, params ReposDeleteDeployKeyParams) (res *ReposDeleteDeployKeyNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-deploy-key"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/keys/{key_id}"),
 	}
 
 	// Run stopwatch.
@@ -64421,6 +65422,8 @@ func (c *Client) ReposDeleteDeployment(ctx context.Context, params ReposDeleteDe
 func (c *Client) sendReposDeleteDeployment(ctx context.Context, params ReposDeleteDeploymentParams) (res ReposDeleteDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-deployment"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments/{deployment_id}"),
 	}
 
 	// Run stopwatch.
@@ -64555,6 +65558,8 @@ func (c *Client) ReposDeleteFile(ctx context.Context, request *ReposDeleteFileRe
 func (c *Client) sendReposDeleteFile(ctx context.Context, request *ReposDeleteFileReq, params ReposDeleteFileParams) (res ReposDeleteFileRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-file"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/contents/{path}"),
 	}
 
 	// Run stopwatch.
@@ -64685,6 +65690,8 @@ func (c *Client) ReposDeleteInvitation(ctx context.Context, params ReposDeleteIn
 func (c *Client) sendReposDeleteInvitation(ctx context.Context, params ReposDeleteInvitationParams) (res *ReposDeleteInvitationNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-invitation"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/invitations/{invitation_id}"),
 	}
 
 	// Run stopwatch.
@@ -64812,6 +65819,8 @@ func (c *Client) ReposDeletePagesSite(ctx context.Context, params ReposDeletePag
 func (c *Client) sendReposDeletePagesSite(ctx context.Context, params ReposDeletePagesSiteParams) (res ReposDeletePagesSiteRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-pages-site"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages"),
 	}
 
 	// Run stopwatch.
@@ -64925,6 +65934,8 @@ func (c *Client) ReposDeletePullRequestReviewProtection(ctx context.Context, par
 func (c *Client) sendReposDeletePullRequestReviewProtection(ctx context.Context, params ReposDeletePullRequestReviewProtectionParams) (res ReposDeletePullRequestReviewProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-pull-request-review-protection"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"),
 	}
 
 	// Run stopwatch.
@@ -65053,6 +66064,8 @@ func (c *Client) ReposDeleteRelease(ctx context.Context, params ReposDeleteRelea
 func (c *Client) sendReposDeleteRelease(ctx context.Context, params ReposDeleteReleaseParams) (res *ReposDeleteReleaseNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-release"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}"),
 	}
 
 	// Run stopwatch.
@@ -65180,6 +66193,8 @@ func (c *Client) ReposDeleteReleaseAsset(ctx context.Context, params ReposDelete
 func (c *Client) sendReposDeleteReleaseAsset(ctx context.Context, params ReposDeleteReleaseAssetParams) (res *ReposDeleteReleaseAssetNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-release-asset"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/assets/{asset_id}"),
 	}
 
 	// Run stopwatch.
@@ -65307,6 +66322,8 @@ func (c *Client) ReposDeleteWebhook(ctx context.Context, params ReposDeleteWebho
 func (c *Client) sendReposDeleteWebhook(ctx context.Context, params ReposDeleteWebhookParams) (res ReposDeleteWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/delete-webhook"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}"),
 	}
 
 	// Run stopwatch.
@@ -65436,6 +66453,8 @@ func (c *Client) ReposDisableAutomatedSecurityFixes(ctx context.Context, params 
 func (c *Client) sendReposDisableAutomatedSecurityFixes(ctx context.Context, params ReposDisableAutomatedSecurityFixesParams) (res *ReposDisableAutomatedSecurityFixesNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/disable-automated-security-fixes"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/automated-security-fixes"),
 	}
 
 	// Run stopwatch.
@@ -65545,6 +66564,8 @@ func (c *Client) ReposDisableLfsForRepo(ctx context.Context, params ReposDisable
 func (c *Client) sendReposDisableLfsForRepo(ctx context.Context, params ReposDisableLfsForRepoParams) (res *ReposDisableLfsForRepoNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/disable-lfs-for-repo"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/lfs"),
 	}
 
 	// Run stopwatch.
@@ -65657,6 +66678,8 @@ func (c *Client) ReposDisableVulnerabilityAlerts(ctx context.Context, params Rep
 func (c *Client) sendReposDisableVulnerabilityAlerts(ctx context.Context, params ReposDisableVulnerabilityAlertsParams) (res *ReposDisableVulnerabilityAlertsNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/disable-vulnerability-alerts"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/vulnerability-alerts"),
 	}
 
 	// Run stopwatch.
@@ -65771,6 +66794,8 @@ func (c *Client) ReposDownloadTarballArchive(ctx context.Context, params ReposDo
 func (c *Client) sendReposDownloadTarballArchive(ctx context.Context, params ReposDownloadTarballArchiveParams) (res *ReposDownloadTarballArchiveFound, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/download-tarball-archive"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/tarball/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -65903,6 +66928,8 @@ func (c *Client) ReposDownloadZipballArchive(ctx context.Context, params ReposDo
 func (c *Client) sendReposDownloadZipballArchive(ctx context.Context, params ReposDownloadZipballArchiveParams) (res *ReposDownloadZipballArchiveFound, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/download-zipball-archive"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/zipball/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -66032,6 +67059,8 @@ func (c *Client) ReposEnableAutomatedSecurityFixes(ctx context.Context, params R
 func (c *Client) sendReposEnableAutomatedSecurityFixes(ctx context.Context, params ReposEnableAutomatedSecurityFixesParams) (res *ReposEnableAutomatedSecurityFixesNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/enable-automated-security-fixes"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/automated-security-fixes"),
 	}
 
 	// Run stopwatch.
@@ -66141,6 +67170,8 @@ func (c *Client) ReposEnableLfsForRepo(ctx context.Context, params ReposEnableLf
 func (c *Client) sendReposEnableLfsForRepo(ctx context.Context, params ReposEnableLfsForRepoParams) (res ReposEnableLfsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/enable-lfs-for-repo"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/lfs"),
 	}
 
 	// Run stopwatch.
@@ -66253,6 +67284,8 @@ func (c *Client) ReposEnableVulnerabilityAlerts(ctx context.Context, params Repo
 func (c *Client) sendReposEnableVulnerabilityAlerts(ctx context.Context, params ReposEnableVulnerabilityAlertsParams) (res *ReposEnableVulnerabilityAlertsNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/enable-vulnerability-alerts"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/vulnerability-alerts"),
 	}
 
 	// Run stopwatch.
@@ -66363,6 +67396,8 @@ func (c *Client) ReposGet(ctx context.Context, params ReposGetParams) (ReposGetR
 func (c *Client) sendReposGet(ctx context.Context, params ReposGetParams) (res ReposGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -66478,6 +67513,8 @@ func (c *Client) ReposGetAccessRestrictions(ctx context.Context, params ReposGet
 func (c *Client) sendReposGetAccessRestrictions(ctx context.Context, params ReposGetAccessRestrictionsParams) (res ReposGetAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-access-restrictions"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions"),
 	}
 
 	// Run stopwatch.
@@ -66610,6 +67647,8 @@ func (c *Client) ReposGetAdminBranchProtection(ctx context.Context, params Repos
 func (c *Client) sendReposGetAdminBranchProtection(ctx context.Context, params ReposGetAdminBranchProtectionParams) (res *ProtectedBranchAdminEnforced, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-admin-branch-protection"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"),
 	}
 
 	// Run stopwatch.
@@ -66742,6 +67781,8 @@ func (c *Client) ReposGetAllStatusCheckContexts(ctx context.Context, params Repo
 func (c *Client) sendReposGetAllStatusCheckContexts(ctx context.Context, params ReposGetAllStatusCheckContextsParams) (res ReposGetAllStatusCheckContextsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-all-status-check-contexts"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"),
 	}
 
 	// Run stopwatch.
@@ -66870,6 +67911,8 @@ func (c *Client) ReposGetAllTopics(ctx context.Context, params ReposGetAllTopics
 func (c *Client) sendReposGetAllTopics(ctx context.Context, params ReposGetAllTopicsParams) (res ReposGetAllTopicsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-all-topics"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/topics"),
 	}
 
 	// Run stopwatch.
@@ -67024,6 +68067,8 @@ func (c *Client) ReposGetAppsWithAccessToProtectedBranch(ctx context.Context, pa
 func (c *Client) sendReposGetAppsWithAccessToProtectedBranch(ctx context.Context, params ReposGetAppsWithAccessToProtectedBranchParams) (res ReposGetAppsWithAccessToProtectedBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-apps-with-access-to-protected-branch"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"),
 	}
 
 	// Run stopwatch.
@@ -67153,6 +68198,8 @@ func (c *Client) ReposGetAutolink(ctx context.Context, params ReposGetAutolinkPa
 func (c *Client) sendReposGetAutolink(ctx context.Context, params ReposGetAutolinkParams) (res ReposGetAutolinkRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-autolink"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/autolinks/{autolink_id}"),
 	}
 
 	// Run stopwatch.
@@ -67280,6 +68327,8 @@ func (c *Client) ReposGetBranch(ctx context.Context, params ReposGetBranchParams
 func (c *Client) sendReposGetBranch(ctx context.Context, params ReposGetBranchParams) (res ReposGetBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-branch"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}"),
 	}
 
 	// Run stopwatch.
@@ -67411,6 +68460,8 @@ func (c *Client) ReposGetBranchProtection(ctx context.Context, params ReposGetBr
 func (c *Client) sendReposGetBranchProtection(ctx context.Context, params ReposGetBranchProtectionParams) (res ReposGetBranchProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-branch-protection"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection"),
 	}
 
 	// Run stopwatch.
@@ -67540,6 +68591,8 @@ func (c *Client) ReposGetClones(ctx context.Context, params ReposGetClonesParams
 func (c *Client) sendReposGetClones(ctx context.Context, params ReposGetClonesParams) (res ReposGetClonesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-clones"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/traffic/clones"),
 	}
 
 	// Run stopwatch.
@@ -67670,6 +68723,8 @@ func (c *Client) ReposGetCodeFrequencyStats(ctx context.Context, params ReposGet
 func (c *Client) sendReposGetCodeFrequencyStats(ctx context.Context, params ReposGetCodeFrequencyStatsParams) (res ReposGetCodeFrequencyStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-code-frequency-stats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/stats/code_frequency"),
 	}
 
 	// Run stopwatch.
@@ -67780,6 +68835,8 @@ func (c *Client) ReposGetCollaboratorPermissionLevel(ctx context.Context, params
 func (c *Client) sendReposGetCollaboratorPermissionLevel(ctx context.Context, params ReposGetCollaboratorPermissionLevelParams) (res ReposGetCollaboratorPermissionLevelRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-collaborator-permission-level"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/collaborators/{username}/permission"),
 	}
 
 	// Run stopwatch.
@@ -67916,6 +68973,8 @@ func (c *Client) ReposGetCombinedStatusForRef(ctx context.Context, params ReposG
 func (c *Client) sendReposGetCombinedStatusForRef(ctx context.Context, params ReposGetCombinedStatusForRefParams) (res ReposGetCombinedStatusForRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-combined-status-for-ref"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{ref}/status"),
 	}
 
 	// Run stopwatch.
@@ -68128,6 +69187,8 @@ func (c *Client) ReposGetCommit(ctx context.Context, params ReposGetCommitParams
 func (c *Client) sendReposGetCommit(ctx context.Context, params ReposGetCommitParams) (res ReposGetCommitRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-commit"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{ref}"),
 	}
 
 	// Run stopwatch.
@@ -68294,6 +69355,8 @@ func (c *Client) ReposGetCommitActivityStats(ctx context.Context, params ReposGe
 func (c *Client) sendReposGetCommitActivityStats(ctx context.Context, params ReposGetCommitActivityStatsParams) (res ReposGetCommitActivityStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-commit-activity-stats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/stats/commit_activity"),
 	}
 
 	// Run stopwatch.
@@ -68403,6 +69466,8 @@ func (c *Client) ReposGetCommitComment(ctx context.Context, params ReposGetCommi
 func (c *Client) sendReposGetCommitComment(ctx context.Context, params ReposGetCommitCommentParams) (res ReposGetCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-commit-comment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -68539,6 +69604,8 @@ func (c *Client) ReposGetCommitSignatureProtection(ctx context.Context, params R
 func (c *Client) sendReposGetCommitSignatureProtection(ctx context.Context, params ReposGetCommitSignatureProtectionParams) (res ReposGetCommitSignatureProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-commit-signature-protection"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"),
 	}
 
 	// Run stopwatch.
@@ -68676,6 +69743,8 @@ func (c *Client) ReposGetCommunityProfileMetrics(ctx context.Context, params Rep
 func (c *Client) sendReposGetCommunityProfileMetrics(ctx context.Context, params ReposGetCommunityProfileMetricsParams) (res *CommunityProfile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-community-profile-metrics"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/community/profile"),
 	}
 
 	// Run stopwatch.
@@ -68790,6 +69859,8 @@ func (c *Client) ReposGetContributorsStats(ctx context.Context, params ReposGetC
 func (c *Client) sendReposGetContributorsStats(ctx context.Context, params ReposGetContributorsStatsParams) (res ReposGetContributorsStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-contributors-stats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/stats/contributors"),
 	}
 
 	// Run stopwatch.
@@ -68899,6 +69970,8 @@ func (c *Client) ReposGetDeployKey(ctx context.Context, params ReposGetDeployKey
 func (c *Client) sendReposGetDeployKey(ctx context.Context, params ReposGetDeployKeyParams) (res ReposGetDeployKeyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-deploy-key"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/keys/{key_id}"),
 	}
 
 	// Run stopwatch.
@@ -69026,6 +70099,8 @@ func (c *Client) ReposGetDeployment(ctx context.Context, params ReposGetDeployme
 func (c *Client) sendReposGetDeployment(ctx context.Context, params ReposGetDeploymentParams) (res ReposGetDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-deployment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments/{deployment_id}"),
 	}
 
 	// Run stopwatch.
@@ -69153,6 +70228,8 @@ func (c *Client) ReposGetDeploymentStatus(ctx context.Context, params ReposGetDe
 func (c *Client) sendReposGetDeploymentStatus(ctx context.Context, params ReposGetDeploymentStatusParams) (res ReposGetDeploymentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-deployment-status"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"),
 	}
 
 	// Run stopwatch.
@@ -69299,6 +70376,8 @@ func (c *Client) ReposGetLatestPagesBuild(ctx context.Context, params ReposGetLa
 func (c *Client) sendReposGetLatestPagesBuild(ctx context.Context, params ReposGetLatestPagesBuildParams) (res *PageBuild, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-latest-pages-build"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages/builds/latest"),
 	}
 
 	// Run stopwatch.
@@ -69411,6 +70490,8 @@ func (c *Client) ReposGetLatestRelease(ctx context.Context, params ReposGetLates
 func (c *Client) sendReposGetLatestRelease(ctx context.Context, params ReposGetLatestReleaseParams) (res *Release, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-latest-release"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/latest"),
 	}
 
 	// Run stopwatch.
@@ -69520,6 +70601,8 @@ func (c *Client) ReposGetPages(ctx context.Context, params ReposGetPagesParams) 
 func (c *Client) sendReposGetPages(ctx context.Context, params ReposGetPagesParams) (res ReposGetPagesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-pages"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages"),
 	}
 
 	// Run stopwatch.
@@ -69629,6 +70712,8 @@ func (c *Client) ReposGetPagesBuild(ctx context.Context, params ReposGetPagesBui
 func (c *Client) sendReposGetPagesBuild(ctx context.Context, params ReposGetPagesBuildParams) (res *PageBuild, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-pages-build"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages/builds/{build_id}"),
 	}
 
 	// Run stopwatch.
@@ -69762,6 +70847,8 @@ func (c *Client) ReposGetPagesHealthCheck(ctx context.Context, params ReposGetPa
 func (c *Client) sendReposGetPagesHealthCheck(ctx context.Context, params ReposGetPagesHealthCheckParams) (res ReposGetPagesHealthCheckRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-pages-health-check"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages/health"),
 	}
 
 	// Run stopwatch.
@@ -69874,6 +70961,8 @@ func (c *Client) ReposGetParticipationStats(ctx context.Context, params ReposGet
 func (c *Client) sendReposGetParticipationStats(ctx context.Context, params ReposGetParticipationStatsParams) (res ReposGetParticipationStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-participation-stats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/stats/participation"),
 	}
 
 	// Run stopwatch.
@@ -69987,6 +71076,8 @@ func (c *Client) ReposGetPullRequestReviewProtection(ctx context.Context, params
 func (c *Client) sendReposGetPullRequestReviewProtection(ctx context.Context, params ReposGetPullRequestReviewProtectionParams) (res *ProtectedBranchPullRequestReview, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-pull-request-review-protection"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"),
 	}
 
 	// Run stopwatch.
@@ -70120,6 +71211,8 @@ func (c *Client) ReposGetPunchCardStats(ctx context.Context, params ReposGetPunc
 func (c *Client) sendReposGetPunchCardStats(ctx context.Context, params ReposGetPunchCardStatsParams) (res ReposGetPunchCardStatsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-punch-card-stats"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/stats/punch_card"),
 	}
 
 	// Run stopwatch.
@@ -70231,6 +71324,8 @@ func (c *Client) ReposGetReadme(ctx context.Context, params ReposGetReadmeParams
 func (c *Client) sendReposGetReadme(ctx context.Context, params ReposGetReadmeParams) (res ReposGetReadmeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-readme"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/readme"),
 	}
 
 	// Run stopwatch.
@@ -70363,6 +71458,8 @@ func (c *Client) ReposGetReadmeInDirectory(ctx context.Context, params ReposGetR
 func (c *Client) sendReposGetReadmeInDirectory(ctx context.Context, params ReposGetReadmeInDirectoryParams) (res ReposGetReadmeInDirectoryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-readme-in-directory"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/readme/{dir}"),
 	}
 
 	// Run stopwatch.
@@ -70513,6 +71610,8 @@ func (c *Client) ReposGetRelease(ctx context.Context, params ReposGetReleasePara
 func (c *Client) sendReposGetRelease(ctx context.Context, params ReposGetReleaseParams) (res ReposGetReleaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-release"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}"),
 	}
 
 	// Run stopwatch.
@@ -70643,6 +71742,8 @@ func (c *Client) ReposGetReleaseAsset(ctx context.Context, params ReposGetReleas
 func (c *Client) sendReposGetReleaseAsset(ctx context.Context, params ReposGetReleaseAssetParams) (res ReposGetReleaseAssetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-release-asset"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/assets/{asset_id}"),
 	}
 
 	// Run stopwatch.
@@ -70770,6 +71871,8 @@ func (c *Client) ReposGetReleaseByTag(ctx context.Context, params ReposGetReleas
 func (c *Client) sendReposGetReleaseByTag(ctx context.Context, params ReposGetReleaseByTagParams) (res ReposGetReleaseByTagRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-release-by-tag"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/tags/{tag}"),
 	}
 
 	// Run stopwatch.
@@ -70901,6 +72004,8 @@ func (c *Client) ReposGetStatusChecksProtection(ctx context.Context, params Repo
 func (c *Client) sendReposGetStatusChecksProtection(ctx context.Context, params ReposGetStatusChecksProtectionParams) (res ReposGetStatusChecksProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-status-checks-protection"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"),
 	}
 
 	// Run stopwatch.
@@ -71034,6 +72139,8 @@ func (c *Client) ReposGetTeamsWithAccessToProtectedBranch(ctx context.Context, p
 func (c *Client) sendReposGetTeamsWithAccessToProtectedBranch(ctx context.Context, params ReposGetTeamsWithAccessToProtectedBranchParams) (res ReposGetTeamsWithAccessToProtectedBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-teams-with-access-to-protected-branch"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"),
 	}
 
 	// Run stopwatch.
@@ -71162,6 +72269,8 @@ func (c *Client) ReposGetTopPaths(ctx context.Context, params ReposGetTopPathsPa
 func (c *Client) sendReposGetTopPaths(ctx context.Context, params ReposGetTopPathsParams) (res ReposGetTopPathsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-top-paths"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/traffic/popular/paths"),
 	}
 
 	// Run stopwatch.
@@ -71271,6 +72380,8 @@ func (c *Client) ReposGetTopReferrers(ctx context.Context, params ReposGetTopRef
 func (c *Client) sendReposGetTopReferrers(ctx context.Context, params ReposGetTopReferrersParams) (res ReposGetTopReferrersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-top-referrers"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/traffic/popular/referrers"),
 	}
 
 	// Run stopwatch.
@@ -71385,6 +72496,8 @@ func (c *Client) ReposGetUsersWithAccessToProtectedBranch(ctx context.Context, p
 func (c *Client) sendReposGetUsersWithAccessToProtectedBranch(ctx context.Context, params ReposGetUsersWithAccessToProtectedBranchParams) (res ReposGetUsersWithAccessToProtectedBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-users-with-access-to-protected-branch"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"),
 	}
 
 	// Run stopwatch.
@@ -71514,6 +72627,8 @@ func (c *Client) ReposGetViews(ctx context.Context, params ReposGetViewsParams) 
 func (c *Client) sendReposGetViews(ctx context.Context, params ReposGetViewsParams) (res ReposGetViewsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-views"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/traffic/views"),
 	}
 
 	// Run stopwatch.
@@ -71646,6 +72761,8 @@ func (c *Client) ReposGetWebhook(ctx context.Context, params ReposGetWebhookPara
 func (c *Client) sendReposGetWebhook(ctx context.Context, params ReposGetWebhookParams) (res ReposGetWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-webhook"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}"),
 	}
 
 	// Run stopwatch.
@@ -71777,6 +72894,8 @@ func (c *Client) ReposGetWebhookConfigForRepo(ctx context.Context, params ReposG
 func (c *Client) sendReposGetWebhookConfigForRepo(ctx context.Context, params ReposGetWebhookConfigForRepoParams) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-webhook-config-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/config"),
 	}
 
 	// Run stopwatch.
@@ -71905,6 +73024,8 @@ func (c *Client) ReposGetWebhookDelivery(ctx context.Context, params ReposGetWeb
 func (c *Client) sendReposGetWebhookDelivery(ctx context.Context, params ReposGetWebhookDeliveryParams) (res ReposGetWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/get-webhook-delivery"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}"),
 	}
 
 	// Run stopwatch.
@@ -72052,6 +73173,8 @@ func (c *Client) ReposListAutolinks(ctx context.Context, params ReposListAutolin
 func (c *Client) sendReposListAutolinks(ctx context.Context, params ReposListAutolinksParams) (res []Autolink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-autolinks"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/autolinks"),
 	}
 
 	// Run stopwatch.
@@ -72182,6 +73305,8 @@ func (c *Client) ReposListBranches(ctx context.Context, params ReposListBranches
 func (c *Client) sendReposListBranches(ctx context.Context, params ReposListBranchesParams) (res ReposListBranchesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-branches"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches"),
 	}
 
 	// Run stopwatch.
@@ -72351,6 +73476,8 @@ func (c *Client) ReposListBranchesForHeadCommit(ctx context.Context, params Repo
 func (c *Client) sendReposListBranchesForHeadCommit(ctx context.Context, params ReposListBranchesForHeadCommitParams) (res ReposListBranchesForHeadCommitRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-branches-for-head-commit"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"),
 	}
 
 	// Run stopwatch.
@@ -72483,6 +73610,8 @@ func (c *Client) ReposListCollaborators(ctx context.Context, params ReposListCol
 func (c *Client) sendReposListCollaborators(ctx context.Context, params ReposListCollaboratorsParams) (res ReposListCollaboratorsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-collaborators"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/collaborators"),
 	}
 
 	// Run stopwatch.
@@ -72647,6 +73776,8 @@ func (c *Client) ReposListCommentsForCommit(ctx context.Context, params ReposLis
 func (c *Client) sendReposListCommentsForCommit(ctx context.Context, params ReposListCommentsForCommitParams) (res *ReposListCommentsForCommitOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-comments-for-commit"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{commit_sha}/comments"),
 	}
 
 	// Run stopwatch.
@@ -72816,6 +73947,8 @@ func (c *Client) ReposListCommitCommentsForRepo(ctx context.Context, params Repo
 func (c *Client) sendReposListCommitCommentsForRepo(ctx context.Context, params ReposListCommitCommentsForRepoParams) (res *ReposListCommitCommentsForRepoOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-commit-comments-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments"),
 	}
 
 	// Run stopwatch.
@@ -72966,6 +74099,8 @@ func (c *Client) ReposListCommitStatusesForRef(ctx context.Context, params Repos
 func (c *Client) sendReposListCommitStatusesForRef(ctx context.Context, params ReposListCommitStatusesForRefParams) (res ReposListCommitStatusesForRefRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-commit-statuses-for-ref"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{ref}/statuses"),
 	}
 
 	// Run stopwatch.
@@ -73163,6 +74298,8 @@ func (c *Client) ReposListCommits(ctx context.Context, params ReposListCommitsPa
 func (c *Client) sendReposListCommits(ctx context.Context, params ReposListCommitsParams) (res ReposListCommitsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-commits"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits"),
 	}
 
 	// Run stopwatch.
@@ -73401,6 +74538,8 @@ func (c *Client) ReposListContributors(ctx context.Context, params ReposListCont
 func (c *Client) sendReposListContributors(ctx context.Context, params ReposListContributorsParams) (res ReposListContributorsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-contributors"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/contributors"),
 	}
 
 	// Run stopwatch.
@@ -73565,6 +74704,8 @@ func (c *Client) ReposListDeployKeys(ctx context.Context, params ReposListDeploy
 func (c *Client) sendReposListDeployKeys(ctx context.Context, params ReposListDeployKeysParams) (res *ReposListDeployKeysOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-deploy-keys"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/keys"),
 	}
 
 	// Run stopwatch.
@@ -73712,6 +74853,8 @@ func (c *Client) ReposListDeploymentStatuses(ctx context.Context, params ReposLi
 func (c *Client) sendReposListDeploymentStatuses(ctx context.Context, params ReposListDeploymentStatusesParams) (res ReposListDeploymentStatusesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-deployment-statuses"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments/{deployment_id}/statuses"),
 	}
 
 	// Run stopwatch.
@@ -73878,6 +75021,8 @@ func (c *Client) ReposListDeployments(ctx context.Context, params ReposListDeplo
 func (c *Client) sendReposListDeployments(ctx context.Context, params ReposListDeploymentsParams) (res *ReposListDeploymentsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-deployments"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/deployments"),
 	}
 
 	// Run stopwatch.
@@ -74096,6 +75241,8 @@ func (c *Client) ReposListForAuthenticatedUser(ctx context.Context, params Repos
 func (c *Client) sendReposListForAuthenticatedUser(ctx context.Context, params ReposListForAuthenticatedUserParams) (res ReposListForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/repos"),
 	}
 
 	// Run stopwatch.
@@ -74324,6 +75471,8 @@ func (c *Client) ReposListForOrg(ctx context.Context, params ReposListForOrgPara
 func (c *Client) sendReposListForOrg(ctx context.Context, params ReposListForOrgParams) (res *ReposListForOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/repos"),
 	}
 
 	// Run stopwatch.
@@ -74504,6 +75653,8 @@ func (c *Client) ReposListForUser(ctx context.Context, params ReposListForUserPa
 func (c *Client) sendReposListForUser(ctx context.Context, params ReposListForUserParams) (res *ReposListForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/repos"),
 	}
 
 	// Run stopwatch.
@@ -74683,6 +75834,8 @@ func (c *Client) ReposListForks(ctx context.Context, params ReposListForksParams
 func (c *Client) sendReposListForks(ctx context.Context, params ReposListForksParams) (res ReposListForksRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-forks"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/forks"),
 	}
 
 	// Run stopwatch.
@@ -74848,6 +76001,8 @@ func (c *Client) ReposListInvitations(ctx context.Context, params ReposListInvit
 func (c *Client) sendReposListInvitations(ctx context.Context, params ReposListInvitationsParams) (res *ReposListInvitationsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-invitations"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/invitations"),
 	}
 
 	// Run stopwatch.
@@ -74996,6 +76151,8 @@ func (c *Client) ReposListInvitationsForAuthenticatedUser(ctx context.Context, p
 func (c *Client) sendReposListInvitationsForAuthenticatedUser(ctx context.Context, params ReposListInvitationsForAuthenticatedUserParams) (res ReposListInvitationsForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-invitations-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/repository_invitations"),
 	}
 
 	// Run stopwatch.
@@ -75106,6 +76263,8 @@ func (c *Client) ReposListLanguages(ctx context.Context, params ReposListLanguag
 func (c *Client) sendReposListLanguages(ctx context.Context, params ReposListLanguagesParams) (res Language, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-languages"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/languages"),
 	}
 
 	// Run stopwatch.
@@ -75215,6 +76374,8 @@ func (c *Client) ReposListPagesBuilds(ctx context.Context, params ReposListPages
 func (c *Client) sendReposListPagesBuilds(ctx context.Context, params ReposListPagesBuildsParams) (res *ReposListPagesBuildsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-pages-builds"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages/builds"),
 	}
 
 	// Run stopwatch.
@@ -75368,6 +76529,8 @@ func (c *Client) ReposListPublic(ctx context.Context, params ReposListPublicPara
 func (c *Client) sendReposListPublic(ctx context.Context, params ReposListPublicParams) (res ReposListPublicRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-public"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repositories"),
 	}
 
 	// Run stopwatch.
@@ -75465,6 +76628,8 @@ func (c *Client) ReposListPullRequestsAssociatedWithCommit(ctx context.Context, 
 func (c *Client) sendReposListPullRequestsAssociatedWithCommit(ctx context.Context, params ReposListPullRequestsAssociatedWithCommitParams) (res *ReposListPullRequestsAssociatedWithCommitOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-pull-requests-associated-with-commit"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/commits/{commit_sha}/pulls"),
 	}
 
 	// Run stopwatch.
@@ -75631,6 +76796,8 @@ func (c *Client) ReposListReleaseAssets(ctx context.Context, params ReposListRel
 func (c *Client) sendReposListReleaseAssets(ctx context.Context, params ReposListReleaseAssetsParams) (res *ReposListReleaseAssetsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-release-assets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}/assets"),
 	}
 
 	// Run stopwatch.
@@ -75801,6 +76968,8 @@ func (c *Client) ReposListReleases(ctx context.Context, params ReposListReleases
 func (c *Client) sendReposListReleases(ctx context.Context, params ReposListReleasesParams) (res ReposListReleasesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-releases"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases"),
 	}
 
 	// Run stopwatch.
@@ -75948,6 +77117,8 @@ func (c *Client) ReposListTags(ctx context.Context, params ReposListTagsParams) 
 func (c *Client) sendReposListTags(ctx context.Context, params ReposListTagsParams) (res *ReposListTagsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-tags"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/tags"),
 	}
 
 	// Run stopwatch.
@@ -76095,6 +77266,8 @@ func (c *Client) ReposListTeams(ctx context.Context, params ReposListTeamsParams
 func (c *Client) sendReposListTeams(ctx context.Context, params ReposListTeamsParams) (res *ReposListTeamsOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-teams"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/teams"),
 	}
 
 	// Run stopwatch.
@@ -76242,6 +77415,8 @@ func (c *Client) ReposListWebhookDeliveries(ctx context.Context, params ReposLis
 func (c *Client) sendReposListWebhookDeliveries(ctx context.Context, params ReposListWebhookDeliveriesParams) (res ReposListWebhookDeliveriesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-webhook-deliveries"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/deliveries"),
 	}
 
 	// Run stopwatch.
@@ -76408,6 +77583,8 @@ func (c *Client) ReposListWebhooks(ctx context.Context, params ReposListWebhooks
 func (c *Client) sendReposListWebhooks(ctx context.Context, params ReposListWebhooksParams) (res ReposListWebhooksRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/list-webhooks"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks"),
 	}
 
 	// Run stopwatch.
@@ -76555,6 +77732,8 @@ func (c *Client) ReposMerge(ctx context.Context, request *ReposMergeReq, params 
 func (c *Client) sendReposMerge(ctx context.Context, request *ReposMergeReq, params ReposMergeParams) (res ReposMergeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/merge"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/merges"),
 	}
 
 	// Run stopwatch.
@@ -76668,6 +77847,8 @@ func (c *Client) ReposMergeUpstream(ctx context.Context, request *ReposMergeUpst
 func (c *Client) sendReposMergeUpstream(ctx context.Context, request *ReposMergeUpstreamReq, params ReposMergeUpstreamParams) (res ReposMergeUpstreamRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/merge-upstream"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/merge-upstream"),
 	}
 
 	// Run stopwatch.
@@ -76781,6 +77962,8 @@ func (c *Client) ReposPingWebhook(ctx context.Context, params ReposPingWebhookPa
 func (c *Client) sendReposPingWebhook(ctx context.Context, params ReposPingWebhookParams) (res ReposPingWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/ping-webhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/pings"),
 	}
 
 	// Run stopwatch.
@@ -76909,6 +78092,8 @@ func (c *Client) ReposRedeliverWebhookDelivery(ctx context.Context, params Repos
 func (c *Client) sendReposRedeliverWebhookDelivery(ctx context.Context, params ReposRedeliverWebhookDeliveryParams) (res ReposRedeliverWebhookDeliveryRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/redeliver-webhook-delivery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}/attempts"),
 	}
 
 	// Run stopwatch.
@@ -77070,6 +78255,8 @@ func (c *Client) ReposRemoveAppAccessRestrictions(ctx context.Context, request O
 func (c *Client) sendReposRemoveAppAccessRestrictions(ctx context.Context, request OptReposRemoveAppAccessRestrictionsReq, params ReposRemoveAppAccessRestrictionsParams) (res ReposRemoveAppAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-app-access-restrictions"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -77217,6 +78404,8 @@ func (c *Client) ReposRemoveCollaborator(ctx context.Context, params ReposRemove
 func (c *Client) sendReposRemoveCollaborator(ctx context.Context, params ReposRemoveCollaboratorParams) (res *ReposRemoveCollaboratorNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-collaborator"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/collaborators/{username}"),
 	}
 
 	// Run stopwatch.
@@ -77348,6 +78537,8 @@ func (c *Client) ReposRemoveStatusCheckContexts(ctx context.Context, request Opt
 func (c *Client) sendReposRemoveStatusCheckContexts(ctx context.Context, request OptReposRemoveStatusCheckContextsReq, params ReposRemoveStatusCheckContextsParams) (res ReposRemoveStatusCheckContextsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-status-check-contexts"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -77499,6 +78690,8 @@ func (c *Client) ReposRemoveStatusCheckProtection(ctx context.Context, params Re
 func (c *Client) sendReposRemoveStatusCheckProtection(ctx context.Context, params ReposRemoveStatusCheckProtectionParams) (res *ReposRemoveStatusCheckProtectionNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-status-check-protection"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"),
 	}
 
 	// Run stopwatch.
@@ -77641,6 +78834,8 @@ func (c *Client) ReposRemoveTeamAccessRestrictions(ctx context.Context, request 
 func (c *Client) sendReposRemoveTeamAccessRestrictions(ctx context.Context, request OptReposRemoveTeamAccessRestrictionsReq, params ReposRemoveTeamAccessRestrictionsParams) (res ReposRemoveTeamAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-team-access-restrictions"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -77801,6 +78996,8 @@ func (c *Client) ReposRemoveUserAccessRestrictions(ctx context.Context, request 
 func (c *Client) sendReposRemoveUserAccessRestrictions(ctx context.Context, request OptReposRemoveUserAccessRestrictionsReq, params ReposRemoveUserAccessRestrictionsParams) (res ReposRemoveUserAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/remove-user-access-restrictions"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -77960,6 +79157,8 @@ func (c *Client) ReposRenameBranch(ctx context.Context, request OptReposRenameBr
 func (c *Client) sendReposRenameBranch(ctx context.Context, request OptReposRenameBranchReq, params ReposRenameBranchParams) (res ReposRenameBranchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/rename-branch"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/rename"),
 	}
 
 	// Run stopwatch.
@@ -78091,6 +79290,8 @@ func (c *Client) ReposReplaceAllTopics(ctx context.Context, request *ReposReplac
 func (c *Client) sendReposReplaceAllTopics(ctx context.Context, request *ReposReplaceAllTopicsReq, params ReposReplaceAllTopicsParams) (res ReposReplaceAllTopicsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/replace-all-topics"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/topics"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -78217,6 +79418,8 @@ func (c *Client) ReposRequestPagesBuild(ctx context.Context, params ReposRequest
 func (c *Client) sendReposRequestPagesBuild(ctx context.Context, params ReposRequestPagesBuildParams) (res *PageBuildStatus, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/request-pages-build"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/pages/builds"),
 	}
 
 	// Run stopwatch.
@@ -78332,6 +79535,8 @@ func (c *Client) ReposSetAdminBranchProtection(ctx context.Context, params Repos
 func (c *Client) sendReposSetAdminBranchProtection(ctx context.Context, params ReposSetAdminBranchProtectionParams) (res *ProtectedBranchAdminEnforced, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/set-admin-branch-protection"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"),
 	}
 
 	// Run stopwatch.
@@ -78476,6 +79681,8 @@ func (c *Client) ReposSetAppAccessRestrictions(ctx context.Context, request OptR
 func (c *Client) sendReposSetAppAccessRestrictions(ctx context.Context, request OptReposSetAppAccessRestrictionsReq, params ReposSetAppAccessRestrictionsParams) (res ReposSetAppAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/set-app-access-restrictions"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -78627,6 +79834,8 @@ func (c *Client) ReposSetStatusCheckContexts(ctx context.Context, request OptRep
 func (c *Client) sendReposSetStatusCheckContexts(ctx context.Context, request OptReposSetStatusCheckContextsReq, params ReposSetStatusCheckContextsParams) (res ReposSetStatusCheckContextsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/set-status-check-contexts"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -78789,6 +79998,8 @@ func (c *Client) ReposSetTeamAccessRestrictions(ctx context.Context, request Opt
 func (c *Client) sendReposSetTeamAccessRestrictions(ctx context.Context, request OptReposSetTeamAccessRestrictionsReq, params ReposSetTeamAccessRestrictionsParams) (res ReposSetTeamAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/set-team-access-restrictions"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -78950,6 +80161,8 @@ func (c *Client) ReposSetUserAccessRestrictions(ctx context.Context, request Opt
 func (c *Client) sendReposSetUserAccessRestrictions(ctx context.Context, request OptReposSetUserAccessRestrictionsReq, params ReposSetUserAccessRestrictionsParams) (res ReposSetUserAccessRestrictionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/set-user-access-restrictions"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -79100,6 +80313,8 @@ func (c *Client) ReposTestPushWebhook(ctx context.Context, params ReposTestPushW
 func (c *Client) sendReposTestPushWebhook(ctx context.Context, params ReposTestPushWebhookParams) (res ReposTestPushWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/test-push-webhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/tests"),
 	}
 
 	// Run stopwatch.
@@ -79232,6 +80447,8 @@ func (c *Client) ReposTransfer(ctx context.Context, request *ReposTransferReq, p
 func (c *Client) sendReposTransfer(ctx context.Context, request *ReposTransferReq, params ReposTransferParams) (res *MinimalRepository, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/transfer"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/transfer"),
 	}
 
 	// Run stopwatch.
@@ -79345,6 +80562,8 @@ func (c *Client) ReposUpdate(ctx context.Context, request OptReposUpdateReq, par
 func (c *Client) sendReposUpdate(ctx context.Context, request OptReposUpdateReq, params ReposUpdateParams) (res ReposUpdateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -79479,6 +80698,8 @@ func (c *Client) ReposUpdateBranchProtection(ctx context.Context, request *Repos
 func (c *Client) sendReposUpdateBranchProtection(ctx context.Context, request *ReposUpdateBranchProtectionReq, params ReposUpdateBranchProtectionParams) (res ReposUpdateBranchProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-branch-protection"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -79619,6 +80840,8 @@ func (c *Client) ReposUpdateCommitComment(ctx context.Context, request *ReposUpd
 func (c *Client) sendReposUpdateCommitComment(ctx context.Context, request *ReposUpdateCommitCommentReq, params ReposUpdateCommitCommentParams) (res ReposUpdateCommitCommentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-commit-comment"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/comments/{comment_id}"),
 	}
 
 	// Run stopwatch.
@@ -79749,6 +80972,8 @@ func (c *Client) ReposUpdateInvitation(ctx context.Context, request OptReposUpda
 func (c *Client) sendReposUpdateInvitation(ctx context.Context, request OptReposUpdateInvitationReq, params ReposUpdateInvitationParams) (res *RepositoryInvitation, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-invitation"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/invitations/{invitation_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -79902,6 +81127,8 @@ func (c *Client) ReposUpdatePullRequestReviewProtection(ctx context.Context, req
 func (c *Client) sendReposUpdatePullRequestReviewProtection(ctx context.Context, request OptReposUpdatePullRequestReviewProtectionReq, params ReposUpdatePullRequestReviewProtectionParams) (res ReposUpdatePullRequestReviewProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-pull-request-review-protection"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"),
 	}
 
 	// Run stopwatch.
@@ -80033,6 +81260,8 @@ func (c *Client) ReposUpdateRelease(ctx context.Context, request OptReposUpdateR
 func (c *Client) sendReposUpdateRelease(ctx context.Context, request OptReposUpdateReleaseReq, params ReposUpdateReleaseParams) (res ReposUpdateReleaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-release"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}"),
 	}
 
 	// Run stopwatch.
@@ -80163,6 +81392,8 @@ func (c *Client) ReposUpdateReleaseAsset(ctx context.Context, request OptReposUp
 func (c *Client) sendReposUpdateReleaseAsset(ctx context.Context, request OptReposUpdateReleaseAssetReq, params ReposUpdateReleaseAssetParams) (res *ReleaseAsset, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-release-asset"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/assets/{asset_id}"),
 	}
 
 	// Run stopwatch.
@@ -80299,6 +81530,8 @@ func (c *Client) ReposUpdateStatusCheckProtection(ctx context.Context, request O
 func (c *Client) sendReposUpdateStatusCheckProtection(ctx context.Context, request OptReposUpdateStatusCheckProtectionReq, params ReposUpdateStatusCheckProtectionParams) (res ReposUpdateStatusCheckProtectionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-status-check-protection"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"),
 	}
 
 	// Run stopwatch.
@@ -80433,6 +81666,8 @@ func (c *Client) ReposUpdateWebhook(ctx context.Context, request OptReposUpdateW
 func (c *Client) sendReposUpdateWebhook(ctx context.Context, request OptReposUpdateWebhookReq, params ReposUpdateWebhookParams) (res ReposUpdateWebhookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-webhook"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -80583,6 +81818,8 @@ func (c *Client) ReposUpdateWebhookConfigForRepo(ctx context.Context, request Op
 func (c *Client) sendReposUpdateWebhookConfigForRepo(ctx context.Context, request OptReposUpdateWebhookConfigForRepoReq, params ReposUpdateWebhookConfigForRepoParams) (res *WebhookConfig, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/update-webhook-config-for-repo"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/hooks/{hook_id}/config"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -80755,6 +81992,8 @@ func (c *Client) ReposUploadReleaseAsset(ctx context.Context, request *ReposUplo
 func (c *Client) sendReposUploadReleaseAsset(ctx context.Context, request *ReposUploadReleaseAssetReqWithContentType, params ReposUploadReleaseAssetParams) (res *ReleaseAsset, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("repos/upload-release-asset"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/releases/{release_id}/assets"),
 	}
 
 	// Run stopwatch.
@@ -80921,6 +82160,8 @@ func (c *Client) ScimDeleteUserFromOrg(ctx context.Context, params ScimDeleteUse
 func (c *Client) sendScimDeleteUserFromOrg(ctx context.Context, params ScimDeleteUserFromOrgParams) (res ScimDeleteUserFromOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("scim/delete-user-from-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/scim/v2/organizations/{org}/Users/{scim_user_id}"),
 	}
 
 	// Run stopwatch.
@@ -81048,6 +82289,8 @@ func (c *Client) SearchCode(ctx context.Context, params SearchCodeParams) (Searc
 func (c *Client) sendSearchCode(ctx context.Context, params SearchCodeParams) (res SearchCodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/code"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/code"),
 	}
 
 	// Run stopwatch.
@@ -81215,6 +82458,8 @@ func (c *Client) SearchCommits(ctx context.Context, params SearchCommitsParams) 
 func (c *Client) sendSearchCommits(ctx context.Context, params SearchCommitsParams) (res SearchCommitsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/commits"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/commits"),
 	}
 
 	// Run stopwatch.
@@ -81394,6 +82639,8 @@ func (c *Client) SearchIssuesAndPullRequests(ctx context.Context, params SearchI
 func (c *Client) sendSearchIssuesAndPullRequests(ctx context.Context, params SearchIssuesAndPullRequestsParams) (res SearchIssuesAndPullRequestsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/issues-and-pull-requests"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/issues"),
 	}
 
 	// Run stopwatch.
@@ -81560,6 +82807,8 @@ func (c *Client) SearchLabels(ctx context.Context, params SearchLabelsParams) (S
 func (c *Client) sendSearchLabels(ctx context.Context, params SearchLabelsParams) (res SearchLabelsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/labels"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/labels"),
 	}
 
 	// Run stopwatch.
@@ -81746,6 +82995,8 @@ func (c *Client) SearchRepos(ctx context.Context, params SearchReposParams) (Sea
 func (c *Client) sendSearchRepos(ctx context.Context, params SearchReposParams) (res SearchReposRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/repos"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/repositories"),
 	}
 
 	// Run stopwatch.
@@ -81916,6 +83167,8 @@ func (c *Client) SearchTopics(ctx context.Context, params SearchTopicsParams) (S
 func (c *Client) sendSearchTopics(ctx context.Context, params SearchTopicsParams) (res SearchTopicsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/topics"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/topics"),
 	}
 
 	// Run stopwatch.
@@ -82050,6 +83303,8 @@ func (c *Client) SearchUsers(ctx context.Context, params SearchUsersParams) (Sea
 func (c *Client) sendSearchUsers(ctx context.Context, params SearchUsersParams) (res SearchUsersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search/users"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/search/users"),
 	}
 
 	// Run stopwatch.
@@ -82210,6 +83465,8 @@ func (c *Client) SecretScanningGetAlert(ctx context.Context, params SecretScanni
 func (c *Client) sendSecretScanningGetAlert(ctx context.Context, params SecretScanningGetAlertParams) (res SecretScanningGetAlertRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("secret-scanning/get-alert"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"),
 	}
 
 	// Run stopwatch.
@@ -82344,6 +83601,8 @@ func (c *Client) SecretScanningListAlertsForOrg(ctx context.Context, params Secr
 func (c *Client) sendSecretScanningListAlertsForOrg(ctx context.Context, params SecretScanningListAlertsForOrgParams) (res SecretScanningListAlertsForOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("secret-scanning/list-alerts-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/secret-scanning/alerts"),
 	}
 
 	// Run stopwatch.
@@ -82509,6 +83768,8 @@ func (c *Client) SecretScanningListAlertsForRepo(ctx context.Context, params Sec
 func (c *Client) sendSecretScanningListAlertsForRepo(ctx context.Context, params SecretScanningListAlertsForRepoParams) (res SecretScanningListAlertsForRepoRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("secret-scanning/list-alerts-for-repo"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/secret-scanning/alerts"),
 	}
 
 	// Run stopwatch.
@@ -82693,6 +83954,8 @@ func (c *Client) SecretScanningUpdateAlert(ctx context.Context, request *SecretS
 func (c *Client) sendSecretScanningUpdateAlert(ctx context.Context, request *SecretScanningUpdateAlertReq, params SecretScanningUpdateAlertParams) (res SecretScanningUpdateAlertRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("secret-scanning/update-alert"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -82856,6 +84119,8 @@ func (c *Client) TeamsAddMemberLegacy(ctx context.Context, params TeamsAddMember
 func (c *Client) sendTeamsAddMemberLegacy(ctx context.Context, params TeamsAddMemberLegacyParams) (res TeamsAddMemberLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-member-legacy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -82985,6 +84250,8 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserInOrg(ctx context.Context, req
 func (c *Client) sendTeamsAddOrUpdateMembershipForUserInOrg(ctx context.Context, request OptTeamsAddOrUpdateMembershipForUserInOrgReq, params TeamsAddOrUpdateMembershipForUserInOrgParams) (res TeamsAddOrUpdateMembershipForUserInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-membership-for-user-in-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/memberships/{username}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83157,6 +84424,8 @@ func (c *Client) TeamsAddOrUpdateMembershipForUserLegacy(ctx context.Context, re
 func (c *Client) sendTeamsAddOrUpdateMembershipForUserLegacy(ctx context.Context, request OptTeamsAddOrUpdateMembershipForUserLegacyReq, params TeamsAddOrUpdateMembershipForUserLegacyParams) (res TeamsAddOrUpdateMembershipForUserLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-membership-for-user-legacy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/memberships/{username}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83288,6 +84557,8 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsInOrg(ctx context.Context, re
 func (c *Client) sendTeamsAddOrUpdateProjectPermissionsInOrg(ctx context.Context, request OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq, params TeamsAddOrUpdateProjectPermissionsInOrgParams) (res TeamsAddOrUpdateProjectPermissionsInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-project-permissions-in-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/projects/{project_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83442,6 +84713,8 @@ func (c *Client) TeamsAddOrUpdateProjectPermissionsLegacy(ctx context.Context, r
 func (c *Client) sendTeamsAddOrUpdateProjectPermissionsLegacy(ctx context.Context, request OptTeamsAddOrUpdateProjectPermissionsLegacyReq, params TeamsAddOrUpdateProjectPermissionsLegacyParams) (res TeamsAddOrUpdateProjectPermissionsLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-project-permissions-legacy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/projects/{project_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83580,6 +84853,8 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsInOrg(ctx context.Context, reque
 func (c *Client) sendTeamsAddOrUpdateRepoPermissionsInOrg(ctx context.Context, request OptTeamsAddOrUpdateRepoPermissionsInOrgReq, params TeamsAddOrUpdateRepoPermissionsInOrgParams) (res *TeamsAddOrUpdateRepoPermissionsInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-repo-permissions-in-org"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83758,6 +85033,8 @@ func (c *Client) TeamsAddOrUpdateRepoPermissionsLegacy(ctx context.Context, requ
 func (c *Client) sendTeamsAddOrUpdateRepoPermissionsLegacy(ctx context.Context, request OptTeamsAddOrUpdateRepoPermissionsLegacyReq, params TeamsAddOrUpdateRepoPermissionsLegacyParams) (res TeamsAddOrUpdateRepoPermissionsLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/add-or-update-repo-permissions-legacy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/repos/{owner}/{repo}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -83907,6 +85184,8 @@ func (c *Client) TeamsCheckPermissionsForProjectInOrg(ctx context.Context, param
 func (c *Client) sendTeamsCheckPermissionsForProjectInOrg(ctx context.Context, params TeamsCheckPermissionsForProjectInOrgParams) (res TeamsCheckPermissionsForProjectInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/check-permissions-for-project-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -84041,6 +85320,8 @@ func (c *Client) TeamsCheckPermissionsForProjectLegacy(ctx context.Context, para
 func (c *Client) sendTeamsCheckPermissionsForProjectLegacy(ctx context.Context, params TeamsCheckPermissionsForProjectLegacyParams) (res TeamsCheckPermissionsForProjectLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/check-permissions-for-project-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -84157,6 +85438,8 @@ func (c *Client) TeamsCheckPermissionsForRepoInOrg(ctx context.Context, params T
 func (c *Client) sendTeamsCheckPermissionsForRepoInOrg(ctx context.Context, params TeamsCheckPermissionsForRepoInOrgParams) (res TeamsCheckPermissionsForRepoInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/check-permissions-for-repo-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -84312,6 +85595,8 @@ func (c *Client) TeamsCheckPermissionsForRepoLegacy(ctx context.Context, params 
 func (c *Client) sendTeamsCheckPermissionsForRepoLegacy(ctx context.Context, params TeamsCheckPermissionsForRepoLegacyParams) (res TeamsCheckPermissionsForRepoLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/check-permissions-for-repo-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -84446,6 +85731,8 @@ func (c *Client) TeamsCreate(ctx context.Context, request *TeamsCreateReq, param
 func (c *Client) sendTeamsCreate(ctx context.Context, request *TeamsCreateReq, params TeamsCreateParams) (res TeamsCreateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -84558,6 +85845,8 @@ func (c *Client) TeamsCreateDiscussionCommentInOrg(ctx context.Context, request 
 func (c *Client) sendTeamsCreateDiscussionCommentInOrg(ctx context.Context, request *TeamsCreateDiscussionCommentInOrgReq, params TeamsCreateDiscussionCommentInOrgParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -84702,6 +85991,8 @@ func (c *Client) TeamsCreateDiscussionCommentLegacy(ctx context.Context, request
 func (c *Client) sendTeamsCreateDiscussionCommentLegacy(ctx context.Context, request *TeamsCreateDiscussionCommentLegacyReq, params TeamsCreateDiscussionCommentLegacyParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -84824,6 +86115,8 @@ func (c *Client) TeamsCreateDiscussionInOrg(ctx context.Context, request *TeamsC
 func (c *Client) sendTeamsCreateDiscussionInOrg(ctx context.Context, request *TeamsCreateDiscussionInOrgReq, params TeamsCreateDiscussionInOrgParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-discussion-in-org"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions"),
 	}
 
 	// Run stopwatch.
@@ -84949,6 +86242,8 @@ func (c *Client) TeamsCreateDiscussionLegacy(ctx context.Context, request *Teams
 func (c *Client) sendTeamsCreateDiscussionLegacy(ctx context.Context, request *TeamsCreateDiscussionLegacyReq, params TeamsCreateDiscussionLegacyParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-discussion-legacy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions"),
 	}
 
 	// Run stopwatch.
@@ -85049,6 +86344,8 @@ func (c *Client) TeamsCreateOrUpdateIdpGroupConnectionsInOrg(ctx context.Context
 func (c *Client) sendTeamsCreateOrUpdateIdpGroupConnectionsInOrg(ctx context.Context, request *TeamsCreateOrUpdateIdpGroupConnectionsInOrgReq, params TeamsCreateOrUpdateIdpGroupConnectionsInOrgParams) (res *GroupMapping, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-or-update-idp-group-connections-in-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/team-sync/group-mappings"),
 	}
 
 	// Run stopwatch.
@@ -85172,6 +86469,8 @@ func (c *Client) TeamsCreateOrUpdateIdpGroupConnectionsLegacy(ctx context.Contex
 func (c *Client) sendTeamsCreateOrUpdateIdpGroupConnectionsLegacy(ctx context.Context, request *TeamsCreateOrUpdateIdpGroupConnectionsLegacyReq, params TeamsCreateOrUpdateIdpGroupConnectionsLegacyParams) (res TeamsCreateOrUpdateIdpGroupConnectionsLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/create-or-update-idp-group-connections-legacy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/team-sync/group-mappings"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -85277,6 +86576,8 @@ func (c *Client) TeamsDeleteDiscussionCommentInOrg(ctx context.Context, params T
 func (c *Client) sendTeamsDeleteDiscussionCommentInOrg(ctx context.Context, params TeamsDeleteDiscussionCommentInOrgParams) (res *TeamsDeleteDiscussionCommentInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -85429,6 +86730,8 @@ func (c *Client) TeamsDeleteDiscussionCommentLegacy(ctx context.Context, params 
 func (c *Client) sendTeamsDeleteDiscussionCommentLegacy(ctx context.Context, params TeamsDeleteDiscussionCommentLegacyParams) (res *TeamsDeleteDiscussionCommentLegacyNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -85559,6 +86862,8 @@ func (c *Client) TeamsDeleteDiscussionInOrg(ctx context.Context, params TeamsDel
 func (c *Client) sendTeamsDeleteDiscussionInOrg(ctx context.Context, params TeamsDeleteDiscussionInOrgParams) (res *TeamsDeleteDiscussionInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-discussion-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -85692,6 +86997,8 @@ func (c *Client) TeamsDeleteDiscussionLegacy(ctx context.Context, params TeamsDe
 func (c *Client) sendTeamsDeleteDiscussionLegacy(ctx context.Context, params TeamsDeleteDiscussionLegacyParams) (res *TeamsDeleteDiscussionLegacyNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-discussion-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -85804,6 +87111,8 @@ func (c *Client) TeamsDeleteInOrg(ctx context.Context, params TeamsDeleteInOrgPa
 func (c *Client) sendTeamsDeleteInOrg(ctx context.Context, params TeamsDeleteInOrgParams) (res *TeamsDeleteInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}"),
 	}
 
 	// Run stopwatch.
@@ -85919,6 +87228,8 @@ func (c *Client) TeamsDeleteLegacy(ctx context.Context, params TeamsDeleteLegacy
 func (c *Client) sendTeamsDeleteLegacy(ctx context.Context, params TeamsDeleteLegacyParams) (res TeamsDeleteLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/delete-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}"),
 	}
 
 	// Run stopwatch.
@@ -86010,6 +87321,8 @@ func (c *Client) TeamsGetByName(ctx context.Context, params TeamsGetByNameParams
 func (c *Client) sendTeamsGetByName(ctx context.Context, params TeamsGetByNameParams) (res TeamsGetByNameRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-by-name"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}"),
 	}
 
 	// Run stopwatch.
@@ -86121,6 +87434,8 @@ func (c *Client) TeamsGetDiscussionCommentInOrg(ctx context.Context, params Team
 func (c *Client) sendTeamsGetDiscussionCommentInOrg(ctx context.Context, params TeamsGetDiscussionCommentInOrgParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -86273,6 +87588,8 @@ func (c *Client) TeamsGetDiscussionCommentLegacy(ctx context.Context, params Tea
 func (c *Client) sendTeamsGetDiscussionCommentLegacy(ctx context.Context, params TeamsGetDiscussionCommentLegacyParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -86403,6 +87720,8 @@ func (c *Client) TeamsGetDiscussionInOrg(ctx context.Context, params TeamsGetDis
 func (c *Client) sendTeamsGetDiscussionInOrg(ctx context.Context, params TeamsGetDiscussionInOrgParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-discussion-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -86536,6 +87855,8 @@ func (c *Client) TeamsGetDiscussionLegacy(ctx context.Context, params TeamsGetDi
 func (c *Client) sendTeamsGetDiscussionLegacy(ctx context.Context, params TeamsGetDiscussionLegacyParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-discussion-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -86648,6 +87969,8 @@ func (c *Client) TeamsGetLegacy(ctx context.Context, params TeamsGetLegacyParams
 func (c *Client) sendTeamsGetLegacy(ctx context.Context, params TeamsGetLegacyParams) (res TeamsGetLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}"),
 	}
 
 	// Run stopwatch.
@@ -86743,6 +88066,8 @@ func (c *Client) TeamsGetMemberLegacy(ctx context.Context, params TeamsGetMember
 func (c *Client) sendTeamsGetMemberLegacy(ctx context.Context, params TeamsGetMemberLegacyParams) (res TeamsGetMemberLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-member-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -86858,6 +88183,8 @@ func (c *Client) TeamsGetMembershipForUserInOrg(ctx context.Context, params Team
 func (c *Client) sendTeamsGetMembershipForUserInOrg(ctx context.Context, params TeamsGetMembershipForUserInOrgParams) (res TeamsGetMembershipForUserInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-membership-for-user-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -86995,6 +88322,8 @@ func (c *Client) TeamsGetMembershipForUserLegacy(ctx context.Context, params Tea
 func (c *Client) sendTeamsGetMembershipForUserLegacy(ctx context.Context, params TeamsGetMembershipForUserLegacyParams) (res TeamsGetMembershipForUserLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/get-membership-for-user-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -87103,6 +88432,8 @@ func (c *Client) TeamsList(ctx context.Context, params TeamsListParams) (TeamsLi
 func (c *Client) sendTeamsList(ctx context.Context, params TeamsListParams) (res TeamsListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams"),
 	}
 
 	// Run stopwatch.
@@ -87233,6 +88564,8 @@ func (c *Client) TeamsListChildInOrg(ctx context.Context, params TeamsListChildI
 func (c *Client) sendTeamsListChildInOrg(ctx context.Context, params TeamsListChildInOrgParams) (res *TeamsListChildInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-child-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/teams"),
 	}
 
 	// Run stopwatch.
@@ -87384,6 +88717,8 @@ func (c *Client) TeamsListChildLegacy(ctx context.Context, params TeamsListChild
 func (c *Client) sendTeamsListChildLegacy(ctx context.Context, params TeamsListChildLegacyParams) (res TeamsListChildLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-child-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/teams"),
 	}
 
 	// Run stopwatch.
@@ -87515,6 +88850,8 @@ func (c *Client) TeamsListDiscussionCommentsInOrg(ctx context.Context, params Te
 func (c *Client) sendTeamsListDiscussionCommentsInOrg(ctx context.Context, params TeamsListDiscussionCommentsInOrgParams) (res *TeamsListDiscussionCommentsInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-discussion-comments-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -87704,6 +89041,8 @@ func (c *Client) TeamsListDiscussionCommentsLegacy(ctx context.Context, params T
 func (c *Client) sendTeamsListDiscussionCommentsLegacy(ctx context.Context, params TeamsListDiscussionCommentsLegacyParams) (res *TeamsListDiscussionCommentsLegacyOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-discussion-comments-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments"),
 	}
 
 	// Run stopwatch.
@@ -87871,6 +89210,8 @@ func (c *Client) TeamsListDiscussionsInOrg(ctx context.Context, params TeamsList
 func (c *Client) sendTeamsListDiscussionsInOrg(ctx context.Context, params TeamsListDiscussionsInOrgParams) (res *TeamsListDiscussionsInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-discussions-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions"),
 	}
 
 	// Run stopwatch.
@@ -88058,6 +89399,8 @@ func (c *Client) TeamsListDiscussionsLegacy(ctx context.Context, params TeamsLis
 func (c *Client) sendTeamsListDiscussionsLegacy(ctx context.Context, params TeamsListDiscussionsLegacyParams) (res *TeamsListDiscussionsLegacyOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-discussions-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions"),
 	}
 
 	// Run stopwatch.
@@ -88206,6 +89549,8 @@ func (c *Client) TeamsListForAuthenticatedUser(ctx context.Context, params Teams
 func (c *Client) sendTeamsListForAuthenticatedUser(ctx context.Context, params TeamsListForAuthenticatedUserParams) (res TeamsListForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/teams"),
 	}
 
 	// Run stopwatch.
@@ -88323,6 +89668,8 @@ func (c *Client) TeamsListIdpGroupsForLegacy(ctx context.Context, params TeamsLi
 func (c *Client) sendTeamsListIdpGroupsForLegacy(ctx context.Context, params TeamsListIdpGroupsForLegacyParams) (res TeamsListIdpGroupsForLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-idp-groups-for-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/team-sync/group-mappings"),
 	}
 
 	// Run stopwatch.
@@ -88419,6 +89766,8 @@ func (c *Client) TeamsListIdpGroupsForOrg(ctx context.Context, params TeamsListI
 func (c *Client) sendTeamsListIdpGroupsForOrg(ctx context.Context, params TeamsListIdpGroupsForOrgParams) (res *GroupMappingHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-idp-groups-for-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/team-sync/groups"),
 	}
 
 	// Run stopwatch.
@@ -88552,6 +89901,8 @@ func (c *Client) TeamsListIdpGroupsInOrg(ctx context.Context, params TeamsListId
 func (c *Client) sendTeamsListIdpGroupsInOrg(ctx context.Context, params TeamsListIdpGroupsInOrgParams) (res *GroupMapping, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-idp-groups-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/team-sync/group-mappings"),
 	}
 
 	// Run stopwatch.
@@ -88662,6 +90013,8 @@ func (c *Client) TeamsListMembersInOrg(ctx context.Context, params TeamsListMemb
 func (c *Client) sendTeamsListMembersInOrg(ctx context.Context, params TeamsListMembersInOrgParams) (res *TeamsListMembersInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-members-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/members"),
 	}
 
 	// Run stopwatch.
@@ -88831,6 +90184,8 @@ func (c *Client) TeamsListMembersLegacy(ctx context.Context, params TeamsListMem
 func (c *Client) sendTeamsListMembersLegacy(ctx context.Context, params TeamsListMembersLegacyParams) (res TeamsListMembersLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-members-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/members"),
 	}
 
 	// Run stopwatch.
@@ -88981,6 +90336,8 @@ func (c *Client) TeamsListPendingInvitationsInOrg(ctx context.Context, params Te
 func (c *Client) sendTeamsListPendingInvitationsInOrg(ctx context.Context, params TeamsListPendingInvitationsInOrgParams) (res *TeamsListPendingInvitationsInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-pending-invitations-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/invitations"),
 	}
 
 	// Run stopwatch.
@@ -89136,6 +90493,8 @@ func (c *Client) TeamsListPendingInvitationsLegacy(ctx context.Context, params T
 func (c *Client) sendTeamsListPendingInvitationsLegacy(ctx context.Context, params TeamsListPendingInvitationsLegacyParams) (res *TeamsListPendingInvitationsLegacyOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-pending-invitations-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/invitations"),
 	}
 
 	// Run stopwatch.
@@ -89266,6 +90625,8 @@ func (c *Client) TeamsListProjectsInOrg(ctx context.Context, params TeamsListPro
 func (c *Client) sendTeamsListProjectsInOrg(ctx context.Context, params TeamsListProjectsInOrgParams) (res *TeamsListProjectsInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-projects-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/projects"),
 	}
 
 	// Run stopwatch.
@@ -89418,6 +90779,8 @@ func (c *Client) TeamsListProjectsLegacy(ctx context.Context, params TeamsListPr
 func (c *Client) sendTeamsListProjectsLegacy(ctx context.Context, params TeamsListProjectsLegacyParams) (res TeamsListProjectsLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-projects-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/projects"),
 	}
 
 	// Run stopwatch.
@@ -89548,6 +90911,8 @@ func (c *Client) TeamsListReposInOrg(ctx context.Context, params TeamsListReposI
 func (c *Client) sendTeamsListReposInOrg(ctx context.Context, params TeamsListReposInOrgParams) (res *TeamsListReposInOrgOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-repos-in-org"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/repos"),
 	}
 
 	// Run stopwatch.
@@ -89699,6 +91064,8 @@ func (c *Client) TeamsListReposLegacy(ctx context.Context, params TeamsListRepos
 func (c *Client) sendTeamsListReposLegacy(ctx context.Context, params TeamsListReposLegacyParams) (res TeamsListReposLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/list-repos-legacy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/repos"),
 	}
 
 	// Run stopwatch.
@@ -89847,6 +91214,8 @@ func (c *Client) TeamsRemoveMemberLegacy(ctx context.Context, params TeamsRemove
 func (c *Client) sendTeamsRemoveMemberLegacy(ctx context.Context, params TeamsRemoveMemberLegacyParams) (res TeamsRemoveMemberLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-member-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/members/{username}"),
 	}
 
 	// Run stopwatch.
@@ -89969,6 +91338,8 @@ func (c *Client) TeamsRemoveMembershipForUserInOrg(ctx context.Context, params T
 func (c *Client) sendTeamsRemoveMembershipForUserInOrg(ctx context.Context, params TeamsRemoveMembershipForUserInOrgParams) (res TeamsRemoveMembershipForUserInOrgRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-membership-for-user-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -90113,6 +91484,8 @@ func (c *Client) TeamsRemoveMembershipForUserLegacy(ctx context.Context, params 
 func (c *Client) sendTeamsRemoveMembershipForUserLegacy(ctx context.Context, params TeamsRemoveMembershipForUserLegacyParams) (res TeamsRemoveMembershipForUserLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-membership-for-user-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/memberships/{username}"),
 	}
 
 	// Run stopwatch.
@@ -90226,6 +91599,8 @@ func (c *Client) TeamsRemoveProjectInOrg(ctx context.Context, params TeamsRemove
 func (c *Client) sendTeamsRemoveProjectInOrg(ctx context.Context, params TeamsRemoveProjectInOrgParams) (res *TeamsRemoveProjectInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-project-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -90361,6 +91736,8 @@ func (c *Client) TeamsRemoveProjectLegacy(ctx context.Context, params TeamsRemov
 func (c *Client) sendTeamsRemoveProjectLegacy(ctx context.Context, params TeamsRemoveProjectLegacyParams) (res TeamsRemoveProjectLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-project-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/projects/{project_id}"),
 	}
 
 	// Run stopwatch.
@@ -90474,6 +91851,8 @@ func (c *Client) TeamsRemoveRepoInOrg(ctx context.Context, params TeamsRemoveRep
 func (c *Client) sendTeamsRemoveRepoInOrg(ctx context.Context, params TeamsRemoveRepoInOrgParams) (res *TeamsRemoveRepoInOrgNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-repo-in-org"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -90628,6 +92007,8 @@ func (c *Client) TeamsRemoveRepoLegacy(ctx context.Context, params TeamsRemoveRe
 func (c *Client) sendTeamsRemoveRepoLegacy(ctx context.Context, params TeamsRemoveRepoLegacyParams) (res *TeamsRemoveRepoLegacyNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/remove-repo-legacy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/repos/{owner}/{repo}"),
 	}
 
 	// Run stopwatch.
@@ -90758,6 +92139,8 @@ func (c *Client) TeamsUpdateDiscussionCommentInOrg(ctx context.Context, request 
 func (c *Client) sendTeamsUpdateDiscussionCommentInOrg(ctx context.Context, request *TeamsUpdateDiscussionCommentInOrgReq, params TeamsUpdateDiscussionCommentInOrgParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-discussion-comment-in-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -90913,6 +92296,8 @@ func (c *Client) TeamsUpdateDiscussionCommentLegacy(ctx context.Context, request
 func (c *Client) sendTeamsUpdateDiscussionCommentLegacy(ctx context.Context, request *TeamsUpdateDiscussionCommentLegacyReq, params TeamsUpdateDiscussionCommentLegacyParams) (res *TeamDiscussionComment, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-discussion-comment-legacy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"),
 	}
 
 	// Run stopwatch.
@@ -91047,6 +92432,8 @@ func (c *Client) TeamsUpdateDiscussionInOrg(ctx context.Context, request OptTeam
 func (c *Client) sendTeamsUpdateDiscussionInOrg(ctx context.Context, request OptTeamsUpdateDiscussionInOrgReq, params TeamsUpdateDiscussionInOrgParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-discussion-in-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -91184,6 +92571,8 @@ func (c *Client) TeamsUpdateDiscussionLegacy(ctx context.Context, request OptTea
 func (c *Client) sendTeamsUpdateDiscussionLegacy(ctx context.Context, request OptTeamsUpdateDiscussionLegacyReq, params TeamsUpdateDiscussionLegacyParams) (res *TeamDiscussion, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-discussion-legacy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}/discussions/{discussion_number}"),
 	}
 
 	// Run stopwatch.
@@ -91297,6 +92686,8 @@ func (c *Client) TeamsUpdateInOrg(ctx context.Context, request OptTeamsUpdateInO
 func (c *Client) sendTeamsUpdateInOrg(ctx context.Context, request OptTeamsUpdateInOrgReq, params TeamsUpdateInOrgParams) (res *TeamFull, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-in-org"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/orgs/{org}/teams/{team_slug}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -91430,6 +92821,8 @@ func (c *Client) TeamsUpdateLegacy(ctx context.Context, request *TeamsUpdateLega
 func (c *Client) sendTeamsUpdateLegacy(ctx context.Context, request *TeamsUpdateLegacyReq, params TeamsUpdateLegacyParams) (res TeamsUpdateLegacyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("teams/update-legacy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/teams/{team_id}"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -91531,6 +92924,8 @@ func (c *Client) UsersAddEmailForAuthenticated(ctx context.Context, request OptU
 func (c *Client) sendUsersAddEmailForAuthenticated(ctx context.Context, request OptUsersAddEmailForAuthenticatedReq) (res UsersAddEmailForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/add-email-for-authenticated"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/emails"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -91621,6 +93016,8 @@ func (c *Client) UsersBlock(ctx context.Context, params UsersBlockParams) (Users
 func (c *Client) sendUsersBlock(ctx context.Context, params UsersBlockParams) (res UsersBlockRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/block"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/user/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -91710,6 +93107,8 @@ func (c *Client) UsersCheckBlocked(ctx context.Context, params UsersCheckBlocked
 func (c *Client) sendUsersCheckBlocked(ctx context.Context, params UsersCheckBlockedParams) (res UsersCheckBlockedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/check-blocked"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -91799,6 +93198,8 @@ func (c *Client) UsersCheckFollowingForUser(ctx context.Context, params UsersChe
 func (c *Client) sendUsersCheckFollowingForUser(ctx context.Context, params UsersCheckFollowingForUserParams) (res UsersCheckFollowingForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/check-following-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/following/{target_user}"),
 	}
 
 	// Run stopwatch.
@@ -91907,6 +93308,8 @@ func (c *Client) UsersCheckPersonIsFollowedByAuthenticated(ctx context.Context, 
 func (c *Client) sendUsersCheckPersonIsFollowedByAuthenticated(ctx context.Context, params UsersCheckPersonIsFollowedByAuthenticatedParams) (res UsersCheckPersonIsFollowedByAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/check-person-is-followed-by-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/following/{username}"),
 	}
 
 	// Run stopwatch.
@@ -91998,6 +93401,8 @@ func (c *Client) UsersCreateGpgKeyForAuthenticated(ctx context.Context, request 
 func (c *Client) sendUsersCreateGpgKeyForAuthenticated(ctx context.Context, request *UsersCreateGpgKeyForAuthenticatedReq) (res UsersCreateGpgKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/create-gpg-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/gpg_keys"),
 	}
 
 	// Run stopwatch.
@@ -92074,6 +93479,8 @@ func (c *Client) UsersCreatePublicSSHKeyForAuthenticated(ctx context.Context, re
 func (c *Client) sendUsersCreatePublicSSHKeyForAuthenticated(ctx context.Context, request *UsersCreatePublicSSHKeyForAuthenticatedReq) (res UsersCreatePublicSSHKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/create-public-ssh-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/user/keys"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -92157,6 +93564,8 @@ func (c *Client) UsersDeleteEmailForAuthenticated(ctx context.Context, request O
 func (c *Client) sendUsersDeleteEmailForAuthenticated(ctx context.Context, request OptUsersDeleteEmailForAuthenticatedReq) (res UsersDeleteEmailForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/delete-email-for-authenticated"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/emails"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -92249,6 +93658,8 @@ func (c *Client) UsersDeleteGpgKeyForAuthenticated(ctx context.Context, params U
 func (c *Client) sendUsersDeleteGpgKeyForAuthenticated(ctx context.Context, params UsersDeleteGpgKeyForAuthenticatedParams) (res UsersDeleteGpgKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/delete-gpg-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/gpg_keys/{gpg_key_id}"),
 	}
 
 	// Run stopwatch.
@@ -92340,6 +93751,8 @@ func (c *Client) UsersDeletePublicSSHKeyForAuthenticated(ctx context.Context, pa
 func (c *Client) sendUsersDeletePublicSSHKeyForAuthenticated(ctx context.Context, params UsersDeletePublicSSHKeyForAuthenticatedParams) (res UsersDeletePublicSSHKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/delete-public-ssh-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/keys/{key_id}"),
 	}
 
 	// Run stopwatch.
@@ -92433,6 +93846,8 @@ func (c *Client) UsersFollow(ctx context.Context, params UsersFollowParams) (Use
 func (c *Client) sendUsersFollow(ctx context.Context, params UsersFollowParams) (res UsersFollowRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/follow"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/user/following/{username}"),
 	}
 
 	// Run stopwatch.
@@ -92525,6 +93940,8 @@ func (c *Client) UsersGetAuthenticated(ctx context.Context) (UsersGetAuthenticat
 func (c *Client) sendUsersGetAuthenticated(ctx context.Context) (res UsersGetAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/get-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user"),
 	}
 
 	// Run stopwatch.
@@ -92610,6 +94027,8 @@ func (c *Client) UsersGetByUsername(ctx context.Context, params UsersGetByUserna
 func (c *Client) sendUsersGetByUsername(ctx context.Context, params UsersGetByUsernameParams) (res UsersGetByUsernameRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/get-by-username"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}"),
 	}
 
 	// Run stopwatch.
@@ -92708,6 +94127,8 @@ func (c *Client) UsersGetContextForUser(ctx context.Context, params UsersGetCont
 func (c *Client) sendUsersGetContextForUser(ctx context.Context, params UsersGetContextForUserParams) (res UsersGetContextForUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/get-context-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/hovercard"),
 	}
 
 	// Run stopwatch.
@@ -92838,6 +94259,8 @@ func (c *Client) UsersGetGpgKeyForAuthenticated(ctx context.Context, params User
 func (c *Client) sendUsersGetGpgKeyForAuthenticated(ctx context.Context, params UsersGetGpgKeyForAuthenticatedParams) (res UsersGetGpgKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/get-gpg-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/gpg_keys/{gpg_key_id}"),
 	}
 
 	// Run stopwatch.
@@ -92929,6 +94352,8 @@ func (c *Client) UsersGetPublicSSHKeyForAuthenticated(ctx context.Context, param
 func (c *Client) sendUsersGetPublicSSHKeyForAuthenticated(ctx context.Context, params UsersGetPublicSSHKeyForAuthenticatedParams) (res UsersGetPublicSSHKeyForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/get-public-ssh-key-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/keys/{key_id}"),
 	}
 
 	// Run stopwatch.
@@ -93022,6 +94447,8 @@ func (c *Client) UsersList(ctx context.Context, params UsersListParams) (UsersLi
 func (c *Client) sendUsersList(ctx context.Context, params UsersListParams) (res UsersListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users"),
 	}
 
 	// Run stopwatch.
@@ -93131,6 +94558,8 @@ func (c *Client) UsersListBlockedByAuthenticated(ctx context.Context) (UsersList
 func (c *Client) sendUsersListBlockedByAuthenticated(ctx context.Context) (res UsersListBlockedByAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-blocked-by-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/blocks"),
 	}
 
 	// Run stopwatch.
@@ -93203,6 +94632,8 @@ func (c *Client) UsersListEmailsForAuthenticated(ctx context.Context, params Use
 func (c *Client) sendUsersListEmailsForAuthenticated(ctx context.Context, params UsersListEmailsForAuthenticatedParams) (res UsersListEmailsForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-emails-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/emails"),
 	}
 
 	// Run stopwatch.
@@ -93312,6 +94743,8 @@ func (c *Client) UsersListFollowedByAuthenticated(ctx context.Context, params Us
 func (c *Client) sendUsersListFollowedByAuthenticated(ctx context.Context, params UsersListFollowedByAuthenticatedParams) (res UsersListFollowedByAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-followed-by-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/following"),
 	}
 
 	// Run stopwatch.
@@ -93421,6 +94854,8 @@ func (c *Client) UsersListFollowersForAuthenticatedUser(ctx context.Context, par
 func (c *Client) sendUsersListFollowersForAuthenticatedUser(ctx context.Context, params UsersListFollowersForAuthenticatedUserParams) (res UsersListFollowersForAuthenticatedUserRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-followers-for-authenticated-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/followers"),
 	}
 
 	// Run stopwatch.
@@ -93530,6 +94965,8 @@ func (c *Client) UsersListFollowersForUser(ctx context.Context, params UsersList
 func (c *Client) sendUsersListFollowersForUser(ctx context.Context, params UsersListFollowersForUserParams) (res *UsersListFollowersForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-followers-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/followers"),
 	}
 
 	// Run stopwatch.
@@ -93658,6 +95095,8 @@ func (c *Client) UsersListFollowingForUser(ctx context.Context, params UsersList
 func (c *Client) sendUsersListFollowingForUser(ctx context.Context, params UsersListFollowingForUserParams) (res *UsersListFollowingForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-following-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/following"),
 	}
 
 	// Run stopwatch.
@@ -93788,6 +95227,8 @@ func (c *Client) UsersListGpgKeysForAuthenticated(ctx context.Context, params Us
 func (c *Client) sendUsersListGpgKeysForAuthenticated(ctx context.Context, params UsersListGpgKeysForAuthenticatedParams) (res UsersListGpgKeysForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-gpg-keys-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/gpg_keys"),
 	}
 
 	// Run stopwatch.
@@ -93897,6 +95338,8 @@ func (c *Client) UsersListGpgKeysForUser(ctx context.Context, params UsersListGp
 func (c *Client) sendUsersListGpgKeysForUser(ctx context.Context, params UsersListGpgKeysForUserParams) (res *UsersListGpgKeysForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-gpg-keys-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/gpg_keys"),
 	}
 
 	// Run stopwatch.
@@ -94028,6 +95471,8 @@ func (c *Client) UsersListPublicEmailsForAuthenticated(ctx context.Context, para
 func (c *Client) sendUsersListPublicEmailsForAuthenticated(ctx context.Context, params UsersListPublicEmailsForAuthenticatedParams) (res UsersListPublicEmailsForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-public-emails-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/public_emails"),
 	}
 
 	// Run stopwatch.
@@ -94137,6 +95582,8 @@ func (c *Client) UsersListPublicKeysForUser(ctx context.Context, params UsersLis
 func (c *Client) sendUsersListPublicKeysForUser(ctx context.Context, params UsersListPublicKeysForUserParams) (res *UsersListPublicKeysForUserOKHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-public-keys-for-user"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/users/{username}/keys"),
 	}
 
 	// Run stopwatch.
@@ -94267,6 +95714,8 @@ func (c *Client) UsersListPublicSSHKeysForAuthenticated(ctx context.Context, par
 func (c *Client) sendUsersListPublicSSHKeysForAuthenticated(ctx context.Context, params UsersListPublicSSHKeysForAuthenticatedParams) (res UsersListPublicSSHKeysForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/list-public-ssh-keys-for-authenticated"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/keys"),
 	}
 
 	// Run stopwatch.
@@ -94376,6 +95825,8 @@ func (c *Client) UsersSetPrimaryEmailVisibilityForAuthenticated(ctx context.Cont
 func (c *Client) sendUsersSetPrimaryEmailVisibilityForAuthenticated(ctx context.Context, request *UsersSetPrimaryEmailVisibilityForAuthenticatedReq) (res UsersSetPrimaryEmailVisibilityForAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/set-primary-email-visibility-for-authenticated"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/user/email/visibility"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -94459,6 +95910,8 @@ func (c *Client) UsersUnblock(ctx context.Context, params UsersUnblockParams) (U
 func (c *Client) sendUsersUnblock(ctx context.Context, params UsersUnblockParams) (res UsersUnblockRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/unblock"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/blocks/{username}"),
 	}
 
 	// Run stopwatch.
@@ -94549,6 +96002,8 @@ func (c *Client) UsersUnfollow(ctx context.Context, params UsersUnfollowParams) 
 func (c *Client) sendUsersUnfollow(ctx context.Context, params UsersUnfollowParams) (res UsersUnfollowRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/unfollow"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/user/following/{username}"),
 	}
 
 	// Run stopwatch.
@@ -94640,6 +96095,8 @@ func (c *Client) UsersUpdateAuthenticated(ctx context.Context, request OptUsersU
 func (c *Client) sendUsersUpdateAuthenticated(ctx context.Context, request OptUsersUpdateAuthenticatedReq) (res UsersUpdateAuthenticatedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("users/update-authenticated"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/user"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_gotd/oas_client_gen.go
+++ b/examples/ex_gotd/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -83,6 +84,8 @@ func (c *Client) AddStickerToSet(ctx context.Context, request *AddStickerToSet) 
 func (c *Client) sendAddStickerToSet(ctx context.Context, request *AddStickerToSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("addStickerToSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/addStickerToSet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -164,6 +167,8 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request *AnswerCallbac
 func (c *Client) sendAnswerCallbackQuery(ctx context.Context, request *AnswerCallbackQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerCallbackQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerCallbackQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -245,6 +250,8 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request *AnswerInlineQue
 func (c *Client) sendAnswerInlineQuery(ctx context.Context, request *AnswerInlineQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerInlineQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerInlineQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -326,6 +333,8 @@ func (c *Client) AnswerPreCheckoutQuery(ctx context.Context, request *AnswerPreC
 func (c *Client) sendAnswerPreCheckoutQuery(ctx context.Context, request *AnswerPreCheckoutQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerPreCheckoutQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerPreCheckoutQuery"),
 	}
 
 	// Run stopwatch.
@@ -398,6 +407,8 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request *AnswerShippin
 func (c *Client) sendAnswerShippingQuery(ctx context.Context, request *AnswerShippingQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerShippingQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerShippingQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -479,6 +490,8 @@ func (c *Client) AnswerWebAppQuery(ctx context.Context, request *AnswerWebAppQue
 func (c *Client) sendAnswerWebAppQuery(ctx context.Context, request *AnswerWebAppQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerWebAppQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerWebAppQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -560,6 +573,8 @@ func (c *Client) ApproveChatJoinRequest(ctx context.Context, request *ApproveCha
 func (c *Client) sendApproveChatJoinRequest(ctx context.Context, request *ApproveChatJoinRequest) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("approveChatJoinRequest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/approveChatJoinRequest"),
 	}
 
 	// Run stopwatch.
@@ -632,6 +647,8 @@ func (c *Client) BanChatMember(ctx context.Context, request *BanChatMember) (*Re
 func (c *Client) sendBanChatMember(ctx context.Context, request *BanChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("banChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/banChatMember"),
 	}
 
 	// Run stopwatch.
@@ -704,6 +721,8 @@ func (c *Client) BanChatSenderChat(ctx context.Context, request *BanChatSenderCh
 func (c *Client) sendBanChatSenderChat(ctx context.Context, request *BanChatSenderChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("banChatSenderChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/banChatSenderChat"),
 	}
 
 	// Run stopwatch.
@@ -776,6 +795,8 @@ func (c *Client) Close(ctx context.Context) (*Result, error) {
 func (c *Client) sendClose(ctx context.Context) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("close"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/close"),
 	}
 
 	// Run stopwatch.
@@ -845,6 +866,8 @@ func (c *Client) CopyMessage(ctx context.Context, request *CopyMessage) (*Result
 func (c *Client) sendCopyMessage(ctx context.Context, request *CopyMessage) (res *ResultMessageId, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("copyMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/copyMessage"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -926,6 +949,8 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request *CreateChatIn
 func (c *Client) sendCreateChatInviteLink(ctx context.Context, request *CreateChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/createChatInviteLink"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1007,6 +1032,8 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request *CreateNewStic
 func (c *Client) sendCreateNewStickerSet(ctx context.Context, request *CreateNewStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createNewStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/createNewStickerSet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1088,6 +1115,8 @@ func (c *Client) DeclineChatJoinRequest(ctx context.Context, request *DeclineCha
 func (c *Client) sendDeclineChatJoinRequest(ctx context.Context, request *DeclineChatJoinRequest) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("declineChatJoinRequest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/declineChatJoinRequest"),
 	}
 
 	// Run stopwatch.
@@ -1160,6 +1189,8 @@ func (c *Client) DeleteChatPhoto(ctx context.Context, request *DeleteChatPhoto) 
 func (c *Client) sendDeleteChatPhoto(ctx context.Context, request *DeleteChatPhoto) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteChatPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteChatPhoto"),
 	}
 
 	// Run stopwatch.
@@ -1232,6 +1263,8 @@ func (c *Client) DeleteChatStickerSet(ctx context.Context, request *DeleteChatSt
 func (c *Client) sendDeleteChatStickerSet(ctx context.Context, request *DeleteChatStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteChatStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteChatStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -1304,6 +1337,8 @@ func (c *Client) DeleteMessage(ctx context.Context, request *DeleteMessage) (*Re
 func (c *Client) sendDeleteMessage(ctx context.Context, request *DeleteMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteMessage"),
 	}
 
 	// Run stopwatch.
@@ -1376,6 +1411,8 @@ func (c *Client) DeleteMyCommands(ctx context.Context, request OptDeleteMyComman
 func (c *Client) sendDeleteMyCommands(ctx context.Context, request OptDeleteMyCommands) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteMyCommands"),
 	}
 
 	// Run stopwatch.
@@ -1448,6 +1485,8 @@ func (c *Client) DeleteStickerFromSet(ctx context.Context, request *DeleteSticke
 func (c *Client) sendDeleteStickerFromSet(ctx context.Context, request *DeleteStickerFromSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteStickerFromSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteStickerFromSet"),
 	}
 
 	// Run stopwatch.
@@ -1520,6 +1559,8 @@ func (c *Client) DeleteWebhook(ctx context.Context, request OptDeleteWebhook) (*
 func (c *Client) sendDeleteWebhook(ctx context.Context, request OptDeleteWebhook) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteWebhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteWebhook"),
 	}
 
 	// Run stopwatch.
@@ -1592,6 +1633,8 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request *EditChatInvite
 func (c *Client) sendEditChatInviteLink(ctx context.Context, request *EditChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editChatInviteLink"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1673,6 +1716,8 @@ func (c *Client) EditMessageCaption(ctx context.Context, request *EditMessageCap
 func (c *Client) sendEditMessageCaption(ctx context.Context, request *EditMessageCaption) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageCaption"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageCaption"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1754,6 +1799,8 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request *EditMessa
 func (c *Client) sendEditMessageLiveLocation(ctx context.Context, request *EditMessageLiveLocation) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageLiveLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageLiveLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1835,6 +1882,8 @@ func (c *Client) EditMessageMedia(ctx context.Context, request *EditMessageMedia
 func (c *Client) sendEditMessageMedia(ctx context.Context, request *EditMessageMedia) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageMedia"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageMedia"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1916,6 +1965,8 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request *EditMessag
 func (c *Client) sendEditMessageReplyMarkup(ctx context.Context, request *EditMessageReplyMarkup) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageReplyMarkup"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageReplyMarkup"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1997,6 +2048,8 @@ func (c *Client) EditMessageText(ctx context.Context, request *EditMessageText) 
 func (c *Client) sendEditMessageText(ctx context.Context, request *EditMessageText) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageText"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageText"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2078,6 +2131,8 @@ func (c *Client) ExportChatInviteLink(ctx context.Context, request *ExportChatIn
 func (c *Client) sendExportChatInviteLink(ctx context.Context, request *ExportChatInviteLink) (res *ResultString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("exportChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/exportChatInviteLink"),
 	}
 
 	// Run stopwatch.
@@ -2150,6 +2205,8 @@ func (c *Client) ForwardMessage(ctx context.Context, request *ForwardMessage) (*
 func (c *Client) sendForwardMessage(ctx context.Context, request *ForwardMessage) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("forwardMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/forwardMessage"),
 	}
 
 	// Run stopwatch.
@@ -2222,6 +2279,8 @@ func (c *Client) GetChat(ctx context.Context, request *GetChat) (*ResultChat, er
 func (c *Client) sendGetChat(ctx context.Context, request *GetChat) (res *ResultChat, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChat"),
 	}
 
 	// Run stopwatch.
@@ -2294,6 +2353,8 @@ func (c *Client) GetChatAdministrators(ctx context.Context, request *GetChatAdmi
 func (c *Client) sendGetChatAdministrators(ctx context.Context, request *GetChatAdministrators) (res *ResultArrayOfChatMember, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatAdministrators"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatAdministrators"),
 	}
 
 	// Run stopwatch.
@@ -2366,6 +2427,8 @@ func (c *Client) GetChatMember(ctx context.Context, request *GetChatMember) (*Re
 func (c *Client) sendGetChatMember(ctx context.Context, request *GetChatMember) (res *ResultChatMember, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatMember"),
 	}
 
 	// Run stopwatch.
@@ -2438,6 +2501,8 @@ func (c *Client) GetChatMemberCount(ctx context.Context, request *GetChatMemberC
 func (c *Client) sendGetChatMemberCount(ctx context.Context, request *GetChatMemberCount) (res *ResultInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatMemberCount"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatMemberCount"),
 	}
 
 	// Run stopwatch.
@@ -2510,6 +2575,8 @@ func (c *Client) GetChatMenuButton(ctx context.Context, request OptGetChatMenuBu
 func (c *Client) sendGetChatMenuButton(ctx context.Context, request OptGetChatMenuButton) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatMenuButton"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatMenuButton"),
 	}
 
 	// Run stopwatch.
@@ -2582,6 +2649,8 @@ func (c *Client) GetFile(ctx context.Context, request *GetFile) (*ResultFile, er
 func (c *Client) sendGetFile(ctx context.Context, request *GetFile) (res *ResultFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getFile"),
 	}
 
 	// Run stopwatch.
@@ -2654,6 +2723,8 @@ func (c *Client) GetGameHighScores(ctx context.Context, request *GetGameHighScor
 func (c *Client) sendGetGameHighScores(ctx context.Context, request *GetGameHighScores) (res *ResultArrayOfGameHighScore, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getGameHighScores"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getGameHighScores"),
 	}
 
 	// Run stopwatch.
@@ -2726,6 +2797,8 @@ func (c *Client) GetMe(ctx context.Context) (*ResultUser, error) {
 func (c *Client) sendGetMe(ctx context.Context) (res *ResultUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMe"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getMe"),
 	}
 
 	// Run stopwatch.
@@ -2795,6 +2868,8 @@ func (c *Client) GetMyCommands(ctx context.Context, request OptGetMyCommands) (*
 func (c *Client) sendGetMyCommands(ctx context.Context, request OptGetMyCommands) (res *ResultArrayOfBotCommand, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getMyCommands"),
 	}
 
 	// Run stopwatch.
@@ -2867,6 +2942,8 @@ func (c *Client) GetMyDefaultAdministratorRights(ctx context.Context, request Op
 func (c *Client) sendGetMyDefaultAdministratorRights(ctx context.Context, request OptGetMyDefaultAdministratorRights) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMyDefaultAdministratorRights"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getMyDefaultAdministratorRights"),
 	}
 
 	// Run stopwatch.
@@ -2939,6 +3016,8 @@ func (c *Client) GetStickerSet(ctx context.Context, request *GetStickerSet) (*Re
 func (c *Client) sendGetStickerSet(ctx context.Context, request *GetStickerSet) (res *ResultStickerSet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -3011,6 +3090,8 @@ func (c *Client) GetUpdates(ctx context.Context, request OptGetUpdates) (*Result
 func (c *Client) sendGetUpdates(ctx context.Context, request OptGetUpdates) (res *ResultArrayOfUpdate, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getUpdates"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getUpdates"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3099,6 +3180,8 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request *GetUserProfi
 func (c *Client) sendGetUserProfilePhotos(ctx context.Context, request *GetUserProfilePhotos) (res *ResultUserProfilePhotos, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getUserProfilePhotos"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getUserProfilePhotos"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3180,6 +3263,8 @@ func (c *Client) GetWebhookInfo(ctx context.Context) (*ResultWebhookInfo, error)
 func (c *Client) sendGetWebhookInfo(ctx context.Context) (res *ResultWebhookInfo, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getWebhookInfo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getWebhookInfo"),
 	}
 
 	// Run stopwatch.
@@ -3249,6 +3334,8 @@ func (c *Client) LeaveChat(ctx context.Context, request *LeaveChat) (*Result, er
 func (c *Client) sendLeaveChat(ctx context.Context, request *LeaveChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("leaveChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/leaveChat"),
 	}
 
 	// Run stopwatch.
@@ -3321,6 +3408,8 @@ func (c *Client) LogOut(ctx context.Context) (*Result, error) {
 func (c *Client) sendLogOut(ctx context.Context) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("logOut"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/logOut"),
 	}
 
 	// Run stopwatch.
@@ -3390,6 +3479,8 @@ func (c *Client) PinChatMessage(ctx context.Context, request *PinChatMessage) (*
 func (c *Client) sendPinChatMessage(ctx context.Context, request *PinChatMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pinChatMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pinChatMessage"),
 	}
 
 	// Run stopwatch.
@@ -3462,6 +3553,8 @@ func (c *Client) PromoteChatMember(ctx context.Context, request *PromoteChatMemb
 func (c *Client) sendPromoteChatMember(ctx context.Context, request *PromoteChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("promoteChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/promoteChatMember"),
 	}
 
 	// Run stopwatch.
@@ -3534,6 +3627,8 @@ func (c *Client) RestrictChatMember(ctx context.Context, request *RestrictChatMe
 func (c *Client) sendRestrictChatMember(ctx context.Context, request *RestrictChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("restrictChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/restrictChatMember"),
 	}
 
 	// Run stopwatch.
@@ -3606,6 +3701,8 @@ func (c *Client) RevokeChatInviteLink(ctx context.Context, request *RevokeChatIn
 func (c *Client) sendRevokeChatInviteLink(ctx context.Context, request *RevokeChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("revokeChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/revokeChatInviteLink"),
 	}
 
 	// Run stopwatch.
@@ -3678,6 +3775,8 @@ func (c *Client) SendAnimation(ctx context.Context, request *SendAnimation) (*Re
 func (c *Client) sendSendAnimation(ctx context.Context, request *SendAnimation) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendAnimation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendAnimation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3759,6 +3858,8 @@ func (c *Client) SendAudio(ctx context.Context, request *SendAudio) (*ResultMess
 func (c *Client) sendSendAudio(ctx context.Context, request *SendAudio) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendAudio"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendAudio"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3840,6 +3941,8 @@ func (c *Client) SendChatAction(ctx context.Context, request *SendChatAction) (*
 func (c *Client) sendSendChatAction(ctx context.Context, request *SendChatAction) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendChatAction"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendChatAction"),
 	}
 
 	// Run stopwatch.
@@ -3912,6 +4015,8 @@ func (c *Client) SendContact(ctx context.Context, request *SendContact) (*Result
 func (c *Client) sendSendContact(ctx context.Context, request *SendContact) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendContact"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendContact"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3993,6 +4098,8 @@ func (c *Client) SendDice(ctx context.Context, request *SendDice) (*ResultMessag
 func (c *Client) sendSendDice(ctx context.Context, request *SendDice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendDice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendDice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4074,6 +4181,8 @@ func (c *Client) SendDocument(ctx context.Context, request *SendDocument) (*Resu
 func (c *Client) sendSendDocument(ctx context.Context, request *SendDocument) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendDocument"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendDocument"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4155,6 +4264,8 @@ func (c *Client) SendGame(ctx context.Context, request *SendGame) (*ResultMessag
 func (c *Client) sendSendGame(ctx context.Context, request *SendGame) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendGame"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendGame"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4236,6 +4347,8 @@ func (c *Client) SendInvoice(ctx context.Context, request *SendInvoice) (*Result
 func (c *Client) sendSendInvoice(ctx context.Context, request *SendInvoice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendInvoice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendInvoice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4317,6 +4430,8 @@ func (c *Client) SendLocation(ctx context.Context, request *SendLocation) (*Resu
 func (c *Client) sendSendLocation(ctx context.Context, request *SendLocation) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4398,6 +4513,8 @@ func (c *Client) SendMediaGroup(ctx context.Context, request *SendMediaGroup) (*
 func (c *Client) sendSendMediaGroup(ctx context.Context, request *SendMediaGroup) (res *ResultArrayOfMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendMediaGroup"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendMediaGroup"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4479,6 +4596,8 @@ func (c *Client) SendMessage(ctx context.Context, request *SendMessage) (*Result
 func (c *Client) sendSendMessage(ctx context.Context, request *SendMessage) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendMessage"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4560,6 +4679,8 @@ func (c *Client) SendPhoto(ctx context.Context, request *SendPhoto) (*ResultMess
 func (c *Client) sendSendPhoto(ctx context.Context, request *SendPhoto) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendPhoto"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4641,6 +4762,8 @@ func (c *Client) SendPoll(ctx context.Context, request *SendPoll) (*ResultMessag
 func (c *Client) sendSendPoll(ctx context.Context, request *SendPoll) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendPoll"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendPoll"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4722,6 +4845,8 @@ func (c *Client) SendSticker(ctx context.Context, request *SendSticker) (*Result
 func (c *Client) sendSendSticker(ctx context.Context, request *SendSticker) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendSticker"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendSticker"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4803,6 +4928,8 @@ func (c *Client) SendVenue(ctx context.Context, request *SendVenue) (*ResultMess
 func (c *Client) sendSendVenue(ctx context.Context, request *SendVenue) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVenue"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVenue"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4884,6 +5011,8 @@ func (c *Client) SendVideo(ctx context.Context, request *SendVideo) (*ResultMess
 func (c *Client) sendSendVideo(ctx context.Context, request *SendVideo) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVideo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVideo"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4965,6 +5094,8 @@ func (c *Client) SendVideoNote(ctx context.Context, request *SendVideoNote) (*Re
 func (c *Client) sendSendVideoNote(ctx context.Context, request *SendVideoNote) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVideoNote"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVideoNote"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5046,6 +5177,8 @@ func (c *Client) SendVoice(ctx context.Context, request *SendVoice) (*ResultMess
 func (c *Client) sendSendVoice(ctx context.Context, request *SendVoice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVoice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVoice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5127,6 +5260,8 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request *S
 func (c *Client) sendSetChatAdministratorCustomTitle(ctx context.Context, request *SetChatAdministratorCustomTitle) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatAdministratorCustomTitle"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatAdministratorCustomTitle"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5208,6 +5343,8 @@ func (c *Client) SetChatDescription(ctx context.Context, request *SetChatDescrip
 func (c *Client) sendSetChatDescription(ctx context.Context, request *SetChatDescription) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatDescription"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatDescription"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5289,6 +5426,8 @@ func (c *Client) SetChatMenuButton(ctx context.Context, request OptSetChatMenuBu
 func (c *Client) sendSetChatMenuButton(ctx context.Context, request OptSetChatMenuButton) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatMenuButton"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatMenuButton"),
 	}
 
 	// Run stopwatch.
@@ -5361,6 +5500,8 @@ func (c *Client) SetChatPermissions(ctx context.Context, request *SetChatPermiss
 func (c *Client) sendSetChatPermissions(ctx context.Context, request *SetChatPermissions) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatPermissions"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatPermissions"),
 	}
 
 	// Run stopwatch.
@@ -5433,6 +5574,8 @@ func (c *Client) SetChatPhoto(ctx context.Context, request *SetChatPhoto) (*Resu
 func (c *Client) sendSetChatPhoto(ctx context.Context, request *SetChatPhoto) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatPhoto"),
 	}
 
 	// Run stopwatch.
@@ -5505,6 +5648,8 @@ func (c *Client) SetChatStickerSet(ctx context.Context, request *SetChatStickerS
 func (c *Client) sendSetChatStickerSet(ctx context.Context, request *SetChatStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -5577,6 +5722,8 @@ func (c *Client) SetChatTitle(ctx context.Context, request *SetChatTitle) (*Resu
 func (c *Client) sendSetChatTitle(ctx context.Context, request *SetChatTitle) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatTitle"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatTitle"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5658,6 +5805,8 @@ func (c *Client) SetGameScore(ctx context.Context, request *SetGameScore) (*Resu
 func (c *Client) sendSetGameScore(ctx context.Context, request *SetGameScore) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setGameScore"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setGameScore"),
 	}
 
 	// Run stopwatch.
@@ -5730,6 +5879,8 @@ func (c *Client) SetMyCommands(ctx context.Context, request *SetMyCommands) (*Re
 func (c *Client) sendSetMyCommands(ctx context.Context, request *SetMyCommands) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setMyCommands"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5811,6 +5962,8 @@ func (c *Client) SetMyDefaultAdministratorRights(ctx context.Context, request Op
 func (c *Client) sendSetMyDefaultAdministratorRights(ctx context.Context, request OptSetMyDefaultAdministratorRights) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setMyDefaultAdministratorRights"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setMyDefaultAdministratorRights"),
 	}
 
 	// Run stopwatch.
@@ -5883,6 +6036,8 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request *SetPassport
 func (c *Client) sendSetPassportDataErrors(ctx context.Context, request *SetPassportDataErrors) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setPassportDataErrors"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setPassportDataErrors"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5964,6 +6119,8 @@ func (c *Client) SetStickerPositionInSet(ctx context.Context, request *SetSticke
 func (c *Client) sendSetStickerPositionInSet(ctx context.Context, request *SetStickerPositionInSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setStickerPositionInSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setStickerPositionInSet"),
 	}
 
 	// Run stopwatch.
@@ -6036,6 +6193,8 @@ func (c *Client) SetStickerSetThumb(ctx context.Context, request *SetStickerSetT
 func (c *Client) sendSetStickerSetThumb(ctx context.Context, request *SetStickerSetThumb) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setStickerSetThumb"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setStickerSetThumb"),
 	}
 
 	// Run stopwatch.
@@ -6108,6 +6267,8 @@ func (c *Client) SetWebhook(ctx context.Context, request *SetWebhook) (*Result, 
 func (c *Client) sendSetWebhook(ctx context.Context, request *SetWebhook) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setWebhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setWebhook"),
 	}
 
 	// Run stopwatch.
@@ -6180,6 +6341,8 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request *StopMessa
 func (c *Client) sendStopMessageLiveLocation(ctx context.Context, request *StopMessageLiveLocation) (res *ResultMessageOrBoolean, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("stopMessageLiveLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/stopMessageLiveLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6261,6 +6424,8 @@ func (c *Client) StopPoll(ctx context.Context, request *StopPoll) (*ResultPoll, 
 func (c *Client) sendStopPoll(ctx context.Context, request *StopPoll) (res *ResultPoll, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("stopPoll"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/stopPoll"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6342,6 +6507,8 @@ func (c *Client) UnbanChatMember(ctx context.Context, request *UnbanChatMember) 
 func (c *Client) sendUnbanChatMember(ctx context.Context, request *UnbanChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unbanChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unbanChatMember"),
 	}
 
 	// Run stopwatch.
@@ -6414,6 +6581,8 @@ func (c *Client) UnbanChatSenderChat(ctx context.Context, request *UnbanChatSend
 func (c *Client) sendUnbanChatSenderChat(ctx context.Context, request *UnbanChatSenderChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unbanChatSenderChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unbanChatSenderChat"),
 	}
 
 	// Run stopwatch.
@@ -6486,6 +6655,8 @@ func (c *Client) UnpinAllChatMessages(ctx context.Context, request *UnpinAllChat
 func (c *Client) sendUnpinAllChatMessages(ctx context.Context, request *UnpinAllChatMessages) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unpinAllChatMessages"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unpinAllChatMessages"),
 	}
 
 	// Run stopwatch.
@@ -6558,6 +6729,8 @@ func (c *Client) UnpinChatMessage(ctx context.Context, request *UnpinChatMessage
 func (c *Client) sendUnpinChatMessage(ctx context.Context, request *UnpinChatMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unpinChatMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unpinChatMessage"),
 	}
 
 	// Run stopwatch.
@@ -6630,6 +6803,8 @@ func (c *Client) UploadStickerFile(ctx context.Context, request *UploadStickerFi
 func (c *Client) sendUploadStickerFile(ctx context.Context, request *UploadStickerFile) (res *ResultFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("uploadStickerFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/uploadStickerFile"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_k8s/oas_client_gen.go
+++ b/examples/ex_k8s/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -85,6 +86,8 @@ func (c *Client) ConnectCoreV1DeleteNamespacedPodProxy(ctx context.Context, para
 func (c *Client) sendConnectCoreV1DeleteNamespacedPodProxy(ctx context.Context, params ConnectCoreV1DeleteNamespacedPodProxyParams) (res ConnectCoreV1DeleteNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -248,6 +251,8 @@ func (c *Client) ConnectCoreV1DeleteNamespacedPodProxyWithPath(ctx context.Conte
 func (c *Client) sendConnectCoreV1DeleteNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1DeleteNamespacedPodProxyWithPathParams) (res ConnectCoreV1DeleteNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -429,6 +434,8 @@ func (c *Client) ConnectCoreV1DeleteNamespacedServiceProxy(ctx context.Context, 
 func (c *Client) sendConnectCoreV1DeleteNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1DeleteNamespacedServiceProxyParams) (res ConnectCoreV1DeleteNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -592,6 +599,8 @@ func (c *Client) ConnectCoreV1DeleteNamespacedServiceProxyWithPath(ctx context.C
 func (c *Client) sendConnectCoreV1DeleteNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1DeleteNamespacedServiceProxyWithPathParams) (res ConnectCoreV1DeleteNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -773,6 +782,8 @@ func (c *Client) ConnectCoreV1DeleteNodeProxy(ctx context.Context, params Connec
 func (c *Client) sendConnectCoreV1DeleteNodeProxy(ctx context.Context, params ConnectCoreV1DeleteNodeProxyParams) (res ConnectCoreV1DeleteNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNodeProxy"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -917,6 +928,8 @@ func (c *Client) ConnectCoreV1DeleteNodeProxyWithPath(ctx context.Context, param
 func (c *Client) sendConnectCoreV1DeleteNodeProxyWithPath(ctx context.Context, params ConnectCoreV1DeleteNodeProxyWithPathParams) (res ConnectCoreV1DeleteNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1DeleteNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -1079,6 +1092,8 @@ func (c *Client) ConnectCoreV1GetNamespacedPodAttach(ctx context.Context, params
 func (c *Client) sendConnectCoreV1GetNamespacedPodAttach(ctx context.Context, params ConnectCoreV1GetNamespacedPodAttachParams) (res ConnectCoreV1GetNamespacedPodAttachRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedPodAttach"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/attach"),
 	}
 
 	// Run stopwatch.
@@ -1310,6 +1325,8 @@ func (c *Client) ConnectCoreV1GetNamespacedPodExec(ctx context.Context, params C
 func (c *Client) sendConnectCoreV1GetNamespacedPodExec(ctx context.Context, params ConnectCoreV1GetNamespacedPodExecParams) (res ConnectCoreV1GetNamespacedPodExecRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedPodExec"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/exec"),
 	}
 
 	// Run stopwatch.
@@ -1558,6 +1575,8 @@ func (c *Client) ConnectCoreV1GetNamespacedPodPortforward(ctx context.Context, p
 func (c *Client) sendConnectCoreV1GetNamespacedPodPortforward(ctx context.Context, params ConnectCoreV1GetNamespacedPodPortforwardParams) (res ConnectCoreV1GetNamespacedPodPortforwardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedPodPortforward"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/portforward"),
 	}
 
 	// Run stopwatch.
@@ -1721,6 +1740,8 @@ func (c *Client) ConnectCoreV1GetNamespacedPodProxy(ctx context.Context, params 
 func (c *Client) sendConnectCoreV1GetNamespacedPodProxy(ctx context.Context, params ConnectCoreV1GetNamespacedPodProxyParams) (res ConnectCoreV1GetNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -1884,6 +1905,8 @@ func (c *Client) ConnectCoreV1GetNamespacedPodProxyWithPath(ctx context.Context,
 func (c *Client) sendConnectCoreV1GetNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1GetNamespacedPodProxyWithPathParams) (res ConnectCoreV1GetNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -2065,6 +2088,8 @@ func (c *Client) ConnectCoreV1GetNamespacedServiceProxy(ctx context.Context, par
 func (c *Client) sendConnectCoreV1GetNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1GetNamespacedServiceProxyParams) (res ConnectCoreV1GetNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -2228,6 +2253,8 @@ func (c *Client) ConnectCoreV1GetNamespacedServiceProxyWithPath(ctx context.Cont
 func (c *Client) sendConnectCoreV1GetNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1GetNamespacedServiceProxyWithPathParams) (res ConnectCoreV1GetNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -2409,6 +2436,8 @@ func (c *Client) ConnectCoreV1GetNodeProxy(ctx context.Context, params ConnectCo
 func (c *Client) sendConnectCoreV1GetNodeProxy(ctx context.Context, params ConnectCoreV1GetNodeProxyParams) (res ConnectCoreV1GetNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNodeProxy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -2553,6 +2582,8 @@ func (c *Client) ConnectCoreV1GetNodeProxyWithPath(ctx context.Context, params C
 func (c *Client) sendConnectCoreV1GetNodeProxyWithPath(ctx context.Context, params ConnectCoreV1GetNodeProxyWithPathParams) (res ConnectCoreV1GetNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1GetNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -2715,6 +2746,8 @@ func (c *Client) ConnectCoreV1HeadNamespacedPodProxy(ctx context.Context, params
 func (c *Client) sendConnectCoreV1HeadNamespacedPodProxy(ctx context.Context, params ConnectCoreV1HeadNamespacedPodProxyParams) (res ConnectCoreV1HeadNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -2878,6 +2911,8 @@ func (c *Client) ConnectCoreV1HeadNamespacedPodProxyWithPath(ctx context.Context
 func (c *Client) sendConnectCoreV1HeadNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1HeadNamespacedPodProxyWithPathParams) (res ConnectCoreV1HeadNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -3059,6 +3094,8 @@ func (c *Client) ConnectCoreV1HeadNamespacedServiceProxy(ctx context.Context, pa
 func (c *Client) sendConnectCoreV1HeadNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1HeadNamespacedServiceProxyParams) (res ConnectCoreV1HeadNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -3222,6 +3259,8 @@ func (c *Client) ConnectCoreV1HeadNamespacedServiceProxyWithPath(ctx context.Con
 func (c *Client) sendConnectCoreV1HeadNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1HeadNamespacedServiceProxyWithPathParams) (res ConnectCoreV1HeadNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -3403,6 +3442,8 @@ func (c *Client) ConnectCoreV1HeadNodeProxy(ctx context.Context, params ConnectC
 func (c *Client) sendConnectCoreV1HeadNodeProxy(ctx context.Context, params ConnectCoreV1HeadNodeProxyParams) (res ConnectCoreV1HeadNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNodeProxy"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -3547,6 +3588,8 @@ func (c *Client) ConnectCoreV1HeadNodeProxyWithPath(ctx context.Context, params 
 func (c *Client) sendConnectCoreV1HeadNodeProxyWithPath(ctx context.Context, params ConnectCoreV1HeadNodeProxyWithPathParams) (res ConnectCoreV1HeadNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1HeadNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("HEAD"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -3709,6 +3752,8 @@ func (c *Client) ConnectCoreV1OptionsNamespacedPodProxy(ctx context.Context, par
 func (c *Client) sendConnectCoreV1OptionsNamespacedPodProxy(ctx context.Context, params ConnectCoreV1OptionsNamespacedPodProxyParams) (res ConnectCoreV1OptionsNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -3872,6 +3917,8 @@ func (c *Client) ConnectCoreV1OptionsNamespacedPodProxyWithPath(ctx context.Cont
 func (c *Client) sendConnectCoreV1OptionsNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1OptionsNamespacedPodProxyWithPathParams) (res ConnectCoreV1OptionsNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -4053,6 +4100,8 @@ func (c *Client) ConnectCoreV1OptionsNamespacedServiceProxy(ctx context.Context,
 func (c *Client) sendConnectCoreV1OptionsNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1OptionsNamespacedServiceProxyParams) (res ConnectCoreV1OptionsNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -4216,6 +4265,8 @@ func (c *Client) ConnectCoreV1OptionsNamespacedServiceProxyWithPath(ctx context.
 func (c *Client) sendConnectCoreV1OptionsNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1OptionsNamespacedServiceProxyWithPathParams) (res ConnectCoreV1OptionsNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -4397,6 +4448,8 @@ func (c *Client) ConnectCoreV1OptionsNodeProxy(ctx context.Context, params Conne
 func (c *Client) sendConnectCoreV1OptionsNodeProxy(ctx context.Context, params ConnectCoreV1OptionsNodeProxyParams) (res ConnectCoreV1OptionsNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNodeProxy"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -4541,6 +4594,8 @@ func (c *Client) ConnectCoreV1OptionsNodeProxyWithPath(ctx context.Context, para
 func (c *Client) sendConnectCoreV1OptionsNodeProxyWithPath(ctx context.Context, params ConnectCoreV1OptionsNodeProxyWithPathParams) (res ConnectCoreV1OptionsNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1OptionsNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("OPTIONS"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -4703,6 +4758,8 @@ func (c *Client) ConnectCoreV1PatchNamespacedPodProxy(ctx context.Context, param
 func (c *Client) sendConnectCoreV1PatchNamespacedPodProxy(ctx context.Context, params ConnectCoreV1PatchNamespacedPodProxyParams) (res ConnectCoreV1PatchNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -4866,6 +4923,8 @@ func (c *Client) ConnectCoreV1PatchNamespacedPodProxyWithPath(ctx context.Contex
 func (c *Client) sendConnectCoreV1PatchNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1PatchNamespacedPodProxyWithPathParams) (res ConnectCoreV1PatchNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -5047,6 +5106,8 @@ func (c *Client) ConnectCoreV1PatchNamespacedServiceProxy(ctx context.Context, p
 func (c *Client) sendConnectCoreV1PatchNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1PatchNamespacedServiceProxyParams) (res ConnectCoreV1PatchNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -5210,6 +5271,8 @@ func (c *Client) ConnectCoreV1PatchNamespacedServiceProxyWithPath(ctx context.Co
 func (c *Client) sendConnectCoreV1PatchNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1PatchNamespacedServiceProxyWithPathParams) (res ConnectCoreV1PatchNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -5391,6 +5454,8 @@ func (c *Client) ConnectCoreV1PatchNodeProxy(ctx context.Context, params Connect
 func (c *Client) sendConnectCoreV1PatchNodeProxy(ctx context.Context, params ConnectCoreV1PatchNodeProxyParams) (res ConnectCoreV1PatchNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNodeProxy"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -5535,6 +5600,8 @@ func (c *Client) ConnectCoreV1PatchNodeProxyWithPath(ctx context.Context, params
 func (c *Client) sendConnectCoreV1PatchNodeProxyWithPath(ctx context.Context, params ConnectCoreV1PatchNodeProxyWithPathParams) (res ConnectCoreV1PatchNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PatchNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -5697,6 +5764,8 @@ func (c *Client) ConnectCoreV1PostNamespacedPodAttach(ctx context.Context, param
 func (c *Client) sendConnectCoreV1PostNamespacedPodAttach(ctx context.Context, params ConnectCoreV1PostNamespacedPodAttachParams) (res ConnectCoreV1PostNamespacedPodAttachRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedPodAttach"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/attach"),
 	}
 
 	// Run stopwatch.
@@ -5928,6 +5997,8 @@ func (c *Client) ConnectCoreV1PostNamespacedPodExec(ctx context.Context, params 
 func (c *Client) sendConnectCoreV1PostNamespacedPodExec(ctx context.Context, params ConnectCoreV1PostNamespacedPodExecParams) (res ConnectCoreV1PostNamespacedPodExecRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedPodExec"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/exec"),
 	}
 
 	// Run stopwatch.
@@ -6176,6 +6247,8 @@ func (c *Client) ConnectCoreV1PostNamespacedPodPortforward(ctx context.Context, 
 func (c *Client) sendConnectCoreV1PostNamespacedPodPortforward(ctx context.Context, params ConnectCoreV1PostNamespacedPodPortforwardParams) (res ConnectCoreV1PostNamespacedPodPortforwardRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedPodPortforward"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/portforward"),
 	}
 
 	// Run stopwatch.
@@ -6339,6 +6412,8 @@ func (c *Client) ConnectCoreV1PostNamespacedPodProxy(ctx context.Context, params
 func (c *Client) sendConnectCoreV1PostNamespacedPodProxy(ctx context.Context, params ConnectCoreV1PostNamespacedPodProxyParams) (res ConnectCoreV1PostNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -6502,6 +6577,8 @@ func (c *Client) ConnectCoreV1PostNamespacedPodProxyWithPath(ctx context.Context
 func (c *Client) sendConnectCoreV1PostNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1PostNamespacedPodProxyWithPathParams) (res ConnectCoreV1PostNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -6683,6 +6760,8 @@ func (c *Client) ConnectCoreV1PostNamespacedServiceProxy(ctx context.Context, pa
 func (c *Client) sendConnectCoreV1PostNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1PostNamespacedServiceProxyParams) (res ConnectCoreV1PostNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -6846,6 +6925,8 @@ func (c *Client) ConnectCoreV1PostNamespacedServiceProxyWithPath(ctx context.Con
 func (c *Client) sendConnectCoreV1PostNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1PostNamespacedServiceProxyWithPathParams) (res ConnectCoreV1PostNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -7027,6 +7108,8 @@ func (c *Client) ConnectCoreV1PostNodeProxy(ctx context.Context, params ConnectC
 func (c *Client) sendConnectCoreV1PostNodeProxy(ctx context.Context, params ConnectCoreV1PostNodeProxyParams) (res ConnectCoreV1PostNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNodeProxy"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -7171,6 +7254,8 @@ func (c *Client) ConnectCoreV1PostNodeProxyWithPath(ctx context.Context, params 
 func (c *Client) sendConnectCoreV1PostNodeProxyWithPath(ctx context.Context, params ConnectCoreV1PostNodeProxyWithPathParams) (res ConnectCoreV1PostNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PostNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -7333,6 +7418,8 @@ func (c *Client) ConnectCoreV1PutNamespacedPodProxy(ctx context.Context, params 
 func (c *Client) sendConnectCoreV1PutNamespacedPodProxy(ctx context.Context, params ConnectCoreV1PutNamespacedPodProxyParams) (res ConnectCoreV1PutNamespacedPodProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNamespacedPodProxy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -7496,6 +7583,8 @@ func (c *Client) ConnectCoreV1PutNamespacedPodProxyWithPath(ctx context.Context,
 func (c *Client) sendConnectCoreV1PutNamespacedPodProxyWithPath(ctx context.Context, params ConnectCoreV1PutNamespacedPodProxyWithPathParams) (res ConnectCoreV1PutNamespacedPodProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNamespacedPodProxyWithPath"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -7677,6 +7766,8 @@ func (c *Client) ConnectCoreV1PutNamespacedServiceProxy(ctx context.Context, par
 func (c *Client) sendConnectCoreV1PutNamespacedServiceProxy(ctx context.Context, params ConnectCoreV1PutNamespacedServiceProxyParams) (res ConnectCoreV1PutNamespacedServiceProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNamespacedServiceProxy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -7840,6 +7931,8 @@ func (c *Client) ConnectCoreV1PutNamespacedServiceProxyWithPath(ctx context.Cont
 func (c *Client) sendConnectCoreV1PutNamespacedServiceProxyWithPath(ctx context.Context, params ConnectCoreV1PutNamespacedServiceProxyWithPathParams) (res ConnectCoreV1PutNamespacedServiceProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNamespacedServiceProxyWithPath"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -8021,6 +8114,8 @@ func (c *Client) ConnectCoreV1PutNodeProxy(ctx context.Context, params ConnectCo
 func (c *Client) sendConnectCoreV1PutNodeProxy(ctx context.Context, params ConnectCoreV1PutNodeProxyParams) (res ConnectCoreV1PutNodeProxyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNodeProxy"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy"),
 	}
 
 	// Run stopwatch.
@@ -8165,6 +8260,8 @@ func (c *Client) ConnectCoreV1PutNodeProxyWithPath(ctx context.Context, params C
 func (c *Client) sendConnectCoreV1PutNodeProxyWithPath(ctx context.Context, params ConnectCoreV1PutNodeProxyWithPathParams) (res ConnectCoreV1PutNodeProxyWithPathRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("connectCoreV1PutNodeProxyWithPath"),
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/proxy/{path}"),
 	}
 
 	// Run stopwatch.
@@ -8327,6 +8424,8 @@ func (c *Client) GetAPIVersions(ctx context.Context) (GetAPIVersionsRes, error) 
 func (c *Client) sendGetAPIVersions(ctx context.Context) (res GetAPIVersionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAPIVersions"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/"),
 	}
 
 	// Run stopwatch.
@@ -8431,6 +8530,8 @@ func (c *Client) GetAdmissionregistrationAPIGroup(ctx context.Context) (GetAdmis
 func (c *Client) sendGetAdmissionregistrationAPIGroup(ctx context.Context) (res GetAdmissionregistrationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAdmissionregistrationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -8535,6 +8636,8 @@ func (c *Client) GetAdmissionregistrationV1APIResources(ctx context.Context) (Ge
 func (c *Client) sendGetAdmissionregistrationV1APIResources(ctx context.Context) (res GetAdmissionregistrationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAdmissionregistrationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -8639,6 +8742,8 @@ func (c *Client) GetApiextensionsAPIGroup(ctx context.Context) (GetApiextensions
 func (c *Client) sendGetApiextensionsAPIGroup(ctx context.Context) (res GetApiextensionsAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getApiextensionsAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -8743,6 +8848,8 @@ func (c *Client) GetApiextensionsV1APIResources(ctx context.Context) (GetApiexte
 func (c *Client) sendGetApiextensionsV1APIResources(ctx context.Context) (res GetApiextensionsV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getApiextensionsV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -8847,6 +8954,8 @@ func (c *Client) GetApiregistrationAPIGroup(ctx context.Context) (GetApiregistra
 func (c *Client) sendGetApiregistrationAPIGroup(ctx context.Context) (res GetApiregistrationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getApiregistrationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -8951,6 +9060,8 @@ func (c *Client) GetApiregistrationV1APIResources(ctx context.Context) (GetApire
 func (c *Client) sendGetApiregistrationV1APIResources(ctx context.Context) (res GetApiregistrationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getApiregistrationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -9055,6 +9166,8 @@ func (c *Client) GetAppsAPIGroup(ctx context.Context) (GetAppsAPIGroupRes, error
 func (c *Client) sendGetAppsAPIGroup(ctx context.Context) (res GetAppsAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAppsAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/"),
 	}
 
 	// Run stopwatch.
@@ -9159,6 +9272,8 @@ func (c *Client) GetAppsV1APIResources(ctx context.Context) (GetAppsV1APIResourc
 func (c *Client) sendGetAppsV1APIResources(ctx context.Context) (res GetAppsV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAppsV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/"),
 	}
 
 	// Run stopwatch.
@@ -9263,6 +9378,8 @@ func (c *Client) GetAuthenticationAPIGroup(ctx context.Context) (GetAuthenticati
 func (c *Client) sendGetAuthenticationAPIGroup(ctx context.Context) (res GetAuthenticationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAuthenticationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/authentication.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -9367,6 +9484,8 @@ func (c *Client) GetAuthenticationV1APIResources(ctx context.Context) (GetAuthen
 func (c *Client) sendGetAuthenticationV1APIResources(ctx context.Context) (res GetAuthenticationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAuthenticationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/authentication.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -9471,6 +9590,8 @@ func (c *Client) GetAuthorizationAPIGroup(ctx context.Context) (GetAuthorization
 func (c *Client) sendGetAuthorizationAPIGroup(ctx context.Context) (res GetAuthorizationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAuthorizationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/authorization.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -9575,6 +9696,8 @@ func (c *Client) GetAuthorizationV1APIResources(ctx context.Context) (GetAuthori
 func (c *Client) sendGetAuthorizationV1APIResources(ctx context.Context) (res GetAuthorizationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAuthorizationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/authorization.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -9679,6 +9802,8 @@ func (c *Client) GetAutoscalingAPIGroup(ctx context.Context) (GetAutoscalingAPIG
 func (c *Client) sendGetAutoscalingAPIGroup(ctx context.Context) (res GetAutoscalingAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAutoscalingAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/"),
 	}
 
 	// Run stopwatch.
@@ -9783,6 +9908,8 @@ func (c *Client) GetAutoscalingV1APIResources(ctx context.Context) (GetAutoscali
 func (c *Client) sendGetAutoscalingV1APIResources(ctx context.Context) (res GetAutoscalingV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAutoscalingV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/"),
 	}
 
 	// Run stopwatch.
@@ -9887,6 +10014,8 @@ func (c *Client) GetAutoscalingV2beta1APIResources(ctx context.Context) (GetAuto
 func (c *Client) sendGetAutoscalingV2beta1APIResources(ctx context.Context) (res GetAutoscalingV2beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAutoscalingV2beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/"),
 	}
 
 	// Run stopwatch.
@@ -9991,6 +10120,8 @@ func (c *Client) GetAutoscalingV2beta2APIResources(ctx context.Context) (GetAuto
 func (c *Client) sendGetAutoscalingV2beta2APIResources(ctx context.Context) (res GetAutoscalingV2beta2APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getAutoscalingV2beta2APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/"),
 	}
 
 	// Run stopwatch.
@@ -10095,6 +10226,8 @@ func (c *Client) GetBatchAPIGroup(ctx context.Context) (GetBatchAPIGroupRes, err
 func (c *Client) sendGetBatchAPIGroup(ctx context.Context) (res GetBatchAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBatchAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/"),
 	}
 
 	// Run stopwatch.
@@ -10199,6 +10332,8 @@ func (c *Client) GetBatchV1APIResources(ctx context.Context) (GetBatchV1APIResou
 func (c *Client) sendGetBatchV1APIResources(ctx context.Context) (res GetBatchV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBatchV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/"),
 	}
 
 	// Run stopwatch.
@@ -10303,6 +10438,8 @@ func (c *Client) GetBatchV1beta1APIResources(ctx context.Context) (GetBatchV1bet
 func (c *Client) sendGetBatchV1beta1APIResources(ctx context.Context) (res GetBatchV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBatchV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -10407,6 +10544,8 @@ func (c *Client) GetCertificatesAPIGroup(ctx context.Context) (GetCertificatesAP
 func (c *Client) sendGetCertificatesAPIGroup(ctx context.Context) (res GetCertificatesAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCertificatesAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -10511,6 +10650,8 @@ func (c *Client) GetCertificatesV1APIResources(ctx context.Context) (GetCertific
 func (c *Client) sendGetCertificatesV1APIResources(ctx context.Context) (res GetCertificatesV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCertificatesV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -10615,6 +10756,8 @@ func (c *Client) GetCodeVersion(ctx context.Context) (GetCodeVersionRes, error) 
 func (c *Client) sendGetCodeVersion(ctx context.Context) (res GetCodeVersionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCodeVersion"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/version/"),
 	}
 
 	// Run stopwatch.
@@ -10719,6 +10862,8 @@ func (c *Client) GetCoordinationAPIGroup(ctx context.Context) (GetCoordinationAP
 func (c *Client) sendGetCoordinationAPIGroup(ctx context.Context) (res GetCoordinationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCoordinationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -10823,6 +10968,8 @@ func (c *Client) GetCoordinationV1APIResources(ctx context.Context) (GetCoordina
 func (c *Client) sendGetCoordinationV1APIResources(ctx context.Context) (res GetCoordinationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCoordinationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -10927,6 +11074,8 @@ func (c *Client) GetCoreAPIVersions(ctx context.Context) (GetCoreAPIVersionsRes,
 func (c *Client) sendGetCoreAPIVersions(ctx context.Context) (res GetCoreAPIVersionsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCoreAPIVersions"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/"),
 	}
 
 	// Run stopwatch.
@@ -11031,6 +11180,8 @@ func (c *Client) GetCoreV1APIResources(ctx context.Context) (GetCoreV1APIResourc
 func (c *Client) sendGetCoreV1APIResources(ctx context.Context) (res GetCoreV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getCoreV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/"),
 	}
 
 	// Run stopwatch.
@@ -11135,6 +11286,8 @@ func (c *Client) GetDiscoveryAPIGroup(ctx context.Context) (GetDiscoveryAPIGroup
 func (c *Client) sendGetDiscoveryAPIGroup(ctx context.Context) (res GetDiscoveryAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getDiscoveryAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -11239,6 +11392,8 @@ func (c *Client) GetDiscoveryV1APIResources(ctx context.Context) (GetDiscoveryV1
 func (c *Client) sendGetDiscoveryV1APIResources(ctx context.Context) (res GetDiscoveryV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getDiscoveryV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -11343,6 +11498,8 @@ func (c *Client) GetDiscoveryV1beta1APIResources(ctx context.Context) (GetDiscov
 func (c *Client) sendGetDiscoveryV1beta1APIResources(ctx context.Context) (res GetDiscoveryV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getDiscoveryV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -11447,6 +11604,8 @@ func (c *Client) GetEventsAPIGroup(ctx context.Context) (GetEventsAPIGroupRes, e
 func (c *Client) sendGetEventsAPIGroup(ctx context.Context) (res GetEventsAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getEventsAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -11551,6 +11710,8 @@ func (c *Client) GetEventsV1APIResources(ctx context.Context) (GetEventsV1APIRes
 func (c *Client) sendGetEventsV1APIResources(ctx context.Context) (res GetEventsV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getEventsV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -11655,6 +11816,8 @@ func (c *Client) GetEventsV1beta1APIResources(ctx context.Context) (GetEventsV1b
 func (c *Client) sendGetEventsV1beta1APIResources(ctx context.Context) (res GetEventsV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getEventsV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -11759,6 +11922,8 @@ func (c *Client) GetFlowcontrolApiserverAPIGroup(ctx context.Context) (GetFlowco
 func (c *Client) sendGetFlowcontrolApiserverAPIGroup(ctx context.Context) (res GetFlowcontrolApiserverAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getFlowcontrolApiserverAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -11863,6 +12028,8 @@ func (c *Client) GetFlowcontrolApiserverV1beta1APIResources(ctx context.Context)
 func (c *Client) sendGetFlowcontrolApiserverV1beta1APIResources(ctx context.Context) (res GetFlowcontrolApiserverV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getFlowcontrolApiserverV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -11967,6 +12134,8 @@ func (c *Client) GetFlowcontrolApiserverV1beta2APIResources(ctx context.Context)
 func (c *Client) sendGetFlowcontrolApiserverV1beta2APIResources(ctx context.Context) (res GetFlowcontrolApiserverV1beta2APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getFlowcontrolApiserverV1beta2APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/"),
 	}
 
 	// Run stopwatch.
@@ -12071,6 +12240,8 @@ func (c *Client) GetInternalApiserverAPIGroup(ctx context.Context) (GetInternalA
 func (c *Client) sendGetInternalApiserverAPIGroup(ctx context.Context) (res GetInternalApiserverAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getInternalApiserverAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -12175,6 +12346,8 @@ func (c *Client) GetInternalApiserverV1alpha1APIResources(ctx context.Context) (
 func (c *Client) sendGetInternalApiserverV1alpha1APIResources(ctx context.Context) (res GetInternalApiserverV1alpha1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getInternalApiserverV1alpha1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/"),
 	}
 
 	// Run stopwatch.
@@ -12279,6 +12452,8 @@ func (c *Client) GetNetworkingAPIGroup(ctx context.Context) (GetNetworkingAPIGro
 func (c *Client) sendGetNetworkingAPIGroup(ctx context.Context) (res GetNetworkingAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNetworkingAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -12383,6 +12558,8 @@ func (c *Client) GetNetworkingV1APIResources(ctx context.Context) (GetNetworking
 func (c *Client) sendGetNetworkingV1APIResources(ctx context.Context) (res GetNetworkingV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNetworkingV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -12487,6 +12664,8 @@ func (c *Client) GetNodeAPIGroup(ctx context.Context) (GetNodeAPIGroupRes, error
 func (c *Client) sendGetNodeAPIGroup(ctx context.Context) (res GetNodeAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNodeAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -12591,6 +12770,8 @@ func (c *Client) GetNodeV1APIResources(ctx context.Context) (GetNodeV1APIResourc
 func (c *Client) sendGetNodeV1APIResources(ctx context.Context) (res GetNodeV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNodeV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -12695,6 +12876,8 @@ func (c *Client) GetNodeV1alpha1APIResources(ctx context.Context) (GetNodeV1alph
 func (c *Client) sendGetNodeV1alpha1APIResources(ctx context.Context) (res GetNodeV1alpha1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNodeV1alpha1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1alpha1/"),
 	}
 
 	// Run stopwatch.
@@ -12799,6 +12982,8 @@ func (c *Client) GetNodeV1beta1APIResources(ctx context.Context) (GetNodeV1beta1
 func (c *Client) sendGetNodeV1beta1APIResources(ctx context.Context) (res GetNodeV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getNodeV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -12903,6 +13088,8 @@ func (c *Client) GetPolicyAPIGroup(ctx context.Context) (GetPolicyAPIGroupRes, e
 func (c *Client) sendGetPolicyAPIGroup(ctx context.Context) (res GetPolicyAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPolicyAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/"),
 	}
 
 	// Run stopwatch.
@@ -13007,6 +13194,8 @@ func (c *Client) GetPolicyV1APIResources(ctx context.Context) (GetPolicyV1APIRes
 func (c *Client) sendGetPolicyV1APIResources(ctx context.Context) (res GetPolicyV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPolicyV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/"),
 	}
 
 	// Run stopwatch.
@@ -13111,6 +13300,8 @@ func (c *Client) GetPolicyV1beta1APIResources(ctx context.Context) (GetPolicyV1b
 func (c *Client) sendGetPolicyV1beta1APIResources(ctx context.Context) (res GetPolicyV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPolicyV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -13215,6 +13406,8 @@ func (c *Client) GetRbacAuthorizationAPIGroup(ctx context.Context) (GetRbacAutho
 func (c *Client) sendGetRbacAuthorizationAPIGroup(ctx context.Context) (res GetRbacAuthorizationAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getRbacAuthorizationAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -13319,6 +13512,8 @@ func (c *Client) GetRbacAuthorizationV1APIResources(ctx context.Context) (GetRba
 func (c *Client) sendGetRbacAuthorizationV1APIResources(ctx context.Context) (res GetRbacAuthorizationV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getRbacAuthorizationV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -13423,6 +13618,8 @@ func (c *Client) GetSchedulingAPIGroup(ctx context.Context) (GetSchedulingAPIGro
 func (c *Client) sendGetSchedulingAPIGroup(ctx context.Context) (res GetSchedulingAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getSchedulingAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -13527,6 +13724,8 @@ func (c *Client) GetSchedulingV1APIResources(ctx context.Context) (GetScheduling
 func (c *Client) sendGetSchedulingV1APIResources(ctx context.Context) (res GetSchedulingV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getSchedulingV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -13631,6 +13830,8 @@ func (c *Client) GetServiceAccountIssuerOpenIDConfiguration(ctx context.Context)
 func (c *Client) sendGetServiceAccountIssuerOpenIDConfiguration(ctx context.Context) (res GetServiceAccountIssuerOpenIDConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getServiceAccountIssuerOpenIDConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/.well-known/openid-configuration/"),
 	}
 
 	// Run stopwatch.
@@ -13735,6 +13936,8 @@ func (c *Client) GetServiceAccountIssuerOpenIDKeyset(ctx context.Context) (GetSe
 func (c *Client) sendGetServiceAccountIssuerOpenIDKeyset(ctx context.Context) (res GetServiceAccountIssuerOpenIDKeysetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getServiceAccountIssuerOpenIDKeyset"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/openid/v1/jwks/"),
 	}
 
 	// Run stopwatch.
@@ -13839,6 +14042,8 @@ func (c *Client) GetStorageAPIGroup(ctx context.Context) (GetStorageAPIGroupRes,
 func (c *Client) sendGetStorageAPIGroup(ctx context.Context) (res GetStorageAPIGroupRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStorageAPIGroup"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/"),
 	}
 
 	// Run stopwatch.
@@ -13943,6 +14148,8 @@ func (c *Client) GetStorageV1APIResources(ctx context.Context) (GetStorageV1APIR
 func (c *Client) sendGetStorageV1APIResources(ctx context.Context) (res GetStorageV1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStorageV1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/"),
 	}
 
 	// Run stopwatch.
@@ -14047,6 +14254,8 @@ func (c *Client) GetStorageV1alpha1APIResources(ctx context.Context) (GetStorage
 func (c *Client) sendGetStorageV1alpha1APIResources(ctx context.Context) (res GetStorageV1alpha1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStorageV1alpha1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/"),
 	}
 
 	// Run stopwatch.
@@ -14151,6 +14360,8 @@ func (c *Client) GetStorageV1beta1APIResources(ctx context.Context) (GetStorageV
 func (c *Client) sendGetStorageV1beta1APIResources(ctx context.Context) (res GetStorageV1beta1APIResourcesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStorageV1beta1APIResources"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/"),
 	}
 
 	// Run stopwatch.
@@ -14255,6 +14466,8 @@ func (c *Client) ListAdmissionregistrationV1MutatingWebhookConfiguration(ctx con
 func (c *Client) sendListAdmissionregistrationV1MutatingWebhookConfiguration(ctx context.Context, params ListAdmissionregistrationV1MutatingWebhookConfigurationParams) (res ListAdmissionregistrationV1MutatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAdmissionregistrationV1MutatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -14533,6 +14746,8 @@ func (c *Client) ListAdmissionregistrationV1ValidatingWebhookConfiguration(ctx c
 func (c *Client) sendListAdmissionregistrationV1ValidatingWebhookConfiguration(ctx context.Context, params ListAdmissionregistrationV1ValidatingWebhookConfigurationParams) (res ListAdmissionregistrationV1ValidatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAdmissionregistrationV1ValidatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -14811,6 +15026,8 @@ func (c *Client) ListApiextensionsV1CustomResourceDefinition(ctx context.Context
 func (c *Client) sendListApiextensionsV1CustomResourceDefinition(ctx context.Context, params ListApiextensionsV1CustomResourceDefinitionParams) (res ListApiextensionsV1CustomResourceDefinitionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listApiextensionsV1CustomResourceDefinition"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/customresourcedefinitions"),
 	}
 
 	// Run stopwatch.
@@ -15089,6 +15306,8 @@ func (c *Client) ListApiregistrationV1APIService(ctx context.Context, params Lis
 func (c *Client) sendListApiregistrationV1APIService(ctx context.Context, params ListApiregistrationV1APIServiceParams) (res ListApiregistrationV1APIServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listApiregistrationV1APIService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/apiservices"),
 	}
 
 	// Run stopwatch.
@@ -15367,6 +15586,8 @@ func (c *Client) ListAppsV1ControllerRevisionForAllNamespaces(ctx context.Contex
 func (c *Client) sendListAppsV1ControllerRevisionForAllNamespaces(ctx context.Context, params ListAppsV1ControllerRevisionForAllNamespacesParams) (res ListAppsV1ControllerRevisionForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1ControllerRevisionForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/controllerrevisions"),
 	}
 
 	// Run stopwatch.
@@ -15645,6 +15866,8 @@ func (c *Client) ListAppsV1DaemonSetForAllNamespaces(ctx context.Context, params
 func (c *Client) sendListAppsV1DaemonSetForAllNamespaces(ctx context.Context, params ListAppsV1DaemonSetForAllNamespacesParams) (res ListAppsV1DaemonSetForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1DaemonSetForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/daemonsets"),
 	}
 
 	// Run stopwatch.
@@ -15923,6 +16146,8 @@ func (c *Client) ListAppsV1DeploymentForAllNamespaces(ctx context.Context, param
 func (c *Client) sendListAppsV1DeploymentForAllNamespaces(ctx context.Context, params ListAppsV1DeploymentForAllNamespacesParams) (res ListAppsV1DeploymentForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1DeploymentForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/deployments"),
 	}
 
 	// Run stopwatch.
@@ -16201,6 +16426,8 @@ func (c *Client) ListAppsV1NamespacedControllerRevision(ctx context.Context, par
 func (c *Client) sendListAppsV1NamespacedControllerRevision(ctx context.Context, params ListAppsV1NamespacedControllerRevisionParams) (res ListAppsV1NamespacedControllerRevisionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1NamespacedControllerRevision"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/controllerrevisions"),
 	}
 
 	// Run stopwatch.
@@ -16498,6 +16725,8 @@ func (c *Client) ListAppsV1NamespacedDaemonSet(ctx context.Context, params ListA
 func (c *Client) sendListAppsV1NamespacedDaemonSet(ctx context.Context, params ListAppsV1NamespacedDaemonSetParams) (res ListAppsV1NamespacedDaemonSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1NamespacedDaemonSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/daemonsets"),
 	}
 
 	// Run stopwatch.
@@ -16795,6 +17024,8 @@ func (c *Client) ListAppsV1NamespacedDeployment(ctx context.Context, params List
 func (c *Client) sendListAppsV1NamespacedDeployment(ctx context.Context, params ListAppsV1NamespacedDeploymentParams) (res ListAppsV1NamespacedDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1NamespacedDeployment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/deployments"),
 	}
 
 	// Run stopwatch.
@@ -17092,6 +17323,8 @@ func (c *Client) ListAppsV1NamespacedReplicaSet(ctx context.Context, params List
 func (c *Client) sendListAppsV1NamespacedReplicaSet(ctx context.Context, params ListAppsV1NamespacedReplicaSetParams) (res ListAppsV1NamespacedReplicaSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1NamespacedReplicaSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/replicasets"),
 	}
 
 	// Run stopwatch.
@@ -17389,6 +17622,8 @@ func (c *Client) ListAppsV1NamespacedStatefulSet(ctx context.Context, params Lis
 func (c *Client) sendListAppsV1NamespacedStatefulSet(ctx context.Context, params ListAppsV1NamespacedStatefulSetParams) (res ListAppsV1NamespacedStatefulSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1NamespacedStatefulSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/statefulsets"),
 	}
 
 	// Run stopwatch.
@@ -17686,6 +17921,8 @@ func (c *Client) ListAppsV1ReplicaSetForAllNamespaces(ctx context.Context, param
 func (c *Client) sendListAppsV1ReplicaSetForAllNamespaces(ctx context.Context, params ListAppsV1ReplicaSetForAllNamespacesParams) (res ListAppsV1ReplicaSetForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1ReplicaSetForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/replicasets"),
 	}
 
 	// Run stopwatch.
@@ -17964,6 +18201,8 @@ func (c *Client) ListAppsV1StatefulSetForAllNamespaces(ctx context.Context, para
 func (c *Client) sendListAppsV1StatefulSetForAllNamespaces(ctx context.Context, params ListAppsV1StatefulSetForAllNamespacesParams) (res ListAppsV1StatefulSetForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAppsV1StatefulSetForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/statefulsets"),
 	}
 
 	// Run stopwatch.
@@ -18242,6 +18481,8 @@ func (c *Client) ListAutoscalingV1HorizontalPodAutoscalerForAllNamespaces(ctx co
 func (c *Client) sendListAutoscalingV1HorizontalPodAutoscalerForAllNamespaces(ctx context.Context, params ListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesParams) (res ListAutoscalingV1HorizontalPodAutoscalerForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -18520,6 +18761,8 @@ func (c *Client) ListAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context.
 func (c *Client) sendListAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context.Context, params ListAutoscalingV1NamespacedHorizontalPodAutoscalerParams) (res ListAutoscalingV1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -18817,6 +19060,8 @@ func (c *Client) ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces(c
 func (c *Client) sendListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces(ctx context.Context, params ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesParams) (res ListAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -19095,6 +19340,8 @@ func (c *Client) ListAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx con
 func (c *Client) sendListAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx context.Context, params ListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams) (res ListAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV2beta1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -19392,6 +19639,8 @@ func (c *Client) ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces(c
 func (c *Client) sendListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces(ctx context.Context, params ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesParams) (res ListAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -19670,6 +19919,8 @@ func (c *Client) ListAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx con
 func (c *Client) sendListAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx context.Context, params ListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams) (res ListAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listAutoscalingV2beta2NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -19967,6 +20218,8 @@ func (c *Client) ListBatchV1CronJobForAllNamespaces(ctx context.Context, params 
 func (c *Client) sendListBatchV1CronJobForAllNamespaces(ctx context.Context, params ListBatchV1CronJobForAllNamespacesParams) (res ListBatchV1CronJobForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1CronJobForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -20245,6 +20498,8 @@ func (c *Client) ListBatchV1JobForAllNamespaces(ctx context.Context, params List
 func (c *Client) sendListBatchV1JobForAllNamespaces(ctx context.Context, params ListBatchV1JobForAllNamespacesParams) (res ListBatchV1JobForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1JobForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/jobs"),
 	}
 
 	// Run stopwatch.
@@ -20523,6 +20778,8 @@ func (c *Client) ListBatchV1NamespacedCronJob(ctx context.Context, params ListBa
 func (c *Client) sendListBatchV1NamespacedCronJob(ctx context.Context, params ListBatchV1NamespacedCronJobParams) (res ListBatchV1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -20820,6 +21077,8 @@ func (c *Client) ListBatchV1NamespacedJob(ctx context.Context, params ListBatchV
 func (c *Client) sendListBatchV1NamespacedJob(ctx context.Context, params ListBatchV1NamespacedJobParams) (res ListBatchV1NamespacedJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1NamespacedJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/jobs"),
 	}
 
 	// Run stopwatch.
@@ -21117,6 +21376,8 @@ func (c *Client) ListBatchV1beta1CronJobForAllNamespaces(ctx context.Context, pa
 func (c *Client) sendListBatchV1beta1CronJobForAllNamespaces(ctx context.Context, params ListBatchV1beta1CronJobForAllNamespacesParams) (res ListBatchV1beta1CronJobForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1beta1CronJobForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -21395,6 +21656,8 @@ func (c *Client) ListBatchV1beta1NamespacedCronJob(ctx context.Context, params L
 func (c *Client) sendListBatchV1beta1NamespacedCronJob(ctx context.Context, params ListBatchV1beta1NamespacedCronJobParams) (res ListBatchV1beta1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listBatchV1beta1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -21692,6 +21955,8 @@ func (c *Client) ListCertificatesV1CertificateSigningRequest(ctx context.Context
 func (c *Client) sendListCertificatesV1CertificateSigningRequest(ctx context.Context, params ListCertificatesV1CertificateSigningRequestParams) (res ListCertificatesV1CertificateSigningRequestRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCertificatesV1CertificateSigningRequest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/certificatesigningrequests"),
 	}
 
 	// Run stopwatch.
@@ -21970,6 +22235,8 @@ func (c *Client) ListCoordinationV1LeaseForAllNamespaces(ctx context.Context, pa
 func (c *Client) sendListCoordinationV1LeaseForAllNamespaces(ctx context.Context, params ListCoordinationV1LeaseForAllNamespacesParams) (res ListCoordinationV1LeaseForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoordinationV1LeaseForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/leases"),
 	}
 
 	// Run stopwatch.
@@ -22248,6 +22515,8 @@ func (c *Client) ListCoordinationV1NamespacedLease(ctx context.Context, params L
 func (c *Client) sendListCoordinationV1NamespacedLease(ctx context.Context, params ListCoordinationV1NamespacedLeaseParams) (res ListCoordinationV1NamespacedLeaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoordinationV1NamespacedLease"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/namespaces/{namespace}/leases"),
 	}
 
 	// Run stopwatch.
@@ -22545,6 +22814,8 @@ func (c *Client) ListCoreV1ComponentStatus(ctx context.Context, params ListCoreV
 func (c *Client) sendListCoreV1ComponentStatus(ctx context.Context, params ListCoreV1ComponentStatusParams) (res ListCoreV1ComponentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ComponentStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/componentstatuses"),
 	}
 
 	// Run stopwatch.
@@ -22823,6 +23094,8 @@ func (c *Client) ListCoreV1ConfigMapForAllNamespaces(ctx context.Context, params
 func (c *Client) sendListCoreV1ConfigMapForAllNamespaces(ctx context.Context, params ListCoreV1ConfigMapForAllNamespacesParams) (res ListCoreV1ConfigMapForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ConfigMapForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/configmaps"),
 	}
 
 	// Run stopwatch.
@@ -23101,6 +23374,8 @@ func (c *Client) ListCoreV1EndpointsForAllNamespaces(ctx context.Context, params
 func (c *Client) sendListCoreV1EndpointsForAllNamespaces(ctx context.Context, params ListCoreV1EndpointsForAllNamespacesParams) (res ListCoreV1EndpointsForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1EndpointsForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/endpoints"),
 	}
 
 	// Run stopwatch.
@@ -23379,6 +23654,8 @@ func (c *Client) ListCoreV1EventForAllNamespaces(ctx context.Context, params Lis
 func (c *Client) sendListCoreV1EventForAllNamespaces(ctx context.Context, params ListCoreV1EventForAllNamespacesParams) (res ListCoreV1EventForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1EventForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/events"),
 	}
 
 	// Run stopwatch.
@@ -23657,6 +23934,8 @@ func (c *Client) ListCoreV1LimitRangeForAllNamespaces(ctx context.Context, param
 func (c *Client) sendListCoreV1LimitRangeForAllNamespaces(ctx context.Context, params ListCoreV1LimitRangeForAllNamespacesParams) (res ListCoreV1LimitRangeForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1LimitRangeForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/limitranges"),
 	}
 
 	// Run stopwatch.
@@ -23935,6 +24214,8 @@ func (c *Client) ListCoreV1Namespace(ctx context.Context, params ListCoreV1Names
 func (c *Client) sendListCoreV1Namespace(ctx context.Context, params ListCoreV1NamespaceParams) (res ListCoreV1NamespaceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1Namespace"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces"),
 	}
 
 	// Run stopwatch.
@@ -24213,6 +24494,8 @@ func (c *Client) ListCoreV1NamespacedConfigMap(ctx context.Context, params ListC
 func (c *Client) sendListCoreV1NamespacedConfigMap(ctx context.Context, params ListCoreV1NamespacedConfigMapParams) (res ListCoreV1NamespacedConfigMapRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedConfigMap"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/configmaps"),
 	}
 
 	// Run stopwatch.
@@ -24510,6 +24793,8 @@ func (c *Client) ListCoreV1NamespacedEndpoints(ctx context.Context, params ListC
 func (c *Client) sendListCoreV1NamespacedEndpoints(ctx context.Context, params ListCoreV1NamespacedEndpointsParams) (res ListCoreV1NamespacedEndpointsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedEndpoints"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/endpoints"),
 	}
 
 	// Run stopwatch.
@@ -24807,6 +25092,8 @@ func (c *Client) ListCoreV1NamespacedEvent(ctx context.Context, params ListCoreV
 func (c *Client) sendListCoreV1NamespacedEvent(ctx context.Context, params ListCoreV1NamespacedEventParams) (res ListCoreV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -25104,6 +25391,8 @@ func (c *Client) ListCoreV1NamespacedLimitRange(ctx context.Context, params List
 func (c *Client) sendListCoreV1NamespacedLimitRange(ctx context.Context, params ListCoreV1NamespacedLimitRangeParams) (res ListCoreV1NamespacedLimitRangeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedLimitRange"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/limitranges"),
 	}
 
 	// Run stopwatch.
@@ -25401,6 +25690,8 @@ func (c *Client) ListCoreV1NamespacedPersistentVolumeClaim(ctx context.Context, 
 func (c *Client) sendListCoreV1NamespacedPersistentVolumeClaim(ctx context.Context, params ListCoreV1NamespacedPersistentVolumeClaimParams) (res ListCoreV1NamespacedPersistentVolumeClaimRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedPersistentVolumeClaim"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/persistentvolumeclaims"),
 	}
 
 	// Run stopwatch.
@@ -25698,6 +25989,8 @@ func (c *Client) ListCoreV1NamespacedPod(ctx context.Context, params ListCoreV1N
 func (c *Client) sendListCoreV1NamespacedPod(ctx context.Context, params ListCoreV1NamespacedPodParams) (res ListCoreV1NamespacedPodRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedPod"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods"),
 	}
 
 	// Run stopwatch.
@@ -25995,6 +26288,8 @@ func (c *Client) ListCoreV1NamespacedPodTemplate(ctx context.Context, params Lis
 func (c *Client) sendListCoreV1NamespacedPodTemplate(ctx context.Context, params ListCoreV1NamespacedPodTemplateParams) (res ListCoreV1NamespacedPodTemplateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedPodTemplate"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/podtemplates"),
 	}
 
 	// Run stopwatch.
@@ -26292,6 +26587,8 @@ func (c *Client) ListCoreV1NamespacedReplicationController(ctx context.Context, 
 func (c *Client) sendListCoreV1NamespacedReplicationController(ctx context.Context, params ListCoreV1NamespacedReplicationControllerParams) (res ListCoreV1NamespacedReplicationControllerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedReplicationController"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/replicationcontrollers"),
 	}
 
 	// Run stopwatch.
@@ -26589,6 +26886,8 @@ func (c *Client) ListCoreV1NamespacedResourceQuota(ctx context.Context, params L
 func (c *Client) sendListCoreV1NamespacedResourceQuota(ctx context.Context, params ListCoreV1NamespacedResourceQuotaParams) (res ListCoreV1NamespacedResourceQuotaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedResourceQuota"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/resourcequotas"),
 	}
 
 	// Run stopwatch.
@@ -26886,6 +27185,8 @@ func (c *Client) ListCoreV1NamespacedSecret(ctx context.Context, params ListCore
 func (c *Client) sendListCoreV1NamespacedSecret(ctx context.Context, params ListCoreV1NamespacedSecretParams) (res ListCoreV1NamespacedSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedSecret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/secrets"),
 	}
 
 	// Run stopwatch.
@@ -27183,6 +27484,8 @@ func (c *Client) ListCoreV1NamespacedService(ctx context.Context, params ListCor
 func (c *Client) sendListCoreV1NamespacedService(ctx context.Context, params ListCoreV1NamespacedServiceParams) (res ListCoreV1NamespacedServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services"),
 	}
 
 	// Run stopwatch.
@@ -27480,6 +27783,8 @@ func (c *Client) ListCoreV1NamespacedServiceAccount(ctx context.Context, params 
 func (c *Client) sendListCoreV1NamespacedServiceAccount(ctx context.Context, params ListCoreV1NamespacedServiceAccountParams) (res ListCoreV1NamespacedServiceAccountRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1NamespacedServiceAccount"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/serviceaccounts"),
 	}
 
 	// Run stopwatch.
@@ -27777,6 +28082,8 @@ func (c *Client) ListCoreV1Node(ctx context.Context, params ListCoreV1NodeParams
 func (c *Client) sendListCoreV1Node(ctx context.Context, params ListCoreV1NodeParams) (res ListCoreV1NodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1Node"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes"),
 	}
 
 	// Run stopwatch.
@@ -28055,6 +28362,8 @@ func (c *Client) ListCoreV1PersistentVolume(ctx context.Context, params ListCore
 func (c *Client) sendListCoreV1PersistentVolume(ctx context.Context, params ListCoreV1PersistentVolumeParams) (res ListCoreV1PersistentVolumeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1PersistentVolume"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/persistentvolumes"),
 	}
 
 	// Run stopwatch.
@@ -28333,6 +28642,8 @@ func (c *Client) ListCoreV1PersistentVolumeClaimForAllNamespaces(ctx context.Con
 func (c *Client) sendListCoreV1PersistentVolumeClaimForAllNamespaces(ctx context.Context, params ListCoreV1PersistentVolumeClaimForAllNamespacesParams) (res ListCoreV1PersistentVolumeClaimForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1PersistentVolumeClaimForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/persistentvolumeclaims"),
 	}
 
 	// Run stopwatch.
@@ -28611,6 +28922,8 @@ func (c *Client) ListCoreV1PodForAllNamespaces(ctx context.Context, params ListC
 func (c *Client) sendListCoreV1PodForAllNamespaces(ctx context.Context, params ListCoreV1PodForAllNamespacesParams) (res ListCoreV1PodForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1PodForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/pods"),
 	}
 
 	// Run stopwatch.
@@ -28889,6 +29202,8 @@ func (c *Client) ListCoreV1PodTemplateForAllNamespaces(ctx context.Context, para
 func (c *Client) sendListCoreV1PodTemplateForAllNamespaces(ctx context.Context, params ListCoreV1PodTemplateForAllNamespacesParams) (res ListCoreV1PodTemplateForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1PodTemplateForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/podtemplates"),
 	}
 
 	// Run stopwatch.
@@ -29167,6 +29482,8 @@ func (c *Client) ListCoreV1ReplicationControllerForAllNamespaces(ctx context.Con
 func (c *Client) sendListCoreV1ReplicationControllerForAllNamespaces(ctx context.Context, params ListCoreV1ReplicationControllerForAllNamespacesParams) (res ListCoreV1ReplicationControllerForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ReplicationControllerForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/replicationcontrollers"),
 	}
 
 	// Run stopwatch.
@@ -29445,6 +29762,8 @@ func (c *Client) ListCoreV1ResourceQuotaForAllNamespaces(ctx context.Context, pa
 func (c *Client) sendListCoreV1ResourceQuotaForAllNamespaces(ctx context.Context, params ListCoreV1ResourceQuotaForAllNamespacesParams) (res ListCoreV1ResourceQuotaForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ResourceQuotaForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/resourcequotas"),
 	}
 
 	// Run stopwatch.
@@ -29723,6 +30042,8 @@ func (c *Client) ListCoreV1SecretForAllNamespaces(ctx context.Context, params Li
 func (c *Client) sendListCoreV1SecretForAllNamespaces(ctx context.Context, params ListCoreV1SecretForAllNamespacesParams) (res ListCoreV1SecretForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1SecretForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/secrets"),
 	}
 
 	// Run stopwatch.
@@ -30001,6 +30322,8 @@ func (c *Client) ListCoreV1ServiceAccountForAllNamespaces(ctx context.Context, p
 func (c *Client) sendListCoreV1ServiceAccountForAllNamespaces(ctx context.Context, params ListCoreV1ServiceAccountForAllNamespacesParams) (res ListCoreV1ServiceAccountForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ServiceAccountForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/serviceaccounts"),
 	}
 
 	// Run stopwatch.
@@ -30279,6 +30602,8 @@ func (c *Client) ListCoreV1ServiceForAllNamespaces(ctx context.Context, params L
 func (c *Client) sendListCoreV1ServiceForAllNamespaces(ctx context.Context, params ListCoreV1ServiceForAllNamespacesParams) (res ListCoreV1ServiceForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listCoreV1ServiceForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/services"),
 	}
 
 	// Run stopwatch.
@@ -30557,6 +30882,8 @@ func (c *Client) ListDiscoveryV1EndpointSliceForAllNamespaces(ctx context.Contex
 func (c *Client) sendListDiscoveryV1EndpointSliceForAllNamespaces(ctx context.Context, params ListDiscoveryV1EndpointSliceForAllNamespacesParams) (res ListDiscoveryV1EndpointSliceForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listDiscoveryV1EndpointSliceForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -30835,6 +31162,8 @@ func (c *Client) ListDiscoveryV1NamespacedEndpointSlice(ctx context.Context, par
 func (c *Client) sendListDiscoveryV1NamespacedEndpointSlice(ctx context.Context, params ListDiscoveryV1NamespacedEndpointSliceParams) (res ListDiscoveryV1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listDiscoveryV1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/namespaces/{namespace}/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -31132,6 +31461,8 @@ func (c *Client) ListDiscoveryV1beta1EndpointSliceForAllNamespaces(ctx context.C
 func (c *Client) sendListDiscoveryV1beta1EndpointSliceForAllNamespaces(ctx context.Context, params ListDiscoveryV1beta1EndpointSliceForAllNamespacesParams) (res ListDiscoveryV1beta1EndpointSliceForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listDiscoveryV1beta1EndpointSliceForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -31410,6 +31741,8 @@ func (c *Client) ListDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Context
 func (c *Client) sendListDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Context, params ListDiscoveryV1beta1NamespacedEndpointSliceParams) (res ListDiscoveryV1beta1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listDiscoveryV1beta1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -31707,6 +32040,8 @@ func (c *Client) ListEventsV1EventForAllNamespaces(ctx context.Context, params L
 func (c *Client) sendListEventsV1EventForAllNamespaces(ctx context.Context, params ListEventsV1EventForAllNamespacesParams) (res ListEventsV1EventForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listEventsV1EventForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/events"),
 	}
 
 	// Run stopwatch.
@@ -31985,6 +32320,8 @@ func (c *Client) ListEventsV1NamespacedEvent(ctx context.Context, params ListEve
 func (c *Client) sendListEventsV1NamespacedEvent(ctx context.Context, params ListEventsV1NamespacedEventParams) (res ListEventsV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listEventsV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -32282,6 +32619,8 @@ func (c *Client) ListEventsV1beta1EventForAllNamespaces(ctx context.Context, par
 func (c *Client) sendListEventsV1beta1EventForAllNamespaces(ctx context.Context, params ListEventsV1beta1EventForAllNamespacesParams) (res ListEventsV1beta1EventForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listEventsV1beta1EventForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/events"),
 	}
 
 	// Run stopwatch.
@@ -32560,6 +32899,8 @@ func (c *Client) ListEventsV1beta1NamespacedEvent(ctx context.Context, params Li
 func (c *Client) sendListEventsV1beta1NamespacedEvent(ctx context.Context, params ListEventsV1beta1NamespacedEventParams) (res ListEventsV1beta1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listEventsV1beta1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -32857,6 +33198,8 @@ func (c *Client) ListFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context, 
 func (c *Client) sendListFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context, params ListFlowcontrolApiserverV1beta1FlowSchemaParams) (res ListFlowcontrolApiserverV1beta1FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFlowcontrolApiserverV1beta1FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas"),
 	}
 
 	// Run stopwatch.
@@ -33135,6 +33478,8 @@ func (c *Client) ListFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx c
 func (c *Client) sendListFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx context.Context, params ListFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams) (res ListFlowcontrolApiserverV1beta1PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFlowcontrolApiserverV1beta1PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -33413,6 +33758,8 @@ func (c *Client) ListFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context, 
 func (c *Client) sendListFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context, params ListFlowcontrolApiserverV1beta2FlowSchemaParams) (res ListFlowcontrolApiserverV1beta2FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFlowcontrolApiserverV1beta2FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas"),
 	}
 
 	// Run stopwatch.
@@ -33691,6 +34038,8 @@ func (c *Client) ListFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx c
 func (c *Client) sendListFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx context.Context, params ListFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams) (res ListFlowcontrolApiserverV1beta2PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFlowcontrolApiserverV1beta2PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -33969,6 +34318,8 @@ func (c *Client) ListInternalApiserverV1alpha1StorageVersion(ctx context.Context
 func (c *Client) sendListInternalApiserverV1alpha1StorageVersion(ctx context.Context, params ListInternalApiserverV1alpha1StorageVersionParams) (res ListInternalApiserverV1alpha1StorageVersionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listInternalApiserverV1alpha1StorageVersion"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions"),
 	}
 
 	// Run stopwatch.
@@ -34247,6 +34598,8 @@ func (c *Client) ListNetworkingV1IngressClass(ctx context.Context, params ListNe
 func (c *Client) sendListNetworkingV1IngressClass(ctx context.Context, params ListNetworkingV1IngressClassParams) (res ListNetworkingV1IngressClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNetworkingV1IngressClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/ingressclasses"),
 	}
 
 	// Run stopwatch.
@@ -34525,6 +34878,8 @@ func (c *Client) ListNetworkingV1IngressForAllNamespaces(ctx context.Context, pa
 func (c *Client) sendListNetworkingV1IngressForAllNamespaces(ctx context.Context, params ListNetworkingV1IngressForAllNamespacesParams) (res ListNetworkingV1IngressForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNetworkingV1IngressForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/ingresses"),
 	}
 
 	// Run stopwatch.
@@ -34803,6 +35158,8 @@ func (c *Client) ListNetworkingV1NamespacedIngress(ctx context.Context, params L
 func (c *Client) sendListNetworkingV1NamespacedIngress(ctx context.Context, params ListNetworkingV1NamespacedIngressParams) (res ListNetworkingV1NamespacedIngressRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNetworkingV1NamespacedIngress"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses"),
 	}
 
 	// Run stopwatch.
@@ -35100,6 +35457,8 @@ func (c *Client) ListNetworkingV1NamespacedNetworkPolicy(ctx context.Context, pa
 func (c *Client) sendListNetworkingV1NamespacedNetworkPolicy(ctx context.Context, params ListNetworkingV1NamespacedNetworkPolicyParams) (res ListNetworkingV1NamespacedNetworkPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNetworkingV1NamespacedNetworkPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies"),
 	}
 
 	// Run stopwatch.
@@ -35397,6 +35756,8 @@ func (c *Client) ListNetworkingV1NetworkPolicyForAllNamespaces(ctx context.Conte
 func (c *Client) sendListNetworkingV1NetworkPolicyForAllNamespaces(ctx context.Context, params ListNetworkingV1NetworkPolicyForAllNamespacesParams) (res ListNetworkingV1NetworkPolicyForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNetworkingV1NetworkPolicyForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/networkpolicies"),
 	}
 
 	// Run stopwatch.
@@ -35675,6 +36036,8 @@ func (c *Client) ListNodeV1RuntimeClass(ctx context.Context, params ListNodeV1Ru
 func (c *Client) sendListNodeV1RuntimeClass(ctx context.Context, params ListNodeV1RuntimeClassParams) (res ListNodeV1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNodeV1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -35953,6 +36316,8 @@ func (c *Client) ListNodeV1alpha1RuntimeClass(ctx context.Context, params ListNo
 func (c *Client) sendListNodeV1alpha1RuntimeClass(ctx context.Context, params ListNodeV1alpha1RuntimeClassParams) (res ListNodeV1alpha1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNodeV1alpha1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1alpha1/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -36231,6 +36596,8 @@ func (c *Client) ListNodeV1beta1RuntimeClass(ctx context.Context, params ListNod
 func (c *Client) sendListNodeV1beta1RuntimeClass(ctx context.Context, params ListNodeV1beta1RuntimeClassParams) (res ListNodeV1beta1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listNodeV1beta1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1beta1/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -36509,6 +36876,8 @@ func (c *Client) ListPolicyV1NamespacedPodDisruptionBudget(ctx context.Context, 
 func (c *Client) sendListPolicyV1NamespacedPodDisruptionBudget(ctx context.Context, params ListPolicyV1NamespacedPodDisruptionBudgetParams) (res ListPolicyV1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPolicyV1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -36806,6 +37175,8 @@ func (c *Client) ListPolicyV1PodDisruptionBudgetForAllNamespaces(ctx context.Con
 func (c *Client) sendListPolicyV1PodDisruptionBudgetForAllNamespaces(ctx context.Context, params ListPolicyV1PodDisruptionBudgetForAllNamespacesParams) (res ListPolicyV1PodDisruptionBudgetForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPolicyV1PodDisruptionBudgetForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -37084,6 +37455,8 @@ func (c *Client) ListPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Cont
 func (c *Client) sendListPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Context, params ListPolicyV1beta1NamespacedPodDisruptionBudgetParams) (res ListPolicyV1beta1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPolicyV1beta1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -37381,6 +37754,8 @@ func (c *Client) ListPolicyV1beta1PodDisruptionBudgetForAllNamespaces(ctx contex
 func (c *Client) sendListPolicyV1beta1PodDisruptionBudgetForAllNamespaces(ctx context.Context, params ListPolicyV1beta1PodDisruptionBudgetForAllNamespacesParams) (res ListPolicyV1beta1PodDisruptionBudgetForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPolicyV1beta1PodDisruptionBudgetForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -37659,6 +38034,8 @@ func (c *Client) ListPolicyV1beta1PodSecurityPolicy(ctx context.Context, params 
 func (c *Client) sendListPolicyV1beta1PodSecurityPolicy(ctx context.Context, params ListPolicyV1beta1PodSecurityPolicyParams) (res ListPolicyV1beta1PodSecurityPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPolicyV1beta1PodSecurityPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/podsecuritypolicies"),
 	}
 
 	// Run stopwatch.
@@ -37937,6 +38314,8 @@ func (c *Client) ListRbacAuthorizationV1ClusterRole(ctx context.Context, params 
 func (c *Client) sendListRbacAuthorizationV1ClusterRole(ctx context.Context, params ListRbacAuthorizationV1ClusterRoleParams) (res ListRbacAuthorizationV1ClusterRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1ClusterRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/clusterroles"),
 	}
 
 	// Run stopwatch.
@@ -38215,6 +38594,8 @@ func (c *Client) ListRbacAuthorizationV1ClusterRoleBinding(ctx context.Context, 
 func (c *Client) sendListRbacAuthorizationV1ClusterRoleBinding(ctx context.Context, params ListRbacAuthorizationV1ClusterRoleBindingParams) (res ListRbacAuthorizationV1ClusterRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1ClusterRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings"),
 	}
 
 	// Run stopwatch.
@@ -38493,6 +38874,8 @@ func (c *Client) ListRbacAuthorizationV1NamespacedRole(ctx context.Context, para
 func (c *Client) sendListRbacAuthorizationV1NamespacedRole(ctx context.Context, params ListRbacAuthorizationV1NamespacedRoleParams) (res ListRbacAuthorizationV1NamespacedRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1NamespacedRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles"),
 	}
 
 	// Run stopwatch.
@@ -38790,6 +39173,8 @@ func (c *Client) ListRbacAuthorizationV1NamespacedRoleBinding(ctx context.Contex
 func (c *Client) sendListRbacAuthorizationV1NamespacedRoleBinding(ctx context.Context, params ListRbacAuthorizationV1NamespacedRoleBindingParams) (res ListRbacAuthorizationV1NamespacedRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1NamespacedRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings"),
 	}
 
 	// Run stopwatch.
@@ -39087,6 +39472,8 @@ func (c *Client) ListRbacAuthorizationV1RoleBindingForAllNamespaces(ctx context.
 func (c *Client) sendListRbacAuthorizationV1RoleBindingForAllNamespaces(ctx context.Context, params ListRbacAuthorizationV1RoleBindingForAllNamespacesParams) (res ListRbacAuthorizationV1RoleBindingForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1RoleBindingForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/rolebindings"),
 	}
 
 	// Run stopwatch.
@@ -39365,6 +39752,8 @@ func (c *Client) ListRbacAuthorizationV1RoleForAllNamespaces(ctx context.Context
 func (c *Client) sendListRbacAuthorizationV1RoleForAllNamespaces(ctx context.Context, params ListRbacAuthorizationV1RoleForAllNamespacesParams) (res ListRbacAuthorizationV1RoleForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listRbacAuthorizationV1RoleForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/roles"),
 	}
 
 	// Run stopwatch.
@@ -39643,6 +40032,8 @@ func (c *Client) ListSchedulingV1PriorityClass(ctx context.Context, params ListS
 func (c *Client) sendListSchedulingV1PriorityClass(ctx context.Context, params ListSchedulingV1PriorityClassParams) (res ListSchedulingV1PriorityClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listSchedulingV1PriorityClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/v1/priorityclasses"),
 	}
 
 	// Run stopwatch.
@@ -39921,6 +40312,8 @@ func (c *Client) ListStorageV1CSIDriver(ctx context.Context, params ListStorageV
 func (c *Client) sendListStorageV1CSIDriver(ctx context.Context, params ListStorageV1CSIDriverParams) (res ListStorageV1CSIDriverRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1CSIDriver"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/csidrivers"),
 	}
 
 	// Run stopwatch.
@@ -40199,6 +40592,8 @@ func (c *Client) ListStorageV1CSINode(ctx context.Context, params ListStorageV1C
 func (c *Client) sendListStorageV1CSINode(ctx context.Context, params ListStorageV1CSINodeParams) (res ListStorageV1CSINodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1CSINode"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/csinodes"),
 	}
 
 	// Run stopwatch.
@@ -40477,6 +40872,8 @@ func (c *Client) ListStorageV1StorageClass(ctx context.Context, params ListStora
 func (c *Client) sendListStorageV1StorageClass(ctx context.Context, params ListStorageV1StorageClassParams) (res ListStorageV1StorageClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1StorageClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/storageclasses"),
 	}
 
 	// Run stopwatch.
@@ -40755,6 +41152,8 @@ func (c *Client) ListStorageV1VolumeAttachment(ctx context.Context, params ListS
 func (c *Client) sendListStorageV1VolumeAttachment(ctx context.Context, params ListStorageV1VolumeAttachmentParams) (res ListStorageV1VolumeAttachmentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1VolumeAttachment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/volumeattachments"),
 	}
 
 	// Run stopwatch.
@@ -41033,6 +41432,8 @@ func (c *Client) ListStorageV1alpha1CSIStorageCapacityForAllNamespaces(ctx conte
 func (c *Client) sendListStorageV1alpha1CSIStorageCapacityForAllNamespaces(ctx context.Context, params ListStorageV1alpha1CSIStorageCapacityForAllNamespacesParams) (res ListStorageV1alpha1CSIStorageCapacityForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1alpha1CSIStorageCapacityForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -41311,6 +41712,8 @@ func (c *Client) ListStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Con
 func (c *Client) sendListStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Context, params ListStorageV1alpha1NamespacedCSIStorageCapacityParams) (res ListStorageV1alpha1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1alpha1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/namespaces/{namespace}/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -41608,6 +42011,8 @@ func (c *Client) ListStorageV1beta1CSIStorageCapacityForAllNamespaces(ctx contex
 func (c *Client) sendListStorageV1beta1CSIStorageCapacityForAllNamespaces(ctx context.Context, params ListStorageV1beta1CSIStorageCapacityForAllNamespacesParams) (res ListStorageV1beta1CSIStorageCapacityForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1beta1CSIStorageCapacityForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -41886,6 +42291,8 @@ func (c *Client) ListStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Cont
 func (c *Client) sendListStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Context, params ListStorageV1beta1NamespacedCSIStorageCapacityParams) (res ListStorageV1beta1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listStorageV1beta1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/namespaces/{namespace}/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -42181,6 +42588,8 @@ func (c *Client) LogFileHandler(ctx context.Context, params LogFileHandlerParams
 func (c *Client) sendLogFileHandler(ctx context.Context, params LogFileHandlerParams) (res *LogFileHandlerUnauthorized, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("logFileHandler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/logs/{logpath}"),
 	}
 
 	// Run stopwatch.
@@ -42301,6 +42710,8 @@ func (c *Client) LogFileListHandler(ctx context.Context) error {
 func (c *Client) sendLogFileListHandler(ctx context.Context) (res *LogFileListHandlerUnauthorized, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("logFileListHandler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/logs/"),
 	}
 
 	// Run stopwatch.
@@ -42405,6 +42816,8 @@ func (c *Client) ReadAdmissionregistrationV1MutatingWebhookConfiguration(ctx con
 func (c *Client) sendReadAdmissionregistrationV1MutatingWebhookConfiguration(ctx context.Context, params ReadAdmissionregistrationV1MutatingWebhookConfigurationParams) (res ReadAdmissionregistrationV1MutatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAdmissionregistrationV1MutatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -42548,6 +42961,8 @@ func (c *Client) ReadAdmissionregistrationV1ValidatingWebhookConfiguration(ctx c
 func (c *Client) sendReadAdmissionregistrationV1ValidatingWebhookConfiguration(ctx context.Context, params ReadAdmissionregistrationV1ValidatingWebhookConfigurationParams) (res ReadAdmissionregistrationV1ValidatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAdmissionregistrationV1ValidatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -42691,6 +43106,8 @@ func (c *Client) ReadApiextensionsV1CustomResourceDefinition(ctx context.Context
 func (c *Client) sendReadApiextensionsV1CustomResourceDefinition(ctx context.Context, params ReadApiextensionsV1CustomResourceDefinitionParams) (res ReadApiextensionsV1CustomResourceDefinitionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readApiextensionsV1CustomResourceDefinition"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -42834,6 +43251,8 @@ func (c *Client) ReadApiextensionsV1CustomResourceDefinitionStatus(ctx context.C
 func (c *Client) sendReadApiextensionsV1CustomResourceDefinitionStatus(ctx context.Context, params ReadApiextensionsV1CustomResourceDefinitionStatusParams) (res ReadApiextensionsV1CustomResourceDefinitionStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readApiextensionsV1CustomResourceDefinitionStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -42978,6 +43397,8 @@ func (c *Client) ReadApiregistrationV1APIService(ctx context.Context, params Rea
 func (c *Client) sendReadApiregistrationV1APIService(ctx context.Context, params ReadApiregistrationV1APIServiceParams) (res ReadApiregistrationV1APIServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readApiregistrationV1APIService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/apiservices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -43121,6 +43542,8 @@ func (c *Client) ReadApiregistrationV1APIServiceStatus(ctx context.Context, para
 func (c *Client) sendReadApiregistrationV1APIServiceStatus(ctx context.Context, params ReadApiregistrationV1APIServiceStatusParams) (res ReadApiregistrationV1APIServiceStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readApiregistrationV1APIServiceStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/apiservices/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -43265,6 +43688,8 @@ func (c *Client) ReadAppsV1NamespacedControllerRevision(ctx context.Context, par
 func (c *Client) sendReadAppsV1NamespacedControllerRevision(ctx context.Context, params ReadAppsV1NamespacedControllerRevisionParams) (res ReadAppsV1NamespacedControllerRevisionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedControllerRevision"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -43427,6 +43852,8 @@ func (c *Client) ReadAppsV1NamespacedDaemonSet(ctx context.Context, params ReadA
 func (c *Client) sendReadAppsV1NamespacedDaemonSet(ctx context.Context, params ReadAppsV1NamespacedDaemonSetParams) (res ReadAppsV1NamespacedDaemonSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedDaemonSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -43589,6 +44016,8 @@ func (c *Client) ReadAppsV1NamespacedDaemonSetStatus(ctx context.Context, params
 func (c *Client) sendReadAppsV1NamespacedDaemonSetStatus(ctx context.Context, params ReadAppsV1NamespacedDaemonSetStatusParams) (res ReadAppsV1NamespacedDaemonSetStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedDaemonSetStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -43752,6 +44181,8 @@ func (c *Client) ReadAppsV1NamespacedDeployment(ctx context.Context, params Read
 func (c *Client) sendReadAppsV1NamespacedDeployment(ctx context.Context, params ReadAppsV1NamespacedDeploymentParams) (res ReadAppsV1NamespacedDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedDeployment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/deployments/{name}"),
 	}
 
 	// Run stopwatch.
@@ -43914,6 +44345,8 @@ func (c *Client) ReadAppsV1NamespacedDeploymentScale(ctx context.Context, params
 func (c *Client) sendReadAppsV1NamespacedDeploymentScale(ctx context.Context, params ReadAppsV1NamespacedDeploymentScaleParams) (res ReadAppsV1NamespacedDeploymentScaleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedDeploymentScale"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale"),
 	}
 
 	// Run stopwatch.
@@ -44077,6 +44510,8 @@ func (c *Client) ReadAppsV1NamespacedDeploymentStatus(ctx context.Context, param
 func (c *Client) sendReadAppsV1NamespacedDeploymentStatus(ctx context.Context, params ReadAppsV1NamespacedDeploymentStatusParams) (res ReadAppsV1NamespacedDeploymentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedDeploymentStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -44240,6 +44675,8 @@ func (c *Client) ReadAppsV1NamespacedReplicaSet(ctx context.Context, params Read
 func (c *Client) sendReadAppsV1NamespacedReplicaSet(ctx context.Context, params ReadAppsV1NamespacedReplicaSetParams) (res ReadAppsV1NamespacedReplicaSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedReplicaSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -44402,6 +44839,8 @@ func (c *Client) ReadAppsV1NamespacedReplicaSetScale(ctx context.Context, params
 func (c *Client) sendReadAppsV1NamespacedReplicaSetScale(ctx context.Context, params ReadAppsV1NamespacedReplicaSetScaleParams) (res ReadAppsV1NamespacedReplicaSetScaleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedReplicaSetScale"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale"),
 	}
 
 	// Run stopwatch.
@@ -44565,6 +45004,8 @@ func (c *Client) ReadAppsV1NamespacedReplicaSetStatus(ctx context.Context, param
 func (c *Client) sendReadAppsV1NamespacedReplicaSetStatus(ctx context.Context, params ReadAppsV1NamespacedReplicaSetStatusParams) (res ReadAppsV1NamespacedReplicaSetStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedReplicaSetStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -44728,6 +45169,8 @@ func (c *Client) ReadAppsV1NamespacedStatefulSet(ctx context.Context, params Rea
 func (c *Client) sendReadAppsV1NamespacedStatefulSet(ctx context.Context, params ReadAppsV1NamespacedStatefulSetParams) (res ReadAppsV1NamespacedStatefulSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedStatefulSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -44890,6 +45333,8 @@ func (c *Client) ReadAppsV1NamespacedStatefulSetScale(ctx context.Context, param
 func (c *Client) sendReadAppsV1NamespacedStatefulSetScale(ctx context.Context, params ReadAppsV1NamespacedStatefulSetScaleParams) (res ReadAppsV1NamespacedStatefulSetScaleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedStatefulSetScale"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale"),
 	}
 
 	// Run stopwatch.
@@ -45053,6 +45498,8 @@ func (c *Client) ReadAppsV1NamespacedStatefulSetStatus(ctx context.Context, para
 func (c *Client) sendReadAppsV1NamespacedStatefulSetStatus(ctx context.Context, params ReadAppsV1NamespacedStatefulSetStatusParams) (res ReadAppsV1NamespacedStatefulSetStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAppsV1NamespacedStatefulSetStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -45216,6 +45663,8 @@ func (c *Client) ReadAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context.
 func (c *Client) sendReadAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context.Context, params ReadAutoscalingV1NamespacedHorizontalPodAutoscalerParams) (res ReadAutoscalingV1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -45378,6 +45827,8 @@ func (c *Client) ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(ctx co
 func (c *Client) sendReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(ctx context.Context, params ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusParams) (res ReadAutoscalingV1NamespacedHorizontalPodAutoscalerStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -45541,6 +45992,8 @@ func (c *Client) ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx con
 func (c *Client) sendReadAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx context.Context, params ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams) (res ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV2beta1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -45703,6 +46156,8 @@ func (c *Client) ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus(c
 func (c *Client) sendReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus(ctx context.Context, params ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusParams) (res ReadAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -45866,6 +46321,8 @@ func (c *Client) ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx con
 func (c *Client) sendReadAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx context.Context, params ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams) (res ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV2beta2NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -46028,6 +46485,8 @@ func (c *Client) ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus(c
 func (c *Client) sendReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus(ctx context.Context, params ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusParams) (res ReadAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -46191,6 +46650,8 @@ func (c *Client) ReadBatchV1NamespacedCronJob(ctx context.Context, params ReadBa
 func (c *Client) sendReadBatchV1NamespacedCronJob(ctx context.Context, params ReadBatchV1NamespacedCronJobParams) (res ReadBatchV1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/cronjobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -46353,6 +46814,8 @@ func (c *Client) ReadBatchV1NamespacedCronJobStatus(ctx context.Context, params 
 func (c *Client) sendReadBatchV1NamespacedCronJobStatus(ctx context.Context, params ReadBatchV1NamespacedCronJobStatusParams) (res ReadBatchV1NamespacedCronJobStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1NamespacedCronJobStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/cronjobs/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -46516,6 +46979,8 @@ func (c *Client) ReadBatchV1NamespacedJob(ctx context.Context, params ReadBatchV
 func (c *Client) sendReadBatchV1NamespacedJob(ctx context.Context, params ReadBatchV1NamespacedJobParams) (res ReadBatchV1NamespacedJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1NamespacedJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/jobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -46678,6 +47143,8 @@ func (c *Client) ReadBatchV1NamespacedJobStatus(ctx context.Context, params Read
 func (c *Client) sendReadBatchV1NamespacedJobStatus(ctx context.Context, params ReadBatchV1NamespacedJobStatusParams) (res ReadBatchV1NamespacedJobStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1NamespacedJobStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -46841,6 +47308,8 @@ func (c *Client) ReadBatchV1beta1NamespacedCronJob(ctx context.Context, params R
 func (c *Client) sendReadBatchV1beta1NamespacedCronJob(ctx context.Context, params ReadBatchV1beta1NamespacedCronJobParams) (res ReadBatchV1beta1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1beta1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -47003,6 +47472,8 @@ func (c *Client) ReadBatchV1beta1NamespacedCronJobStatus(ctx context.Context, pa
 func (c *Client) sendReadBatchV1beta1NamespacedCronJobStatus(ctx context.Context, params ReadBatchV1beta1NamespacedCronJobStatusParams) (res ReadBatchV1beta1NamespacedCronJobStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readBatchV1beta1NamespacedCronJobStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -47166,6 +47637,8 @@ func (c *Client) ReadCertificatesV1CertificateSigningRequest(ctx context.Context
 func (c *Client) sendReadCertificatesV1CertificateSigningRequest(ctx context.Context, params ReadCertificatesV1CertificateSigningRequestParams) (res ReadCertificatesV1CertificateSigningRequestRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCertificatesV1CertificateSigningRequest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}"),
 	}
 
 	// Run stopwatch.
@@ -47309,6 +47782,8 @@ func (c *Client) ReadCertificatesV1CertificateSigningRequestApproval(ctx context
 func (c *Client) sendReadCertificatesV1CertificateSigningRequestApproval(ctx context.Context, params ReadCertificatesV1CertificateSigningRequestApprovalParams) (res ReadCertificatesV1CertificateSigningRequestApprovalRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCertificatesV1CertificateSigningRequestApproval"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/approval"),
 	}
 
 	// Run stopwatch.
@@ -47453,6 +47928,8 @@ func (c *Client) ReadCertificatesV1CertificateSigningRequestStatus(ctx context.C
 func (c *Client) sendReadCertificatesV1CertificateSigningRequestStatus(ctx context.Context, params ReadCertificatesV1CertificateSigningRequestStatusParams) (res ReadCertificatesV1CertificateSigningRequestStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCertificatesV1CertificateSigningRequestStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -47597,6 +48074,8 @@ func (c *Client) ReadCoordinationV1NamespacedLease(ctx context.Context, params R
 func (c *Client) sendReadCoordinationV1NamespacedLease(ctx context.Context, params ReadCoordinationV1NamespacedLeaseParams) (res ReadCoordinationV1NamespacedLeaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoordinationV1NamespacedLease"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}"),
 	}
 
 	// Run stopwatch.
@@ -47759,6 +48238,8 @@ func (c *Client) ReadCoreV1ComponentStatus(ctx context.Context, params ReadCoreV
 func (c *Client) sendReadCoreV1ComponentStatus(ctx context.Context, params ReadCoreV1ComponentStatusParams) (res ReadCoreV1ComponentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1ComponentStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/componentstatuses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -47902,6 +48383,8 @@ func (c *Client) ReadCoreV1Namespace(ctx context.Context, params ReadCoreV1Names
 func (c *Client) sendReadCoreV1Namespace(ctx context.Context, params ReadCoreV1NamespaceParams) (res ReadCoreV1NamespaceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1Namespace"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48045,6 +48528,8 @@ func (c *Client) ReadCoreV1NamespaceStatus(ctx context.Context, params ReadCoreV
 func (c *Client) sendReadCoreV1NamespaceStatus(ctx context.Context, params ReadCoreV1NamespaceStatusParams) (res ReadCoreV1NamespaceStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespaceStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -48189,6 +48674,8 @@ func (c *Client) ReadCoreV1NamespacedConfigMap(ctx context.Context, params ReadC
 func (c *Client) sendReadCoreV1NamespacedConfigMap(ctx context.Context, params ReadCoreV1NamespacedConfigMapParams) (res ReadCoreV1NamespacedConfigMapRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedConfigMap"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/configmaps/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48351,6 +48838,8 @@ func (c *Client) ReadCoreV1NamespacedEndpoints(ctx context.Context, params ReadC
 func (c *Client) sendReadCoreV1NamespacedEndpoints(ctx context.Context, params ReadCoreV1NamespacedEndpointsParams) (res ReadCoreV1NamespacedEndpointsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedEndpoints"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/endpoints/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48513,6 +49002,8 @@ func (c *Client) ReadCoreV1NamespacedEvent(ctx context.Context, params ReadCoreV
 func (c *Client) sendReadCoreV1NamespacedEvent(ctx context.Context, params ReadCoreV1NamespacedEventParams) (res ReadCoreV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48675,6 +49166,8 @@ func (c *Client) ReadCoreV1NamespacedLimitRange(ctx context.Context, params Read
 func (c *Client) sendReadCoreV1NamespacedLimitRange(ctx context.Context, params ReadCoreV1NamespacedLimitRangeParams) (res ReadCoreV1NamespacedLimitRangeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedLimitRange"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/limitranges/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48837,6 +49330,8 @@ func (c *Client) ReadCoreV1NamespacedPersistentVolumeClaim(ctx context.Context, 
 func (c *Client) sendReadCoreV1NamespacedPersistentVolumeClaim(ctx context.Context, params ReadCoreV1NamespacedPersistentVolumeClaimParams) (res ReadCoreV1NamespacedPersistentVolumeClaimRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPersistentVolumeClaim"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}"),
 	}
 
 	// Run stopwatch.
@@ -48999,6 +49494,8 @@ func (c *Client) ReadCoreV1NamespacedPersistentVolumeClaimStatus(ctx context.Con
 func (c *Client) sendReadCoreV1NamespacedPersistentVolumeClaimStatus(ctx context.Context, params ReadCoreV1NamespacedPersistentVolumeClaimStatusParams) (res ReadCoreV1NamespacedPersistentVolumeClaimStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPersistentVolumeClaimStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -49162,6 +49659,8 @@ func (c *Client) ReadCoreV1NamespacedPod(ctx context.Context, params ReadCoreV1N
 func (c *Client) sendReadCoreV1NamespacedPod(ctx context.Context, params ReadCoreV1NamespacedPodParams) (res ReadCoreV1NamespacedPodRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPod"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}"),
 	}
 
 	// Run stopwatch.
@@ -49324,6 +49823,8 @@ func (c *Client) ReadCoreV1NamespacedPodEphemeralcontainers(ctx context.Context,
 func (c *Client) sendReadCoreV1NamespacedPodEphemeralcontainers(ctx context.Context, params ReadCoreV1NamespacedPodEphemeralcontainersParams) (res ReadCoreV1NamespacedPodEphemeralcontainersRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPodEphemeralcontainers"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/ephemeralcontainers"),
 	}
 
 	// Run stopwatch.
@@ -49487,6 +49988,8 @@ func (c *Client) ReadCoreV1NamespacedPodLog(ctx context.Context, params ReadCore
 func (c *Client) sendReadCoreV1NamespacedPodLog(ctx context.Context, params ReadCoreV1NamespacedPodLogParams) (res ReadCoreV1NamespacedPodLogRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPodLog"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/log"),
 	}
 
 	// Run stopwatch.
@@ -49786,6 +50289,8 @@ func (c *Client) ReadCoreV1NamespacedPodStatus(ctx context.Context, params ReadC
 func (c *Client) sendReadCoreV1NamespacedPodStatus(ctx context.Context, params ReadCoreV1NamespacedPodStatusParams) (res ReadCoreV1NamespacedPodStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPodStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/pods/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -49949,6 +50454,8 @@ func (c *Client) ReadCoreV1NamespacedPodTemplate(ctx context.Context, params Rea
 func (c *Client) sendReadCoreV1NamespacedPodTemplate(ctx context.Context, params ReadCoreV1NamespacedPodTemplateParams) (res ReadCoreV1NamespacedPodTemplateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedPodTemplate"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/podtemplates/{name}"),
 	}
 
 	// Run stopwatch.
@@ -50111,6 +50618,8 @@ func (c *Client) ReadCoreV1NamespacedReplicationController(ctx context.Context, 
 func (c *Client) sendReadCoreV1NamespacedReplicationController(ctx context.Context, params ReadCoreV1NamespacedReplicationControllerParams) (res ReadCoreV1NamespacedReplicationControllerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedReplicationController"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -50273,6 +50782,8 @@ func (c *Client) ReadCoreV1NamespacedReplicationControllerScale(ctx context.Cont
 func (c *Client) sendReadCoreV1NamespacedReplicationControllerScale(ctx context.Context, params ReadCoreV1NamespacedReplicationControllerScaleParams) (res ReadCoreV1NamespacedReplicationControllerScaleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedReplicationControllerScale"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale"),
 	}
 
 	// Run stopwatch.
@@ -50436,6 +50947,8 @@ func (c *Client) ReadCoreV1NamespacedReplicationControllerStatus(ctx context.Con
 func (c *Client) sendReadCoreV1NamespacedReplicationControllerStatus(ctx context.Context, params ReadCoreV1NamespacedReplicationControllerStatusParams) (res ReadCoreV1NamespacedReplicationControllerStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedReplicationControllerStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -50599,6 +51112,8 @@ func (c *Client) ReadCoreV1NamespacedResourceQuota(ctx context.Context, params R
 func (c *Client) sendReadCoreV1NamespacedResourceQuota(ctx context.Context, params ReadCoreV1NamespacedResourceQuotaParams) (res ReadCoreV1NamespacedResourceQuotaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedResourceQuota"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/resourcequotas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -50761,6 +51276,8 @@ func (c *Client) ReadCoreV1NamespacedResourceQuotaStatus(ctx context.Context, pa
 func (c *Client) sendReadCoreV1NamespacedResourceQuotaStatus(ctx context.Context, params ReadCoreV1NamespacedResourceQuotaStatusParams) (res ReadCoreV1NamespacedResourceQuotaStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedResourceQuotaStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/resourcequotas/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -50924,6 +51441,8 @@ func (c *Client) ReadCoreV1NamespacedSecret(ctx context.Context, params ReadCore
 func (c *Client) sendReadCoreV1NamespacedSecret(ctx context.Context, params ReadCoreV1NamespacedSecretParams) (res ReadCoreV1NamespacedSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedSecret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/secrets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -51086,6 +51605,8 @@ func (c *Client) ReadCoreV1NamespacedService(ctx context.Context, params ReadCor
 func (c *Client) sendReadCoreV1NamespacedService(ctx context.Context, params ReadCoreV1NamespacedServiceParams) (res ReadCoreV1NamespacedServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}"),
 	}
 
 	// Run stopwatch.
@@ -51248,6 +51769,8 @@ func (c *Client) ReadCoreV1NamespacedServiceAccount(ctx context.Context, params 
 func (c *Client) sendReadCoreV1NamespacedServiceAccount(ctx context.Context, params ReadCoreV1NamespacedServiceAccountParams) (res ReadCoreV1NamespacedServiceAccountRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedServiceAccount"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/serviceaccounts/{name}"),
 	}
 
 	// Run stopwatch.
@@ -51410,6 +51933,8 @@ func (c *Client) ReadCoreV1NamespacedServiceStatus(ctx context.Context, params R
 func (c *Client) sendReadCoreV1NamespacedServiceStatus(ctx context.Context, params ReadCoreV1NamespacedServiceStatusParams) (res ReadCoreV1NamespacedServiceStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NamespacedServiceStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/namespaces/{namespace}/services/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -51573,6 +52098,8 @@ func (c *Client) ReadCoreV1Node(ctx context.Context, params ReadCoreV1NodeParams
 func (c *Client) sendReadCoreV1Node(ctx context.Context, params ReadCoreV1NodeParams) (res ReadCoreV1NodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1Node"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -51716,6 +52243,8 @@ func (c *Client) ReadCoreV1NodeStatus(ctx context.Context, params ReadCoreV1Node
 func (c *Client) sendReadCoreV1NodeStatus(ctx context.Context, params ReadCoreV1NodeStatusParams) (res ReadCoreV1NodeStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1NodeStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/nodes/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -51860,6 +52389,8 @@ func (c *Client) ReadCoreV1PersistentVolume(ctx context.Context, params ReadCore
 func (c *Client) sendReadCoreV1PersistentVolume(ctx context.Context, params ReadCoreV1PersistentVolumeParams) (res ReadCoreV1PersistentVolumeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1PersistentVolume"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/persistentvolumes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52003,6 +52534,8 @@ func (c *Client) ReadCoreV1PersistentVolumeStatus(ctx context.Context, params Re
 func (c *Client) sendReadCoreV1PersistentVolumeStatus(ctx context.Context, params ReadCoreV1PersistentVolumeStatusParams) (res ReadCoreV1PersistentVolumeStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readCoreV1PersistentVolumeStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/persistentvolumes/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -52147,6 +52680,8 @@ func (c *Client) ReadDiscoveryV1NamespacedEndpointSlice(ctx context.Context, par
 func (c *Client) sendReadDiscoveryV1NamespacedEndpointSlice(ctx context.Context, params ReadDiscoveryV1NamespacedEndpointSliceParams) (res ReadDiscoveryV1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readDiscoveryV1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/namespaces/{namespace}/endpointslices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52309,6 +52844,8 @@ func (c *Client) ReadDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Context
 func (c *Client) sendReadDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Context, params ReadDiscoveryV1beta1NamespacedEndpointSliceParams) (res ReadDiscoveryV1beta1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readDiscoveryV1beta1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52471,6 +53008,8 @@ func (c *Client) ReadEventsV1NamespacedEvent(ctx context.Context, params ReadEve
 func (c *Client) sendReadEventsV1NamespacedEvent(ctx context.Context, params ReadEventsV1NamespacedEventParams) (res ReadEventsV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readEventsV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52633,6 +53172,8 @@ func (c *Client) ReadEventsV1beta1NamespacedEvent(ctx context.Context, params Re
 func (c *Client) sendReadEventsV1beta1NamespacedEvent(ctx context.Context, params ReadEventsV1beta1NamespacedEventParams) (res ReadEventsV1beta1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readEventsV1beta1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52795,6 +53336,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context, 
 func (c *Client) sendReadFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context, params ReadFlowcontrolApiserverV1beta1FlowSchemaParams) (res ReadFlowcontrolApiserverV1beta1FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta1FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -52938,6 +53481,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta1FlowSchemaStatus(ctx context.Con
 func (c *Client) sendReadFlowcontrolApiserverV1beta1FlowSchemaStatus(ctx context.Context, params ReadFlowcontrolApiserverV1beta1FlowSchemaStatusParams) (res ReadFlowcontrolApiserverV1beta1FlowSchemaStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta1FlowSchemaStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -53082,6 +53627,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx c
 func (c *Client) sendReadFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx context.Context, params ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams) (res ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta1PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -53225,6 +53772,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus
 func (c *Client) sendReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus(ctx context.Context, params ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusParams) (res ReadFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -53369,6 +53918,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context, 
 func (c *Client) sendReadFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context, params ReadFlowcontrolApiserverV1beta2FlowSchemaParams) (res ReadFlowcontrolApiserverV1beta2FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta2FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -53512,6 +54063,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta2FlowSchemaStatus(ctx context.Con
 func (c *Client) sendReadFlowcontrolApiserverV1beta2FlowSchemaStatus(ctx context.Context, params ReadFlowcontrolApiserverV1beta2FlowSchemaStatusParams) (res ReadFlowcontrolApiserverV1beta2FlowSchemaStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta2FlowSchemaStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -53656,6 +54209,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx c
 func (c *Client) sendReadFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx context.Context, params ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams) (res ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta2PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -53799,6 +54354,8 @@ func (c *Client) ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatus
 func (c *Client) sendReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatus(ctx context.Context, params ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusParams) (res ReadFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readFlowcontrolApiserverV1beta2PriorityLevelConfigurationStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/prioritylevelconfigurations/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -53943,6 +54500,8 @@ func (c *Client) ReadInternalApiserverV1alpha1StorageVersion(ctx context.Context
 func (c *Client) sendReadInternalApiserverV1alpha1StorageVersion(ctx context.Context, params ReadInternalApiserverV1alpha1StorageVersionParams) (res ReadInternalApiserverV1alpha1StorageVersionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readInternalApiserverV1alpha1StorageVersion"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -54086,6 +54645,8 @@ func (c *Client) ReadInternalApiserverV1alpha1StorageVersionStatus(ctx context.C
 func (c *Client) sendReadInternalApiserverV1alpha1StorageVersionStatus(ctx context.Context, params ReadInternalApiserverV1alpha1StorageVersionStatusParams) (res ReadInternalApiserverV1alpha1StorageVersionStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readInternalApiserverV1alpha1StorageVersionStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -54230,6 +54791,8 @@ func (c *Client) ReadNetworkingV1IngressClass(ctx context.Context, params ReadNe
 func (c *Client) sendReadNetworkingV1IngressClass(ctx context.Context, params ReadNetworkingV1IngressClassParams) (res ReadNetworkingV1IngressClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNetworkingV1IngressClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/ingressclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -54373,6 +54936,8 @@ func (c *Client) ReadNetworkingV1NamespacedIngress(ctx context.Context, params R
 func (c *Client) sendReadNetworkingV1NamespacedIngress(ctx context.Context, params ReadNetworkingV1NamespacedIngressParams) (res ReadNetworkingV1NamespacedIngressRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNetworkingV1NamespacedIngress"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -54535,6 +55100,8 @@ func (c *Client) ReadNetworkingV1NamespacedIngressStatus(ctx context.Context, pa
 func (c *Client) sendReadNetworkingV1NamespacedIngressStatus(ctx context.Context, params ReadNetworkingV1NamespacedIngressStatusParams) (res ReadNetworkingV1NamespacedIngressStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNetworkingV1NamespacedIngressStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -54698,6 +55265,8 @@ func (c *Client) ReadNetworkingV1NamespacedNetworkPolicy(ctx context.Context, pa
 func (c *Client) sendReadNetworkingV1NamespacedNetworkPolicy(ctx context.Context, params ReadNetworkingV1NamespacedNetworkPolicyParams) (res ReadNetworkingV1NamespacedNetworkPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNetworkingV1NamespacedNetworkPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}"),
 	}
 
 	// Run stopwatch.
@@ -54860,6 +55429,8 @@ func (c *Client) ReadNodeV1RuntimeClass(ctx context.Context, params ReadNodeV1Ru
 func (c *Client) sendReadNodeV1RuntimeClass(ctx context.Context, params ReadNodeV1RuntimeClassParams) (res ReadNodeV1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNodeV1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -55003,6 +55574,8 @@ func (c *Client) ReadNodeV1alpha1RuntimeClass(ctx context.Context, params ReadNo
 func (c *Client) sendReadNodeV1alpha1RuntimeClass(ctx context.Context, params ReadNodeV1alpha1RuntimeClassParams) (res ReadNodeV1alpha1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNodeV1alpha1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1alpha1/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -55146,6 +55719,8 @@ func (c *Client) ReadNodeV1beta1RuntimeClass(ctx context.Context, params ReadNod
 func (c *Client) sendReadNodeV1beta1RuntimeClass(ctx context.Context, params ReadNodeV1beta1RuntimeClassParams) (res ReadNodeV1beta1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readNodeV1beta1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1beta1/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -55289,6 +55864,8 @@ func (c *Client) ReadPolicyV1NamespacedPodDisruptionBudget(ctx context.Context, 
 func (c *Client) sendReadPolicyV1NamespacedPodDisruptionBudget(ctx context.Context, params ReadPolicyV1NamespacedPodDisruptionBudgetParams) (res ReadPolicyV1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPolicyV1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -55451,6 +56028,8 @@ func (c *Client) ReadPolicyV1NamespacedPodDisruptionBudgetStatus(ctx context.Con
 func (c *Client) sendReadPolicyV1NamespacedPodDisruptionBudgetStatus(ctx context.Context, params ReadPolicyV1NamespacedPodDisruptionBudgetStatusParams) (res ReadPolicyV1NamespacedPodDisruptionBudgetStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPolicyV1NamespacedPodDisruptionBudgetStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/namespaces/{namespace}/poddisruptionbudgets/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -55614,6 +56193,8 @@ func (c *Client) ReadPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Cont
 func (c *Client) sendReadPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Context, params ReadPolicyV1beta1NamespacedPodDisruptionBudgetParams) (res ReadPolicyV1beta1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPolicyV1beta1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -55776,6 +56357,8 @@ func (c *Client) ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatus(ctx contex
 func (c *Client) sendReadPolicyV1beta1NamespacedPodDisruptionBudgetStatus(ctx context.Context, params ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusParams) (res ReadPolicyV1beta1NamespacedPodDisruptionBudgetStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPolicyV1beta1NamespacedPodDisruptionBudgetStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -55939,6 +56522,8 @@ func (c *Client) ReadPolicyV1beta1PodSecurityPolicy(ctx context.Context, params 
 func (c *Client) sendReadPolicyV1beta1PodSecurityPolicy(ctx context.Context, params ReadPolicyV1beta1PodSecurityPolicyParams) (res ReadPolicyV1beta1PodSecurityPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readPolicyV1beta1PodSecurityPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/podsecuritypolicies/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56082,6 +56667,8 @@ func (c *Client) ReadRbacAuthorizationV1ClusterRole(ctx context.Context, params 
 func (c *Client) sendReadRbacAuthorizationV1ClusterRole(ctx context.Context, params ReadRbacAuthorizationV1ClusterRoleParams) (res ReadRbacAuthorizationV1ClusterRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readRbacAuthorizationV1ClusterRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56225,6 +56812,8 @@ func (c *Client) ReadRbacAuthorizationV1ClusterRoleBinding(ctx context.Context, 
 func (c *Client) sendReadRbacAuthorizationV1ClusterRoleBinding(ctx context.Context, params ReadRbacAuthorizationV1ClusterRoleBindingParams) (res ReadRbacAuthorizationV1ClusterRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readRbacAuthorizationV1ClusterRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56368,6 +56957,8 @@ func (c *Client) ReadRbacAuthorizationV1NamespacedRole(ctx context.Context, para
 func (c *Client) sendReadRbacAuthorizationV1NamespacedRole(ctx context.Context, params ReadRbacAuthorizationV1NamespacedRoleParams) (res ReadRbacAuthorizationV1NamespacedRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readRbacAuthorizationV1NamespacedRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56530,6 +57121,8 @@ func (c *Client) ReadRbacAuthorizationV1NamespacedRoleBinding(ctx context.Contex
 func (c *Client) sendReadRbacAuthorizationV1NamespacedRoleBinding(ctx context.Context, params ReadRbacAuthorizationV1NamespacedRoleBindingParams) (res ReadRbacAuthorizationV1NamespacedRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readRbacAuthorizationV1NamespacedRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56692,6 +57285,8 @@ func (c *Client) ReadSchedulingV1PriorityClass(ctx context.Context, params ReadS
 func (c *Client) sendReadSchedulingV1PriorityClass(ctx context.Context, params ReadSchedulingV1PriorityClassParams) (res ReadSchedulingV1PriorityClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readSchedulingV1PriorityClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/v1/priorityclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56835,6 +57430,8 @@ func (c *Client) ReadStorageV1CSIDriver(ctx context.Context, params ReadStorageV
 func (c *Client) sendReadStorageV1CSIDriver(ctx context.Context, params ReadStorageV1CSIDriverParams) (res ReadStorageV1CSIDriverRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1CSIDriver"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/csidrivers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -56978,6 +57575,8 @@ func (c *Client) ReadStorageV1CSINode(ctx context.Context, params ReadStorageV1C
 func (c *Client) sendReadStorageV1CSINode(ctx context.Context, params ReadStorageV1CSINodeParams) (res ReadStorageV1CSINodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1CSINode"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/csinodes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -57121,6 +57720,8 @@ func (c *Client) ReadStorageV1StorageClass(ctx context.Context, params ReadStora
 func (c *Client) sendReadStorageV1StorageClass(ctx context.Context, params ReadStorageV1StorageClassParams) (res ReadStorageV1StorageClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1StorageClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/storageclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -57264,6 +57865,8 @@ func (c *Client) ReadStorageV1VolumeAttachment(ctx context.Context, params ReadS
 func (c *Client) sendReadStorageV1VolumeAttachment(ctx context.Context, params ReadStorageV1VolumeAttachmentParams) (res ReadStorageV1VolumeAttachmentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1VolumeAttachment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/volumeattachments/{name}"),
 	}
 
 	// Run stopwatch.
@@ -57407,6 +58010,8 @@ func (c *Client) ReadStorageV1VolumeAttachmentStatus(ctx context.Context, params
 func (c *Client) sendReadStorageV1VolumeAttachmentStatus(ctx context.Context, params ReadStorageV1VolumeAttachmentStatusParams) (res ReadStorageV1VolumeAttachmentStatusRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1VolumeAttachmentStatus"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/volumeattachments/{name}/status"),
 	}
 
 	// Run stopwatch.
@@ -57551,6 +58156,8 @@ func (c *Client) ReadStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Con
 func (c *Client) sendReadStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Context, params ReadStorageV1alpha1NamespacedCSIStorageCapacityParams) (res ReadStorageV1alpha1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1alpha1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/namespaces/{namespace}/csistoragecapacities/{name}"),
 	}
 
 	// Run stopwatch.
@@ -57713,6 +58320,8 @@ func (c *Client) ReadStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Cont
 func (c *Client) sendReadStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Context, params ReadStorageV1beta1NamespacedCSIStorageCapacityParams) (res ReadStorageV1beta1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("readStorageV1beta1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/namespaces/{namespace}/csistoragecapacities/{name}"),
 	}
 
 	// Run stopwatch.
@@ -57877,6 +58486,8 @@ func (c *Client) WatchAdmissionregistrationV1MutatingWebhookConfiguration(ctx co
 func (c *Client) sendWatchAdmissionregistrationV1MutatingWebhookConfiguration(ctx context.Context, params WatchAdmissionregistrationV1MutatingWebhookConfigurationParams) (res WatchAdmissionregistrationV1MutatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAdmissionregistrationV1MutatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/watch/mutatingwebhookconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -58174,6 +58785,8 @@ func (c *Client) WatchAdmissionregistrationV1MutatingWebhookConfigurationList(ct
 func (c *Client) sendWatchAdmissionregistrationV1MutatingWebhookConfigurationList(ctx context.Context, params WatchAdmissionregistrationV1MutatingWebhookConfigurationListParams) (res WatchAdmissionregistrationV1MutatingWebhookConfigurationListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAdmissionregistrationV1MutatingWebhookConfigurationList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/watch/mutatingwebhookconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -58454,6 +59067,8 @@ func (c *Client) WatchAdmissionregistrationV1ValidatingWebhookConfiguration(ctx 
 func (c *Client) sendWatchAdmissionregistrationV1ValidatingWebhookConfiguration(ctx context.Context, params WatchAdmissionregistrationV1ValidatingWebhookConfigurationParams) (res WatchAdmissionregistrationV1ValidatingWebhookConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAdmissionregistrationV1ValidatingWebhookConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/watch/validatingwebhookconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -58751,6 +59366,8 @@ func (c *Client) WatchAdmissionregistrationV1ValidatingWebhookConfigurationList(
 func (c *Client) sendWatchAdmissionregistrationV1ValidatingWebhookConfigurationList(ctx context.Context, params WatchAdmissionregistrationV1ValidatingWebhookConfigurationListParams) (res WatchAdmissionregistrationV1ValidatingWebhookConfigurationListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAdmissionregistrationV1ValidatingWebhookConfigurationList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/admissionregistration.k8s.io/v1/watch/validatingwebhookconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -59030,6 +59647,8 @@ func (c *Client) WatchApiextensionsV1CustomResourceDefinition(ctx context.Contex
 func (c *Client) sendWatchApiextensionsV1CustomResourceDefinition(ctx context.Context, params WatchApiextensionsV1CustomResourceDefinitionParams) (res WatchApiextensionsV1CustomResourceDefinitionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchApiextensionsV1CustomResourceDefinition"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -59327,6 +59946,8 @@ func (c *Client) WatchApiextensionsV1CustomResourceDefinitionList(ctx context.Co
 func (c *Client) sendWatchApiextensionsV1CustomResourceDefinitionList(ctx context.Context, params WatchApiextensionsV1CustomResourceDefinitionListParams) (res WatchApiextensionsV1CustomResourceDefinitionListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchApiextensionsV1CustomResourceDefinitionList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions"),
 	}
 
 	// Run stopwatch.
@@ -59606,6 +60227,8 @@ func (c *Client) WatchApiregistrationV1APIService(ctx context.Context, params Wa
 func (c *Client) sendWatchApiregistrationV1APIService(ctx context.Context, params WatchApiregistrationV1APIServiceParams) (res WatchApiregistrationV1APIServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchApiregistrationV1APIService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/watch/apiservices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -59903,6 +60526,8 @@ func (c *Client) WatchApiregistrationV1APIServiceList(ctx context.Context, param
 func (c *Client) sendWatchApiregistrationV1APIServiceList(ctx context.Context, params WatchApiregistrationV1APIServiceListParams) (res WatchApiregistrationV1APIServiceListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchApiregistrationV1APIServiceList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apiregistration.k8s.io/v1/watch/apiservices"),
 	}
 
 	// Run stopwatch.
@@ -60182,6 +60807,8 @@ func (c *Client) WatchAppsV1ControllerRevisionListForAllNamespaces(ctx context.C
 func (c *Client) sendWatchAppsV1ControllerRevisionListForAllNamespaces(ctx context.Context, params WatchAppsV1ControllerRevisionListForAllNamespacesParams) (res WatchAppsV1ControllerRevisionListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1ControllerRevisionListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/controllerrevisions"),
 	}
 
 	// Run stopwatch.
@@ -60461,6 +61088,8 @@ func (c *Client) WatchAppsV1DaemonSetListForAllNamespaces(ctx context.Context, p
 func (c *Client) sendWatchAppsV1DaemonSetListForAllNamespaces(ctx context.Context, params WatchAppsV1DaemonSetListForAllNamespacesParams) (res WatchAppsV1DaemonSetListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1DaemonSetListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/daemonsets"),
 	}
 
 	// Run stopwatch.
@@ -60740,6 +61369,8 @@ func (c *Client) WatchAppsV1DeploymentListForAllNamespaces(ctx context.Context, 
 func (c *Client) sendWatchAppsV1DeploymentListForAllNamespaces(ctx context.Context, params WatchAppsV1DeploymentListForAllNamespacesParams) (res WatchAppsV1DeploymentListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1DeploymentListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/deployments"),
 	}
 
 	// Run stopwatch.
@@ -61019,6 +61650,8 @@ func (c *Client) WatchAppsV1NamespacedControllerRevision(ctx context.Context, pa
 func (c *Client) sendWatchAppsV1NamespacedControllerRevision(ctx context.Context, params WatchAppsV1NamespacedControllerRevisionParams) (res WatchAppsV1NamespacedControllerRevisionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedControllerRevision"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -61335,6 +61968,8 @@ func (c *Client) WatchAppsV1NamespacedControllerRevisionList(ctx context.Context
 func (c *Client) sendWatchAppsV1NamespacedControllerRevisionList(ctx context.Context, params WatchAppsV1NamespacedControllerRevisionListParams) (res WatchAppsV1NamespacedControllerRevisionListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedControllerRevisionList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions"),
 	}
 
 	// Run stopwatch.
@@ -61633,6 +62268,8 @@ func (c *Client) WatchAppsV1NamespacedDaemonSet(ctx context.Context, params Watc
 func (c *Client) sendWatchAppsV1NamespacedDaemonSet(ctx context.Context, params WatchAppsV1NamespacedDaemonSetParams) (res WatchAppsV1NamespacedDaemonSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedDaemonSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/daemonsets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -61949,6 +62586,8 @@ func (c *Client) WatchAppsV1NamespacedDaemonSetList(ctx context.Context, params 
 func (c *Client) sendWatchAppsV1NamespacedDaemonSetList(ctx context.Context, params WatchAppsV1NamespacedDaemonSetListParams) (res WatchAppsV1NamespacedDaemonSetListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedDaemonSetList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/daemonsets"),
 	}
 
 	// Run stopwatch.
@@ -62247,6 +62886,8 @@ func (c *Client) WatchAppsV1NamespacedDeployment(ctx context.Context, params Wat
 func (c *Client) sendWatchAppsV1NamespacedDeployment(ctx context.Context, params WatchAppsV1NamespacedDeploymentParams) (res WatchAppsV1NamespacedDeploymentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedDeployment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/deployments/{name}"),
 	}
 
 	// Run stopwatch.
@@ -62563,6 +63204,8 @@ func (c *Client) WatchAppsV1NamespacedDeploymentList(ctx context.Context, params
 func (c *Client) sendWatchAppsV1NamespacedDeploymentList(ctx context.Context, params WatchAppsV1NamespacedDeploymentListParams) (res WatchAppsV1NamespacedDeploymentListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedDeploymentList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/deployments"),
 	}
 
 	// Run stopwatch.
@@ -62861,6 +63504,8 @@ func (c *Client) WatchAppsV1NamespacedReplicaSet(ctx context.Context, params Wat
 func (c *Client) sendWatchAppsV1NamespacedReplicaSet(ctx context.Context, params WatchAppsV1NamespacedReplicaSetParams) (res WatchAppsV1NamespacedReplicaSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedReplicaSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/replicasets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -63177,6 +63822,8 @@ func (c *Client) WatchAppsV1NamespacedReplicaSetList(ctx context.Context, params
 func (c *Client) sendWatchAppsV1NamespacedReplicaSetList(ctx context.Context, params WatchAppsV1NamespacedReplicaSetListParams) (res WatchAppsV1NamespacedReplicaSetListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedReplicaSetList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/replicasets"),
 	}
 
 	// Run stopwatch.
@@ -63475,6 +64122,8 @@ func (c *Client) WatchAppsV1NamespacedStatefulSet(ctx context.Context, params Wa
 func (c *Client) sendWatchAppsV1NamespacedStatefulSet(ctx context.Context, params WatchAppsV1NamespacedStatefulSetParams) (res WatchAppsV1NamespacedStatefulSetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedStatefulSet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/statefulsets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -63791,6 +64440,8 @@ func (c *Client) WatchAppsV1NamespacedStatefulSetList(ctx context.Context, param
 func (c *Client) sendWatchAppsV1NamespacedStatefulSetList(ctx context.Context, params WatchAppsV1NamespacedStatefulSetListParams) (res WatchAppsV1NamespacedStatefulSetListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1NamespacedStatefulSetList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/namespaces/{namespace}/statefulsets"),
 	}
 
 	// Run stopwatch.
@@ -64089,6 +64740,8 @@ func (c *Client) WatchAppsV1ReplicaSetListForAllNamespaces(ctx context.Context, 
 func (c *Client) sendWatchAppsV1ReplicaSetListForAllNamespaces(ctx context.Context, params WatchAppsV1ReplicaSetListForAllNamespacesParams) (res WatchAppsV1ReplicaSetListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1ReplicaSetListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/replicasets"),
 	}
 
 	// Run stopwatch.
@@ -64368,6 +65021,8 @@ func (c *Client) WatchAppsV1StatefulSetListForAllNamespaces(ctx context.Context,
 func (c *Client) sendWatchAppsV1StatefulSetListForAllNamespaces(ctx context.Context, params WatchAppsV1StatefulSetListForAllNamespacesParams) (res WatchAppsV1StatefulSetListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAppsV1StatefulSetListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/apps/v1/watch/statefulsets"),
 	}
 
 	// Run stopwatch.
@@ -64647,6 +65302,8 @@ func (c *Client) WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces(c
 func (c *Client) sendWatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces(ctx context.Context, params WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesParams) (res WatchAutoscalingV1HorizontalPodAutoscalerListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/watch/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -64926,6 +65583,8 @@ func (c *Client) WatchAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context
 func (c *Client) sendWatchAutoscalingV1NamespacedHorizontalPodAutoscaler(ctx context.Context, params WatchAutoscalingV1NamespacedHorizontalPodAutoscalerParams) (res WatchAutoscalingV1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -65242,6 +65901,8 @@ func (c *Client) WatchAutoscalingV1NamespacedHorizontalPodAutoscalerList(ctx con
 func (c *Client) sendWatchAutoscalingV1NamespacedHorizontalPodAutoscalerList(ctx context.Context, params WatchAutoscalingV1NamespacedHorizontalPodAutoscalerListParams) (res WatchAutoscalingV1NamespacedHorizontalPodAutoscalerListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV1NamespacedHorizontalPodAutoscalerList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -65540,6 +66201,8 @@ func (c *Client) WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespa
 func (c *Client) sendWatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespaces(ctx context.Context, params WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesParams) (res WatchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta1HorizontalPodAutoscalerListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/watch/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -65819,6 +66482,8 @@ func (c *Client) WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx co
 func (c *Client) sendWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(ctx context.Context, params WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerParams) (res WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta1NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -66135,6 +66800,8 @@ func (c *Client) WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerList(ct
 func (c *Client) sendWatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerList(ctx context.Context, params WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListParams) (res WatchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta1NamespacedHorizontalPodAutoscalerList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -66433,6 +67100,8 @@ func (c *Client) WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespa
 func (c *Client) sendWatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespaces(ctx context.Context, params WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesParams) (res WatchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta2HorizontalPodAutoscalerListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/watch/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -66712,6 +67381,8 @@ func (c *Client) WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx co
 func (c *Client) sendWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(ctx context.Context, params WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerParams) (res WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta2NamespacedHorizontalPodAutoscaler"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -67028,6 +67699,8 @@ func (c *Client) WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerList(ct
 func (c *Client) sendWatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerList(ctx context.Context, params WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListParams) (res WatchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchAutoscalingV2beta2NamespacedHorizontalPodAutoscalerList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/autoscaling/v2beta2/watch/namespaces/{namespace}/horizontalpodautoscalers"),
 	}
 
 	// Run stopwatch.
@@ -67326,6 +67999,8 @@ func (c *Client) WatchBatchV1CronJobListForAllNamespaces(ctx context.Context, pa
 func (c *Client) sendWatchBatchV1CronJobListForAllNamespaces(ctx context.Context, params WatchBatchV1CronJobListForAllNamespacesParams) (res WatchBatchV1CronJobListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1CronJobListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -67605,6 +68280,8 @@ func (c *Client) WatchBatchV1JobListForAllNamespaces(ctx context.Context, params
 func (c *Client) sendWatchBatchV1JobListForAllNamespaces(ctx context.Context, params WatchBatchV1JobListForAllNamespacesParams) (res WatchBatchV1JobListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1JobListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/jobs"),
 	}
 
 	// Run stopwatch.
@@ -67884,6 +68561,8 @@ func (c *Client) WatchBatchV1NamespacedCronJob(ctx context.Context, params Watch
 func (c *Client) sendWatchBatchV1NamespacedCronJob(ctx context.Context, params WatchBatchV1NamespacedCronJobParams) (res WatchBatchV1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/namespaces/{namespace}/cronjobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -68200,6 +68879,8 @@ func (c *Client) WatchBatchV1NamespacedCronJobList(ctx context.Context, params W
 func (c *Client) sendWatchBatchV1NamespacedCronJobList(ctx context.Context, params WatchBatchV1NamespacedCronJobListParams) (res WatchBatchV1NamespacedCronJobListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1NamespacedCronJobList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/namespaces/{namespace}/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -68498,6 +69179,8 @@ func (c *Client) WatchBatchV1NamespacedJob(ctx context.Context, params WatchBatc
 func (c *Client) sendWatchBatchV1NamespacedJob(ctx context.Context, params WatchBatchV1NamespacedJobParams) (res WatchBatchV1NamespacedJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1NamespacedJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/namespaces/{namespace}/jobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -68814,6 +69497,8 @@ func (c *Client) WatchBatchV1NamespacedJobList(ctx context.Context, params Watch
 func (c *Client) sendWatchBatchV1NamespacedJobList(ctx context.Context, params WatchBatchV1NamespacedJobListParams) (res WatchBatchV1NamespacedJobListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1NamespacedJobList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1/watch/namespaces/{namespace}/jobs"),
 	}
 
 	// Run stopwatch.
@@ -69112,6 +69797,8 @@ func (c *Client) WatchBatchV1beta1CronJobListForAllNamespaces(ctx context.Contex
 func (c *Client) sendWatchBatchV1beta1CronJobListForAllNamespaces(ctx context.Context, params WatchBatchV1beta1CronJobListForAllNamespacesParams) (res WatchBatchV1beta1CronJobListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1beta1CronJobListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/watch/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -69391,6 +70078,8 @@ func (c *Client) WatchBatchV1beta1NamespacedCronJob(ctx context.Context, params 
 func (c *Client) sendWatchBatchV1beta1NamespacedCronJob(ctx context.Context, params WatchBatchV1beta1NamespacedCronJobParams) (res WatchBatchV1beta1NamespacedCronJobRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1beta1NamespacedCronJob"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs/{name}"),
 	}
 
 	// Run stopwatch.
@@ -69707,6 +70396,8 @@ func (c *Client) WatchBatchV1beta1NamespacedCronJobList(ctx context.Context, par
 func (c *Client) sendWatchBatchV1beta1NamespacedCronJobList(ctx context.Context, params WatchBatchV1beta1NamespacedCronJobListParams) (res WatchBatchV1beta1NamespacedCronJobListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchBatchV1beta1NamespacedCronJobList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs"),
 	}
 
 	// Run stopwatch.
@@ -70006,6 +70697,8 @@ func (c *Client) WatchCertificatesV1CertificateSigningRequest(ctx context.Contex
 func (c *Client) sendWatchCertificatesV1CertificateSigningRequest(ctx context.Context, params WatchCertificatesV1CertificateSigningRequestParams) (res WatchCertificatesV1CertificateSigningRequestRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCertificatesV1CertificateSigningRequest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/watch/certificatesigningrequests/{name}"),
 	}
 
 	// Run stopwatch.
@@ -70303,6 +70996,8 @@ func (c *Client) WatchCertificatesV1CertificateSigningRequestList(ctx context.Co
 func (c *Client) sendWatchCertificatesV1CertificateSigningRequestList(ctx context.Context, params WatchCertificatesV1CertificateSigningRequestListParams) (res WatchCertificatesV1CertificateSigningRequestListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCertificatesV1CertificateSigningRequestList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/certificates.k8s.io/v1/watch/certificatesigningrequests"),
 	}
 
 	// Run stopwatch.
@@ -70582,6 +71277,8 @@ func (c *Client) WatchCoordinationV1LeaseListForAllNamespaces(ctx context.Contex
 func (c *Client) sendWatchCoordinationV1LeaseListForAllNamespaces(ctx context.Context, params WatchCoordinationV1LeaseListForAllNamespacesParams) (res WatchCoordinationV1LeaseListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoordinationV1LeaseListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/watch/leases"),
 	}
 
 	// Run stopwatch.
@@ -70861,6 +71558,8 @@ func (c *Client) WatchCoordinationV1NamespacedLease(ctx context.Context, params 
 func (c *Client) sendWatchCoordinationV1NamespacedLease(ctx context.Context, params WatchCoordinationV1NamespacedLeaseParams) (res WatchCoordinationV1NamespacedLeaseRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoordinationV1NamespacedLease"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/watch/namespaces/{namespace}/leases/{name}"),
 	}
 
 	// Run stopwatch.
@@ -71177,6 +71876,8 @@ func (c *Client) WatchCoordinationV1NamespacedLeaseList(ctx context.Context, par
 func (c *Client) sendWatchCoordinationV1NamespacedLeaseList(ctx context.Context, params WatchCoordinationV1NamespacedLeaseListParams) (res WatchCoordinationV1NamespacedLeaseListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoordinationV1NamespacedLeaseList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/coordination.k8s.io/v1/watch/namespaces/{namespace}/leases"),
 	}
 
 	// Run stopwatch.
@@ -71475,6 +72176,8 @@ func (c *Client) WatchCoreV1ConfigMapListForAllNamespaces(ctx context.Context, p
 func (c *Client) sendWatchCoreV1ConfigMapListForAllNamespaces(ctx context.Context, params WatchCoreV1ConfigMapListForAllNamespacesParams) (res WatchCoreV1ConfigMapListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1ConfigMapListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/configmaps"),
 	}
 
 	// Run stopwatch.
@@ -71754,6 +72457,8 @@ func (c *Client) WatchCoreV1EndpointsListForAllNamespaces(ctx context.Context, p
 func (c *Client) sendWatchCoreV1EndpointsListForAllNamespaces(ctx context.Context, params WatchCoreV1EndpointsListForAllNamespacesParams) (res WatchCoreV1EndpointsListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1EndpointsListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/endpoints"),
 	}
 
 	// Run stopwatch.
@@ -72033,6 +72738,8 @@ func (c *Client) WatchCoreV1EventListForAllNamespaces(ctx context.Context, param
 func (c *Client) sendWatchCoreV1EventListForAllNamespaces(ctx context.Context, params WatchCoreV1EventListForAllNamespacesParams) (res WatchCoreV1EventListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1EventListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/events"),
 	}
 
 	// Run stopwatch.
@@ -72312,6 +73019,8 @@ func (c *Client) WatchCoreV1LimitRangeListForAllNamespaces(ctx context.Context, 
 func (c *Client) sendWatchCoreV1LimitRangeListForAllNamespaces(ctx context.Context, params WatchCoreV1LimitRangeListForAllNamespacesParams) (res WatchCoreV1LimitRangeListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1LimitRangeListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/limitranges"),
 	}
 
 	// Run stopwatch.
@@ -72591,6 +73300,8 @@ func (c *Client) WatchCoreV1Namespace(ctx context.Context, params WatchCoreV1Nam
 func (c *Client) sendWatchCoreV1Namespace(ctx context.Context, params WatchCoreV1NamespaceParams) (res WatchCoreV1NamespaceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1Namespace"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{name}"),
 	}
 
 	// Run stopwatch.
@@ -72888,6 +73599,8 @@ func (c *Client) WatchCoreV1NamespaceList(ctx context.Context, params WatchCoreV
 func (c *Client) sendWatchCoreV1NamespaceList(ctx context.Context, params WatchCoreV1NamespaceListParams) (res WatchCoreV1NamespaceListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespaceList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces"),
 	}
 
 	// Run stopwatch.
@@ -73167,6 +73880,8 @@ func (c *Client) WatchCoreV1NamespacedConfigMap(ctx context.Context, params Watc
 func (c *Client) sendWatchCoreV1NamespacedConfigMap(ctx context.Context, params WatchCoreV1NamespacedConfigMapParams) (res WatchCoreV1NamespacedConfigMapRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedConfigMap"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/configmaps/{name}"),
 	}
 
 	// Run stopwatch.
@@ -73483,6 +74198,8 @@ func (c *Client) WatchCoreV1NamespacedConfigMapList(ctx context.Context, params 
 func (c *Client) sendWatchCoreV1NamespacedConfigMapList(ctx context.Context, params WatchCoreV1NamespacedConfigMapListParams) (res WatchCoreV1NamespacedConfigMapListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedConfigMapList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/configmaps"),
 	}
 
 	// Run stopwatch.
@@ -73781,6 +74498,8 @@ func (c *Client) WatchCoreV1NamespacedEndpoints(ctx context.Context, params Watc
 func (c *Client) sendWatchCoreV1NamespacedEndpoints(ctx context.Context, params WatchCoreV1NamespacedEndpointsParams) (res WatchCoreV1NamespacedEndpointsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedEndpoints"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/endpoints/{name}"),
 	}
 
 	// Run stopwatch.
@@ -74097,6 +74816,8 @@ func (c *Client) WatchCoreV1NamespacedEndpointsList(ctx context.Context, params 
 func (c *Client) sendWatchCoreV1NamespacedEndpointsList(ctx context.Context, params WatchCoreV1NamespacedEndpointsListParams) (res WatchCoreV1NamespacedEndpointsListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedEndpointsList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/endpoints"),
 	}
 
 	// Run stopwatch.
@@ -74395,6 +75116,8 @@ func (c *Client) WatchCoreV1NamespacedEvent(ctx context.Context, params WatchCor
 func (c *Client) sendWatchCoreV1NamespacedEvent(ctx context.Context, params WatchCoreV1NamespacedEventParams) (res WatchCoreV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -74711,6 +75434,8 @@ func (c *Client) WatchCoreV1NamespacedEventList(ctx context.Context, params Watc
 func (c *Client) sendWatchCoreV1NamespacedEventList(ctx context.Context, params WatchCoreV1NamespacedEventListParams) (res WatchCoreV1NamespacedEventListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedEventList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -75009,6 +75734,8 @@ func (c *Client) WatchCoreV1NamespacedLimitRange(ctx context.Context, params Wat
 func (c *Client) sendWatchCoreV1NamespacedLimitRange(ctx context.Context, params WatchCoreV1NamespacedLimitRangeParams) (res WatchCoreV1NamespacedLimitRangeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedLimitRange"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/limitranges/{name}"),
 	}
 
 	// Run stopwatch.
@@ -75325,6 +76052,8 @@ func (c *Client) WatchCoreV1NamespacedLimitRangeList(ctx context.Context, params
 func (c *Client) sendWatchCoreV1NamespacedLimitRangeList(ctx context.Context, params WatchCoreV1NamespacedLimitRangeListParams) (res WatchCoreV1NamespacedLimitRangeListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedLimitRangeList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/limitranges"),
 	}
 
 	// Run stopwatch.
@@ -75623,6 +76352,8 @@ func (c *Client) WatchCoreV1NamespacedPersistentVolumeClaim(ctx context.Context,
 func (c *Client) sendWatchCoreV1NamespacedPersistentVolumeClaim(ctx context.Context, params WatchCoreV1NamespacedPersistentVolumeClaimParams) (res WatchCoreV1NamespacedPersistentVolumeClaimRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPersistentVolumeClaim"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims/{name}"),
 	}
 
 	// Run stopwatch.
@@ -75939,6 +76670,8 @@ func (c *Client) WatchCoreV1NamespacedPersistentVolumeClaimList(ctx context.Cont
 func (c *Client) sendWatchCoreV1NamespacedPersistentVolumeClaimList(ctx context.Context, params WatchCoreV1NamespacedPersistentVolumeClaimListParams) (res WatchCoreV1NamespacedPersistentVolumeClaimListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPersistentVolumeClaimList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims"),
 	}
 
 	// Run stopwatch.
@@ -76237,6 +76970,8 @@ func (c *Client) WatchCoreV1NamespacedPod(ctx context.Context, params WatchCoreV
 func (c *Client) sendWatchCoreV1NamespacedPod(ctx context.Context, params WatchCoreV1NamespacedPodParams) (res WatchCoreV1NamespacedPodRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPod"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/pods/{name}"),
 	}
 
 	// Run stopwatch.
@@ -76553,6 +77288,8 @@ func (c *Client) WatchCoreV1NamespacedPodList(ctx context.Context, params WatchC
 func (c *Client) sendWatchCoreV1NamespacedPodList(ctx context.Context, params WatchCoreV1NamespacedPodListParams) (res WatchCoreV1NamespacedPodListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPodList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/pods"),
 	}
 
 	// Run stopwatch.
@@ -76851,6 +77588,8 @@ func (c *Client) WatchCoreV1NamespacedPodTemplate(ctx context.Context, params Wa
 func (c *Client) sendWatchCoreV1NamespacedPodTemplate(ctx context.Context, params WatchCoreV1NamespacedPodTemplateParams) (res WatchCoreV1NamespacedPodTemplateRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPodTemplate"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/podtemplates/{name}"),
 	}
 
 	// Run stopwatch.
@@ -77167,6 +77906,8 @@ func (c *Client) WatchCoreV1NamespacedPodTemplateList(ctx context.Context, param
 func (c *Client) sendWatchCoreV1NamespacedPodTemplateList(ctx context.Context, params WatchCoreV1NamespacedPodTemplateListParams) (res WatchCoreV1NamespacedPodTemplateListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedPodTemplateList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/podtemplates"),
 	}
 
 	// Run stopwatch.
@@ -77465,6 +78206,8 @@ func (c *Client) WatchCoreV1NamespacedReplicationController(ctx context.Context,
 func (c *Client) sendWatchCoreV1NamespacedReplicationController(ctx context.Context, params WatchCoreV1NamespacedReplicationControllerParams) (res WatchCoreV1NamespacedReplicationControllerRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedReplicationController"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/replicationcontrollers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -77781,6 +78524,8 @@ func (c *Client) WatchCoreV1NamespacedReplicationControllerList(ctx context.Cont
 func (c *Client) sendWatchCoreV1NamespacedReplicationControllerList(ctx context.Context, params WatchCoreV1NamespacedReplicationControllerListParams) (res WatchCoreV1NamespacedReplicationControllerListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedReplicationControllerList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/replicationcontrollers"),
 	}
 
 	// Run stopwatch.
@@ -78079,6 +78824,8 @@ func (c *Client) WatchCoreV1NamespacedResourceQuota(ctx context.Context, params 
 func (c *Client) sendWatchCoreV1NamespacedResourceQuota(ctx context.Context, params WatchCoreV1NamespacedResourceQuotaParams) (res WatchCoreV1NamespacedResourceQuotaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedResourceQuota"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/resourcequotas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -78395,6 +79142,8 @@ func (c *Client) WatchCoreV1NamespacedResourceQuotaList(ctx context.Context, par
 func (c *Client) sendWatchCoreV1NamespacedResourceQuotaList(ctx context.Context, params WatchCoreV1NamespacedResourceQuotaListParams) (res WatchCoreV1NamespacedResourceQuotaListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedResourceQuotaList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/resourcequotas"),
 	}
 
 	// Run stopwatch.
@@ -78693,6 +79442,8 @@ func (c *Client) WatchCoreV1NamespacedSecret(ctx context.Context, params WatchCo
 func (c *Client) sendWatchCoreV1NamespacedSecret(ctx context.Context, params WatchCoreV1NamespacedSecretParams) (res WatchCoreV1NamespacedSecretRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedSecret"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/secrets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -79009,6 +79760,8 @@ func (c *Client) WatchCoreV1NamespacedSecretList(ctx context.Context, params Wat
 func (c *Client) sendWatchCoreV1NamespacedSecretList(ctx context.Context, params WatchCoreV1NamespacedSecretListParams) (res WatchCoreV1NamespacedSecretListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedSecretList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/secrets"),
 	}
 
 	// Run stopwatch.
@@ -79307,6 +80060,8 @@ func (c *Client) WatchCoreV1NamespacedService(ctx context.Context, params WatchC
 func (c *Client) sendWatchCoreV1NamespacedService(ctx context.Context, params WatchCoreV1NamespacedServiceParams) (res WatchCoreV1NamespacedServiceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedService"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/services/{name}"),
 	}
 
 	// Run stopwatch.
@@ -79623,6 +80378,8 @@ func (c *Client) WatchCoreV1NamespacedServiceAccount(ctx context.Context, params
 func (c *Client) sendWatchCoreV1NamespacedServiceAccount(ctx context.Context, params WatchCoreV1NamespacedServiceAccountParams) (res WatchCoreV1NamespacedServiceAccountRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedServiceAccount"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/serviceaccounts/{name}"),
 	}
 
 	// Run stopwatch.
@@ -79939,6 +80696,8 @@ func (c *Client) WatchCoreV1NamespacedServiceAccountList(ctx context.Context, pa
 func (c *Client) sendWatchCoreV1NamespacedServiceAccountList(ctx context.Context, params WatchCoreV1NamespacedServiceAccountListParams) (res WatchCoreV1NamespacedServiceAccountListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedServiceAccountList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/serviceaccounts"),
 	}
 
 	// Run stopwatch.
@@ -80237,6 +80996,8 @@ func (c *Client) WatchCoreV1NamespacedServiceList(ctx context.Context, params Wa
 func (c *Client) sendWatchCoreV1NamespacedServiceList(ctx context.Context, params WatchCoreV1NamespacedServiceListParams) (res WatchCoreV1NamespacedServiceListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NamespacedServiceList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/namespaces/{namespace}/services"),
 	}
 
 	// Run stopwatch.
@@ -80535,6 +81296,8 @@ func (c *Client) WatchCoreV1Node(ctx context.Context, params WatchCoreV1NodePara
 func (c *Client) sendWatchCoreV1Node(ctx context.Context, params WatchCoreV1NodeParams) (res WatchCoreV1NodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1Node"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/nodes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -80832,6 +81595,8 @@ func (c *Client) WatchCoreV1NodeList(ctx context.Context, params WatchCoreV1Node
 func (c *Client) sendWatchCoreV1NodeList(ctx context.Context, params WatchCoreV1NodeListParams) (res WatchCoreV1NodeListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1NodeList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/nodes"),
 	}
 
 	// Run stopwatch.
@@ -81111,6 +81876,8 @@ func (c *Client) WatchCoreV1PersistentVolume(ctx context.Context, params WatchCo
 func (c *Client) sendWatchCoreV1PersistentVolume(ctx context.Context, params WatchCoreV1PersistentVolumeParams) (res WatchCoreV1PersistentVolumeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1PersistentVolume"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/persistentvolumes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -81408,6 +82175,8 @@ func (c *Client) WatchCoreV1PersistentVolumeClaimListForAllNamespaces(ctx contex
 func (c *Client) sendWatchCoreV1PersistentVolumeClaimListForAllNamespaces(ctx context.Context, params WatchCoreV1PersistentVolumeClaimListForAllNamespacesParams) (res WatchCoreV1PersistentVolumeClaimListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1PersistentVolumeClaimListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/persistentvolumeclaims"),
 	}
 
 	// Run stopwatch.
@@ -81687,6 +82456,8 @@ func (c *Client) WatchCoreV1PersistentVolumeList(ctx context.Context, params Wat
 func (c *Client) sendWatchCoreV1PersistentVolumeList(ctx context.Context, params WatchCoreV1PersistentVolumeListParams) (res WatchCoreV1PersistentVolumeListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1PersistentVolumeList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/persistentvolumes"),
 	}
 
 	// Run stopwatch.
@@ -81966,6 +82737,8 @@ func (c *Client) WatchCoreV1PodListForAllNamespaces(ctx context.Context, params 
 func (c *Client) sendWatchCoreV1PodListForAllNamespaces(ctx context.Context, params WatchCoreV1PodListForAllNamespacesParams) (res WatchCoreV1PodListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1PodListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/pods"),
 	}
 
 	// Run stopwatch.
@@ -82245,6 +83018,8 @@ func (c *Client) WatchCoreV1PodTemplateListForAllNamespaces(ctx context.Context,
 func (c *Client) sendWatchCoreV1PodTemplateListForAllNamespaces(ctx context.Context, params WatchCoreV1PodTemplateListForAllNamespacesParams) (res WatchCoreV1PodTemplateListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1PodTemplateListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/podtemplates"),
 	}
 
 	// Run stopwatch.
@@ -82524,6 +83299,8 @@ func (c *Client) WatchCoreV1ReplicationControllerListForAllNamespaces(ctx contex
 func (c *Client) sendWatchCoreV1ReplicationControllerListForAllNamespaces(ctx context.Context, params WatchCoreV1ReplicationControllerListForAllNamespacesParams) (res WatchCoreV1ReplicationControllerListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1ReplicationControllerListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/replicationcontrollers"),
 	}
 
 	// Run stopwatch.
@@ -82803,6 +83580,8 @@ func (c *Client) WatchCoreV1ResourceQuotaListForAllNamespaces(ctx context.Contex
 func (c *Client) sendWatchCoreV1ResourceQuotaListForAllNamespaces(ctx context.Context, params WatchCoreV1ResourceQuotaListForAllNamespacesParams) (res WatchCoreV1ResourceQuotaListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1ResourceQuotaListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/resourcequotas"),
 	}
 
 	// Run stopwatch.
@@ -83082,6 +83861,8 @@ func (c *Client) WatchCoreV1SecretListForAllNamespaces(ctx context.Context, para
 func (c *Client) sendWatchCoreV1SecretListForAllNamespaces(ctx context.Context, params WatchCoreV1SecretListForAllNamespacesParams) (res WatchCoreV1SecretListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1SecretListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/secrets"),
 	}
 
 	// Run stopwatch.
@@ -83361,6 +84142,8 @@ func (c *Client) WatchCoreV1ServiceAccountListForAllNamespaces(ctx context.Conte
 func (c *Client) sendWatchCoreV1ServiceAccountListForAllNamespaces(ctx context.Context, params WatchCoreV1ServiceAccountListForAllNamespacesParams) (res WatchCoreV1ServiceAccountListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1ServiceAccountListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/serviceaccounts"),
 	}
 
 	// Run stopwatch.
@@ -83640,6 +84423,8 @@ func (c *Client) WatchCoreV1ServiceListForAllNamespaces(ctx context.Context, par
 func (c *Client) sendWatchCoreV1ServiceListForAllNamespaces(ctx context.Context, params WatchCoreV1ServiceListForAllNamespacesParams) (res WatchCoreV1ServiceListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchCoreV1ServiceListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/watch/services"),
 	}
 
 	// Run stopwatch.
@@ -83919,6 +84704,8 @@ func (c *Client) WatchDiscoveryV1EndpointSliceListForAllNamespaces(ctx context.C
 func (c *Client) sendWatchDiscoveryV1EndpointSliceListForAllNamespaces(ctx context.Context, params WatchDiscoveryV1EndpointSliceListForAllNamespacesParams) (res WatchDiscoveryV1EndpointSliceListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1EndpointSliceListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/watch/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -84198,6 +84985,8 @@ func (c *Client) WatchDiscoveryV1NamespacedEndpointSlice(ctx context.Context, pa
 func (c *Client) sendWatchDiscoveryV1NamespacedEndpointSlice(ctx context.Context, params WatchDiscoveryV1NamespacedEndpointSliceParams) (res WatchDiscoveryV1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/watch/namespaces/{namespace}/endpointslices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -84514,6 +85303,8 @@ func (c *Client) WatchDiscoveryV1NamespacedEndpointSliceList(ctx context.Context
 func (c *Client) sendWatchDiscoveryV1NamespacedEndpointSliceList(ctx context.Context, params WatchDiscoveryV1NamespacedEndpointSliceListParams) (res WatchDiscoveryV1NamespacedEndpointSliceListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1NamespacedEndpointSliceList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1/watch/namespaces/{namespace}/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -84812,6 +85603,8 @@ func (c *Client) WatchDiscoveryV1beta1EndpointSliceListForAllNamespaces(ctx cont
 func (c *Client) sendWatchDiscoveryV1beta1EndpointSliceListForAllNamespaces(ctx context.Context, params WatchDiscoveryV1beta1EndpointSliceListForAllNamespacesParams) (res WatchDiscoveryV1beta1EndpointSliceListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1beta1EndpointSliceListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/watch/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -85091,6 +85884,8 @@ func (c *Client) WatchDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Contex
 func (c *Client) sendWatchDiscoveryV1beta1NamespacedEndpointSlice(ctx context.Context, params WatchDiscoveryV1beta1NamespacedEndpointSliceParams) (res WatchDiscoveryV1beta1NamespacedEndpointSliceRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1beta1NamespacedEndpointSlice"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/watch/namespaces/{namespace}/endpointslices/{name}"),
 	}
 
 	// Run stopwatch.
@@ -85407,6 +86202,8 @@ func (c *Client) WatchDiscoveryV1beta1NamespacedEndpointSliceList(ctx context.Co
 func (c *Client) sendWatchDiscoveryV1beta1NamespacedEndpointSliceList(ctx context.Context, params WatchDiscoveryV1beta1NamespacedEndpointSliceListParams) (res WatchDiscoveryV1beta1NamespacedEndpointSliceListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchDiscoveryV1beta1NamespacedEndpointSliceList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/discovery.k8s.io/v1beta1/watch/namespaces/{namespace}/endpointslices"),
 	}
 
 	// Run stopwatch.
@@ -85705,6 +86502,8 @@ func (c *Client) WatchEventsV1EventListForAllNamespaces(ctx context.Context, par
 func (c *Client) sendWatchEventsV1EventListForAllNamespaces(ctx context.Context, params WatchEventsV1EventListForAllNamespacesParams) (res WatchEventsV1EventListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1EventListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/watch/events"),
 	}
 
 	// Run stopwatch.
@@ -85984,6 +86783,8 @@ func (c *Client) WatchEventsV1NamespacedEvent(ctx context.Context, params WatchE
 func (c *Client) sendWatchEventsV1NamespacedEvent(ctx context.Context, params WatchEventsV1NamespacedEventParams) (res WatchEventsV1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/watch/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -86300,6 +87101,8 @@ func (c *Client) WatchEventsV1NamespacedEventList(ctx context.Context, params Wa
 func (c *Client) sendWatchEventsV1NamespacedEventList(ctx context.Context, params WatchEventsV1NamespacedEventListParams) (res WatchEventsV1NamespacedEventListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1NamespacedEventList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1/watch/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -86598,6 +87401,8 @@ func (c *Client) WatchEventsV1beta1EventListForAllNamespaces(ctx context.Context
 func (c *Client) sendWatchEventsV1beta1EventListForAllNamespaces(ctx context.Context, params WatchEventsV1beta1EventListForAllNamespacesParams) (res WatchEventsV1beta1EventListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1beta1EventListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/watch/events"),
 	}
 
 	// Run stopwatch.
@@ -86877,6 +87682,8 @@ func (c *Client) WatchEventsV1beta1NamespacedEvent(ctx context.Context, params W
 func (c *Client) sendWatchEventsV1beta1NamespacedEvent(ctx context.Context, params WatchEventsV1beta1NamespacedEventParams) (res WatchEventsV1beta1NamespacedEventRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1beta1NamespacedEvent"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events/{name}"),
 	}
 
 	// Run stopwatch.
@@ -87193,6 +88000,8 @@ func (c *Client) WatchEventsV1beta1NamespacedEventList(ctx context.Context, para
 func (c *Client) sendWatchEventsV1beta1NamespacedEventList(ctx context.Context, params WatchEventsV1beta1NamespacedEventListParams) (res WatchEventsV1beta1NamespacedEventListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchEventsV1beta1NamespacedEventList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events"),
 	}
 
 	// Run stopwatch.
@@ -87491,6 +88300,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context,
 func (c *Client) sendWatchFlowcontrolApiserverV1beta1FlowSchema(ctx context.Context, params WatchFlowcontrolApiserverV1beta1FlowSchemaParams) (res WatchFlowcontrolApiserverV1beta1FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta1FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/flowschemas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -87788,6 +88599,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta1FlowSchemaList(ctx context.Cont
 func (c *Client) sendWatchFlowcontrolApiserverV1beta1FlowSchemaList(ctx context.Context, params WatchFlowcontrolApiserverV1beta1FlowSchemaListParams) (res WatchFlowcontrolApiserverV1beta1FlowSchemaListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta1FlowSchemaList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/flowschemas"),
 	}
 
 	// Run stopwatch.
@@ -88068,6 +88881,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx 
 func (c *Client) sendWatchFlowcontrolApiserverV1beta1PriorityLevelConfiguration(ctx context.Context, params WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationParams) (res WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta1PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/prioritylevelconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -88365,6 +89180,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationList(
 func (c *Client) sendWatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationList(ctx context.Context, params WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListParams) (res WatchFlowcontrolApiserverV1beta1PriorityLevelConfigurationListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta1PriorityLevelConfigurationList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/prioritylevelconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -88644,6 +89461,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context,
 func (c *Client) sendWatchFlowcontrolApiserverV1beta2FlowSchema(ctx context.Context, params WatchFlowcontrolApiserverV1beta2FlowSchemaParams) (res WatchFlowcontrolApiserverV1beta2FlowSchemaRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta2FlowSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/flowschemas/{name}"),
 	}
 
 	// Run stopwatch.
@@ -88941,6 +89760,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta2FlowSchemaList(ctx context.Cont
 func (c *Client) sendWatchFlowcontrolApiserverV1beta2FlowSchemaList(ctx context.Context, params WatchFlowcontrolApiserverV1beta2FlowSchemaListParams) (res WatchFlowcontrolApiserverV1beta2FlowSchemaListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta2FlowSchemaList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/flowschemas"),
 	}
 
 	// Run stopwatch.
@@ -89221,6 +90042,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx 
 func (c *Client) sendWatchFlowcontrolApiserverV1beta2PriorityLevelConfiguration(ctx context.Context, params WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationParams) (res WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta2PriorityLevelConfiguration"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/prioritylevelconfigurations/{name}"),
 	}
 
 	// Run stopwatch.
@@ -89518,6 +90341,8 @@ func (c *Client) WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationList(
 func (c *Client) sendWatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationList(ctx context.Context, params WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListParams) (res WatchFlowcontrolApiserverV1beta2PriorityLevelConfigurationListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchFlowcontrolApiserverV1beta2PriorityLevelConfigurationList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/flowcontrol.apiserver.k8s.io/v1beta2/watch/prioritylevelconfigurations"),
 	}
 
 	// Run stopwatch.
@@ -89797,6 +90622,8 @@ func (c *Client) WatchInternalApiserverV1alpha1StorageVersion(ctx context.Contex
 func (c *Client) sendWatchInternalApiserverV1alpha1StorageVersion(ctx context.Context, params WatchInternalApiserverV1alpha1StorageVersionParams) (res WatchInternalApiserverV1alpha1StorageVersionRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchInternalApiserverV1alpha1StorageVersion"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/watch/storageversions/{name}"),
 	}
 
 	// Run stopwatch.
@@ -90094,6 +90921,8 @@ func (c *Client) WatchInternalApiserverV1alpha1StorageVersionList(ctx context.Co
 func (c *Client) sendWatchInternalApiserverV1alpha1StorageVersionList(ctx context.Context, params WatchInternalApiserverV1alpha1StorageVersionListParams) (res WatchInternalApiserverV1alpha1StorageVersionListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchInternalApiserverV1alpha1StorageVersionList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/internal.apiserver.k8s.io/v1alpha1/watch/storageversions"),
 	}
 
 	// Run stopwatch.
@@ -90373,6 +91202,8 @@ func (c *Client) WatchNetworkingV1IngressClass(ctx context.Context, params Watch
 func (c *Client) sendWatchNetworkingV1IngressClass(ctx context.Context, params WatchNetworkingV1IngressClassParams) (res WatchNetworkingV1IngressClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1IngressClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/ingressclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -90670,6 +91501,8 @@ func (c *Client) WatchNetworkingV1IngressClassList(ctx context.Context, params W
 func (c *Client) sendWatchNetworkingV1IngressClassList(ctx context.Context, params WatchNetworkingV1IngressClassListParams) (res WatchNetworkingV1IngressClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1IngressClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/ingressclasses"),
 	}
 
 	// Run stopwatch.
@@ -90949,6 +91782,8 @@ func (c *Client) WatchNetworkingV1IngressListForAllNamespaces(ctx context.Contex
 func (c *Client) sendWatchNetworkingV1IngressListForAllNamespaces(ctx context.Context, params WatchNetworkingV1IngressListForAllNamespacesParams) (res WatchNetworkingV1IngressListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1IngressListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/ingresses"),
 	}
 
 	// Run stopwatch.
@@ -91228,6 +92063,8 @@ func (c *Client) WatchNetworkingV1NamespacedIngress(ctx context.Context, params 
 func (c *Client) sendWatchNetworkingV1NamespacedIngress(ctx context.Context, params WatchNetworkingV1NamespacedIngressParams) (res WatchNetworkingV1NamespacedIngressRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1NamespacedIngress"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/ingresses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -91544,6 +92381,8 @@ func (c *Client) WatchNetworkingV1NamespacedIngressList(ctx context.Context, par
 func (c *Client) sendWatchNetworkingV1NamespacedIngressList(ctx context.Context, params WatchNetworkingV1NamespacedIngressListParams) (res WatchNetworkingV1NamespacedIngressListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1NamespacedIngressList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/ingresses"),
 	}
 
 	// Run stopwatch.
@@ -91842,6 +92681,8 @@ func (c *Client) WatchNetworkingV1NamespacedNetworkPolicy(ctx context.Context, p
 func (c *Client) sendWatchNetworkingV1NamespacedNetworkPolicy(ctx context.Context, params WatchNetworkingV1NamespacedNetworkPolicyParams) (res WatchNetworkingV1NamespacedNetworkPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1NamespacedNetworkPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies/{name}"),
 	}
 
 	// Run stopwatch.
@@ -92158,6 +92999,8 @@ func (c *Client) WatchNetworkingV1NamespacedNetworkPolicyList(ctx context.Contex
 func (c *Client) sendWatchNetworkingV1NamespacedNetworkPolicyList(ctx context.Context, params WatchNetworkingV1NamespacedNetworkPolicyListParams) (res WatchNetworkingV1NamespacedNetworkPolicyListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1NamespacedNetworkPolicyList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies"),
 	}
 
 	// Run stopwatch.
@@ -92456,6 +93299,8 @@ func (c *Client) WatchNetworkingV1NetworkPolicyListForAllNamespaces(ctx context.
 func (c *Client) sendWatchNetworkingV1NetworkPolicyListForAllNamespaces(ctx context.Context, params WatchNetworkingV1NetworkPolicyListForAllNamespacesParams) (res WatchNetworkingV1NetworkPolicyListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNetworkingV1NetworkPolicyListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/networking.k8s.io/v1/watch/networkpolicies"),
 	}
 
 	// Run stopwatch.
@@ -92735,6 +93580,8 @@ func (c *Client) WatchNodeV1RuntimeClass(ctx context.Context, params WatchNodeV1
 func (c *Client) sendWatchNodeV1RuntimeClass(ctx context.Context, params WatchNodeV1RuntimeClassParams) (res WatchNodeV1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1/watch/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -93032,6 +93879,8 @@ func (c *Client) WatchNodeV1RuntimeClassList(ctx context.Context, params WatchNo
 func (c *Client) sendWatchNodeV1RuntimeClassList(ctx context.Context, params WatchNodeV1RuntimeClassListParams) (res WatchNodeV1RuntimeClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1RuntimeClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1/watch/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -93311,6 +94160,8 @@ func (c *Client) WatchNodeV1alpha1RuntimeClass(ctx context.Context, params Watch
 func (c *Client) sendWatchNodeV1alpha1RuntimeClass(ctx context.Context, params WatchNodeV1alpha1RuntimeClassParams) (res WatchNodeV1alpha1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1alpha1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1alpha1/watch/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -93608,6 +94459,8 @@ func (c *Client) WatchNodeV1alpha1RuntimeClassList(ctx context.Context, params W
 func (c *Client) sendWatchNodeV1alpha1RuntimeClassList(ctx context.Context, params WatchNodeV1alpha1RuntimeClassListParams) (res WatchNodeV1alpha1RuntimeClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1alpha1RuntimeClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1alpha1/watch/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -93887,6 +94740,8 @@ func (c *Client) WatchNodeV1beta1RuntimeClass(ctx context.Context, params WatchN
 func (c *Client) sendWatchNodeV1beta1RuntimeClass(ctx context.Context, params WatchNodeV1beta1RuntimeClassParams) (res WatchNodeV1beta1RuntimeClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1beta1RuntimeClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1beta1/watch/runtimeclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -94184,6 +95039,8 @@ func (c *Client) WatchNodeV1beta1RuntimeClassList(ctx context.Context, params Wa
 func (c *Client) sendWatchNodeV1beta1RuntimeClassList(ctx context.Context, params WatchNodeV1beta1RuntimeClassListParams) (res WatchNodeV1beta1RuntimeClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchNodeV1beta1RuntimeClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/node.k8s.io/v1beta1/watch/runtimeclasses"),
 	}
 
 	// Run stopwatch.
@@ -94463,6 +95320,8 @@ func (c *Client) WatchPolicyV1NamespacedPodDisruptionBudget(ctx context.Context,
 func (c *Client) sendWatchPolicyV1NamespacedPodDisruptionBudget(ctx context.Context, params WatchPolicyV1NamespacedPodDisruptionBudgetParams) (res WatchPolicyV1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -94779,6 +95638,8 @@ func (c *Client) WatchPolicyV1NamespacedPodDisruptionBudgetList(ctx context.Cont
 func (c *Client) sendWatchPolicyV1NamespacedPodDisruptionBudgetList(ctx context.Context, params WatchPolicyV1NamespacedPodDisruptionBudgetListParams) (res WatchPolicyV1NamespacedPodDisruptionBudgetListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1NamespacedPodDisruptionBudgetList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/watch/namespaces/{namespace}/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -95077,6 +95938,8 @@ func (c *Client) WatchPolicyV1PodDisruptionBudgetListForAllNamespaces(ctx contex
 func (c *Client) sendWatchPolicyV1PodDisruptionBudgetListForAllNamespaces(ctx context.Context, params WatchPolicyV1PodDisruptionBudgetListForAllNamespacesParams) (res WatchPolicyV1PodDisruptionBudgetListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1PodDisruptionBudgetListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1/watch/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -95356,6 +96219,8 @@ func (c *Client) WatchPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Con
 func (c *Client) sendWatchPolicyV1beta1NamespacedPodDisruptionBudget(ctx context.Context, params WatchPolicyV1beta1NamespacedPodDisruptionBudgetParams) (res WatchPolicyV1beta1NamespacedPodDisruptionBudgetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1beta1NamespacedPodDisruptionBudget"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}"),
 	}
 
 	// Run stopwatch.
@@ -95672,6 +96537,8 @@ func (c *Client) WatchPolicyV1beta1NamespacedPodDisruptionBudgetList(ctx context
 func (c *Client) sendWatchPolicyV1beta1NamespacedPodDisruptionBudgetList(ctx context.Context, params WatchPolicyV1beta1NamespacedPodDisruptionBudgetListParams) (res WatchPolicyV1beta1NamespacedPodDisruptionBudgetListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1beta1NamespacedPodDisruptionBudgetList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -95970,6 +96837,8 @@ func (c *Client) WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces(ctx c
 func (c *Client) sendWatchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces(ctx context.Context, params WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesParams) (res WatchPolicyV1beta1PodDisruptionBudgetListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/watch/poddisruptionbudgets"),
 	}
 
 	// Run stopwatch.
@@ -96249,6 +97118,8 @@ func (c *Client) WatchPolicyV1beta1PodSecurityPolicy(ctx context.Context, params
 func (c *Client) sendWatchPolicyV1beta1PodSecurityPolicy(ctx context.Context, params WatchPolicyV1beta1PodSecurityPolicyParams) (res WatchPolicyV1beta1PodSecurityPolicyRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1beta1PodSecurityPolicy"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/watch/podsecuritypolicies/{name}"),
 	}
 
 	// Run stopwatch.
@@ -96546,6 +97417,8 @@ func (c *Client) WatchPolicyV1beta1PodSecurityPolicyList(ctx context.Context, pa
 func (c *Client) sendWatchPolicyV1beta1PodSecurityPolicyList(ctx context.Context, params WatchPolicyV1beta1PodSecurityPolicyListParams) (res WatchPolicyV1beta1PodSecurityPolicyListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchPolicyV1beta1PodSecurityPolicyList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/policy/v1beta1/watch/podsecuritypolicies"),
 	}
 
 	// Run stopwatch.
@@ -96825,6 +97698,8 @@ func (c *Client) WatchRbacAuthorizationV1ClusterRole(ctx context.Context, params
 func (c *Client) sendWatchRbacAuthorizationV1ClusterRole(ctx context.Context, params WatchRbacAuthorizationV1ClusterRoleParams) (res WatchRbacAuthorizationV1ClusterRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1ClusterRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/clusterroles/{name}"),
 	}
 
 	// Run stopwatch.
@@ -97122,6 +97997,8 @@ func (c *Client) WatchRbacAuthorizationV1ClusterRoleBinding(ctx context.Context,
 func (c *Client) sendWatchRbacAuthorizationV1ClusterRoleBinding(ctx context.Context, params WatchRbacAuthorizationV1ClusterRoleBindingParams) (res WatchRbacAuthorizationV1ClusterRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1ClusterRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings/{name}"),
 	}
 
 	// Run stopwatch.
@@ -97419,6 +98296,8 @@ func (c *Client) WatchRbacAuthorizationV1ClusterRoleBindingList(ctx context.Cont
 func (c *Client) sendWatchRbacAuthorizationV1ClusterRoleBindingList(ctx context.Context, params WatchRbacAuthorizationV1ClusterRoleBindingListParams) (res WatchRbacAuthorizationV1ClusterRoleBindingListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1ClusterRoleBindingList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings"),
 	}
 
 	// Run stopwatch.
@@ -97698,6 +98577,8 @@ func (c *Client) WatchRbacAuthorizationV1ClusterRoleList(ctx context.Context, pa
 func (c *Client) sendWatchRbacAuthorizationV1ClusterRoleList(ctx context.Context, params WatchRbacAuthorizationV1ClusterRoleListParams) (res WatchRbacAuthorizationV1ClusterRoleListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1ClusterRoleList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/clusterroles"),
 	}
 
 	// Run stopwatch.
@@ -97977,6 +98858,8 @@ func (c *Client) WatchRbacAuthorizationV1NamespacedRole(ctx context.Context, par
 func (c *Client) sendWatchRbacAuthorizationV1NamespacedRole(ctx context.Context, params WatchRbacAuthorizationV1NamespacedRoleParams) (res WatchRbacAuthorizationV1NamespacedRoleRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1NamespacedRole"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles/{name}"),
 	}
 
 	// Run stopwatch.
@@ -98293,6 +99176,8 @@ func (c *Client) WatchRbacAuthorizationV1NamespacedRoleBinding(ctx context.Conte
 func (c *Client) sendWatchRbacAuthorizationV1NamespacedRoleBinding(ctx context.Context, params WatchRbacAuthorizationV1NamespacedRoleBindingParams) (res WatchRbacAuthorizationV1NamespacedRoleBindingRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1NamespacedRoleBinding"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings/{name}"),
 	}
 
 	// Run stopwatch.
@@ -98609,6 +99494,8 @@ func (c *Client) WatchRbacAuthorizationV1NamespacedRoleBindingList(ctx context.C
 func (c *Client) sendWatchRbacAuthorizationV1NamespacedRoleBindingList(ctx context.Context, params WatchRbacAuthorizationV1NamespacedRoleBindingListParams) (res WatchRbacAuthorizationV1NamespacedRoleBindingListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1NamespacedRoleBindingList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings"),
 	}
 
 	// Run stopwatch.
@@ -98907,6 +99794,8 @@ func (c *Client) WatchRbacAuthorizationV1NamespacedRoleList(ctx context.Context,
 func (c *Client) sendWatchRbacAuthorizationV1NamespacedRoleList(ctx context.Context, params WatchRbacAuthorizationV1NamespacedRoleListParams) (res WatchRbacAuthorizationV1NamespacedRoleListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1NamespacedRoleList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles"),
 	}
 
 	// Run stopwatch.
@@ -99205,6 +100094,8 @@ func (c *Client) WatchRbacAuthorizationV1RoleBindingListForAllNamespaces(ctx con
 func (c *Client) sendWatchRbacAuthorizationV1RoleBindingListForAllNamespaces(ctx context.Context, params WatchRbacAuthorizationV1RoleBindingListForAllNamespacesParams) (res WatchRbacAuthorizationV1RoleBindingListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1RoleBindingListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/rolebindings"),
 	}
 
 	// Run stopwatch.
@@ -99484,6 +100375,8 @@ func (c *Client) WatchRbacAuthorizationV1RoleListForAllNamespaces(ctx context.Co
 func (c *Client) sendWatchRbacAuthorizationV1RoleListForAllNamespaces(ctx context.Context, params WatchRbacAuthorizationV1RoleListForAllNamespacesParams) (res WatchRbacAuthorizationV1RoleListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchRbacAuthorizationV1RoleListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/rbac.authorization.k8s.io/v1/watch/roles"),
 	}
 
 	// Run stopwatch.
@@ -99763,6 +100656,8 @@ func (c *Client) WatchSchedulingV1PriorityClass(ctx context.Context, params Watc
 func (c *Client) sendWatchSchedulingV1PriorityClass(ctx context.Context, params WatchSchedulingV1PriorityClassParams) (res WatchSchedulingV1PriorityClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchSchedulingV1PriorityClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/v1/watch/priorityclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -100060,6 +100955,8 @@ func (c *Client) WatchSchedulingV1PriorityClassList(ctx context.Context, params 
 func (c *Client) sendWatchSchedulingV1PriorityClassList(ctx context.Context, params WatchSchedulingV1PriorityClassListParams) (res WatchSchedulingV1PriorityClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchSchedulingV1PriorityClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/scheduling.k8s.io/v1/watch/priorityclasses"),
 	}
 
 	// Run stopwatch.
@@ -100339,6 +101236,8 @@ func (c *Client) WatchStorageV1CSIDriver(ctx context.Context, params WatchStorag
 func (c *Client) sendWatchStorageV1CSIDriver(ctx context.Context, params WatchStorageV1CSIDriverParams) (res WatchStorageV1CSIDriverRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1CSIDriver"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/csidrivers/{name}"),
 	}
 
 	// Run stopwatch.
@@ -100636,6 +101535,8 @@ func (c *Client) WatchStorageV1CSIDriverList(ctx context.Context, params WatchSt
 func (c *Client) sendWatchStorageV1CSIDriverList(ctx context.Context, params WatchStorageV1CSIDriverListParams) (res WatchStorageV1CSIDriverListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1CSIDriverList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/csidrivers"),
 	}
 
 	// Run stopwatch.
@@ -100915,6 +101816,8 @@ func (c *Client) WatchStorageV1CSINode(ctx context.Context, params WatchStorageV
 func (c *Client) sendWatchStorageV1CSINode(ctx context.Context, params WatchStorageV1CSINodeParams) (res WatchStorageV1CSINodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1CSINode"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/csinodes/{name}"),
 	}
 
 	// Run stopwatch.
@@ -101212,6 +102115,8 @@ func (c *Client) WatchStorageV1CSINodeList(ctx context.Context, params WatchStor
 func (c *Client) sendWatchStorageV1CSINodeList(ctx context.Context, params WatchStorageV1CSINodeListParams) (res WatchStorageV1CSINodeListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1CSINodeList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/csinodes"),
 	}
 
 	// Run stopwatch.
@@ -101491,6 +102396,8 @@ func (c *Client) WatchStorageV1StorageClass(ctx context.Context, params WatchSto
 func (c *Client) sendWatchStorageV1StorageClass(ctx context.Context, params WatchStorageV1StorageClassParams) (res WatchStorageV1StorageClassRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1StorageClass"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/storageclasses/{name}"),
 	}
 
 	// Run stopwatch.
@@ -101788,6 +102695,8 @@ func (c *Client) WatchStorageV1StorageClassList(ctx context.Context, params Watc
 func (c *Client) sendWatchStorageV1StorageClassList(ctx context.Context, params WatchStorageV1StorageClassListParams) (res WatchStorageV1StorageClassListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1StorageClassList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/storageclasses"),
 	}
 
 	// Run stopwatch.
@@ -102067,6 +102976,8 @@ func (c *Client) WatchStorageV1VolumeAttachment(ctx context.Context, params Watc
 func (c *Client) sendWatchStorageV1VolumeAttachment(ctx context.Context, params WatchStorageV1VolumeAttachmentParams) (res WatchStorageV1VolumeAttachmentRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1VolumeAttachment"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/volumeattachments/{name}"),
 	}
 
 	// Run stopwatch.
@@ -102364,6 +103275,8 @@ func (c *Client) WatchStorageV1VolumeAttachmentList(ctx context.Context, params 
 func (c *Client) sendWatchStorageV1VolumeAttachmentList(ctx context.Context, params WatchStorageV1VolumeAttachmentListParams) (res WatchStorageV1VolumeAttachmentListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1VolumeAttachmentList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1/watch/volumeattachments"),
 	}
 
 	// Run stopwatch.
@@ -102643,6 +103556,8 @@ func (c *Client) WatchStorageV1alpha1CSIStorageCapacityListForAllNamespaces(ctx 
 func (c *Client) sendWatchStorageV1alpha1CSIStorageCapacityListForAllNamespaces(ctx context.Context, params WatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesParams) (res WatchStorageV1alpha1CSIStorageCapacityListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1alpha1CSIStorageCapacityListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/watch/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -102922,6 +103837,8 @@ func (c *Client) WatchStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Co
 func (c *Client) sendWatchStorageV1alpha1NamespacedCSIStorageCapacity(ctx context.Context, params WatchStorageV1alpha1NamespacedCSIStorageCapacityParams) (res WatchStorageV1alpha1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1alpha1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/watch/namespaces/{namespace}/csistoragecapacities/{name}"),
 	}
 
 	// Run stopwatch.
@@ -103238,6 +104155,8 @@ func (c *Client) WatchStorageV1alpha1NamespacedCSIStorageCapacityList(ctx contex
 func (c *Client) sendWatchStorageV1alpha1NamespacedCSIStorageCapacityList(ctx context.Context, params WatchStorageV1alpha1NamespacedCSIStorageCapacityListParams) (res WatchStorageV1alpha1NamespacedCSIStorageCapacityListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1alpha1NamespacedCSIStorageCapacityList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1alpha1/watch/namespaces/{namespace}/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -103536,6 +104455,8 @@ func (c *Client) WatchStorageV1beta1CSIStorageCapacityListForAllNamespaces(ctx c
 func (c *Client) sendWatchStorageV1beta1CSIStorageCapacityListForAllNamespaces(ctx context.Context, params WatchStorageV1beta1CSIStorageCapacityListForAllNamespacesParams) (res WatchStorageV1beta1CSIStorageCapacityListForAllNamespacesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1beta1CSIStorageCapacityListForAllNamespaces"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/watch/csistoragecapacities"),
 	}
 
 	// Run stopwatch.
@@ -103815,6 +104736,8 @@ func (c *Client) WatchStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Con
 func (c *Client) sendWatchStorageV1beta1NamespacedCSIStorageCapacity(ctx context.Context, params WatchStorageV1beta1NamespacedCSIStorageCapacityParams) (res WatchStorageV1beta1NamespacedCSIStorageCapacityRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1beta1NamespacedCSIStorageCapacity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/watch/namespaces/{namespace}/csistoragecapacities/{name}"),
 	}
 
 	// Run stopwatch.
@@ -104131,6 +105054,8 @@ func (c *Client) WatchStorageV1beta1NamespacedCSIStorageCapacityList(ctx context
 func (c *Client) sendWatchStorageV1beta1NamespacedCSIStorageCapacityList(ctx context.Context, params WatchStorageV1beta1NamespacedCSIStorageCapacityListParams) (res WatchStorageV1beta1NamespacedCSIStorageCapacityListRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("watchStorageV1beta1NamespacedCSIStorageCapacityList"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/apis/storage.k8s.io/v1beta1/watch/namespaces/{namespace}/csistoragecapacities"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_manga/oas_client_gen.go
+++ b/examples/ex_manga/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -82,6 +83,8 @@ func (c *Client) GetBook(ctx context.Context, params GetBookParams) (GetBookRes,
 func (c *Client) sendGetBook(ctx context.Context, params GetBookParams) (res GetBookRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBook"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/gallery/{book_id}"),
 	}
 
 	// Run stopwatch.
@@ -171,6 +174,8 @@ func (c *Client) GetPageCoverImage(ctx context.Context, params GetPageCoverImage
 func (c *Client) sendGetPageCoverImage(ctx context.Context, params GetPageCoverImageParams) (res GetPageCoverImageRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPageCoverImage"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/galleries/{media_id}/cover.{format}"),
 	}
 
 	// Run stopwatch.
@@ -279,6 +284,8 @@ func (c *Client) GetPageImage(ctx context.Context, params GetPageImageParams) (G
 func (c *Client) sendGetPageImage(ctx context.Context, params GetPageImageParams) (res GetPageImageRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPageImage"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/galleries/{media_id}/{page}.{format}"),
 	}
 
 	// Run stopwatch.
@@ -406,6 +413,8 @@ func (c *Client) GetPageThumbnailImage(ctx context.Context, params GetPageThumbn
 func (c *Client) sendGetPageThumbnailImage(ctx context.Context, params GetPageThumbnailImageParams) (res GetPageThumbnailImageRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getPageThumbnailImage"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/galleries/{media_id}/{page}t.{format}"),
 	}
 
 	// Run stopwatch.
@@ -533,6 +542,8 @@ func (c *Client) Search(ctx context.Context, params SearchParams) (SearchRes, er
 func (c *Client) sendSearch(ctx context.Context, params SearchParams) (res SearchRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("search"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/galleries/search"),
 	}
 
 	// Run stopwatch.
@@ -639,6 +650,8 @@ func (c *Client) SearchByTagID(ctx context.Context, params SearchByTagIDParams) 
 func (c *Client) sendSearchByTagID(ctx context.Context, params SearchByTagIDParams) (res SearchByTagIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("searchByTagID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/galleries/tagged"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_openai/oas_client_gen.go
+++ b/examples/ex_openai/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -82,6 +83,8 @@ func (c *Client) CancelFineTune(ctx context.Context, params CancelFineTuneParams
 func (c *Client) sendCancelFineTune(ctx context.Context, params CancelFineTuneParams) (res FineTune, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("cancelFineTune"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/fine-tunes/{fine_tune_id}/cancel"),
 	}
 
 	// Run stopwatch.
@@ -177,6 +180,8 @@ func (c *Client) CreateAnswer(ctx context.Context, request *CreateAnswerRequest)
 func (c *Client) sendCreateAnswer(ctx context.Context, request *CreateAnswerRequest) (res *CreateAnswerResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createAnswer"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answers"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -260,6 +265,8 @@ func (c *Client) CreateChatCompletion(ctx context.Context, request *CreateChatCo
 func (c *Client) sendCreateChatCompletion(ctx context.Context, request *CreateChatCompletionRequest) (res *CreateChatCompletionResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createChatCompletion"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/chat/completions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -351,6 +358,8 @@ func (c *Client) CreateClassification(ctx context.Context, request *CreateClassi
 func (c *Client) sendCreateClassification(ctx context.Context, request *CreateClassificationRequest) (res *CreateClassificationResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createClassification"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/classifications"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -434,6 +443,8 @@ func (c *Client) CreateCompletion(ctx context.Context, request *CreateCompletion
 func (c *Client) sendCreateCompletion(ctx context.Context, request *CreateCompletionRequest) (res *CreateCompletionResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createCompletion"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/completions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -517,6 +528,8 @@ func (c *Client) CreateEdit(ctx context.Context, request *CreateEditRequest) (*C
 func (c *Client) sendCreateEdit(ctx context.Context, request *CreateEditRequest) (res *CreateEditResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createEdit"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/edits"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -600,6 +613,8 @@ func (c *Client) CreateEmbedding(ctx context.Context, request *CreateEmbeddingRe
 func (c *Client) sendCreateEmbedding(ctx context.Context, request *CreateEmbeddingRequest) (res *CreateEmbeddingResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createEmbedding"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/embeddings"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -685,6 +700,8 @@ func (c *Client) CreateFile(ctx context.Context, request *CreateFileRequestMulti
 func (c *Client) sendCreateFile(ctx context.Context, request *CreateFileRequestMultipart) (res OpenAIFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/files"),
 	}
 
 	// Run stopwatch.
@@ -762,6 +779,8 @@ func (c *Client) CreateFineTune(ctx context.Context, request *CreateFineTuneRequ
 func (c *Client) sendCreateFineTune(ctx context.Context, request *CreateFineTuneRequest) (res FineTune, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createFineTune"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/fine-tunes"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -845,6 +864,8 @@ func (c *Client) CreateImage(ctx context.Context, request *CreateImageRequest) (
 func (c *Client) sendCreateImage(ctx context.Context, request *CreateImageRequest) (res ImagesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createImage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/images/generations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -928,6 +949,8 @@ func (c *Client) CreateImageEdit(ctx context.Context, request *CreateImageEditRe
 func (c *Client) sendCreateImageEdit(ctx context.Context, request *CreateImageEditRequestMultipart) (res ImagesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createImageEdit"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/images/edits"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1011,6 +1034,8 @@ func (c *Client) CreateImageVariation(ctx context.Context, request *CreateImageV
 func (c *Client) sendCreateImageVariation(ctx context.Context, request *CreateImageVariationRequestMultipart) (res ImagesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createImageVariation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/images/variations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1094,6 +1119,8 @@ func (c *Client) CreateModeration(ctx context.Context, request *CreateModeration
 func (c *Client) sendCreateModeration(ctx context.Context, request *CreateModerationRequest) (res *CreateModerationResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createModeration"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/moderations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1186,6 +1213,8 @@ func (c *Client) CreateSearch(ctx context.Context, request *CreateSearchRequest,
 func (c *Client) sendCreateSearch(ctx context.Context, request *CreateSearchRequest, params CreateSearchParams) (res *CreateSearchResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createSearch"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/engines/{engine_id}/search"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1288,6 +1317,8 @@ func (c *Client) CreateTranscription(ctx context.Context, request *CreateTranscr
 func (c *Client) sendCreateTranscription(ctx context.Context, request *CreateTranscriptionRequestMultipart) (res *CreateTranscriptionResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createTranscription"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/audio/transcriptions"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1371,6 +1402,8 @@ func (c *Client) CreateTranslation(ctx context.Context, request *CreateTranslati
 func (c *Client) sendCreateTranslation(ctx context.Context, request *CreateTranslationRequestMultipart) (res *CreateTranslationResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createTranslation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/audio/translations"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1454,6 +1487,8 @@ func (c *Client) DeleteFile(ctx context.Context, params DeleteFileParams) (*Dele
 func (c *Client) sendDeleteFile(ctx context.Context, params DeleteFileParams) (res *DeleteFileResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteFile"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/files/{file_id}"),
 	}
 
 	// Run stopwatch.
@@ -1543,6 +1578,8 @@ func (c *Client) DeleteModel(ctx context.Context, params DeleteModelParams) (*De
 func (c *Client) sendDeleteModel(ctx context.Context, params DeleteModelParams) (res *DeleteModelResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteModel"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/models/{model}"),
 	}
 
 	// Run stopwatch.
@@ -1632,6 +1669,8 @@ func (c *Client) DownloadFile(ctx context.Context, params DownloadFileParams) (s
 func (c *Client) sendDownloadFile(ctx context.Context, params DownloadFileParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("downloadFile"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/files/{file_id}/content"),
 	}
 
 	// Run stopwatch.
@@ -1725,6 +1764,8 @@ func (c *Client) ListEngines(ctx context.Context) (*ListEnginesResponse, error) 
 func (c *Client) sendListEngines(ctx context.Context) (res *ListEnginesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listEngines"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/engines"),
 	}
 
 	// Run stopwatch.
@@ -1796,6 +1837,8 @@ func (c *Client) ListFiles(ctx context.Context) (*ListFilesResponse, error) {
 func (c *Client) sendListFiles(ctx context.Context) (res *ListFilesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFiles"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/files"),
 	}
 
 	// Run stopwatch.
@@ -1867,6 +1910,8 @@ func (c *Client) ListFineTuneEvents(ctx context.Context, params ListFineTuneEven
 func (c *Client) sendListFineTuneEvents(ctx context.Context, params ListFineTuneEventsParams) (res *ListFineTuneEventsResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFineTuneEvents"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/fine-tunes/{fine_tune_id}/events"),
 	}
 
 	// Run stopwatch.
@@ -1978,6 +2023,8 @@ func (c *Client) ListFineTunes(ctx context.Context) (*ListFineTunesResponse, err
 func (c *Client) sendListFineTunes(ctx context.Context) (res *ListFineTunesResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listFineTunes"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/fine-tunes"),
 	}
 
 	// Run stopwatch.
@@ -2050,6 +2097,8 @@ func (c *Client) ListModels(ctx context.Context) (*ListModelsResponse, error) {
 func (c *Client) sendListModels(ctx context.Context) (res *ListModelsResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listModels"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/models"),
 	}
 
 	// Run stopwatch.
@@ -2124,6 +2173,8 @@ func (c *Client) RetrieveEngine(ctx context.Context, params RetrieveEngineParams
 func (c *Client) sendRetrieveEngine(ctx context.Context, params RetrieveEngineParams) (res Engine, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("retrieveEngine"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/engines/{engine_id}"),
 	}
 
 	// Run stopwatch.
@@ -2213,6 +2264,8 @@ func (c *Client) RetrieveFile(ctx context.Context, params RetrieveFileParams) (O
 func (c *Client) sendRetrieveFile(ctx context.Context, params RetrieveFileParams) (res OpenAIFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("retrieveFile"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/files/{file_id}"),
 	}
 
 	// Run stopwatch.
@@ -2303,6 +2356,8 @@ func (c *Client) RetrieveFineTune(ctx context.Context, params RetrieveFineTunePa
 func (c *Client) sendRetrieveFineTune(ctx context.Context, params RetrieveFineTuneParams) (res FineTune, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("retrieveFineTune"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/fine-tunes/{fine_tune_id}"),
 	}
 
 	// Run stopwatch.
@@ -2393,6 +2448,8 @@ func (c *Client) RetrieveModel(ctx context.Context, params RetrieveModelParams) 
 func (c *Client) sendRetrieveModel(ctx context.Context, params RetrieveModelParams) (res Model, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("retrieveModel"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/models/{model}"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_petstore/oas_client_gen.go
+++ b/examples/ex_petstore/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -86,6 +87,8 @@ func (c *Client) CreatePets(ctx context.Context) error {
 func (c *Client) sendCreatePets(ctx context.Context) (res *CreatePetsCreated, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createPets"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.
@@ -157,6 +160,8 @@ func (c *Client) ListPets(ctx context.Context, params ListPetsParams) (*PetsHead
 func (c *Client) sendListPets(ctx context.Context, params ListPetsParams) (res *PetsHeaders, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listPets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.
@@ -249,6 +254,8 @@ func (c *Client) ShowPetById(ctx context.Context, params ShowPetByIdParams) (*Pe
 func (c *Client) sendShowPetById(ctx context.Context, params ShowPetByIdParams) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("showPetById"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{petId}"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_petstore_expanded/oas_client_gen.go
+++ b/examples/ex_petstore_expanded/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -86,6 +87,8 @@ func (c *Client) AddPet(ctx context.Context, request *NewPet) (*Pet, error) {
 func (c *Client) sendAddPet(ctx context.Context, request *NewPet) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("addPet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.
@@ -160,6 +163,8 @@ func (c *Client) DeletePet(ctx context.Context, params DeletePetParams) error {
 func (c *Client) sendDeletePet(ctx context.Context, params DeletePetParams) (res *DeletePetNoContent, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deletePet"),
+		semconv.HTTPMethodKey.String("DELETE"),
+		semconv.HTTPRouteKey.String("/pets/{id}"),
 	}
 
 	// Run stopwatch.
@@ -249,6 +254,8 @@ func (c *Client) FindPetByID(ctx context.Context, params FindPetByIDParams) (*Pe
 func (c *Client) sendFindPetByID(ctx context.Context, params FindPetByIDParams) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("find pet by id"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets/{id}"),
 	}
 
 	// Run stopwatch.
@@ -356,6 +363,8 @@ func (c *Client) FindPets(ctx context.Context, params FindPetsParams) ([]Pet, er
 func (c *Client) sendFindPets(ctx context.Context, params FindPetsParams) (res []Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("findPets"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pets"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_route_params/oas_client_gen.go
+++ b/examples/ex_route_params/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -82,6 +83,8 @@ func (c *Client) DataGet(ctx context.Context, params DataGetParams) (string, err
 func (c *Client) sendDataGet(ctx context.Context, params DataGetParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/name/{id}/{key}"),
 	}
 
 	// Run stopwatch.
@@ -190,6 +193,8 @@ func (c *Client) DataGetAny(ctx context.Context) (string, error) {
 func (c *Client) sendDataGetAny(ctx context.Context) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGetAny"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/name"),
 	}
 
 	// Run stopwatch.
@@ -261,6 +266,8 @@ func (c *Client) DataGetID(ctx context.Context, params DataGetIDParams) (string,
 func (c *Client) sendDataGetID(ctx context.Context, params DataGetIDParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGetID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/name/{id}"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_telegram/oas_client_gen.go
+++ b/examples/ex_telegram/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -83,6 +84,8 @@ func (c *Client) AddStickerToSet(ctx context.Context, request *AddStickerToSet) 
 func (c *Client) sendAddStickerToSet(ctx context.Context, request *AddStickerToSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("addStickerToSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/addStickerToSet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -164,6 +167,8 @@ func (c *Client) AnswerCallbackQuery(ctx context.Context, request *AnswerCallbac
 func (c *Client) sendAnswerCallbackQuery(ctx context.Context, request *AnswerCallbackQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerCallbackQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerCallbackQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -245,6 +250,8 @@ func (c *Client) AnswerInlineQuery(ctx context.Context, request *AnswerInlineQue
 func (c *Client) sendAnswerInlineQuery(ctx context.Context, request *AnswerInlineQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerInlineQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerInlineQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -326,6 +333,8 @@ func (c *Client) AnswerPreCheckoutQuery(ctx context.Context, request *AnswerPreC
 func (c *Client) sendAnswerPreCheckoutQuery(ctx context.Context, request *AnswerPreCheckoutQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerPreCheckoutQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerPreCheckoutQuery"),
 	}
 
 	// Run stopwatch.
@@ -398,6 +407,8 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, request *AnswerShippin
 func (c *Client) sendAnswerShippingQuery(ctx context.Context, request *AnswerShippingQuery) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("answerShippingQuery"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/answerShippingQuery"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -479,6 +490,8 @@ func (c *Client) ApproveChatJoinRequest(ctx context.Context, request *ApproveCha
 func (c *Client) sendApproveChatJoinRequest(ctx context.Context, request *ApproveChatJoinRequest) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("approveChatJoinRequest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/approveChatJoinRequest"),
 	}
 
 	// Run stopwatch.
@@ -551,6 +564,8 @@ func (c *Client) BanChatMember(ctx context.Context, request *BanChatMember) (*Re
 func (c *Client) sendBanChatMember(ctx context.Context, request *BanChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("banChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/banChatMember"),
 	}
 
 	// Run stopwatch.
@@ -623,6 +638,8 @@ func (c *Client) BanChatSenderChat(ctx context.Context, request *BanChatSenderCh
 func (c *Client) sendBanChatSenderChat(ctx context.Context, request *BanChatSenderChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("banChatSenderChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/banChatSenderChat"),
 	}
 
 	// Run stopwatch.
@@ -695,6 +712,8 @@ func (c *Client) Close(ctx context.Context) (*Result, error) {
 func (c *Client) sendClose(ctx context.Context) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("close"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/close"),
 	}
 
 	// Run stopwatch.
@@ -764,6 +783,8 @@ func (c *Client) CopyMessage(ctx context.Context, request *CopyMessage) (*Result
 func (c *Client) sendCopyMessage(ctx context.Context, request *CopyMessage) (res *ResultMessageId, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("copyMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/copyMessage"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -845,6 +866,8 @@ func (c *Client) CreateChatInviteLink(ctx context.Context, request *CreateChatIn
 func (c *Client) sendCreateChatInviteLink(ctx context.Context, request *CreateChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/createChatInviteLink"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -926,6 +949,8 @@ func (c *Client) CreateNewStickerSet(ctx context.Context, request *CreateNewStic
 func (c *Client) sendCreateNewStickerSet(ctx context.Context, request *CreateNewStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("createNewStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/createNewStickerSet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1007,6 +1032,8 @@ func (c *Client) DeclineChatJoinRequest(ctx context.Context, request *DeclineCha
 func (c *Client) sendDeclineChatJoinRequest(ctx context.Context, request *DeclineChatJoinRequest) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("declineChatJoinRequest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/declineChatJoinRequest"),
 	}
 
 	// Run stopwatch.
@@ -1079,6 +1106,8 @@ func (c *Client) DeleteChatPhoto(ctx context.Context, request *DeleteChatPhoto) 
 func (c *Client) sendDeleteChatPhoto(ctx context.Context, request *DeleteChatPhoto) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteChatPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteChatPhoto"),
 	}
 
 	// Run stopwatch.
@@ -1151,6 +1180,8 @@ func (c *Client) DeleteChatStickerSet(ctx context.Context, request *DeleteChatSt
 func (c *Client) sendDeleteChatStickerSet(ctx context.Context, request *DeleteChatStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteChatStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteChatStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -1223,6 +1254,8 @@ func (c *Client) DeleteMessage(ctx context.Context, request *DeleteMessage) (*Re
 func (c *Client) sendDeleteMessage(ctx context.Context, request *DeleteMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteMessage"),
 	}
 
 	// Run stopwatch.
@@ -1295,6 +1328,8 @@ func (c *Client) DeleteMyCommands(ctx context.Context, request OptDeleteMyComman
 func (c *Client) sendDeleteMyCommands(ctx context.Context, request OptDeleteMyCommands) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteMyCommands"),
 	}
 
 	// Run stopwatch.
@@ -1367,6 +1402,8 @@ func (c *Client) DeleteStickerFromSet(ctx context.Context, request *DeleteSticke
 func (c *Client) sendDeleteStickerFromSet(ctx context.Context, request *DeleteStickerFromSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteStickerFromSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteStickerFromSet"),
 	}
 
 	// Run stopwatch.
@@ -1439,6 +1476,8 @@ func (c *Client) DeleteWebhook(ctx context.Context, request OptDeleteWebhook) (*
 func (c *Client) sendDeleteWebhook(ctx context.Context, request OptDeleteWebhook) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("deleteWebhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/deleteWebhook"),
 	}
 
 	// Run stopwatch.
@@ -1511,6 +1550,8 @@ func (c *Client) EditChatInviteLink(ctx context.Context, request *EditChatInvite
 func (c *Client) sendEditChatInviteLink(ctx context.Context, request *EditChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editChatInviteLink"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1592,6 +1633,8 @@ func (c *Client) EditMessageCaption(ctx context.Context, request *EditMessageCap
 func (c *Client) sendEditMessageCaption(ctx context.Context, request *EditMessageCaption) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageCaption"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageCaption"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1673,6 +1716,8 @@ func (c *Client) EditMessageLiveLocation(ctx context.Context, request *EditMessa
 func (c *Client) sendEditMessageLiveLocation(ctx context.Context, request *EditMessageLiveLocation) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageLiveLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageLiveLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1754,6 +1799,8 @@ func (c *Client) EditMessageMedia(ctx context.Context, request *EditMessageMedia
 func (c *Client) sendEditMessageMedia(ctx context.Context, request *EditMessageMedia) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageMedia"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageMedia"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1835,6 +1882,8 @@ func (c *Client) EditMessageReplyMarkup(ctx context.Context, request *EditMessag
 func (c *Client) sendEditMessageReplyMarkup(ctx context.Context, request *EditMessageReplyMarkup) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageReplyMarkup"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageReplyMarkup"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1916,6 +1965,8 @@ func (c *Client) EditMessageText(ctx context.Context, request *EditMessageText) 
 func (c *Client) sendEditMessageText(ctx context.Context, request *EditMessageText) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("editMessageText"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/editMessageText"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1997,6 +2048,8 @@ func (c *Client) ExportChatInviteLink(ctx context.Context, request *ExportChatIn
 func (c *Client) sendExportChatInviteLink(ctx context.Context, request *ExportChatInviteLink) (res *ResultString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("exportChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/exportChatInviteLink"),
 	}
 
 	// Run stopwatch.
@@ -2069,6 +2122,8 @@ func (c *Client) ForwardMessage(ctx context.Context, request *ForwardMessage) (*
 func (c *Client) sendForwardMessage(ctx context.Context, request *ForwardMessage) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("forwardMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/forwardMessage"),
 	}
 
 	// Run stopwatch.
@@ -2141,6 +2196,8 @@ func (c *Client) GetChat(ctx context.Context, request *GetChat) (*ResultChat, er
 func (c *Client) sendGetChat(ctx context.Context, request *GetChat) (res *ResultChat, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChat"),
 	}
 
 	// Run stopwatch.
@@ -2213,6 +2270,8 @@ func (c *Client) GetChatAdministrators(ctx context.Context, request *GetChatAdmi
 func (c *Client) sendGetChatAdministrators(ctx context.Context, request *GetChatAdministrators) (res *ResultArrayOfChatMember, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatAdministrators"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatAdministrators"),
 	}
 
 	// Run stopwatch.
@@ -2285,6 +2344,8 @@ func (c *Client) GetChatMember(ctx context.Context, request *GetChatMember) (*Re
 func (c *Client) sendGetChatMember(ctx context.Context, request *GetChatMember) (res *ResultChatMember, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatMember"),
 	}
 
 	// Run stopwatch.
@@ -2357,6 +2418,8 @@ func (c *Client) GetChatMemberCount(ctx context.Context, request *GetChatMemberC
 func (c *Client) sendGetChatMemberCount(ctx context.Context, request *GetChatMemberCount) (res *ResultInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getChatMemberCount"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getChatMemberCount"),
 	}
 
 	// Run stopwatch.
@@ -2429,6 +2492,8 @@ func (c *Client) GetFile(ctx context.Context, request *GetFile) (*Result, error)
 func (c *Client) sendGetFile(ctx context.Context, request *GetFile) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getFile"),
 	}
 
 	// Run stopwatch.
@@ -2501,6 +2566,8 @@ func (c *Client) GetGameHighScores(ctx context.Context, request *GetGameHighScor
 func (c *Client) sendGetGameHighScores(ctx context.Context, request *GetGameHighScores) (res *ResultArrayOfGameHighScore, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getGameHighScores"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getGameHighScores"),
 	}
 
 	// Run stopwatch.
@@ -2573,6 +2640,8 @@ func (c *Client) GetMe(ctx context.Context) (*ResultUser, error) {
 func (c *Client) sendGetMe(ctx context.Context) (res *ResultUser, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMe"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getMe"),
 	}
 
 	// Run stopwatch.
@@ -2642,6 +2711,8 @@ func (c *Client) GetMyCommands(ctx context.Context, request OptGetMyCommands) (*
 func (c *Client) sendGetMyCommands(ctx context.Context, request OptGetMyCommands) (res *ResultArrayOfBotCommand, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getMyCommands"),
 	}
 
 	// Run stopwatch.
@@ -2714,6 +2785,8 @@ func (c *Client) GetStickerSet(ctx context.Context, request *GetStickerSet) (*Re
 func (c *Client) sendGetStickerSet(ctx context.Context, request *GetStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -2786,6 +2859,8 @@ func (c *Client) GetUpdates(ctx context.Context, request OptGetUpdates) (*Result
 func (c *Client) sendGetUpdates(ctx context.Context, request OptGetUpdates) (res *ResultArrayOfUpdate, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getUpdates"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getUpdates"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2874,6 +2949,8 @@ func (c *Client) GetUserProfilePhotos(ctx context.Context, request *GetUserProfi
 func (c *Client) sendGetUserProfilePhotos(ctx context.Context, request *GetUserProfilePhotos) (res *ResultUserProfilePhotos, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getUserProfilePhotos"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getUserProfilePhotos"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2955,6 +3032,8 @@ func (c *Client) GetWebhookInfo(ctx context.Context) (*ResultWebhookInfo, error)
 func (c *Client) sendGetWebhookInfo(ctx context.Context) (res *ResultWebhookInfo, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getWebhookInfo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/getWebhookInfo"),
 	}
 
 	// Run stopwatch.
@@ -3024,6 +3103,8 @@ func (c *Client) LeaveChat(ctx context.Context, request *LeaveChat) (*Result, er
 func (c *Client) sendLeaveChat(ctx context.Context, request *LeaveChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("leaveChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/leaveChat"),
 	}
 
 	// Run stopwatch.
@@ -3096,6 +3177,8 @@ func (c *Client) LogOut(ctx context.Context) (*Result, error) {
 func (c *Client) sendLogOut(ctx context.Context) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("logOut"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/logOut"),
 	}
 
 	// Run stopwatch.
@@ -3165,6 +3248,8 @@ func (c *Client) PinChatMessage(ctx context.Context, request *PinChatMessage) (*
 func (c *Client) sendPinChatMessage(ctx context.Context, request *PinChatMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pinChatMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pinChatMessage"),
 	}
 
 	// Run stopwatch.
@@ -3237,6 +3322,8 @@ func (c *Client) PromoteChatMember(ctx context.Context, request *PromoteChatMemb
 func (c *Client) sendPromoteChatMember(ctx context.Context, request *PromoteChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("promoteChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/promoteChatMember"),
 	}
 
 	// Run stopwatch.
@@ -3309,6 +3396,8 @@ func (c *Client) RestrictChatMember(ctx context.Context, request *RestrictChatMe
 func (c *Client) sendRestrictChatMember(ctx context.Context, request *RestrictChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("restrictChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/restrictChatMember"),
 	}
 
 	// Run stopwatch.
@@ -3381,6 +3470,8 @@ func (c *Client) RevokeChatInviteLink(ctx context.Context, request *RevokeChatIn
 func (c *Client) sendRevokeChatInviteLink(ctx context.Context, request *RevokeChatInviteLink) (res *ResultChatInviteLink, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("revokeChatInviteLink"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/revokeChatInviteLink"),
 	}
 
 	// Run stopwatch.
@@ -3453,6 +3544,8 @@ func (c *Client) SendAnimation(ctx context.Context, request *SendAnimation) (*Re
 func (c *Client) sendSendAnimation(ctx context.Context, request *SendAnimation) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendAnimation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendAnimation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3534,6 +3627,8 @@ func (c *Client) SendAudio(ctx context.Context, request *SendAudio) (*ResultMess
 func (c *Client) sendSendAudio(ctx context.Context, request *SendAudio) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendAudio"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendAudio"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3615,6 +3710,8 @@ func (c *Client) SendChatAction(ctx context.Context, request *SendChatAction) (*
 func (c *Client) sendSendChatAction(ctx context.Context, request *SendChatAction) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendChatAction"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendChatAction"),
 	}
 
 	// Run stopwatch.
@@ -3687,6 +3784,8 @@ func (c *Client) SendContact(ctx context.Context, request *SendContact) (*Result
 func (c *Client) sendSendContact(ctx context.Context, request *SendContact) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendContact"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendContact"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3768,6 +3867,8 @@ func (c *Client) SendDice(ctx context.Context, request *SendDice) (*ResultMessag
 func (c *Client) sendSendDice(ctx context.Context, request *SendDice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendDice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendDice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3849,6 +3950,8 @@ func (c *Client) SendDocument(ctx context.Context, request *SendDocument) (*Resu
 func (c *Client) sendSendDocument(ctx context.Context, request *SendDocument) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendDocument"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendDocument"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3930,6 +4033,8 @@ func (c *Client) SendGame(ctx context.Context, request *SendGame) (*ResultMessag
 func (c *Client) sendSendGame(ctx context.Context, request *SendGame) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendGame"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendGame"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4011,6 +4116,8 @@ func (c *Client) SendInvoice(ctx context.Context, request *SendInvoice) (*Result
 func (c *Client) sendSendInvoice(ctx context.Context, request *SendInvoice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendInvoice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendInvoice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4092,6 +4199,8 @@ func (c *Client) SendLocation(ctx context.Context, request *SendLocation) (*Resu
 func (c *Client) sendSendLocation(ctx context.Context, request *SendLocation) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4173,6 +4282,8 @@ func (c *Client) SendMediaGroup(ctx context.Context, request *SendMediaGroup) (*
 func (c *Client) sendSendMediaGroup(ctx context.Context, request *SendMediaGroup) (res *ResultArrayOfMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendMediaGroup"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendMediaGroup"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4254,6 +4365,8 @@ func (c *Client) SendMessage(ctx context.Context, request *SendMessage) (*Result
 func (c *Client) sendSendMessage(ctx context.Context, request *SendMessage) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendMessage"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4335,6 +4448,8 @@ func (c *Client) SendPhoto(ctx context.Context, request *SendPhoto) (*ResultMess
 func (c *Client) sendSendPhoto(ctx context.Context, request *SendPhoto) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendPhoto"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4416,6 +4531,8 @@ func (c *Client) SendPoll(ctx context.Context, request *SendPoll) (*ResultMessag
 func (c *Client) sendSendPoll(ctx context.Context, request *SendPoll) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendPoll"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendPoll"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4497,6 +4614,8 @@ func (c *Client) SendSticker(ctx context.Context, request *SendSticker) (*Result
 func (c *Client) sendSendSticker(ctx context.Context, request *SendSticker) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendSticker"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendSticker"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4578,6 +4697,8 @@ func (c *Client) SendVenue(ctx context.Context, request *SendVenue) (*ResultMess
 func (c *Client) sendSendVenue(ctx context.Context, request *SendVenue) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVenue"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVenue"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4659,6 +4780,8 @@ func (c *Client) SendVideo(ctx context.Context, request *SendVideo) (*ResultMess
 func (c *Client) sendSendVideo(ctx context.Context, request *SendVideo) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVideo"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVideo"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4740,6 +4863,8 @@ func (c *Client) SendVideoNote(ctx context.Context, request *SendVideoNote) (*Re
 func (c *Client) sendSendVideoNote(ctx context.Context, request *SendVideoNote) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVideoNote"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVideoNote"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4821,6 +4946,8 @@ func (c *Client) SendVoice(ctx context.Context, request *SendVoice) (*ResultMess
 func (c *Client) sendSendVoice(ctx context.Context, request *SendVoice) (res *ResultMessage, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sendVoice"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sendVoice"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4902,6 +5029,8 @@ func (c *Client) SetChatAdministratorCustomTitle(ctx context.Context, request *S
 func (c *Client) sendSetChatAdministratorCustomTitle(ctx context.Context, request *SetChatAdministratorCustomTitle) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatAdministratorCustomTitle"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatAdministratorCustomTitle"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4983,6 +5112,8 @@ func (c *Client) SetChatDescription(ctx context.Context, request *SetChatDescrip
 func (c *Client) sendSetChatDescription(ctx context.Context, request *SetChatDescription) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatDescription"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatDescription"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5064,6 +5195,8 @@ func (c *Client) SetChatPermissions(ctx context.Context, request *SetChatPermiss
 func (c *Client) sendSetChatPermissions(ctx context.Context, request *SetChatPermissions) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatPermissions"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatPermissions"),
 	}
 
 	// Run stopwatch.
@@ -5136,6 +5269,8 @@ func (c *Client) SetChatPhoto(ctx context.Context, request *SetChatPhoto) (*Resu
 func (c *Client) sendSetChatPhoto(ctx context.Context, request *SetChatPhoto) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatPhoto"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatPhoto"),
 	}
 
 	// Run stopwatch.
@@ -5208,6 +5343,8 @@ func (c *Client) SetChatStickerSet(ctx context.Context, request *SetChatStickerS
 func (c *Client) sendSetChatStickerSet(ctx context.Context, request *SetChatStickerSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatStickerSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatStickerSet"),
 	}
 
 	// Run stopwatch.
@@ -5280,6 +5417,8 @@ func (c *Client) SetChatTitle(ctx context.Context, request *SetChatTitle) (*Resu
 func (c *Client) sendSetChatTitle(ctx context.Context, request *SetChatTitle) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setChatTitle"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setChatTitle"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5361,6 +5500,8 @@ func (c *Client) SetGameScore(ctx context.Context, request *SetGameScore) (*Resu
 func (c *Client) sendSetGameScore(ctx context.Context, request *SetGameScore) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setGameScore"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setGameScore"),
 	}
 
 	// Run stopwatch.
@@ -5433,6 +5574,8 @@ func (c *Client) SetMyCommands(ctx context.Context, request *SetMyCommands) (*Re
 func (c *Client) sendSetMyCommands(ctx context.Context, request *SetMyCommands) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setMyCommands"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setMyCommands"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5514,6 +5657,8 @@ func (c *Client) SetPassportDataErrors(ctx context.Context, request *SetPassport
 func (c *Client) sendSetPassportDataErrors(ctx context.Context, request *SetPassportDataErrors) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setPassportDataErrors"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setPassportDataErrors"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5595,6 +5740,8 @@ func (c *Client) SetStickerPositionInSet(ctx context.Context, request *SetSticke
 func (c *Client) sendSetStickerPositionInSet(ctx context.Context, request *SetStickerPositionInSet) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setStickerPositionInSet"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setStickerPositionInSet"),
 	}
 
 	// Run stopwatch.
@@ -5667,6 +5814,8 @@ func (c *Client) SetStickerSetThumb(ctx context.Context, request *SetStickerSetT
 func (c *Client) sendSetStickerSetThumb(ctx context.Context, request *SetStickerSetThumb) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setStickerSetThumb"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setStickerSetThumb"),
 	}
 
 	// Run stopwatch.
@@ -5739,6 +5888,8 @@ func (c *Client) SetWebhook(ctx context.Context, request *SetWebhook) (*Result, 
 func (c *Client) sendSetWebhook(ctx context.Context, request *SetWebhook) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("setWebhook"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/setWebhook"),
 	}
 
 	// Run stopwatch.
@@ -5811,6 +5962,8 @@ func (c *Client) StopMessageLiveLocation(ctx context.Context, request *StopMessa
 func (c *Client) sendStopMessageLiveLocation(ctx context.Context, request *StopMessageLiveLocation) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("stopMessageLiveLocation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/stopMessageLiveLocation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5892,6 +6045,8 @@ func (c *Client) StopPoll(ctx context.Context, request *StopPoll) (*ResultPoll, 
 func (c *Client) sendStopPoll(ctx context.Context, request *StopPoll) (res *ResultPoll, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("stopPoll"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/stopPoll"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5973,6 +6128,8 @@ func (c *Client) UnbanChatMember(ctx context.Context, request *UnbanChatMember) 
 func (c *Client) sendUnbanChatMember(ctx context.Context, request *UnbanChatMember) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unbanChatMember"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unbanChatMember"),
 	}
 
 	// Run stopwatch.
@@ -6045,6 +6202,8 @@ func (c *Client) UnbanChatSenderChat(ctx context.Context, request *UnbanChatSend
 func (c *Client) sendUnbanChatSenderChat(ctx context.Context, request *UnbanChatSenderChat) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unbanChatSenderChat"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unbanChatSenderChat"),
 	}
 
 	// Run stopwatch.
@@ -6117,6 +6276,8 @@ func (c *Client) UnpinAllChatMessages(ctx context.Context, request *UnpinAllChat
 func (c *Client) sendUnpinAllChatMessages(ctx context.Context, request *UnpinAllChatMessages) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unpinAllChatMessages"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unpinAllChatMessages"),
 	}
 
 	// Run stopwatch.
@@ -6189,6 +6350,8 @@ func (c *Client) UnpinChatMessage(ctx context.Context, request *UnpinChatMessage
 func (c *Client) sendUnpinChatMessage(ctx context.Context, request *UnpinChatMessage) (res *Result, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("unpinChatMessage"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/unpinChatMessage"),
 	}
 
 	// Run stopwatch.
@@ -6261,6 +6424,8 @@ func (c *Client) UploadStickerFile(ctx context.Context, request *UploadStickerFi
 func (c *Client) sendUploadStickerFile(ctx context.Context, request *UploadStickerFile) (res *ResultFile, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("uploadStickerFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/uploadStickerFile"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_test_format/oas_client_gen.go
+++ b/examples/ex_test_format/oas_client_gen.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -85,6 +86,8 @@ func (c *Client) TestQueryParameter(ctx context.Context, request string, params 
 func (c *Client) sendTestQueryParameter(ctx context.Context, request string, params TestQueryParameterParams) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_query_parameter"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_query_parameter"),
 	}
 
 	// Run stopwatch.
@@ -2159,6 +2162,8 @@ func (c *Client) TestRequestAny(ctx context.Context, request jx.Raw) (*Error, er
 func (c *Client) sendTestRequestAny(ctx context.Context, request jx.Raw) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_Any"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_Any"),
 	}
 
 	// Run stopwatch.
@@ -2231,6 +2236,8 @@ func (c *Client) TestRequestBoolean(ctx context.Context, request OptBool) (*Erro
 func (c *Client) sendTestRequestBoolean(ctx context.Context, request OptBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean"),
 	}
 
 	// Run stopwatch.
@@ -2303,6 +2310,8 @@ func (c *Client) TestRequestBooleanArray(ctx context.Context, request []bool) (*
 func (c *Client) sendTestRequestBooleanArray(ctx context.Context, request []bool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean_array"),
 	}
 
 	// Run stopwatch.
@@ -2375,6 +2384,8 @@ func (c *Client) TestRequestBooleanArrayArray(ctx context.Context, request [][]b
 func (c *Client) sendTestRequestBooleanArrayArray(ctx context.Context, request [][]bool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2470,6 +2481,8 @@ func (c *Client) TestRequestBooleanNullable(ctx context.Context, request OptNilB
 func (c *Client) sendTestRequestBooleanNullable(ctx context.Context, request OptNilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean_nullable"),
 	}
 
 	// Run stopwatch.
@@ -2542,6 +2555,8 @@ func (c *Client) TestRequestBooleanNullableArray(ctx context.Context, request []
 func (c *Client) sendTestRequestBooleanNullableArray(ctx context.Context, request []NilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -2614,6 +2629,8 @@ func (c *Client) TestRequestBooleanNullableArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestBooleanNullableArrayArray(ctx context.Context, request [][]NilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_boolean_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_boolean_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2709,6 +2726,8 @@ func (c *Client) TestRequestEmptyStruct(ctx context.Context, request *TestReques
 func (c *Client) sendTestRequestEmptyStruct(ctx context.Context, request *TestRequestEmptyStructReq) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_EmptyStruct"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_EmptyStruct"),
 	}
 
 	// Run stopwatch.
@@ -2781,6 +2800,8 @@ func (c *Client) TestRequestFormatTest(ctx context.Context, request OptTestReque
 func (c *Client) sendTestRequestFormatTest(ctx context.Context, request OptTestRequestFormatTestReq) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_FormatTest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_FormatTest"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2869,6 +2890,8 @@ func (c *Client) TestRequestInteger(ctx context.Context, request OptInt) (*Error
 func (c *Client) sendTestRequestInteger(ctx context.Context, request OptInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer"),
 	}
 
 	// Run stopwatch.
@@ -2941,6 +2964,8 @@ func (c *Client) TestRequestIntegerArray(ctx context.Context, request []int) (*E
 func (c *Client) sendTestRequestIntegerArray(ctx context.Context, request []int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_array"),
 	}
 
 	// Run stopwatch.
@@ -3013,6 +3038,8 @@ func (c *Client) TestRequestIntegerArrayArray(ctx context.Context, request [][]i
 func (c *Client) sendTestRequestIntegerArrayArray(ctx context.Context, request [][]int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3108,6 +3135,8 @@ func (c *Client) TestRequestIntegerInt16(ctx context.Context, request OptInt16) 
 func (c *Client) sendTestRequestIntegerInt16(ctx context.Context, request OptInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16"),
 	}
 
 	// Run stopwatch.
@@ -3180,6 +3209,8 @@ func (c *Client) TestRequestIntegerInt16Array(ctx context.Context, request []int
 func (c *Client) sendTestRequestIntegerInt16Array(ctx context.Context, request []int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16_array"),
 	}
 
 	// Run stopwatch.
@@ -3252,6 +3283,8 @@ func (c *Client) TestRequestIntegerInt16ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestIntegerInt16ArrayArray(ctx context.Context, request [][]int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3347,6 +3380,8 @@ func (c *Client) TestRequestIntegerInt16Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestIntegerInt16Nullable(ctx context.Context, request OptNilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -3419,6 +3454,8 @@ func (c *Client) TestRequestIntegerInt16NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerInt16NullableArray(ctx context.Context, request []NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -3491,6 +3528,8 @@ func (c *Client) TestRequestIntegerInt16NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestIntegerInt16NullableArrayArray(ctx context.Context, request [][]NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3586,6 +3625,8 @@ func (c *Client) TestRequestIntegerInt32(ctx context.Context, request OptInt32) 
 func (c *Client) sendTestRequestIntegerInt32(ctx context.Context, request OptInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32"),
 	}
 
 	// Run stopwatch.
@@ -3658,6 +3699,8 @@ func (c *Client) TestRequestIntegerInt32Array(ctx context.Context, request []int
 func (c *Client) sendTestRequestIntegerInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -3730,6 +3773,8 @@ func (c *Client) TestRequestIntegerInt32ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestIntegerInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -3825,6 +3870,8 @@ func (c *Client) TestRequestIntegerInt32Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestIntegerInt32Nullable(ctx context.Context, request OptNilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -3897,6 +3944,8 @@ func (c *Client) TestRequestIntegerInt32NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerInt32NullableArray(ctx context.Context, request []NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -3969,6 +4018,8 @@ func (c *Client) TestRequestIntegerInt32NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestIntegerInt32NullableArrayArray(ctx context.Context, request [][]NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4064,6 +4115,8 @@ func (c *Client) TestRequestIntegerInt64(ctx context.Context, request OptInt64) 
 func (c *Client) sendTestRequestIntegerInt64(ctx context.Context, request OptInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64"),
 	}
 
 	// Run stopwatch.
@@ -4136,6 +4189,8 @@ func (c *Client) TestRequestIntegerInt64Array(ctx context.Context, request []int
 func (c *Client) sendTestRequestIntegerInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -4208,6 +4263,8 @@ func (c *Client) TestRequestIntegerInt64ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestIntegerInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4303,6 +4360,8 @@ func (c *Client) TestRequestIntegerInt64Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestIntegerInt64Nullable(ctx context.Context, request OptNilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -4375,6 +4434,8 @@ func (c *Client) TestRequestIntegerInt64NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerInt64NullableArray(ctx context.Context, request []NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -4447,6 +4508,8 @@ func (c *Client) TestRequestIntegerInt64NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestIntegerInt64NullableArrayArray(ctx context.Context, request [][]NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4542,6 +4605,8 @@ func (c *Client) TestRequestIntegerInt8(ctx context.Context, request OptInt8) (*
 func (c *Client) sendTestRequestIntegerInt8(ctx context.Context, request OptInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8"),
 	}
 
 	// Run stopwatch.
@@ -4614,6 +4679,8 @@ func (c *Client) TestRequestIntegerInt8Array(ctx context.Context, request []int8
 func (c *Client) sendTestRequestIntegerInt8Array(ctx context.Context, request []int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8_array"),
 	}
 
 	// Run stopwatch.
@@ -4686,6 +4753,8 @@ func (c *Client) TestRequestIntegerInt8ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestIntegerInt8ArrayArray(ctx context.Context, request [][]int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -4781,6 +4850,8 @@ func (c *Client) TestRequestIntegerInt8Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestIntegerInt8Nullable(ctx context.Context, request OptNilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -4853,6 +4924,8 @@ func (c *Client) TestRequestIntegerInt8NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestIntegerInt8NullableArray(ctx context.Context, request []NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -4925,6 +4998,8 @@ func (c *Client) TestRequestIntegerInt8NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestIntegerInt8NullableArrayArray(ctx context.Context, request [][]NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_int8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5020,6 +5095,8 @@ func (c *Client) TestRequestIntegerNullable(ctx context.Context, request OptNilI
 func (c *Client) sendTestRequestIntegerNullable(ctx context.Context, request OptNilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_nullable"),
 	}
 
 	// Run stopwatch.
@@ -5092,6 +5169,8 @@ func (c *Client) TestRequestIntegerNullableArray(ctx context.Context, request []
 func (c *Client) sendTestRequestIntegerNullableArray(ctx context.Context, request []NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -5164,6 +5243,8 @@ func (c *Client) TestRequestIntegerNullableArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerNullableArrayArray(ctx context.Context, request [][]NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5259,6 +5340,8 @@ func (c *Client) TestRequestIntegerUint(ctx context.Context, request OptUint) (*
 func (c *Client) sendTestRequestIntegerUint(ctx context.Context, request OptUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint"),
 	}
 
 	// Run stopwatch.
@@ -5331,6 +5414,8 @@ func (c *Client) TestRequestIntegerUint16(ctx context.Context, request OptUint16
 func (c *Client) sendTestRequestIntegerUint16(ctx context.Context, request OptUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16"),
 	}
 
 	// Run stopwatch.
@@ -5403,6 +5488,8 @@ func (c *Client) TestRequestIntegerUint16Array(ctx context.Context, request []ui
 func (c *Client) sendTestRequestIntegerUint16Array(ctx context.Context, request []uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16_array"),
 	}
 
 	// Run stopwatch.
@@ -5475,6 +5562,8 @@ func (c *Client) TestRequestIntegerUint16ArrayArray(ctx context.Context, request
 func (c *Client) sendTestRequestIntegerUint16ArrayArray(ctx context.Context, request [][]uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5570,6 +5659,8 @@ func (c *Client) TestRequestIntegerUint16Nullable(ctx context.Context, request O
 func (c *Client) sendTestRequestIntegerUint16Nullable(ctx context.Context, request OptNilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -5642,6 +5733,8 @@ func (c *Client) TestRequestIntegerUint16NullableArray(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUint16NullableArray(ctx context.Context, request []NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -5714,6 +5807,8 @@ func (c *Client) TestRequestIntegerUint16NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestIntegerUint16NullableArrayArray(ctx context.Context, request [][]NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -5809,6 +5904,8 @@ func (c *Client) TestRequestIntegerUint32(ctx context.Context, request OptUint32
 func (c *Client) sendTestRequestIntegerUint32(ctx context.Context, request OptUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32"),
 	}
 
 	// Run stopwatch.
@@ -5881,6 +5978,8 @@ func (c *Client) TestRequestIntegerUint32Array(ctx context.Context, request []ui
 func (c *Client) sendTestRequestIntegerUint32Array(ctx context.Context, request []uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32_array"),
 	}
 
 	// Run stopwatch.
@@ -5953,6 +6052,8 @@ func (c *Client) TestRequestIntegerUint32ArrayArray(ctx context.Context, request
 func (c *Client) sendTestRequestIntegerUint32ArrayArray(ctx context.Context, request [][]uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6048,6 +6149,8 @@ func (c *Client) TestRequestIntegerUint32Nullable(ctx context.Context, request O
 func (c *Client) sendTestRequestIntegerUint32Nullable(ctx context.Context, request OptNilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -6120,6 +6223,8 @@ func (c *Client) TestRequestIntegerUint32NullableArray(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUint32NullableArray(ctx context.Context, request []NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -6192,6 +6297,8 @@ func (c *Client) TestRequestIntegerUint32NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestIntegerUint32NullableArrayArray(ctx context.Context, request [][]NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6287,6 +6394,8 @@ func (c *Client) TestRequestIntegerUint64(ctx context.Context, request OptUint64
 func (c *Client) sendTestRequestIntegerUint64(ctx context.Context, request OptUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64"),
 	}
 
 	// Run stopwatch.
@@ -6359,6 +6468,8 @@ func (c *Client) TestRequestIntegerUint64Array(ctx context.Context, request []ui
 func (c *Client) sendTestRequestIntegerUint64Array(ctx context.Context, request []uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64_array"),
 	}
 
 	// Run stopwatch.
@@ -6431,6 +6542,8 @@ func (c *Client) TestRequestIntegerUint64ArrayArray(ctx context.Context, request
 func (c *Client) sendTestRequestIntegerUint64ArrayArray(ctx context.Context, request [][]uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6526,6 +6639,8 @@ func (c *Client) TestRequestIntegerUint64Nullable(ctx context.Context, request O
 func (c *Client) sendTestRequestIntegerUint64Nullable(ctx context.Context, request OptNilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -6598,6 +6713,8 @@ func (c *Client) TestRequestIntegerUint64NullableArray(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUint64NullableArray(ctx context.Context, request []NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -6670,6 +6787,8 @@ func (c *Client) TestRequestIntegerUint64NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestIntegerUint64NullableArrayArray(ctx context.Context, request [][]NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -6765,6 +6884,8 @@ func (c *Client) TestRequestIntegerUint8(ctx context.Context, request OptUint8) 
 func (c *Client) sendTestRequestIntegerUint8(ctx context.Context, request OptUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8"),
 	}
 
 	// Run stopwatch.
@@ -6837,6 +6958,8 @@ func (c *Client) TestRequestIntegerUint8Array(ctx context.Context, request []uin
 func (c *Client) sendTestRequestIntegerUint8Array(ctx context.Context, request []uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8_array"),
 	}
 
 	// Run stopwatch.
@@ -6909,6 +7032,8 @@ func (c *Client) TestRequestIntegerUint8ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestIntegerUint8ArrayArray(ctx context.Context, request [][]uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -7004,6 +7129,8 @@ func (c *Client) TestRequestIntegerUint8Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestIntegerUint8Nullable(ctx context.Context, request OptNilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -7076,6 +7203,8 @@ func (c *Client) TestRequestIntegerUint8NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerUint8NullableArray(ctx context.Context, request []NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -7148,6 +7277,8 @@ func (c *Client) TestRequestIntegerUint8NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestIntegerUint8NullableArrayArray(ctx context.Context, request [][]NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -7243,6 +7374,8 @@ func (c *Client) TestRequestIntegerUintArray(ctx context.Context, request []uint
 func (c *Client) sendTestRequestIntegerUintArray(ctx context.Context, request []uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint_array"),
 	}
 
 	// Run stopwatch.
@@ -7315,6 +7448,8 @@ func (c *Client) TestRequestIntegerUintArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestIntegerUintArrayArray(ctx context.Context, request [][]uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -7410,6 +7545,8 @@ func (c *Client) TestRequestIntegerUintNullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestIntegerUintNullable(ctx context.Context, request OptNilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -7482,6 +7619,8 @@ func (c *Client) TestRequestIntegerUintNullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestIntegerUintNullableArray(ctx context.Context, request []NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -7554,6 +7693,8 @@ func (c *Client) TestRequestIntegerUintNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestIntegerUintNullableArrayArray(ctx context.Context, request [][]NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_uint_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -7649,6 +7790,8 @@ func (c *Client) TestRequestIntegerUnix(ctx context.Context, request OptUnixSeco
 func (c *Client) sendTestRequestIntegerUnix(ctx context.Context, request OptUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix"),
 	}
 
 	// Run stopwatch.
@@ -7721,6 +7864,8 @@ func (c *Client) TestRequestIntegerUnixArray(ctx context.Context, request []time
 func (c *Client) sendTestRequestIntegerUnixArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix_array"),
 	}
 
 	// Run stopwatch.
@@ -7793,6 +7938,8 @@ func (c *Client) TestRequestIntegerUnixArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestIntegerUnixArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -7888,6 +8035,8 @@ func (c *Client) TestRequestIntegerUnixMicro(ctx context.Context, request OptUni
 func (c *Client) sendTestRequestIntegerUnixMicro(ctx context.Context, request OptUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -7960,6 +8109,8 @@ func (c *Client) TestRequestIntegerUnixMicroArray(ctx context.Context, request [
 func (c *Client) sendTestRequestIntegerUnixMicroArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro_array"),
 	}
 
 	// Run stopwatch.
@@ -8032,6 +8183,8 @@ func (c *Client) TestRequestIntegerUnixMicroArrayArray(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUnixMicroArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -8127,6 +8280,8 @@ func (c *Client) TestRequestIntegerUnixMicroNullable(ctx context.Context, reques
 func (c *Client) sendTestRequestIntegerUnixMicroNullable(ctx context.Context, request OptNilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -8199,6 +8354,8 @@ func (c *Client) TestRequestIntegerUnixMicroNullableArray(ctx context.Context, r
 func (c *Client) sendTestRequestIntegerUnixMicroNullableArray(ctx context.Context, request []NilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -8271,6 +8428,8 @@ func (c *Client) TestRequestIntegerUnixMicroNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestRequestIntegerUnixMicroNullableArrayArray(ctx context.Context, request [][]NilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-micro_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -8366,6 +8525,8 @@ func (c *Client) TestRequestIntegerUnixMilli(ctx context.Context, request OptUni
 func (c *Client) sendTestRequestIntegerUnixMilli(ctx context.Context, request OptUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -8438,6 +8599,8 @@ func (c *Client) TestRequestIntegerUnixMilliArray(ctx context.Context, request [
 func (c *Client) sendTestRequestIntegerUnixMilliArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli_array"),
 	}
 
 	// Run stopwatch.
@@ -8510,6 +8673,8 @@ func (c *Client) TestRequestIntegerUnixMilliArrayArray(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUnixMilliArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -8605,6 +8770,8 @@ func (c *Client) TestRequestIntegerUnixMilliNullable(ctx context.Context, reques
 func (c *Client) sendTestRequestIntegerUnixMilliNullable(ctx context.Context, request OptNilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -8677,6 +8844,8 @@ func (c *Client) TestRequestIntegerUnixMilliNullableArray(ctx context.Context, r
 func (c *Client) sendTestRequestIntegerUnixMilliNullableArray(ctx context.Context, request []NilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -8749,6 +8918,8 @@ func (c *Client) TestRequestIntegerUnixMilliNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestRequestIntegerUnixMilliNullableArrayArray(ctx context.Context, request [][]NilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-milli_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -8844,6 +9015,8 @@ func (c *Client) TestRequestIntegerUnixNano(ctx context.Context, request OptUnix
 func (c *Client) sendTestRequestIntegerUnixNano(ctx context.Context, request OptUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -8916,6 +9089,8 @@ func (c *Client) TestRequestIntegerUnixNanoArray(ctx context.Context, request []
 func (c *Client) sendTestRequestIntegerUnixNanoArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano_array"),
 	}
 
 	// Run stopwatch.
@@ -8988,6 +9163,8 @@ func (c *Client) TestRequestIntegerUnixNanoArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestIntegerUnixNanoArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9083,6 +9260,8 @@ func (c *Client) TestRequestIntegerUnixNanoNullable(ctx context.Context, request
 func (c *Client) sendTestRequestIntegerUnixNanoNullable(ctx context.Context, request OptNilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -9155,6 +9334,8 @@ func (c *Client) TestRequestIntegerUnixNanoNullableArray(ctx context.Context, re
 func (c *Client) sendTestRequestIntegerUnixNanoNullableArray(ctx context.Context, request []NilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -9227,6 +9408,8 @@ func (c *Client) TestRequestIntegerUnixNanoNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestIntegerUnixNanoNullableArrayArray(ctx context.Context, request [][]NilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-nano_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9322,6 +9505,8 @@ func (c *Client) TestRequestIntegerUnixNullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestIntegerUnixNullable(ctx context.Context, request OptNilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -9394,6 +9579,8 @@ func (c *Client) TestRequestIntegerUnixNullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestIntegerUnixNullableArray(ctx context.Context, request []NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -9466,6 +9653,8 @@ func (c *Client) TestRequestIntegerUnixNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestIntegerUnixNullableArrayArray(ctx context.Context, request [][]NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9561,6 +9750,8 @@ func (c *Client) TestRequestIntegerUnixSeconds(ctx context.Context, request OptU
 func (c *Client) sendTestRequestIntegerUnixSeconds(ctx context.Context, request OptUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -9633,6 +9824,8 @@ func (c *Client) TestRequestIntegerUnixSecondsArray(ctx context.Context, request
 func (c *Client) sendTestRequestIntegerUnixSecondsArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds_array"),
 	}
 
 	// Run stopwatch.
@@ -9705,6 +9898,8 @@ func (c *Client) TestRequestIntegerUnixSecondsArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestIntegerUnixSecondsArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -9800,6 +9995,8 @@ func (c *Client) TestRequestIntegerUnixSecondsNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestIntegerUnixSecondsNullable(ctx context.Context, request OptNilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -9872,6 +10069,8 @@ func (c *Client) TestRequestIntegerUnixSecondsNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestIntegerUnixSecondsNullableArray(ctx context.Context, request []NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -9944,6 +10143,8 @@ func (c *Client) TestRequestIntegerUnixSecondsNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestIntegerUnixSecondsNullableArrayArray(ctx context.Context, request [][]NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_integer_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_integer_unix-seconds_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10039,6 +10240,8 @@ func (c *Client) TestRequestNull(ctx context.Context, request OptNull) (*Error, 
 func (c *Client) sendTestRequestNull(ctx context.Context, request OptNull) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null"),
 	}
 
 	// Run stopwatch.
@@ -10111,6 +10314,8 @@ func (c *Client) TestRequestNullArray(ctx context.Context, request []struct{}) (
 func (c *Client) sendTestRequestNullArray(ctx context.Context, request []struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null_array"),
 	}
 
 	// Run stopwatch.
@@ -10183,6 +10388,8 @@ func (c *Client) TestRequestNullArrayArray(ctx context.Context, request [][]stru
 func (c *Client) sendTestRequestNullArrayArray(ctx context.Context, request [][]struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10278,6 +10485,8 @@ func (c *Client) TestRequestNullNullable(ctx context.Context, request OptNull) (
 func (c *Client) sendTestRequestNullNullable(ctx context.Context, request OptNull) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null_nullable"),
 	}
 
 	// Run stopwatch.
@@ -10350,6 +10559,8 @@ func (c *Client) TestRequestNullNullableArray(ctx context.Context, request []str
 func (c *Client) sendTestRequestNullNullableArray(ctx context.Context, request []struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -10422,6 +10633,8 @@ func (c *Client) TestRequestNullNullableArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestNullNullableArrayArray(ctx context.Context, request [][]struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_null_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_null_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10517,6 +10730,8 @@ func (c *Client) TestRequestNumber(ctx context.Context, request OptFloat64) (*Er
 func (c *Client) sendTestRequestNumber(ctx context.Context, request OptFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10605,6 +10820,8 @@ func (c *Client) TestRequestNumberArray(ctx context.Context, request []float64) 
 func (c *Client) sendTestRequestNumberArray(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10700,6 +10917,8 @@ func (c *Client) TestRequestNumberArrayArray(ctx context.Context, request [][]fl
 func (c *Client) sendTestRequestNumberArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10812,6 +11031,8 @@ func (c *Client) TestRequestNumberDouble(ctx context.Context, request OptFloat64
 func (c *Client) sendTestRequestNumberDouble(ctx context.Context, request OptFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10900,6 +11121,8 @@ func (c *Client) TestRequestNumberDoubleArray(ctx context.Context, request []flo
 func (c *Client) sendTestRequestNumberDoubleArray(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -10995,6 +11218,8 @@ func (c *Client) TestRequestNumberDoubleArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestNumberDoubleArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11107,6 +11332,8 @@ func (c *Client) TestRequestNumberDoubleNullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestNumberDoubleNullable(ctx context.Context, request OptNilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11195,6 +11422,8 @@ func (c *Client) TestRequestNumberDoubleNullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestNumberDoubleNullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11297,6 +11526,8 @@ func (c *Client) TestRequestNumberDoubleNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestNumberDoubleNullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_double_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_double_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11416,6 +11647,8 @@ func (c *Client) TestRequestNumberFloat(ctx context.Context, request OptFloat32)
 func (c *Client) sendTestRequestNumberFloat(ctx context.Context, request OptFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11504,6 +11737,8 @@ func (c *Client) TestRequestNumberFloatArray(ctx context.Context, request []floa
 func (c *Client) sendTestRequestNumberFloatArray(ctx context.Context, request []float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11599,6 +11834,8 @@ func (c *Client) TestRequestNumberFloatArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestNumberFloatArrayArray(ctx context.Context, request [][]float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11711,6 +11948,8 @@ func (c *Client) TestRequestNumberFloatNullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestNumberFloatNullable(ctx context.Context, request OptNilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11799,6 +12038,8 @@ func (c *Client) TestRequestNumberFloatNullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestNumberFloatNullableArray(ctx context.Context, request []NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -11901,6 +12142,8 @@ func (c *Client) TestRequestNumberFloatNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestNumberFloatNullableArrayArray(ctx context.Context, request [][]NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_float_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_float_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -12020,6 +12263,8 @@ func (c *Client) TestRequestNumberInt32(ctx context.Context, request OptInt32) (
 func (c *Client) sendTestRequestNumberInt32(ctx context.Context, request OptInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32"),
 	}
 
 	// Run stopwatch.
@@ -12092,6 +12337,8 @@ func (c *Client) TestRequestNumberInt32Array(ctx context.Context, request []int3
 func (c *Client) sendTestRequestNumberInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -12164,6 +12411,8 @@ func (c *Client) TestRequestNumberInt32ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestNumberInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -12259,6 +12508,8 @@ func (c *Client) TestRequestNumberInt32Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestNumberInt32Nullable(ctx context.Context, request OptNilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -12331,6 +12582,8 @@ func (c *Client) TestRequestNumberInt32NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestNumberInt32NullableArray(ctx context.Context, request []NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -12403,6 +12656,8 @@ func (c *Client) TestRequestNumberInt32NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestNumberInt32NullableArrayArray(ctx context.Context, request [][]NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -12498,6 +12753,8 @@ func (c *Client) TestRequestNumberInt64(ctx context.Context, request OptInt64) (
 func (c *Client) sendTestRequestNumberInt64(ctx context.Context, request OptInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64"),
 	}
 
 	// Run stopwatch.
@@ -12570,6 +12827,8 @@ func (c *Client) TestRequestNumberInt64Array(ctx context.Context, request []int6
 func (c *Client) sendTestRequestNumberInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -12642,6 +12901,8 @@ func (c *Client) TestRequestNumberInt64ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestNumberInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -12737,6 +12998,8 @@ func (c *Client) TestRequestNumberInt64Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestNumberInt64Nullable(ctx context.Context, request OptNilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -12809,6 +13072,8 @@ func (c *Client) TestRequestNumberInt64NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestNumberInt64NullableArray(ctx context.Context, request []NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -12881,6 +13146,8 @@ func (c *Client) TestRequestNumberInt64NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestNumberInt64NullableArrayArray(ctx context.Context, request [][]NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -12976,6 +13243,8 @@ func (c *Client) TestRequestNumberNullable(ctx context.Context, request OptNilFl
 func (c *Client) sendTestRequestNumberNullable(ctx context.Context, request OptNilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13064,6 +13333,8 @@ func (c *Client) TestRequestNumberNullableArray(ctx context.Context, request []N
 func (c *Client) sendTestRequestNumberNullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13166,6 +13437,8 @@ func (c *Client) TestRequestNumberNullableArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestNumberNullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_number_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_number_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13285,6 +13558,8 @@ func (c *Client) TestRequestRequiredAny(ctx context.Context, request jx.Raw) (*E
 func (c *Client) sendTestRequestRequiredAny(ctx context.Context, request jx.Raw) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_Any"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_Any"),
 	}
 
 	// Run stopwatch.
@@ -13357,6 +13632,8 @@ func (c *Client) TestRequestRequiredBoolean(ctx context.Context, request bool) (
 func (c *Client) sendTestRequestRequiredBoolean(ctx context.Context, request bool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean"),
 	}
 
 	// Run stopwatch.
@@ -13429,6 +13706,8 @@ func (c *Client) TestRequestRequiredBooleanArray(ctx context.Context, request []
 func (c *Client) sendTestRequestRequiredBooleanArray(ctx context.Context, request []bool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13510,6 +13789,8 @@ func (c *Client) TestRequestRequiredBooleanArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredBooleanArrayArray(ctx context.Context, request [][]bool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13608,6 +13889,8 @@ func (c *Client) TestRequestRequiredBooleanNullable(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredBooleanNullable(ctx context.Context, request NilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean_nullable"),
 	}
 
 	// Run stopwatch.
@@ -13680,6 +13963,8 @@ func (c *Client) TestRequestRequiredBooleanNullableArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredBooleanNullableArray(ctx context.Context, request []NilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13761,6 +14046,8 @@ func (c *Client) TestRequestRequiredBooleanNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredBooleanNullableArrayArray(ctx context.Context, request [][]NilBool) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_boolean_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_boolean_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -13859,6 +14146,8 @@ func (c *Client) TestRequestRequiredEmptyStruct(ctx context.Context, request *Te
 func (c *Client) sendTestRequestRequiredEmptyStruct(ctx context.Context, request *TestRequestRequiredEmptyStructReq) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_EmptyStruct"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_EmptyStruct"),
 	}
 
 	// Run stopwatch.
@@ -13931,6 +14220,8 @@ func (c *Client) TestRequestRequiredFormatTest(ctx context.Context, request *Tes
 func (c *Client) sendTestRequestRequiredFormatTest(ctx context.Context, request *TestRequestRequiredFormatTestReq) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_FormatTest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_FormatTest"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14012,6 +14303,8 @@ func (c *Client) TestRequestRequiredInteger(ctx context.Context, request int) (*
 func (c *Client) sendTestRequestRequiredInteger(ctx context.Context, request int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer"),
 	}
 
 	// Run stopwatch.
@@ -14084,6 +14377,8 @@ func (c *Client) TestRequestRequiredIntegerArray(ctx context.Context, request []
 func (c *Client) sendTestRequestRequiredIntegerArray(ctx context.Context, request []int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14165,6 +14460,8 @@ func (c *Client) TestRequestRequiredIntegerArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredIntegerArrayArray(ctx context.Context, request [][]int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14263,6 +14560,8 @@ func (c *Client) TestRequestRequiredIntegerInt16(ctx context.Context, request in
 func (c *Client) sendTestRequestRequiredIntegerInt16(ctx context.Context, request int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16"),
 	}
 
 	// Run stopwatch.
@@ -14335,6 +14634,8 @@ func (c *Client) TestRequestRequiredIntegerInt16Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredIntegerInt16Array(ctx context.Context, request []int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14416,6 +14717,8 @@ func (c *Client) TestRequestRequiredIntegerInt16ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredIntegerInt16ArrayArray(ctx context.Context, request [][]int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14514,6 +14817,8 @@ func (c *Client) TestRequestRequiredIntegerInt16Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerInt16Nullable(ctx context.Context, request NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -14586,6 +14891,8 @@ func (c *Client) TestRequestRequiredIntegerInt16NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerInt16NullableArray(ctx context.Context, request []NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14667,6 +14974,8 @@ func (c *Client) TestRequestRequiredIntegerInt16NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredIntegerInt16NullableArrayArray(ctx context.Context, request [][]NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14765,6 +15074,8 @@ func (c *Client) TestRequestRequiredIntegerInt32(ctx context.Context, request in
 func (c *Client) sendTestRequestRequiredIntegerInt32(ctx context.Context, request int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32"),
 	}
 
 	// Run stopwatch.
@@ -14837,6 +15148,8 @@ func (c *Client) TestRequestRequiredIntegerInt32Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredIntegerInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -14918,6 +15231,8 @@ func (c *Client) TestRequestRequiredIntegerInt32ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredIntegerInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15016,6 +15331,8 @@ func (c *Client) TestRequestRequiredIntegerInt32Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerInt32Nullable(ctx context.Context, request NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -15088,6 +15405,8 @@ func (c *Client) TestRequestRequiredIntegerInt32NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerInt32NullableArray(ctx context.Context, request []NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15169,6 +15488,8 @@ func (c *Client) TestRequestRequiredIntegerInt32NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredIntegerInt32NullableArrayArray(ctx context.Context, request [][]NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15267,6 +15588,8 @@ func (c *Client) TestRequestRequiredIntegerInt64(ctx context.Context, request in
 func (c *Client) sendTestRequestRequiredIntegerInt64(ctx context.Context, request int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64"),
 	}
 
 	// Run stopwatch.
@@ -15339,6 +15662,8 @@ func (c *Client) TestRequestRequiredIntegerInt64Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredIntegerInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15420,6 +15745,8 @@ func (c *Client) TestRequestRequiredIntegerInt64ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredIntegerInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15518,6 +15845,8 @@ func (c *Client) TestRequestRequiredIntegerInt64Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerInt64Nullable(ctx context.Context, request NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -15590,6 +15919,8 @@ func (c *Client) TestRequestRequiredIntegerInt64NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerInt64NullableArray(ctx context.Context, request []NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15671,6 +16002,8 @@ func (c *Client) TestRequestRequiredIntegerInt64NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredIntegerInt64NullableArrayArray(ctx context.Context, request [][]NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15769,6 +16102,8 @@ func (c *Client) TestRequestRequiredIntegerInt8(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredIntegerInt8(ctx context.Context, request int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8"),
 	}
 
 	// Run stopwatch.
@@ -15841,6 +16176,8 @@ func (c *Client) TestRequestRequiredIntegerInt8Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredIntegerInt8Array(ctx context.Context, request []int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -15922,6 +16259,8 @@ func (c *Client) TestRequestRequiredIntegerInt8ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerInt8ArrayArray(ctx context.Context, request [][]int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16020,6 +16359,8 @@ func (c *Client) TestRequestRequiredIntegerInt8Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredIntegerInt8Nullable(ctx context.Context, request NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -16092,6 +16433,8 @@ func (c *Client) TestRequestRequiredIntegerInt8NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredIntegerInt8NullableArray(ctx context.Context, request []NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16173,6 +16516,8 @@ func (c *Client) TestRequestRequiredIntegerInt8NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredIntegerInt8NullableArrayArray(ctx context.Context, request [][]NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_int8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16271,6 +16616,8 @@ func (c *Client) TestRequestRequiredIntegerNullable(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredIntegerNullable(ctx context.Context, request NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_nullable"),
 	}
 
 	// Run stopwatch.
@@ -16343,6 +16690,8 @@ func (c *Client) TestRequestRequiredIntegerNullableArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerNullableArray(ctx context.Context, request []NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16424,6 +16773,8 @@ func (c *Client) TestRequestRequiredIntegerNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerNullableArrayArray(ctx context.Context, request [][]NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16522,6 +16873,8 @@ func (c *Client) TestRequestRequiredIntegerUint(ctx context.Context, request uin
 func (c *Client) sendTestRequestRequiredIntegerUint(ctx context.Context, request uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint"),
 	}
 
 	// Run stopwatch.
@@ -16594,6 +16947,8 @@ func (c *Client) TestRequestRequiredIntegerUint16(ctx context.Context, request u
 func (c *Client) sendTestRequestRequiredIntegerUint16(ctx context.Context, request uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16"),
 	}
 
 	// Run stopwatch.
@@ -16666,6 +17021,8 @@ func (c *Client) TestRequestRequiredIntegerUint16Array(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredIntegerUint16Array(ctx context.Context, request []uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16747,6 +17104,8 @@ func (c *Client) TestRequestRequiredIntegerUint16ArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredIntegerUint16ArrayArray(ctx context.Context, request [][]uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16845,6 +17204,8 @@ func (c *Client) TestRequestRequiredIntegerUint16Nullable(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUint16Nullable(ctx context.Context, request NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -16917,6 +17278,8 @@ func (c *Client) TestRequestRequiredIntegerUint16NullableArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUint16NullableArray(ctx context.Context, request []NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -16998,6 +17361,8 @@ func (c *Client) TestRequestRequiredIntegerUint16NullableArrayArray(ctx context.
 func (c *Client) sendTestRequestRequiredIntegerUint16NullableArrayArray(ctx context.Context, request [][]NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17096,6 +17461,8 @@ func (c *Client) TestRequestRequiredIntegerUint32(ctx context.Context, request u
 func (c *Client) sendTestRequestRequiredIntegerUint32(ctx context.Context, request uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32"),
 	}
 
 	// Run stopwatch.
@@ -17168,6 +17535,8 @@ func (c *Client) TestRequestRequiredIntegerUint32Array(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredIntegerUint32Array(ctx context.Context, request []uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17249,6 +17618,8 @@ func (c *Client) TestRequestRequiredIntegerUint32ArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredIntegerUint32ArrayArray(ctx context.Context, request [][]uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17347,6 +17718,8 @@ func (c *Client) TestRequestRequiredIntegerUint32Nullable(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUint32Nullable(ctx context.Context, request NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -17419,6 +17792,8 @@ func (c *Client) TestRequestRequiredIntegerUint32NullableArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUint32NullableArray(ctx context.Context, request []NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17500,6 +17875,8 @@ func (c *Client) TestRequestRequiredIntegerUint32NullableArrayArray(ctx context.
 func (c *Client) sendTestRequestRequiredIntegerUint32NullableArrayArray(ctx context.Context, request [][]NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17598,6 +17975,8 @@ func (c *Client) TestRequestRequiredIntegerUint64(ctx context.Context, request u
 func (c *Client) sendTestRequestRequiredIntegerUint64(ctx context.Context, request uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64"),
 	}
 
 	// Run stopwatch.
@@ -17670,6 +18049,8 @@ func (c *Client) TestRequestRequiredIntegerUint64Array(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredIntegerUint64Array(ctx context.Context, request []uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17751,6 +18132,8 @@ func (c *Client) TestRequestRequiredIntegerUint64ArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredIntegerUint64ArrayArray(ctx context.Context, request [][]uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -17849,6 +18232,8 @@ func (c *Client) TestRequestRequiredIntegerUint64Nullable(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUint64Nullable(ctx context.Context, request NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -17921,6 +18306,8 @@ func (c *Client) TestRequestRequiredIntegerUint64NullableArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUint64NullableArray(ctx context.Context, request []NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18002,6 +18389,8 @@ func (c *Client) TestRequestRequiredIntegerUint64NullableArrayArray(ctx context.
 func (c *Client) sendTestRequestRequiredIntegerUint64NullableArrayArray(ctx context.Context, request [][]NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18100,6 +18489,8 @@ func (c *Client) TestRequestRequiredIntegerUint8(ctx context.Context, request ui
 func (c *Client) sendTestRequestRequiredIntegerUint8(ctx context.Context, request uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8"),
 	}
 
 	// Run stopwatch.
@@ -18172,6 +18563,8 @@ func (c *Client) TestRequestRequiredIntegerUint8Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredIntegerUint8Array(ctx context.Context, request []uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18253,6 +18646,8 @@ func (c *Client) TestRequestRequiredIntegerUint8ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredIntegerUint8ArrayArray(ctx context.Context, request [][]uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18351,6 +18746,8 @@ func (c *Client) TestRequestRequiredIntegerUint8Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerUint8Nullable(ctx context.Context, request NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -18423,6 +18820,8 @@ func (c *Client) TestRequestRequiredIntegerUint8NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerUint8NullableArray(ctx context.Context, request []NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18504,6 +18903,8 @@ func (c *Client) TestRequestRequiredIntegerUint8NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredIntegerUint8NullableArrayArray(ctx context.Context, request [][]NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18602,6 +19003,8 @@ func (c *Client) TestRequestRequiredIntegerUintArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredIntegerUintArray(ctx context.Context, request []uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18683,6 +19086,8 @@ func (c *Client) TestRequestRequiredIntegerUintArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUintArrayArray(ctx context.Context, request [][]uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18781,6 +19186,8 @@ func (c *Client) TestRequestRequiredIntegerUintNullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredIntegerUintNullable(ctx context.Context, request NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -18853,6 +19260,8 @@ func (c *Client) TestRequestRequiredIntegerUintNullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredIntegerUintNullableArray(ctx context.Context, request []NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -18934,6 +19343,8 @@ func (c *Client) TestRequestRequiredIntegerUintNullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredIntegerUintNullableArrayArray(ctx context.Context, request [][]NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_uint_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19032,6 +19443,8 @@ func (c *Client) TestRequestRequiredIntegerUnix(ctx context.Context, request tim
 func (c *Client) sendTestRequestRequiredIntegerUnix(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix"),
 	}
 
 	// Run stopwatch.
@@ -19104,6 +19517,8 @@ func (c *Client) TestRequestRequiredIntegerUnixArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredIntegerUnixArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19185,6 +19600,8 @@ func (c *Client) TestRequestRequiredIntegerUnixArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUnixArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19283,6 +19700,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicro(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredIntegerUnixMicro(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -19355,6 +19774,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicroArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUnixMicroArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19436,6 +19857,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicroArrayArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUnixMicroArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19534,6 +19957,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicroNullable(ctx context.Context
 func (c *Client) sendTestRequestRequiredIntegerUnixMicroNullable(ctx context.Context, request NilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -19606,6 +20031,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicroNullableArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredIntegerUnixMicroNullableArray(ctx context.Context, request []NilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19687,6 +20114,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMicroNullableArrayArray(ctx conte
 func (c *Client) sendTestRequestRequiredIntegerUnixMicroNullableArrayArray(ctx context.Context, request [][]NilUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-micro_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19785,6 +20214,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilli(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredIntegerUnixMilli(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -19857,6 +20288,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilliArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredIntegerUnixMilliArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -19938,6 +20371,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilliArrayArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUnixMilliArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20036,6 +20471,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilliNullable(ctx context.Context
 func (c *Client) sendTestRequestRequiredIntegerUnixMilliNullable(ctx context.Context, request NilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -20108,6 +20545,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilliNullableArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredIntegerUnixMilliNullableArray(ctx context.Context, request []NilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20189,6 +20628,8 @@ func (c *Client) TestRequestRequiredIntegerUnixMilliNullableArrayArray(ctx conte
 func (c *Client) sendTestRequestRequiredIntegerUnixMilliNullableArrayArray(ctx context.Context, request [][]NilUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-milli_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20287,6 +20728,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNano(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredIntegerUnixNano(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -20359,6 +20802,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNanoArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredIntegerUnixNanoArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20440,6 +20885,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNanoArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredIntegerUnixNanoArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20538,6 +20985,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNanoNullable(ctx context.Context,
 func (c *Client) sendTestRequestRequiredIntegerUnixNanoNullable(ctx context.Context, request NilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -20610,6 +21059,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNanoNullableArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredIntegerUnixNanoNullableArray(ctx context.Context, request []NilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20691,6 +21142,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNanoNullableArrayArray(ctx contex
 func (c *Client) sendTestRequestRequiredIntegerUnixNanoNullableArrayArray(ctx context.Context, request [][]NilUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-nano_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20789,6 +21242,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredIntegerUnixNullable(ctx context.Context, request NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -20861,6 +21316,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredIntegerUnixNullableArray(ctx context.Context, request []NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -20942,6 +21399,8 @@ func (c *Client) TestRequestRequiredIntegerUnixNullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredIntegerUnixNullableArrayArray(ctx context.Context, request [][]NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21040,6 +21499,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSeconds(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredIntegerUnixSeconds(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -21112,6 +21573,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSecondsArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredIntegerUnixSecondsArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21193,6 +21656,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSecondsArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredIntegerUnixSecondsArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21291,6 +21756,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSecondsNullable(ctx context.Conte
 func (c *Client) sendTestRequestRequiredIntegerUnixSecondsNullable(ctx context.Context, request NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -21363,6 +21830,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSecondsNullableArray(ctx context.
 func (c *Client) sendTestRequestRequiredIntegerUnixSecondsNullableArray(ctx context.Context, request []NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21444,6 +21913,8 @@ func (c *Client) TestRequestRequiredIntegerUnixSecondsNullableArrayArray(ctx con
 func (c *Client) sendTestRequestRequiredIntegerUnixSecondsNullableArrayArray(ctx context.Context, request [][]NilUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_integer_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_integer_unix-seconds_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21542,6 +22013,8 @@ func (c *Client) TestRequestRequiredNull(ctx context.Context, request struct{}) 
 func (c *Client) sendTestRequestRequiredNull(ctx context.Context, request struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null"),
 	}
 
 	// Run stopwatch.
@@ -21614,6 +22087,8 @@ func (c *Client) TestRequestRequiredNullArray(ctx context.Context, request []str
 func (c *Client) sendTestRequestRequiredNullArray(ctx context.Context, request []struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21695,6 +22170,8 @@ func (c *Client) TestRequestRequiredNullArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredNullArrayArray(ctx context.Context, request [][]struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21793,6 +22270,8 @@ func (c *Client) TestRequestRequiredNullNullable(ctx context.Context, request st
 func (c *Client) sendTestRequestRequiredNullNullable(ctx context.Context, request struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null_nullable"),
 	}
 
 	// Run stopwatch.
@@ -21865,6 +22344,8 @@ func (c *Client) TestRequestRequiredNullNullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredNullNullableArray(ctx context.Context, request []struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -21946,6 +22427,8 @@ func (c *Client) TestRequestRequiredNullNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredNullNullableArrayArray(ctx context.Context, request [][]struct{}) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_null_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_null_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22044,6 +22527,8 @@ func (c *Client) TestRequestRequiredNumber(ctx context.Context, request float64)
 func (c *Client) sendTestRequestRequiredNumber(ctx context.Context, request float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22125,6 +22610,8 @@ func (c *Client) TestRequestRequiredNumberArray(ctx context.Context, request []f
 func (c *Client) sendTestRequestRequiredNumberArray(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22223,6 +22710,8 @@ func (c *Client) TestRequestRequiredNumberArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredNumberArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22338,6 +22827,8 @@ func (c *Client) TestRequestRequiredNumberDouble(ctx context.Context, request fl
 func (c *Client) sendTestRequestRequiredNumberDouble(ctx context.Context, request float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22419,6 +22910,8 @@ func (c *Client) TestRequestRequiredNumberDoubleArray(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredNumberDoubleArray(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22517,6 +23010,8 @@ func (c *Client) TestRequestRequiredNumberDoubleArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredNumberDoubleArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22632,6 +23127,8 @@ func (c *Client) TestRequestRequiredNumberDoubleNullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredNumberDoubleNullable(ctx context.Context, request NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22720,6 +23217,8 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredNumberDoubleNullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22825,6 +23324,8 @@ func (c *Client) TestRequestRequiredNumberDoubleNullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredNumberDoubleNullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_double_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_double_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -22947,6 +23448,8 @@ func (c *Client) TestRequestRequiredNumberFloat(ctx context.Context, request flo
 func (c *Client) sendTestRequestRequiredNumberFloat(ctx context.Context, request float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23028,6 +23531,8 @@ func (c *Client) TestRequestRequiredNumberFloatArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredNumberFloatArray(ctx context.Context, request []float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23126,6 +23631,8 @@ func (c *Client) TestRequestRequiredNumberFloatArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredNumberFloatArrayArray(ctx context.Context, request [][]float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23241,6 +23748,8 @@ func (c *Client) TestRequestRequiredNumberFloatNullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredNumberFloatNullable(ctx context.Context, request NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23329,6 +23838,8 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredNumberFloatNullableArray(ctx context.Context, request []NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23434,6 +23945,8 @@ func (c *Client) TestRequestRequiredNumberFloatNullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredNumberFloatNullableArrayArray(ctx context.Context, request [][]NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_float_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_float_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23556,6 +24069,8 @@ func (c *Client) TestRequestRequiredNumberInt32(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredNumberInt32(ctx context.Context, request int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32"),
 	}
 
 	// Run stopwatch.
@@ -23628,6 +24143,8 @@ func (c *Client) TestRequestRequiredNumberInt32Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredNumberInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23709,6 +24226,8 @@ func (c *Client) TestRequestRequiredNumberInt32ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredNumberInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23807,6 +24326,8 @@ func (c *Client) TestRequestRequiredNumberInt32Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredNumberInt32Nullable(ctx context.Context, request NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -23879,6 +24400,8 @@ func (c *Client) TestRequestRequiredNumberInt32NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredNumberInt32NullableArray(ctx context.Context, request []NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -23960,6 +24483,8 @@ func (c *Client) TestRequestRequiredNumberInt32NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredNumberInt32NullableArrayArray(ctx context.Context, request [][]NilInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24058,6 +24583,8 @@ func (c *Client) TestRequestRequiredNumberInt64(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredNumberInt64(ctx context.Context, request int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64"),
 	}
 
 	// Run stopwatch.
@@ -24130,6 +24657,8 @@ func (c *Client) TestRequestRequiredNumberInt64Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredNumberInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24211,6 +24740,8 @@ func (c *Client) TestRequestRequiredNumberInt64ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredNumberInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24309,6 +24840,8 @@ func (c *Client) TestRequestRequiredNumberInt64Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredNumberInt64Nullable(ctx context.Context, request NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -24381,6 +24914,8 @@ func (c *Client) TestRequestRequiredNumberInt64NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredNumberInt64NullableArray(ctx context.Context, request []NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24462,6 +24997,8 @@ func (c *Client) TestRequestRequiredNumberInt64NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredNumberInt64NullableArrayArray(ctx context.Context, request [][]NilInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24560,6 +25097,8 @@ func (c *Client) TestRequestRequiredNumberNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredNumberNullable(ctx context.Context, request NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24648,6 +25187,8 @@ func (c *Client) TestRequestRequiredNumberNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredNumberNullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24753,6 +25294,8 @@ func (c *Client) TestRequestRequiredNumberNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredNumberNullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_number_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_number_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -24875,6 +25418,8 @@ func (c *Client) TestRequestRequiredString(ctx context.Context, request string) 
 func (c *Client) sendTestRequestRequiredString(ctx context.Context, request string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string"),
 	}
 
 	// Run stopwatch.
@@ -24947,6 +25492,8 @@ func (c *Client) TestRequestRequiredStringArray(ctx context.Context, request []s
 func (c *Client) sendTestRequestRequiredStringArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25028,6 +25575,8 @@ func (c *Client) TestRequestRequiredStringArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25126,6 +25675,8 @@ func (c *Client) TestRequestRequiredStringBase64(ctx context.Context, request []
 func (c *Client) sendTestRequestRequiredStringBase64(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64"),
 	}
 
 	// Run stopwatch.
@@ -25198,6 +25749,8 @@ func (c *Client) TestRequestRequiredStringBase64Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringBase64Array(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25279,6 +25832,8 @@ func (c *Client) TestRequestRequiredStringBase64ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringBase64ArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25377,6 +25932,8 @@ func (c *Client) TestRequestRequiredStringBase64Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringBase64Nullable(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -25449,6 +26006,8 @@ func (c *Client) TestRequestRequiredStringBase64NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringBase64NullableArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25530,6 +26089,8 @@ func (c *Client) TestRequestRequiredStringBase64NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringBase64NullableArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_base64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_base64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25628,6 +26189,8 @@ func (c *Client) TestRequestRequiredStringBinary(ctx context.Context, request st
 func (c *Client) sendTestRequestRequiredStringBinary(ctx context.Context, request string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary"),
 	}
 
 	// Run stopwatch.
@@ -25700,6 +26263,8 @@ func (c *Client) TestRequestRequiredStringBinaryArray(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringBinaryArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25781,6 +26346,8 @@ func (c *Client) TestRequestRequiredStringBinaryArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringBinaryArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -25879,6 +26446,8 @@ func (c *Client) TestRequestRequiredStringBinaryNullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringBinaryNullable(ctx context.Context, request NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary_nullable"),
 	}
 
 	// Run stopwatch.
@@ -25951,6 +26520,8 @@ func (c *Client) TestRequestRequiredStringBinaryNullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringBinaryNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26032,6 +26603,8 @@ func (c *Client) TestRequestRequiredStringBinaryNullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringBinaryNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_binary_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_binary_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26130,6 +26703,8 @@ func (c *Client) TestRequestRequiredStringByte(ctx context.Context, request []by
 func (c *Client) sendTestRequestRequiredStringByte(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte"),
 	}
 
 	// Run stopwatch.
@@ -26202,6 +26777,8 @@ func (c *Client) TestRequestRequiredStringByteArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringByteArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26283,6 +26860,8 @@ func (c *Client) TestRequestRequiredStringByteArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringByteArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26381,6 +26960,8 @@ func (c *Client) TestRequestRequiredStringByteNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringByteNullable(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte_nullable"),
 	}
 
 	// Run stopwatch.
@@ -26453,6 +27034,8 @@ func (c *Client) TestRequestRequiredStringByteNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringByteNullableArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26534,6 +27117,8 @@ func (c *Client) TestRequestRequiredStringByteNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringByteNullableArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_byte_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_byte_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26632,6 +27217,8 @@ func (c *Client) TestRequestRequiredStringDate(ctx context.Context, request time
 func (c *Client) sendTestRequestRequiredStringDate(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date"),
 	}
 
 	// Run stopwatch.
@@ -26704,6 +27291,8 @@ func (c *Client) TestRequestRequiredStringDateArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringDateArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26785,6 +27374,8 @@ func (c *Client) TestRequestRequiredStringDateArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringDateArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -26883,6 +27474,8 @@ func (c *Client) TestRequestRequiredStringDateNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringDateNullable(ctx context.Context, request NilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date_nullable"),
 	}
 
 	// Run stopwatch.
@@ -26955,6 +27548,8 @@ func (c *Client) TestRequestRequiredStringDateNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringDateNullableArray(ctx context.Context, request []NilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27036,6 +27631,8 @@ func (c *Client) TestRequestRequiredStringDateNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringDateNullableArrayArray(ctx context.Context, request [][]NilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27134,6 +27731,8 @@ func (c *Client) TestRequestRequiredStringDateTime(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringDateTime(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time"),
 	}
 
 	// Run stopwatch.
@@ -27206,6 +27805,8 @@ func (c *Client) TestRequestRequiredStringDateTimeArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringDateTimeArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27287,6 +27888,8 @@ func (c *Client) TestRequestRequiredStringDateTimeArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringDateTimeArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27385,6 +27988,8 @@ func (c *Client) TestRequestRequiredStringDateTimeNullable(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringDateTimeNullable(ctx context.Context, request NilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -27457,6 +28062,8 @@ func (c *Client) TestRequestRequiredStringDateTimeNullableArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringDateTimeNullableArray(ctx context.Context, request []NilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27538,6 +28145,8 @@ func (c *Client) TestRequestRequiredStringDateTimeNullableArrayArray(ctx context
 func (c *Client) sendTestRequestRequiredStringDateTimeNullableArrayArray(ctx context.Context, request [][]NilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_date-time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_date-time_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27636,6 +28245,8 @@ func (c *Client) TestRequestRequiredStringDuration(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringDuration(ctx context.Context, request time.Duration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration"),
 	}
 
 	// Run stopwatch.
@@ -27708,6 +28319,8 @@ func (c *Client) TestRequestRequiredStringDurationArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringDurationArray(ctx context.Context, request []time.Duration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27789,6 +28402,8 @@ func (c *Client) TestRequestRequiredStringDurationArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringDurationArrayArray(ctx context.Context, request [][]time.Duration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -27887,6 +28502,8 @@ func (c *Client) TestRequestRequiredStringDurationNullable(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringDurationNullable(ctx context.Context, request NilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration_nullable"),
 	}
 
 	// Run stopwatch.
@@ -27959,6 +28576,8 @@ func (c *Client) TestRequestRequiredStringDurationNullableArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringDurationNullableArray(ctx context.Context, request []NilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28040,6 +28659,8 @@ func (c *Client) TestRequestRequiredStringDurationNullableArrayArray(ctx context
 func (c *Client) sendTestRequestRequiredStringDurationNullableArrayArray(ctx context.Context, request [][]NilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_duration_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_duration_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28138,6 +28759,8 @@ func (c *Client) TestRequestRequiredStringEmail(ctx context.Context, request str
 func (c *Client) sendTestRequestRequiredStringEmail(ctx context.Context, request string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28227,6 +28850,8 @@ func (c *Client) TestRequestRequiredStringEmailArray(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringEmailArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28333,6 +28958,8 @@ func (c *Client) TestRequestRequiredStringEmailArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringEmailArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28456,6 +29083,8 @@ func (c *Client) TestRequestRequiredStringEmailNullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringEmailNullable(ctx context.Context, request NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28552,6 +29181,8 @@ func (c *Client) TestRequestRequiredStringEmailNullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringEmailNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28665,6 +29296,8 @@ func (c *Client) TestRequestRequiredStringEmailNullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredStringEmailNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_email_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_email_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28795,6 +29428,8 @@ func (c *Client) TestRequestRequiredStringFloat32(ctx context.Context, request f
 func (c *Client) sendTestRequestRequiredStringFloat32(ctx context.Context, request float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28876,6 +29511,8 @@ func (c *Client) TestRequestRequiredStringFloat32Array(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringFloat32Array(ctx context.Context, request []float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -28974,6 +29611,8 @@ func (c *Client) TestRequestRequiredStringFloat32ArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringFloat32ArrayArray(ctx context.Context, request [][]float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29089,6 +29728,8 @@ func (c *Client) TestRequestRequiredStringFloat32Nullable(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringFloat32Nullable(ctx context.Context, request NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29177,6 +29818,8 @@ func (c *Client) TestRequestRequiredStringFloat32NullableArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredStringFloat32NullableArray(ctx context.Context, request []NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29282,6 +29925,8 @@ func (c *Client) TestRequestRequiredStringFloat32NullableArrayArray(ctx context.
 func (c *Client) sendTestRequestRequiredStringFloat32NullableArrayArray(ctx context.Context, request [][]NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29404,6 +30049,8 @@ func (c *Client) TestRequestRequiredStringFloat64(ctx context.Context, request f
 func (c *Client) sendTestRequestRequiredStringFloat64(ctx context.Context, request float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29485,6 +30132,8 @@ func (c *Client) TestRequestRequiredStringFloat64Array(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringFloat64Array(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29583,6 +30232,8 @@ func (c *Client) TestRequestRequiredStringFloat64ArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringFloat64ArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29698,6 +30349,8 @@ func (c *Client) TestRequestRequiredStringFloat64Nullable(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringFloat64Nullable(ctx context.Context, request NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29786,6 +30439,8 @@ func (c *Client) TestRequestRequiredStringFloat64NullableArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredStringFloat64NullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -29891,6 +30546,8 @@ func (c *Client) TestRequestRequiredStringFloat64NullableArrayArray(ctx context.
 func (c *Client) sendTestRequestRequiredStringFloat64NullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_float64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_float64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30013,6 +30670,8 @@ func (c *Client) TestRequestRequiredStringHostname(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringHostname(ctx context.Context, request string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30102,6 +30761,8 @@ func (c *Client) TestRequestRequiredStringHostnameArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringHostnameArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30208,6 +30869,8 @@ func (c *Client) TestRequestRequiredStringHostnameArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringHostnameArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30331,6 +30994,8 @@ func (c *Client) TestRequestRequiredStringHostnameNullable(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringHostnameNullable(ctx context.Context, request NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30427,6 +31092,8 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringHostnameNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30540,6 +31207,8 @@ func (c *Client) TestRequestRequiredStringHostnameNullableArrayArray(ctx context
 func (c *Client) sendTestRequestRequiredStringHostnameNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_hostname_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_hostname_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30670,6 +31339,8 @@ func (c *Client) TestRequestRequiredStringIP(ctx context.Context, request netip.
 func (c *Client) sendTestRequestRequiredStringIP(ctx context.Context, request netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip"),
 	}
 
 	// Run stopwatch.
@@ -30742,6 +31413,8 @@ func (c *Client) TestRequestRequiredStringIPArray(ctx context.Context, request [
 func (c *Client) sendTestRequestRequiredStringIPArray(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30823,6 +31496,8 @@ func (c *Client) TestRequestRequiredStringIPArrayArray(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringIPArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -30921,6 +31596,8 @@ func (c *Client) TestRequestRequiredStringIPNullable(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringIPNullable(ctx context.Context, request NilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip_nullable"),
 	}
 
 	// Run stopwatch.
@@ -30993,6 +31670,8 @@ func (c *Client) TestRequestRequiredStringIPNullableArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringIPNullableArray(ctx context.Context, request []NilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31074,6 +31753,8 @@ func (c *Client) TestRequestRequiredStringIPNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestRequestRequiredStringIPNullableArrayArray(ctx context.Context, request [][]NilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ip_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ip_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31172,6 +31853,8 @@ func (c *Client) TestRequestRequiredStringInt(ctx context.Context, request int) 
 func (c *Client) sendTestRequestRequiredStringInt(ctx context.Context, request int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int"),
 	}
 
 	// Run stopwatch.
@@ -31244,6 +31927,8 @@ func (c *Client) TestRequestRequiredStringInt16(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredStringInt16(ctx context.Context, request int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16"),
 	}
 
 	// Run stopwatch.
@@ -31316,6 +32001,8 @@ func (c *Client) TestRequestRequiredStringInt16Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringInt16Array(ctx context.Context, request []int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31397,6 +32084,8 @@ func (c *Client) TestRequestRequiredStringInt16ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringInt16ArrayArray(ctx context.Context, request [][]int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31495,6 +32184,8 @@ func (c *Client) TestRequestRequiredStringInt16Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringInt16Nullable(ctx context.Context, request NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -31567,6 +32258,8 @@ func (c *Client) TestRequestRequiredStringInt16NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringInt16NullableArray(ctx context.Context, request []NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31648,6 +32341,8 @@ func (c *Client) TestRequestRequiredStringInt16NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredStringInt16NullableArrayArray(ctx context.Context, request [][]NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31746,6 +32441,8 @@ func (c *Client) TestRequestRequiredStringInt32(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredStringInt32(ctx context.Context, request int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32"),
 	}
 
 	// Run stopwatch.
@@ -31818,6 +32515,8 @@ func (c *Client) TestRequestRequiredStringInt32Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31899,6 +32598,8 @@ func (c *Client) TestRequestRequiredStringInt32ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -31997,6 +32698,8 @@ func (c *Client) TestRequestRequiredStringInt32Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringInt32Nullable(ctx context.Context, request NilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -32069,6 +32772,8 @@ func (c *Client) TestRequestRequiredStringInt32NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringInt32NullableArray(ctx context.Context, request []NilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32150,6 +32855,8 @@ func (c *Client) TestRequestRequiredStringInt32NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredStringInt32NullableArrayArray(ctx context.Context, request [][]NilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32248,6 +32955,8 @@ func (c *Client) TestRequestRequiredStringInt64(ctx context.Context, request int
 func (c *Client) sendTestRequestRequiredStringInt64(ctx context.Context, request int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64"),
 	}
 
 	// Run stopwatch.
@@ -32320,6 +33029,8 @@ func (c *Client) TestRequestRequiredStringInt64Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32401,6 +33112,8 @@ func (c *Client) TestRequestRequiredStringInt64ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32499,6 +33212,8 @@ func (c *Client) TestRequestRequiredStringInt64Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringInt64Nullable(ctx context.Context, request NilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -32571,6 +33286,8 @@ func (c *Client) TestRequestRequiredStringInt64NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringInt64NullableArray(ctx context.Context, request []NilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32652,6 +33369,8 @@ func (c *Client) TestRequestRequiredStringInt64NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredStringInt64NullableArrayArray(ctx context.Context, request [][]NilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32750,6 +33469,8 @@ func (c *Client) TestRequestRequiredStringInt8(ctx context.Context, request int8
 func (c *Client) sendTestRequestRequiredStringInt8(ctx context.Context, request int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8"),
 	}
 
 	// Run stopwatch.
@@ -32822,6 +33543,8 @@ func (c *Client) TestRequestRequiredStringInt8Array(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringInt8Array(ctx context.Context, request []int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -32903,6 +33626,8 @@ func (c *Client) TestRequestRequiredStringInt8ArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringInt8ArrayArray(ctx context.Context, request [][]int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33001,6 +33726,8 @@ func (c *Client) TestRequestRequiredStringInt8Nullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringInt8Nullable(ctx context.Context, request NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -33073,6 +33800,8 @@ func (c *Client) TestRequestRequiredStringInt8NullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringInt8NullableArray(ctx context.Context, request []NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33154,6 +33883,8 @@ func (c *Client) TestRequestRequiredStringInt8NullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringInt8NullableArrayArray(ctx context.Context, request [][]NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33252,6 +33983,8 @@ func (c *Client) TestRequestRequiredStringIntArray(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringIntArray(ctx context.Context, request []int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33333,6 +34066,8 @@ func (c *Client) TestRequestRequiredStringIntArrayArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringIntArrayArray(ctx context.Context, request [][]int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33431,6 +34166,8 @@ func (c *Client) TestRequestRequiredStringIntNullable(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringIntNullable(ctx context.Context, request NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int_nullable"),
 	}
 
 	// Run stopwatch.
@@ -33503,6 +34240,8 @@ func (c *Client) TestRequestRequiredStringIntNullableArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringIntNullableArray(ctx context.Context, request []NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33584,6 +34323,8 @@ func (c *Client) TestRequestRequiredStringIntNullableArrayArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringIntNullableArrayArray(ctx context.Context, request [][]NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_int_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_int_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33682,6 +34423,8 @@ func (c *Client) TestRequestRequiredStringIpv4(ctx context.Context, request neti
 func (c *Client) sendTestRequestRequiredStringIpv4(ctx context.Context, request netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4"),
 	}
 
 	// Run stopwatch.
@@ -33754,6 +34497,8 @@ func (c *Client) TestRequestRequiredStringIpv4Array(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringIpv4Array(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33835,6 +34580,8 @@ func (c *Client) TestRequestRequiredStringIpv4ArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringIpv4ArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -33933,6 +34680,8 @@ func (c *Client) TestRequestRequiredStringIpv4Nullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringIpv4Nullable(ctx context.Context, request NilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4_nullable"),
 	}
 
 	// Run stopwatch.
@@ -34005,6 +34754,8 @@ func (c *Client) TestRequestRequiredStringIpv4NullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringIpv4NullableArray(ctx context.Context, request []NilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34086,6 +34837,8 @@ func (c *Client) TestRequestRequiredStringIpv4NullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringIpv4NullableArrayArray(ctx context.Context, request [][]NilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv4_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv4_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34184,6 +34937,8 @@ func (c *Client) TestRequestRequiredStringIpv6(ctx context.Context, request neti
 func (c *Client) sendTestRequestRequiredStringIpv6(ctx context.Context, request netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6"),
 	}
 
 	// Run stopwatch.
@@ -34256,6 +35011,8 @@ func (c *Client) TestRequestRequiredStringIpv6Array(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringIpv6Array(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34337,6 +35094,8 @@ func (c *Client) TestRequestRequiredStringIpv6ArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringIpv6ArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34435,6 +35194,8 @@ func (c *Client) TestRequestRequiredStringIpv6Nullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringIpv6Nullable(ctx context.Context, request NilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6_nullable"),
 	}
 
 	// Run stopwatch.
@@ -34507,6 +35268,8 @@ func (c *Client) TestRequestRequiredStringIpv6NullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringIpv6NullableArray(ctx context.Context, request []NilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34588,6 +35351,8 @@ func (c *Client) TestRequestRequiredStringIpv6NullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringIpv6NullableArrayArray(ctx context.Context, request [][]NilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_ipv6_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_ipv6_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34686,6 +35451,8 @@ func (c *Client) TestRequestRequiredStringNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringNullable(ctx context.Context, request NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_nullable"),
 	}
 
 	// Run stopwatch.
@@ -34758,6 +35525,8 @@ func (c *Client) TestRequestRequiredStringNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34839,6 +35608,8 @@ func (c *Client) TestRequestRequiredStringNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -34937,6 +35708,8 @@ func (c *Client) TestRequestRequiredStringPassword(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringPassword(ctx context.Context, request string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password"),
 	}
 
 	// Run stopwatch.
@@ -35009,6 +35782,8 @@ func (c *Client) TestRequestRequiredStringPasswordArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringPasswordArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35090,6 +35865,8 @@ func (c *Client) TestRequestRequiredStringPasswordArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringPasswordArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35188,6 +35965,8 @@ func (c *Client) TestRequestRequiredStringPasswordNullable(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringPasswordNullable(ctx context.Context, request NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password_nullable"),
 	}
 
 	// Run stopwatch.
@@ -35260,6 +36039,8 @@ func (c *Client) TestRequestRequiredStringPasswordNullableArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringPasswordNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35341,6 +36122,8 @@ func (c *Client) TestRequestRequiredStringPasswordNullableArrayArray(ctx context
 func (c *Client) sendTestRequestRequiredStringPasswordNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_password_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_password_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35439,6 +36222,8 @@ func (c *Client) TestRequestRequiredStringTime(ctx context.Context, request time
 func (c *Client) sendTestRequestRequiredStringTime(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time"),
 	}
 
 	// Run stopwatch.
@@ -35511,6 +36296,8 @@ func (c *Client) TestRequestRequiredStringTimeArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringTimeArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35592,6 +36379,8 @@ func (c *Client) TestRequestRequiredStringTimeArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringTimeArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35690,6 +36479,8 @@ func (c *Client) TestRequestRequiredStringTimeNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringTimeNullable(ctx context.Context, request NilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -35762,6 +36553,8 @@ func (c *Client) TestRequestRequiredStringTimeNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringTimeNullableArray(ctx context.Context, request []NilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35843,6 +36636,8 @@ func (c *Client) TestRequestRequiredStringTimeNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringTimeNullableArrayArray(ctx context.Context, request [][]NilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_time_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -35941,6 +36736,8 @@ func (c *Client) TestRequestRequiredStringURI(ctx context.Context, request url.U
 func (c *Client) sendTestRequestRequiredStringURI(ctx context.Context, request url.URL) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri"),
 	}
 
 	// Run stopwatch.
@@ -36013,6 +36810,8 @@ func (c *Client) TestRequestRequiredStringURIArray(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringURIArray(ctx context.Context, request []url.URL) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36094,6 +36893,8 @@ func (c *Client) TestRequestRequiredStringURIArrayArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringURIArrayArray(ctx context.Context, request [][]url.URL) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36192,6 +36993,8 @@ func (c *Client) TestRequestRequiredStringURINullable(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringURINullable(ctx context.Context, request NilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri_nullable"),
 	}
 
 	// Run stopwatch.
@@ -36264,6 +37067,8 @@ func (c *Client) TestRequestRequiredStringURINullableArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringURINullableArray(ctx context.Context, request []NilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36345,6 +37150,8 @@ func (c *Client) TestRequestRequiredStringURINullableArrayArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringURINullableArrayArray(ctx context.Context, request [][]NilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uri_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uri_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36443,6 +37250,8 @@ func (c *Client) TestRequestRequiredStringUUID(ctx context.Context, request uuid
 func (c *Client) sendTestRequestRequiredStringUUID(ctx context.Context, request uuid.UUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid"),
 	}
 
 	// Run stopwatch.
@@ -36515,6 +37324,8 @@ func (c *Client) TestRequestRequiredStringUUIDArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringUUIDArray(ctx context.Context, request []uuid.UUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36596,6 +37407,8 @@ func (c *Client) TestRequestRequiredStringUUIDArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUUIDArrayArray(ctx context.Context, request [][]uuid.UUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36694,6 +37507,8 @@ func (c *Client) TestRequestRequiredStringUUIDNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringUUIDNullable(ctx context.Context, request NilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid_nullable"),
 	}
 
 	// Run stopwatch.
@@ -36766,6 +37581,8 @@ func (c *Client) TestRequestRequiredStringUUIDNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringUUIDNullableArray(ctx context.Context, request []NilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36847,6 +37664,8 @@ func (c *Client) TestRequestRequiredStringUUIDNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringUUIDNullableArrayArray(ctx context.Context, request [][]NilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uuid_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uuid_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -36945,6 +37764,8 @@ func (c *Client) TestRequestRequiredStringUint(ctx context.Context, request uint
 func (c *Client) sendTestRequestRequiredStringUint(ctx context.Context, request uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint"),
 	}
 
 	// Run stopwatch.
@@ -37017,6 +37838,8 @@ func (c *Client) TestRequestRequiredStringUint16(ctx context.Context, request ui
 func (c *Client) sendTestRequestRequiredStringUint16(ctx context.Context, request uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16"),
 	}
 
 	// Run stopwatch.
@@ -37089,6 +37912,8 @@ func (c *Client) TestRequestRequiredStringUint16Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringUint16Array(ctx context.Context, request []uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37170,6 +37995,8 @@ func (c *Client) TestRequestRequiredStringUint16ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringUint16ArrayArray(ctx context.Context, request [][]uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37268,6 +38095,8 @@ func (c *Client) TestRequestRequiredStringUint16Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUint16Nullable(ctx context.Context, request NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -37340,6 +38169,8 @@ func (c *Client) TestRequestRequiredStringUint16NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUint16NullableArray(ctx context.Context, request []NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37421,6 +38252,8 @@ func (c *Client) TestRequestRequiredStringUint16NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringUint16NullableArrayArray(ctx context.Context, request [][]NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37519,6 +38352,8 @@ func (c *Client) TestRequestRequiredStringUint32(ctx context.Context, request ui
 func (c *Client) sendTestRequestRequiredStringUint32(ctx context.Context, request uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32"),
 	}
 
 	// Run stopwatch.
@@ -37591,6 +38426,8 @@ func (c *Client) TestRequestRequiredStringUint32Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringUint32Array(ctx context.Context, request []uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37672,6 +38509,8 @@ func (c *Client) TestRequestRequiredStringUint32ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringUint32ArrayArray(ctx context.Context, request [][]uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37770,6 +38609,8 @@ func (c *Client) TestRequestRequiredStringUint32Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUint32Nullable(ctx context.Context, request NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -37842,6 +38683,8 @@ func (c *Client) TestRequestRequiredStringUint32NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUint32NullableArray(ctx context.Context, request []NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -37923,6 +38766,8 @@ func (c *Client) TestRequestRequiredStringUint32NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringUint32NullableArrayArray(ctx context.Context, request [][]NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38021,6 +38866,8 @@ func (c *Client) TestRequestRequiredStringUint64(ctx context.Context, request ui
 func (c *Client) sendTestRequestRequiredStringUint64(ctx context.Context, request uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64"),
 	}
 
 	// Run stopwatch.
@@ -38093,6 +38940,8 @@ func (c *Client) TestRequestRequiredStringUint64Array(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringUint64Array(ctx context.Context, request []uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38174,6 +39023,8 @@ func (c *Client) TestRequestRequiredStringUint64ArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringUint64ArrayArray(ctx context.Context, request [][]uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38272,6 +39123,8 @@ func (c *Client) TestRequestRequiredStringUint64Nullable(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUint64Nullable(ctx context.Context, request NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -38344,6 +39197,8 @@ func (c *Client) TestRequestRequiredStringUint64NullableArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUint64NullableArray(ctx context.Context, request []NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38425,6 +39280,8 @@ func (c *Client) TestRequestRequiredStringUint64NullableArrayArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringUint64NullableArrayArray(ctx context.Context, request [][]NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38523,6 +39380,8 @@ func (c *Client) TestRequestRequiredStringUint8(ctx context.Context, request uin
 func (c *Client) sendTestRequestRequiredStringUint8(ctx context.Context, request uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8"),
 	}
 
 	// Run stopwatch.
@@ -38595,6 +39454,8 @@ func (c *Client) TestRequestRequiredStringUint8Array(ctx context.Context, reques
 func (c *Client) sendTestRequestRequiredStringUint8Array(ctx context.Context, request []uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38676,6 +39537,8 @@ func (c *Client) TestRequestRequiredStringUint8ArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestRequiredStringUint8ArrayArray(ctx context.Context, request [][]uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38774,6 +39637,8 @@ func (c *Client) TestRequestRequiredStringUint8Nullable(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringUint8Nullable(ctx context.Context, request NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -38846,6 +39711,8 @@ func (c *Client) TestRequestRequiredStringUint8NullableArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringUint8NullableArray(ctx context.Context, request []NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -38927,6 +39794,8 @@ func (c *Client) TestRequestRequiredStringUint8NullableArrayArray(ctx context.Co
 func (c *Client) sendTestRequestRequiredStringUint8NullableArrayArray(ctx context.Context, request [][]NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39025,6 +39894,8 @@ func (c *Client) TestRequestRequiredStringUintArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringUintArray(ctx context.Context, request []uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39106,6 +39977,8 @@ func (c *Client) TestRequestRequiredStringUintArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUintArrayArray(ctx context.Context, request [][]uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39204,6 +40077,8 @@ func (c *Client) TestRequestRequiredStringUintNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringUintNullable(ctx context.Context, request NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -39276,6 +40151,8 @@ func (c *Client) TestRequestRequiredStringUintNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringUintNullableArray(ctx context.Context, request []NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39357,6 +40234,8 @@ func (c *Client) TestRequestRequiredStringUintNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringUintNullableArrayArray(ctx context.Context, request [][]NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_uint_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39455,6 +40334,8 @@ func (c *Client) TestRequestRequiredStringUnix(ctx context.Context, request time
 func (c *Client) sendTestRequestRequiredStringUnix(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix"),
 	}
 
 	// Run stopwatch.
@@ -39527,6 +40408,8 @@ func (c *Client) TestRequestRequiredStringUnixArray(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringUnixArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39608,6 +40491,8 @@ func (c *Client) TestRequestRequiredStringUnixArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUnixArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39706,6 +40591,8 @@ func (c *Client) TestRequestRequiredStringUnixMicro(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringUnixMicro(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -39778,6 +40665,8 @@ func (c *Client) TestRequestRequiredStringUnixMicroArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUnixMicroArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39859,6 +40748,8 @@ func (c *Client) TestRequestRequiredStringUnixMicroArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUnixMicroArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -39957,6 +40848,8 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullable(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringUnixMicroNullable(ctx context.Context, request NilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -40029,6 +40922,8 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullableArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringUnixMicroNullableArray(ctx context.Context, request []NilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40110,6 +41005,8 @@ func (c *Client) TestRequestRequiredStringUnixMicroNullableArrayArray(ctx contex
 func (c *Client) sendTestRequestRequiredStringUnixMicroNullableArrayArray(ctx context.Context, request [][]NilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-micro_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40208,6 +41105,8 @@ func (c *Client) TestRequestRequiredStringUnixMilli(ctx context.Context, request
 func (c *Client) sendTestRequestRequiredStringUnixMilli(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -40280,6 +41179,8 @@ func (c *Client) TestRequestRequiredStringUnixMilliArray(ctx context.Context, re
 func (c *Client) sendTestRequestRequiredStringUnixMilliArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40361,6 +41262,8 @@ func (c *Client) TestRequestRequiredStringUnixMilliArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUnixMilliArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40459,6 +41362,8 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullable(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringUnixMilliNullable(ctx context.Context, request NilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -40531,6 +41436,8 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullableArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringUnixMilliNullableArray(ctx context.Context, request []NilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40612,6 +41519,8 @@ func (c *Client) TestRequestRequiredStringUnixMilliNullableArrayArray(ctx contex
 func (c *Client) sendTestRequestRequiredStringUnixMilliNullableArrayArray(ctx context.Context, request [][]NilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-milli_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40710,6 +41619,8 @@ func (c *Client) TestRequestRequiredStringUnixNano(ctx context.Context, request 
 func (c *Client) sendTestRequestRequiredStringUnixNano(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -40782,6 +41693,8 @@ func (c *Client) TestRequestRequiredStringUnixNanoArray(ctx context.Context, req
 func (c *Client) sendTestRequestRequiredStringUnixNanoArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40863,6 +41776,8 @@ func (c *Client) TestRequestRequiredStringUnixNanoArrayArray(ctx context.Context
 func (c *Client) sendTestRequestRequiredStringUnixNanoArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -40961,6 +41876,8 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullable(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringUnixNanoNullable(ctx context.Context, request NilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -41033,6 +41950,8 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullableArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringUnixNanoNullableArray(ctx context.Context, request []NilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41114,6 +42033,8 @@ func (c *Client) TestRequestRequiredStringUnixNanoNullableArrayArray(ctx context
 func (c *Client) sendTestRequestRequiredStringUnixNanoNullableArrayArray(ctx context.Context, request [][]NilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-nano_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41212,6 +42133,8 @@ func (c *Client) TestRequestRequiredStringUnixNullable(ctx context.Context, requ
 func (c *Client) sendTestRequestRequiredStringUnixNullable(ctx context.Context, request NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -41284,6 +42207,8 @@ func (c *Client) TestRequestRequiredStringUnixNullableArray(ctx context.Context,
 func (c *Client) sendTestRequestRequiredStringUnixNullableArray(ctx context.Context, request []NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41365,6 +42290,8 @@ func (c *Client) TestRequestRequiredStringUnixNullableArrayArray(ctx context.Con
 func (c *Client) sendTestRequestRequiredStringUnixNullableArrayArray(ctx context.Context, request [][]NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41463,6 +42390,8 @@ func (c *Client) TestRequestRequiredStringUnixSeconds(ctx context.Context, reque
 func (c *Client) sendTestRequestRequiredStringUnixSeconds(ctx context.Context, request time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -41535,6 +42464,8 @@ func (c *Client) TestRequestRequiredStringUnixSecondsArray(ctx context.Context, 
 func (c *Client) sendTestRequestRequiredStringUnixSecondsArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41616,6 +42547,8 @@ func (c *Client) TestRequestRequiredStringUnixSecondsArrayArray(ctx context.Cont
 func (c *Client) sendTestRequestRequiredStringUnixSecondsArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41714,6 +42647,8 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullable(ctx context.Contex
 func (c *Client) sendTestRequestRequiredStringUnixSecondsNullable(ctx context.Context, request NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -41786,6 +42721,8 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullableArray(ctx context.C
 func (c *Client) sendTestRequestRequiredStringUnixSecondsNullableArray(ctx context.Context, request []NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41867,6 +42804,8 @@ func (c *Client) TestRequestRequiredStringUnixSecondsNullableArrayArray(ctx cont
 func (c *Client) sendTestRequestRequiredStringUnixSecondsNullableArrayArray(ctx context.Context, request [][]NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_required_string_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_unix-seconds_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -41965,6 +42904,8 @@ func (c *Client) TestRequestString(ctx context.Context, request OptString) (*Err
 func (c *Client) sendTestRequestString(ctx context.Context, request OptString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string"),
 	}
 
 	// Run stopwatch.
@@ -42037,6 +42978,8 @@ func (c *Client) TestRequestStringArray(ctx context.Context, request []string) (
 func (c *Client) sendTestRequestStringArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_array"),
 	}
 
 	// Run stopwatch.
@@ -42109,6 +43052,8 @@ func (c *Client) TestRequestStringArrayArray(ctx context.Context, request [][]st
 func (c *Client) sendTestRequestStringArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -42204,6 +43149,8 @@ func (c *Client) TestRequestStringBase64(ctx context.Context, request []byte) (*
 func (c *Client) sendTestRequestStringBase64(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64"),
 	}
 
 	// Run stopwatch.
@@ -42276,6 +43223,8 @@ func (c *Client) TestRequestStringBase64Array(ctx context.Context, request [][]b
 func (c *Client) sendTestRequestStringBase64Array(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64_array"),
 	}
 
 	// Run stopwatch.
@@ -42348,6 +43297,8 @@ func (c *Client) TestRequestStringBase64ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringBase64ArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -42443,6 +43394,8 @@ func (c *Client) TestRequestStringBase64Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestStringBase64Nullable(ctx context.Context, request OptNilByte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -42515,6 +43468,8 @@ func (c *Client) TestRequestStringBase64NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringBase64NullableArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -42587,6 +43542,8 @@ func (c *Client) TestRequestStringBase64NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringBase64NullableArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_base64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_base64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -42682,6 +43639,8 @@ func (c *Client) TestRequestStringBinary(ctx context.Context, request OptString)
 func (c *Client) sendTestRequestStringBinary(ctx context.Context, request OptString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary"),
 	}
 
 	// Run stopwatch.
@@ -42754,6 +43713,8 @@ func (c *Client) TestRequestStringBinaryArray(ctx context.Context, request []str
 func (c *Client) sendTestRequestStringBinaryArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary_array"),
 	}
 
 	// Run stopwatch.
@@ -42826,6 +43787,8 @@ func (c *Client) TestRequestStringBinaryArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringBinaryArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -42921,6 +43884,8 @@ func (c *Client) TestRequestStringBinaryNullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestStringBinaryNullable(ctx context.Context, request OptNilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary_nullable"),
 	}
 
 	// Run stopwatch.
@@ -42993,6 +43958,8 @@ func (c *Client) TestRequestStringBinaryNullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringBinaryNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -43065,6 +44032,8 @@ func (c *Client) TestRequestStringBinaryNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringBinaryNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_binary_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_binary_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -43160,6 +44129,8 @@ func (c *Client) TestRequestStringByte(ctx context.Context, request []byte) (*Er
 func (c *Client) sendTestRequestStringByte(ctx context.Context, request []byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte"),
 	}
 
 	// Run stopwatch.
@@ -43232,6 +44203,8 @@ func (c *Client) TestRequestStringByteArray(ctx context.Context, request [][]byt
 func (c *Client) sendTestRequestStringByteArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte_array"),
 	}
 
 	// Run stopwatch.
@@ -43304,6 +44277,8 @@ func (c *Client) TestRequestStringByteArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringByteArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -43399,6 +44374,8 @@ func (c *Client) TestRequestStringByteNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringByteNullable(ctx context.Context, request OptNilByte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte_nullable"),
 	}
 
 	// Run stopwatch.
@@ -43471,6 +44448,8 @@ func (c *Client) TestRequestStringByteNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringByteNullableArray(ctx context.Context, request [][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -43543,6 +44522,8 @@ func (c *Client) TestRequestStringByteNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringByteNullableArrayArray(ctx context.Context, request [][][]byte) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_byte_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_byte_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -43638,6 +44619,8 @@ func (c *Client) TestRequestStringDate(ctx context.Context, request OptDate) (*E
 func (c *Client) sendTestRequestStringDate(ctx context.Context, request OptDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date"),
 	}
 
 	// Run stopwatch.
@@ -43710,6 +44693,8 @@ func (c *Client) TestRequestStringDateArray(ctx context.Context, request []time.
 func (c *Client) sendTestRequestStringDateArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date_array"),
 	}
 
 	// Run stopwatch.
@@ -43782,6 +44767,8 @@ func (c *Client) TestRequestStringDateArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringDateArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -43877,6 +44864,8 @@ func (c *Client) TestRequestStringDateNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringDateNullable(ctx context.Context, request OptNilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date_nullable"),
 	}
 
 	// Run stopwatch.
@@ -43949,6 +44938,8 @@ func (c *Client) TestRequestStringDateNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringDateNullableArray(ctx context.Context, request []NilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -44021,6 +45012,8 @@ func (c *Client) TestRequestStringDateNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringDateNullableArrayArray(ctx context.Context, request [][]NilDate) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -44116,6 +45109,8 @@ func (c *Client) TestRequestStringDateTime(ctx context.Context, request OptDateT
 func (c *Client) sendTestRequestStringDateTime(ctx context.Context, request OptDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time"),
 	}
 
 	// Run stopwatch.
@@ -44188,6 +45183,8 @@ func (c *Client) TestRequestStringDateTimeArray(ctx context.Context, request []t
 func (c *Client) sendTestRequestStringDateTimeArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time_array"),
 	}
 
 	// Run stopwatch.
@@ -44260,6 +45257,8 @@ func (c *Client) TestRequestStringDateTimeArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringDateTimeArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -44355,6 +45354,8 @@ func (c *Client) TestRequestStringDateTimeNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestStringDateTimeNullable(ctx context.Context, request OptNilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -44427,6 +45428,8 @@ func (c *Client) TestRequestStringDateTimeNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringDateTimeNullableArray(ctx context.Context, request []NilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -44499,6 +45502,8 @@ func (c *Client) TestRequestStringDateTimeNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestStringDateTimeNullableArrayArray(ctx context.Context, request [][]NilDateTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_date-time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_date-time_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -44594,6 +45599,8 @@ func (c *Client) TestRequestStringDuration(ctx context.Context, request OptDurat
 func (c *Client) sendTestRequestStringDuration(ctx context.Context, request OptDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration"),
 	}
 
 	// Run stopwatch.
@@ -44666,6 +45673,8 @@ func (c *Client) TestRequestStringDurationArray(ctx context.Context, request []t
 func (c *Client) sendTestRequestStringDurationArray(ctx context.Context, request []time.Duration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration_array"),
 	}
 
 	// Run stopwatch.
@@ -44738,6 +45747,8 @@ func (c *Client) TestRequestStringDurationArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringDurationArrayArray(ctx context.Context, request [][]time.Duration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -44833,6 +45844,8 @@ func (c *Client) TestRequestStringDurationNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestStringDurationNullable(ctx context.Context, request OptNilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration_nullable"),
 	}
 
 	// Run stopwatch.
@@ -44905,6 +45918,8 @@ func (c *Client) TestRequestStringDurationNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringDurationNullableArray(ctx context.Context, request []NilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -44977,6 +45992,8 @@ func (c *Client) TestRequestStringDurationNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestStringDurationNullableArrayArray(ctx context.Context, request [][]NilDuration) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_duration_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_duration_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45072,6 +46089,8 @@ func (c *Client) TestRequestStringEmail(ctx context.Context, request OptString) 
 func (c *Client) sendTestRequestStringEmail(ctx context.Context, request OptString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45168,6 +46187,8 @@ func (c *Client) TestRequestStringEmailArray(ctx context.Context, request []stri
 func (c *Client) sendTestRequestStringEmailArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45271,6 +46292,8 @@ func (c *Client) TestRequestStringEmailArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringEmailArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45391,6 +46414,8 @@ func (c *Client) TestRequestStringEmailNullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestStringEmailNullable(ctx context.Context, request OptNilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45487,6 +46512,8 @@ func (c *Client) TestRequestStringEmailNullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringEmailNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45597,6 +46624,8 @@ func (c *Client) TestRequestStringEmailNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestStringEmailNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_email_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_email_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45724,6 +46753,8 @@ func (c *Client) TestRequestStringFloat32(ctx context.Context, request OptFloat3
 func (c *Client) sendTestRequestStringFloat32(ctx context.Context, request OptFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45812,6 +46843,8 @@ func (c *Client) TestRequestStringFloat32Array(ctx context.Context, request []fl
 func (c *Client) sendTestRequestStringFloat32Array(ctx context.Context, request []float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -45907,6 +46940,8 @@ func (c *Client) TestRequestStringFloat32ArrayArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringFloat32ArrayArray(ctx context.Context, request [][]float32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46019,6 +47054,8 @@ func (c *Client) TestRequestStringFloat32Nullable(ctx context.Context, request O
 func (c *Client) sendTestRequestStringFloat32Nullable(ctx context.Context, request OptNilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46107,6 +47144,8 @@ func (c *Client) TestRequestStringFloat32NullableArray(ctx context.Context, requ
 func (c *Client) sendTestRequestStringFloat32NullableArray(ctx context.Context, request []NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46209,6 +47248,8 @@ func (c *Client) TestRequestStringFloat32NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestStringFloat32NullableArrayArray(ctx context.Context, request [][]NilFloat32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46328,6 +47369,8 @@ func (c *Client) TestRequestStringFloat64(ctx context.Context, request OptFloat6
 func (c *Client) sendTestRequestStringFloat64(ctx context.Context, request OptFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46416,6 +47459,8 @@ func (c *Client) TestRequestStringFloat64Array(ctx context.Context, request []fl
 func (c *Client) sendTestRequestStringFloat64Array(ctx context.Context, request []float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46511,6 +47556,8 @@ func (c *Client) TestRequestStringFloat64ArrayArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringFloat64ArrayArray(ctx context.Context, request [][]float64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46623,6 +47670,8 @@ func (c *Client) TestRequestStringFloat64Nullable(ctx context.Context, request O
 func (c *Client) sendTestRequestStringFloat64Nullable(ctx context.Context, request OptNilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46711,6 +47760,8 @@ func (c *Client) TestRequestStringFloat64NullableArray(ctx context.Context, requ
 func (c *Client) sendTestRequestStringFloat64NullableArray(ctx context.Context, request []NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46813,6 +47864,8 @@ func (c *Client) TestRequestStringFloat64NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestRequestStringFloat64NullableArrayArray(ctx context.Context, request [][]NilFloat64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_float64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_float64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -46932,6 +47985,8 @@ func (c *Client) TestRequestStringHostname(ctx context.Context, request OptStrin
 func (c *Client) sendTestRequestStringHostname(ctx context.Context, request OptString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47028,6 +48083,8 @@ func (c *Client) TestRequestStringHostnameArray(ctx context.Context, request []s
 func (c *Client) sendTestRequestStringHostnameArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47131,6 +48188,8 @@ func (c *Client) TestRequestStringHostnameArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringHostnameArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47251,6 +48310,8 @@ func (c *Client) TestRequestStringHostnameNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestStringHostnameNullable(ctx context.Context, request OptNilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname_nullable"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47347,6 +48408,8 @@ func (c *Client) TestRequestStringHostnameNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringHostnameNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname_nullable_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47457,6 +48520,8 @@ func (c *Client) TestRequestStringHostnameNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestStringHostnameNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_hostname_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_hostname_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47584,6 +48649,8 @@ func (c *Client) TestRequestStringIP(ctx context.Context, request OptIP) (*Error
 func (c *Client) sendTestRequestStringIP(ctx context.Context, request OptIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip"),
 	}
 
 	// Run stopwatch.
@@ -47656,6 +48723,8 @@ func (c *Client) TestRequestStringIPArray(ctx context.Context, request []netip.A
 func (c *Client) sendTestRequestStringIPArray(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip_array"),
 	}
 
 	// Run stopwatch.
@@ -47728,6 +48797,8 @@ func (c *Client) TestRequestStringIPArrayArray(ctx context.Context, request [][]
 func (c *Client) sendTestRequestStringIPArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -47823,6 +48894,8 @@ func (c *Client) TestRequestStringIPNullable(ctx context.Context, request OptNil
 func (c *Client) sendTestRequestStringIPNullable(ctx context.Context, request OptNilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip_nullable"),
 	}
 
 	// Run stopwatch.
@@ -47895,6 +48968,8 @@ func (c *Client) TestRequestStringIPNullableArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringIPNullableArray(ctx context.Context, request []NilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -47967,6 +49042,8 @@ func (c *Client) TestRequestStringIPNullableArrayArray(ctx context.Context, requ
 func (c *Client) sendTestRequestStringIPNullableArrayArray(ctx context.Context, request [][]NilIP) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ip_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ip_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -48062,6 +49139,8 @@ func (c *Client) TestRequestStringInt(ctx context.Context, request OptInt) (*Err
 func (c *Client) sendTestRequestStringInt(ctx context.Context, request OptInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int"),
 	}
 
 	// Run stopwatch.
@@ -48134,6 +49213,8 @@ func (c *Client) TestRequestStringInt16(ctx context.Context, request OptInt16) (
 func (c *Client) sendTestRequestStringInt16(ctx context.Context, request OptInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16"),
 	}
 
 	// Run stopwatch.
@@ -48206,6 +49287,8 @@ func (c *Client) TestRequestStringInt16Array(ctx context.Context, request []int1
 func (c *Client) sendTestRequestStringInt16Array(ctx context.Context, request []int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16_array"),
 	}
 
 	// Run stopwatch.
@@ -48278,6 +49361,8 @@ func (c *Client) TestRequestStringInt16ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringInt16ArrayArray(ctx context.Context, request [][]int16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -48373,6 +49458,8 @@ func (c *Client) TestRequestStringInt16Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestStringInt16Nullable(ctx context.Context, request OptNilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -48445,6 +49532,8 @@ func (c *Client) TestRequestStringInt16NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringInt16NullableArray(ctx context.Context, request []NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -48517,6 +49606,8 @@ func (c *Client) TestRequestStringInt16NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestStringInt16NullableArrayArray(ctx context.Context, request [][]NilInt16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -48612,6 +49703,8 @@ func (c *Client) TestRequestStringInt32(ctx context.Context, request OptStringIn
 func (c *Client) sendTestRequestStringInt32(ctx context.Context, request OptStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32"),
 	}
 
 	// Run stopwatch.
@@ -48684,6 +49777,8 @@ func (c *Client) TestRequestStringInt32Array(ctx context.Context, request []int3
 func (c *Client) sendTestRequestStringInt32Array(ctx context.Context, request []int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -48756,6 +49851,8 @@ func (c *Client) TestRequestStringInt32ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringInt32ArrayArray(ctx context.Context, request [][]int32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -48851,6 +49948,8 @@ func (c *Client) TestRequestStringInt32Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestStringInt32Nullable(ctx context.Context, request OptNilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -48923,6 +50022,8 @@ func (c *Client) TestRequestStringInt32NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringInt32NullableArray(ctx context.Context, request []NilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -48995,6 +50096,8 @@ func (c *Client) TestRequestStringInt32NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestStringInt32NullableArrayArray(ctx context.Context, request [][]NilStringInt32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -49090,6 +50193,8 @@ func (c *Client) TestRequestStringInt64(ctx context.Context, request OptStringIn
 func (c *Client) sendTestRequestStringInt64(ctx context.Context, request OptStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64"),
 	}
 
 	// Run stopwatch.
@@ -49162,6 +50267,8 @@ func (c *Client) TestRequestStringInt64Array(ctx context.Context, request []int6
 func (c *Client) sendTestRequestStringInt64Array(ctx context.Context, request []int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -49234,6 +50341,8 @@ func (c *Client) TestRequestStringInt64ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringInt64ArrayArray(ctx context.Context, request [][]int64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -49329,6 +50438,8 @@ func (c *Client) TestRequestStringInt64Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestStringInt64Nullable(ctx context.Context, request OptNilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -49401,6 +50512,8 @@ func (c *Client) TestRequestStringInt64NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringInt64NullableArray(ctx context.Context, request []NilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -49473,6 +50586,8 @@ func (c *Client) TestRequestStringInt64NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestStringInt64NullableArrayArray(ctx context.Context, request [][]NilStringInt64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -49568,6 +50683,8 @@ func (c *Client) TestRequestStringInt8(ctx context.Context, request OptInt8) (*E
 func (c *Client) sendTestRequestStringInt8(ctx context.Context, request OptInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8"),
 	}
 
 	// Run stopwatch.
@@ -49640,6 +50757,8 @@ func (c *Client) TestRequestStringInt8Array(ctx context.Context, request []int8)
 func (c *Client) sendTestRequestStringInt8Array(ctx context.Context, request []int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8_array"),
 	}
 
 	// Run stopwatch.
@@ -49712,6 +50831,8 @@ func (c *Client) TestRequestStringInt8ArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringInt8ArrayArray(ctx context.Context, request [][]int8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -49807,6 +50928,8 @@ func (c *Client) TestRequestStringInt8Nullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringInt8Nullable(ctx context.Context, request OptNilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -49879,6 +51002,8 @@ func (c *Client) TestRequestStringInt8NullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringInt8NullableArray(ctx context.Context, request []NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -49951,6 +51076,8 @@ func (c *Client) TestRequestStringInt8NullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringInt8NullableArrayArray(ctx context.Context, request [][]NilInt8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -50046,6 +51173,8 @@ func (c *Client) TestRequestStringIntArray(ctx context.Context, request []int) (
 func (c *Client) sendTestRequestStringIntArray(ctx context.Context, request []int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int_array"),
 	}
 
 	// Run stopwatch.
@@ -50118,6 +51247,8 @@ func (c *Client) TestRequestStringIntArrayArray(ctx context.Context, request [][
 func (c *Client) sendTestRequestStringIntArrayArray(ctx context.Context, request [][]int) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -50213,6 +51344,8 @@ func (c *Client) TestRequestStringIntNullable(ctx context.Context, request OptNi
 func (c *Client) sendTestRequestStringIntNullable(ctx context.Context, request OptNilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int_nullable"),
 	}
 
 	// Run stopwatch.
@@ -50285,6 +51418,8 @@ func (c *Client) TestRequestStringIntNullableArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringIntNullableArray(ctx context.Context, request []NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -50357,6 +51492,8 @@ func (c *Client) TestRequestStringIntNullableArrayArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringIntNullableArrayArray(ctx context.Context, request [][]NilInt) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_int_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_int_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -50452,6 +51589,8 @@ func (c *Client) TestRequestStringIpv4(ctx context.Context, request OptIPv4) (*E
 func (c *Client) sendTestRequestStringIpv4(ctx context.Context, request OptIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4"),
 	}
 
 	// Run stopwatch.
@@ -50524,6 +51663,8 @@ func (c *Client) TestRequestStringIpv4Array(ctx context.Context, request []netip
 func (c *Client) sendTestRequestStringIpv4Array(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4_array"),
 	}
 
 	// Run stopwatch.
@@ -50596,6 +51737,8 @@ func (c *Client) TestRequestStringIpv4ArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringIpv4ArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -50691,6 +51834,8 @@ func (c *Client) TestRequestStringIpv4Nullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringIpv4Nullable(ctx context.Context, request OptNilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4_nullable"),
 	}
 
 	// Run stopwatch.
@@ -50763,6 +51908,8 @@ func (c *Client) TestRequestStringIpv4NullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringIpv4NullableArray(ctx context.Context, request []NilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -50835,6 +51982,8 @@ func (c *Client) TestRequestStringIpv4NullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringIpv4NullableArrayArray(ctx context.Context, request [][]NilIPv4) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv4_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv4_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -50930,6 +52079,8 @@ func (c *Client) TestRequestStringIpv6(ctx context.Context, request OptIPv6) (*E
 func (c *Client) sendTestRequestStringIpv6(ctx context.Context, request OptIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6"),
 	}
 
 	// Run stopwatch.
@@ -51002,6 +52153,8 @@ func (c *Client) TestRequestStringIpv6Array(ctx context.Context, request []netip
 func (c *Client) sendTestRequestStringIpv6Array(ctx context.Context, request []netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6_array"),
 	}
 
 	// Run stopwatch.
@@ -51074,6 +52227,8 @@ func (c *Client) TestRequestStringIpv6ArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringIpv6ArrayArray(ctx context.Context, request [][]netip.Addr) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51169,6 +52324,8 @@ func (c *Client) TestRequestStringIpv6Nullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringIpv6Nullable(ctx context.Context, request OptNilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6_nullable"),
 	}
 
 	// Run stopwatch.
@@ -51241,6 +52398,8 @@ func (c *Client) TestRequestStringIpv6NullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringIpv6NullableArray(ctx context.Context, request []NilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -51313,6 +52472,8 @@ func (c *Client) TestRequestStringIpv6NullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringIpv6NullableArrayArray(ctx context.Context, request [][]NilIPv6) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_ipv6_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_ipv6_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51408,6 +52569,8 @@ func (c *Client) TestRequestStringNullable(ctx context.Context, request OptNilSt
 func (c *Client) sendTestRequestStringNullable(ctx context.Context, request OptNilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_nullable"),
 	}
 
 	// Run stopwatch.
@@ -51480,6 +52643,8 @@ func (c *Client) TestRequestStringNullableArray(ctx context.Context, request []N
 func (c *Client) sendTestRequestStringNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -51552,6 +52717,8 @@ func (c *Client) TestRequestStringNullableArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51647,6 +52814,8 @@ func (c *Client) TestRequestStringPassword(ctx context.Context, request OptStrin
 func (c *Client) sendTestRequestStringPassword(ctx context.Context, request OptString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password"),
 	}
 
 	// Run stopwatch.
@@ -51719,6 +52888,8 @@ func (c *Client) TestRequestStringPasswordArray(ctx context.Context, request []s
 func (c *Client) sendTestRequestStringPasswordArray(ctx context.Context, request []string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password_array"),
 	}
 
 	// Run stopwatch.
@@ -51791,6 +52962,8 @@ func (c *Client) TestRequestStringPasswordArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringPasswordArrayArray(ctx context.Context, request [][]string) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -51886,6 +53059,8 @@ func (c *Client) TestRequestStringPasswordNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestStringPasswordNullable(ctx context.Context, request OptNilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password_nullable"),
 	}
 
 	// Run stopwatch.
@@ -51958,6 +53133,8 @@ func (c *Client) TestRequestStringPasswordNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringPasswordNullableArray(ctx context.Context, request []NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -52030,6 +53207,8 @@ func (c *Client) TestRequestStringPasswordNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestStringPasswordNullableArrayArray(ctx context.Context, request [][]NilString) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_password_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_password_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52125,6 +53304,8 @@ func (c *Client) TestRequestStringTime(ctx context.Context, request OptTime) (*E
 func (c *Client) sendTestRequestStringTime(ctx context.Context, request OptTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time"),
 	}
 
 	// Run stopwatch.
@@ -52197,6 +53378,8 @@ func (c *Client) TestRequestStringTimeArray(ctx context.Context, request []time.
 func (c *Client) sendTestRequestStringTimeArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time_array"),
 	}
 
 	// Run stopwatch.
@@ -52269,6 +53452,8 @@ func (c *Client) TestRequestStringTimeArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringTimeArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52364,6 +53549,8 @@ func (c *Client) TestRequestStringTimeNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringTimeNullable(ctx context.Context, request OptNilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -52436,6 +53623,8 @@ func (c *Client) TestRequestStringTimeNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringTimeNullableArray(ctx context.Context, request []NilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -52508,6 +53697,8 @@ func (c *Client) TestRequestStringTimeNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringTimeNullableArrayArray(ctx context.Context, request [][]NilTime) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_time_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52603,6 +53794,8 @@ func (c *Client) TestRequestStringURI(ctx context.Context, request OptURI) (*Err
 func (c *Client) sendTestRequestStringURI(ctx context.Context, request OptURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri"),
 	}
 
 	// Run stopwatch.
@@ -52675,6 +53868,8 @@ func (c *Client) TestRequestStringURIArray(ctx context.Context, request []url.UR
 func (c *Client) sendTestRequestStringURIArray(ctx context.Context, request []url.URL) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri_array"),
 	}
 
 	// Run stopwatch.
@@ -52747,6 +53942,8 @@ func (c *Client) TestRequestStringURIArrayArray(ctx context.Context, request [][
 func (c *Client) sendTestRequestStringURIArrayArray(ctx context.Context, request [][]url.URL) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -52842,6 +54039,8 @@ func (c *Client) TestRequestStringURINullable(ctx context.Context, request OptNi
 func (c *Client) sendTestRequestStringURINullable(ctx context.Context, request OptNilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri_nullable"),
 	}
 
 	// Run stopwatch.
@@ -52914,6 +54113,8 @@ func (c *Client) TestRequestStringURINullableArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringURINullableArray(ctx context.Context, request []NilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -52986,6 +54187,8 @@ func (c *Client) TestRequestStringURINullableArrayArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringURINullableArrayArray(ctx context.Context, request [][]NilURI) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uri_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uri_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -53081,6 +54284,8 @@ func (c *Client) TestRequestStringUUID(ctx context.Context, request OptUUID) (*E
 func (c *Client) sendTestRequestStringUUID(ctx context.Context, request OptUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid"),
 	}
 
 	// Run stopwatch.
@@ -53153,6 +54358,8 @@ func (c *Client) TestRequestStringUUIDArray(ctx context.Context, request []uuid.
 func (c *Client) sendTestRequestStringUUIDArray(ctx context.Context, request []uuid.UUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid_array"),
 	}
 
 	// Run stopwatch.
@@ -53225,6 +54432,8 @@ func (c *Client) TestRequestStringUUIDArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringUUIDArrayArray(ctx context.Context, request [][]uuid.UUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -53320,6 +54529,8 @@ func (c *Client) TestRequestStringUUIDNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringUUIDNullable(ctx context.Context, request OptNilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid_nullable"),
 	}
 
 	// Run stopwatch.
@@ -53392,6 +54603,8 @@ func (c *Client) TestRequestStringUUIDNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringUUIDNullableArray(ctx context.Context, request []NilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -53464,6 +54677,8 @@ func (c *Client) TestRequestStringUUIDNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringUUIDNullableArrayArray(ctx context.Context, request [][]NilUUID) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uuid_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uuid_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -53559,6 +54774,8 @@ func (c *Client) TestRequestStringUint(ctx context.Context, request OptUint) (*E
 func (c *Client) sendTestRequestStringUint(ctx context.Context, request OptUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint"),
 	}
 
 	// Run stopwatch.
@@ -53631,6 +54848,8 @@ func (c *Client) TestRequestStringUint16(ctx context.Context, request OptUint16)
 func (c *Client) sendTestRequestStringUint16(ctx context.Context, request OptUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16"),
 	}
 
 	// Run stopwatch.
@@ -53703,6 +54922,8 @@ func (c *Client) TestRequestStringUint16Array(ctx context.Context, request []uin
 func (c *Client) sendTestRequestStringUint16Array(ctx context.Context, request []uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16_array"),
 	}
 
 	// Run stopwatch.
@@ -53775,6 +54996,8 @@ func (c *Client) TestRequestStringUint16ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringUint16ArrayArray(ctx context.Context, request [][]uint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -53870,6 +55093,8 @@ func (c *Client) TestRequestStringUint16Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestStringUint16Nullable(ctx context.Context, request OptNilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -53942,6 +55167,8 @@ func (c *Client) TestRequestStringUint16NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUint16NullableArray(ctx context.Context, request []NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -54014,6 +55241,8 @@ func (c *Client) TestRequestStringUint16NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringUint16NullableArrayArray(ctx context.Context, request [][]NilUint16) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint16_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -54109,6 +55338,8 @@ func (c *Client) TestRequestStringUint32(ctx context.Context, request OptUint32)
 func (c *Client) sendTestRequestStringUint32(ctx context.Context, request OptUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32"),
 	}
 
 	// Run stopwatch.
@@ -54181,6 +55412,8 @@ func (c *Client) TestRequestStringUint32Array(ctx context.Context, request []uin
 func (c *Client) sendTestRequestStringUint32Array(ctx context.Context, request []uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32_array"),
 	}
 
 	// Run stopwatch.
@@ -54253,6 +55486,8 @@ func (c *Client) TestRequestStringUint32ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringUint32ArrayArray(ctx context.Context, request [][]uint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -54348,6 +55583,8 @@ func (c *Client) TestRequestStringUint32Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestStringUint32Nullable(ctx context.Context, request OptNilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -54420,6 +55657,8 @@ func (c *Client) TestRequestStringUint32NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUint32NullableArray(ctx context.Context, request []NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -54492,6 +55731,8 @@ func (c *Client) TestRequestStringUint32NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringUint32NullableArrayArray(ctx context.Context, request [][]NilUint32) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint32_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -54587,6 +55828,8 @@ func (c *Client) TestRequestStringUint64(ctx context.Context, request OptUint64)
 func (c *Client) sendTestRequestStringUint64(ctx context.Context, request OptUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64"),
 	}
 
 	// Run stopwatch.
@@ -54659,6 +55902,8 @@ func (c *Client) TestRequestStringUint64Array(ctx context.Context, request []uin
 func (c *Client) sendTestRequestStringUint64Array(ctx context.Context, request []uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64_array"),
 	}
 
 	// Run stopwatch.
@@ -54731,6 +55976,8 @@ func (c *Client) TestRequestStringUint64ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringUint64ArrayArray(ctx context.Context, request [][]uint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -54826,6 +56073,8 @@ func (c *Client) TestRequestStringUint64Nullable(ctx context.Context, request Op
 func (c *Client) sendTestRequestStringUint64Nullable(ctx context.Context, request OptNilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -54898,6 +56147,8 @@ func (c *Client) TestRequestStringUint64NullableArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUint64NullableArray(ctx context.Context, request []NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -54970,6 +56221,8 @@ func (c *Client) TestRequestStringUint64NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringUint64NullableArrayArray(ctx context.Context, request [][]NilUint64) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint64_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55065,6 +56318,8 @@ func (c *Client) TestRequestStringUint8(ctx context.Context, request OptUint8) (
 func (c *Client) sendTestRequestStringUint8(ctx context.Context, request OptUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8"),
 	}
 
 	// Run stopwatch.
@@ -55137,6 +56392,8 @@ func (c *Client) TestRequestStringUint8Array(ctx context.Context, request []uint
 func (c *Client) sendTestRequestStringUint8Array(ctx context.Context, request []uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8_array"),
 	}
 
 	// Run stopwatch.
@@ -55209,6 +56466,8 @@ func (c *Client) TestRequestStringUint8ArrayArray(ctx context.Context, request [
 func (c *Client) sendTestRequestStringUint8ArrayArray(ctx context.Context, request [][]uint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55304,6 +56563,8 @@ func (c *Client) TestRequestStringUint8Nullable(ctx context.Context, request Opt
 func (c *Client) sendTestRequestStringUint8Nullable(ctx context.Context, request OptNilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -55376,6 +56637,8 @@ func (c *Client) TestRequestStringUint8NullableArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringUint8NullableArray(ctx context.Context, request []NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -55448,6 +56711,8 @@ func (c *Client) TestRequestStringUint8NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestRequestStringUint8NullableArrayArray(ctx context.Context, request [][]NilUint8) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint8_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55543,6 +56808,8 @@ func (c *Client) TestRequestStringUintArray(ctx context.Context, request []uint)
 func (c *Client) sendTestRequestStringUintArray(ctx context.Context, request []uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint_array"),
 	}
 
 	// Run stopwatch.
@@ -55615,6 +56882,8 @@ func (c *Client) TestRequestStringUintArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringUintArrayArray(ctx context.Context, request [][]uint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55710,6 +56979,8 @@ func (c *Client) TestRequestStringUintNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringUintNullable(ctx context.Context, request OptNilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -55782,6 +57053,8 @@ func (c *Client) TestRequestStringUintNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringUintNullableArray(ctx context.Context, request []NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -55854,6 +57127,8 @@ func (c *Client) TestRequestStringUintNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringUintNullableArrayArray(ctx context.Context, request [][]NilUint) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_uint_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -55949,6 +57224,8 @@ func (c *Client) TestRequestStringUnix(ctx context.Context, request OptStringUni
 func (c *Client) sendTestRequestStringUnix(ctx context.Context, request OptStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix"),
 	}
 
 	// Run stopwatch.
@@ -56021,6 +57298,8 @@ func (c *Client) TestRequestStringUnixArray(ctx context.Context, request []time.
 func (c *Client) sendTestRequestStringUnixArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix_array"),
 	}
 
 	// Run stopwatch.
@@ -56093,6 +57372,8 @@ func (c *Client) TestRequestStringUnixArrayArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringUnixArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56188,6 +57469,8 @@ func (c *Client) TestRequestStringUnixMicro(ctx context.Context, request OptStri
 func (c *Client) sendTestRequestStringUnixMicro(ctx context.Context, request OptStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -56260,6 +57543,8 @@ func (c *Client) TestRequestStringUnixMicroArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringUnixMicroArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro_array"),
 	}
 
 	// Run stopwatch.
@@ -56332,6 +57617,8 @@ func (c *Client) TestRequestStringUnixMicroArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUnixMicroArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56427,6 +57714,8 @@ func (c *Client) TestRequestStringUnixMicroNullable(ctx context.Context, request
 func (c *Client) sendTestRequestStringUnixMicroNullable(ctx context.Context, request OptNilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -56499,6 +57788,8 @@ func (c *Client) TestRequestStringUnixMicroNullableArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringUnixMicroNullableArray(ctx context.Context, request []NilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -56571,6 +57862,8 @@ func (c *Client) TestRequestStringUnixMicroNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestStringUnixMicroNullableArrayArray(ctx context.Context, request [][]NilStringUnixMicro) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-micro_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56666,6 +57959,8 @@ func (c *Client) TestRequestStringUnixMilli(ctx context.Context, request OptStri
 func (c *Client) sendTestRequestStringUnixMilli(ctx context.Context, request OptStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -56738,6 +58033,8 @@ func (c *Client) TestRequestStringUnixMilliArray(ctx context.Context, request []
 func (c *Client) sendTestRequestStringUnixMilliArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli_array"),
 	}
 
 	// Run stopwatch.
@@ -56810,6 +58107,8 @@ func (c *Client) TestRequestStringUnixMilliArrayArray(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUnixMilliArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -56905,6 +58204,8 @@ func (c *Client) TestRequestStringUnixMilliNullable(ctx context.Context, request
 func (c *Client) sendTestRequestStringUnixMilliNullable(ctx context.Context, request OptNilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -56977,6 +58278,8 @@ func (c *Client) TestRequestStringUnixMilliNullableArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringUnixMilliNullableArray(ctx context.Context, request []NilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -57049,6 +58352,8 @@ func (c *Client) TestRequestStringUnixMilliNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestRequestStringUnixMilliNullableArrayArray(ctx context.Context, request [][]NilStringUnixMilli) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-milli_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57144,6 +58449,8 @@ func (c *Client) TestRequestStringUnixNano(ctx context.Context, request OptStrin
 func (c *Client) sendTestRequestStringUnixNano(ctx context.Context, request OptStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -57216,6 +58523,8 @@ func (c *Client) TestRequestStringUnixNanoArray(ctx context.Context, request []t
 func (c *Client) sendTestRequestStringUnixNanoArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano_array"),
 	}
 
 	// Run stopwatch.
@@ -57288,6 +58597,8 @@ func (c *Client) TestRequestStringUnixNanoArrayArray(ctx context.Context, reques
 func (c *Client) sendTestRequestStringUnixNanoArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57383,6 +58694,8 @@ func (c *Client) TestRequestStringUnixNanoNullable(ctx context.Context, request 
 func (c *Client) sendTestRequestStringUnixNanoNullable(ctx context.Context, request OptNilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -57455,6 +58768,8 @@ func (c *Client) TestRequestStringUnixNanoNullableArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringUnixNanoNullableArray(ctx context.Context, request []NilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -57527,6 +58842,8 @@ func (c *Client) TestRequestStringUnixNanoNullableArrayArray(ctx context.Context
 func (c *Client) sendTestRequestStringUnixNanoNullableArrayArray(ctx context.Context, request [][]NilStringUnixNano) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-nano_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57622,6 +58939,8 @@ func (c *Client) TestRequestStringUnixNullable(ctx context.Context, request OptN
 func (c *Client) sendTestRequestStringUnixNullable(ctx context.Context, request OptNilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -57694,6 +59013,8 @@ func (c *Client) TestRequestStringUnixNullableArray(ctx context.Context, request
 func (c *Client) sendTestRequestStringUnixNullableArray(ctx context.Context, request []NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -57766,6 +59087,8 @@ func (c *Client) TestRequestStringUnixNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestRequestStringUnixNullableArrayArray(ctx context.Context, request [][]NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -57861,6 +59184,8 @@ func (c *Client) TestRequestStringUnixSeconds(ctx context.Context, request OptSt
 func (c *Client) sendTestRequestStringUnixSeconds(ctx context.Context, request OptStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -57933,6 +59258,8 @@ func (c *Client) TestRequestStringUnixSecondsArray(ctx context.Context, request 
 func (c *Client) sendTestRequestStringUnixSecondsArray(ctx context.Context, request []time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds_array"),
 	}
 
 	// Run stopwatch.
@@ -58005,6 +59332,8 @@ func (c *Client) TestRequestStringUnixSecondsArrayArray(ctx context.Context, req
 func (c *Client) sendTestRequestStringUnixSecondsArrayArray(ctx context.Context, request [][]time.Time) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -58100,6 +59429,8 @@ func (c *Client) TestRequestStringUnixSecondsNullable(ctx context.Context, reque
 func (c *Client) sendTestRequestStringUnixSecondsNullable(ctx context.Context, request OptNilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -58172,6 +59503,8 @@ func (c *Client) TestRequestStringUnixSecondsNullableArray(ctx context.Context, 
 func (c *Client) sendTestRequestStringUnixSecondsNullableArray(ctx context.Context, request []NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -58244,6 +59577,8 @@ func (c *Client) TestRequestStringUnixSecondsNullableArrayArray(ctx context.Cont
 func (c *Client) sendTestRequestStringUnixSecondsNullableArrayArray(ctx context.Context, request [][]NilStringUnixSeconds) (res *Error, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_request_string_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_unix-seconds_nullable_array_array"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -58339,6 +59674,8 @@ func (c *Client) TestResponseAny(ctx context.Context, request string) (jx.Raw, e
 func (c *Client) sendTestResponseAny(ctx context.Context, request string) (res jx.Raw, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_Any"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_Any"),
 	}
 
 	// Run stopwatch.
@@ -58411,6 +59748,8 @@ func (c *Client) TestResponseBoolean(ctx context.Context, request string) (bool,
 func (c *Client) sendTestResponseBoolean(ctx context.Context, request string) (res bool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean"),
 	}
 
 	// Run stopwatch.
@@ -58483,6 +59822,8 @@ func (c *Client) TestResponseBooleanArray(ctx context.Context, request string) (
 func (c *Client) sendTestResponseBooleanArray(ctx context.Context, request string) (res []bool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean_array"),
 	}
 
 	// Run stopwatch.
@@ -58555,6 +59896,8 @@ func (c *Client) TestResponseBooleanArrayArray(ctx context.Context, request stri
 func (c *Client) sendTestResponseBooleanArrayArray(ctx context.Context, request string) (res [][]bool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean_array_array"),
 	}
 
 	// Run stopwatch.
@@ -58627,6 +59970,8 @@ func (c *Client) TestResponseBooleanNullable(ctx context.Context, request string
 func (c *Client) sendTestResponseBooleanNullable(ctx context.Context, request string) (res NilBool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean_nullable"),
 	}
 
 	// Run stopwatch.
@@ -58699,6 +60044,8 @@ func (c *Client) TestResponseBooleanNullableArray(ctx context.Context, request s
 func (c *Client) sendTestResponseBooleanNullableArray(ctx context.Context, request string) (res []NilBool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -58771,6 +60118,8 @@ func (c *Client) TestResponseBooleanNullableArrayArray(ctx context.Context, requ
 func (c *Client) sendTestResponseBooleanNullableArrayArray(ctx context.Context, request string) (res [][]NilBool, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_boolean_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_boolean_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -58843,6 +60192,8 @@ func (c *Client) TestResponseEmptyStruct(ctx context.Context, request string) er
 func (c *Client) sendTestResponseEmptyStruct(ctx context.Context, request string) (res *TestResponseEmptyStructOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_EmptyStruct"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_EmptyStruct"),
 	}
 
 	// Run stopwatch.
@@ -58915,6 +60266,8 @@ func (c *Client) TestResponseFormatTest(ctx context.Context, request string) (*T
 func (c *Client) sendTestResponseFormatTest(ctx context.Context, request string) (res *TestResponseFormatTestOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_FormatTest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_FormatTest"),
 	}
 
 	// Run stopwatch.
@@ -58987,6 +60340,8 @@ func (c *Client) TestResponseInteger(ctx context.Context, request string) (int, 
 func (c *Client) sendTestResponseInteger(ctx context.Context, request string) (res int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer"),
 	}
 
 	// Run stopwatch.
@@ -59059,6 +60414,8 @@ func (c *Client) TestResponseIntegerArray(ctx context.Context, request string) (
 func (c *Client) sendTestResponseIntegerArray(ctx context.Context, request string) (res []int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_array"),
 	}
 
 	// Run stopwatch.
@@ -59131,6 +60488,8 @@ func (c *Client) TestResponseIntegerArrayArray(ctx context.Context, request stri
 func (c *Client) sendTestResponseIntegerArrayArray(ctx context.Context, request string) (res [][]int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_array_array"),
 	}
 
 	// Run stopwatch.
@@ -59203,6 +60562,8 @@ func (c *Client) TestResponseIntegerInt16(ctx context.Context, request string) (
 func (c *Client) sendTestResponseIntegerInt16(ctx context.Context, request string) (res int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16"),
 	}
 
 	// Run stopwatch.
@@ -59275,6 +60636,8 @@ func (c *Client) TestResponseIntegerInt16Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseIntegerInt16Array(ctx context.Context, request string) (res []int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16_array"),
 	}
 
 	// Run stopwatch.
@@ -59347,6 +60710,8 @@ func (c *Client) TestResponseIntegerInt16ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseIntegerInt16ArrayArray(ctx context.Context, request string) (res [][]int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16_array_array"),
 	}
 
 	// Run stopwatch.
@@ -59419,6 +60784,8 @@ func (c *Client) TestResponseIntegerInt16Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerInt16Nullable(ctx context.Context, request string) (res NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -59491,6 +60858,8 @@ func (c *Client) TestResponseIntegerInt16NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerInt16NullableArray(ctx context.Context, request string) (res []NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -59563,6 +60932,8 @@ func (c *Client) TestResponseIntegerInt16NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseIntegerInt16NullableArrayArray(ctx context.Context, request string) (res [][]NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int16_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -59635,6 +61006,8 @@ func (c *Client) TestResponseIntegerInt32(ctx context.Context, request string) (
 func (c *Client) sendTestResponseIntegerInt32(ctx context.Context, request string) (res int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32"),
 	}
 
 	// Run stopwatch.
@@ -59707,6 +61080,8 @@ func (c *Client) TestResponseIntegerInt32Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseIntegerInt32Array(ctx context.Context, request string) (res []int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -59779,6 +61154,8 @@ func (c *Client) TestResponseIntegerInt32ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseIntegerInt32ArrayArray(ctx context.Context, request string) (res [][]int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -59851,6 +61228,8 @@ func (c *Client) TestResponseIntegerInt32Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerInt32Nullable(ctx context.Context, request string) (res NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -59923,6 +61302,8 @@ func (c *Client) TestResponseIntegerInt32NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerInt32NullableArray(ctx context.Context, request string) (res []NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -59995,6 +61376,8 @@ func (c *Client) TestResponseIntegerInt32NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseIntegerInt32NullableArrayArray(ctx context.Context, request string) (res [][]NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -60067,6 +61450,8 @@ func (c *Client) TestResponseIntegerInt64(ctx context.Context, request string) (
 func (c *Client) sendTestResponseIntegerInt64(ctx context.Context, request string) (res int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64"),
 	}
 
 	// Run stopwatch.
@@ -60139,6 +61524,8 @@ func (c *Client) TestResponseIntegerInt64Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseIntegerInt64Array(ctx context.Context, request string) (res []int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -60211,6 +61598,8 @@ func (c *Client) TestResponseIntegerInt64ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseIntegerInt64ArrayArray(ctx context.Context, request string) (res [][]int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -60283,6 +61672,8 @@ func (c *Client) TestResponseIntegerInt64Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerInt64Nullable(ctx context.Context, request string) (res NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -60355,6 +61746,8 @@ func (c *Client) TestResponseIntegerInt64NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerInt64NullableArray(ctx context.Context, request string) (res []NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -60427,6 +61820,8 @@ func (c *Client) TestResponseIntegerInt64NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseIntegerInt64NullableArrayArray(ctx context.Context, request string) (res [][]NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -60499,6 +61894,8 @@ func (c *Client) TestResponseIntegerInt8(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseIntegerInt8(ctx context.Context, request string) (res int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8"),
 	}
 
 	// Run stopwatch.
@@ -60571,6 +61968,8 @@ func (c *Client) TestResponseIntegerInt8Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseIntegerInt8Array(ctx context.Context, request string) (res []int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8_array"),
 	}
 
 	// Run stopwatch.
@@ -60643,6 +62042,8 @@ func (c *Client) TestResponseIntegerInt8ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerInt8ArrayArray(ctx context.Context, request string) (res [][]int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8_array_array"),
 	}
 
 	// Run stopwatch.
@@ -60715,6 +62116,8 @@ func (c *Client) TestResponseIntegerInt8Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseIntegerInt8Nullable(ctx context.Context, request string) (res NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -60787,6 +62190,8 @@ func (c *Client) TestResponseIntegerInt8NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseIntegerInt8NullableArray(ctx context.Context, request string) (res []NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -60859,6 +62264,8 @@ func (c *Client) TestResponseIntegerInt8NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseIntegerInt8NullableArrayArray(ctx context.Context, request string) (res [][]NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_int8_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -60931,6 +62338,8 @@ func (c *Client) TestResponseIntegerNullable(ctx context.Context, request string
 func (c *Client) sendTestResponseIntegerNullable(ctx context.Context, request string) (res NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_nullable"),
 	}
 
 	// Run stopwatch.
@@ -61003,6 +62412,8 @@ func (c *Client) TestResponseIntegerNullableArray(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerNullableArray(ctx context.Context, request string) (res []NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -61075,6 +62486,8 @@ func (c *Client) TestResponseIntegerNullableArrayArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerNullableArrayArray(ctx context.Context, request string) (res [][]NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -61147,6 +62560,8 @@ func (c *Client) TestResponseIntegerUint(ctx context.Context, request string) (u
 func (c *Client) sendTestResponseIntegerUint(ctx context.Context, request string) (res uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint"),
 	}
 
 	// Run stopwatch.
@@ -61219,6 +62634,8 @@ func (c *Client) TestResponseIntegerUint16(ctx context.Context, request string) 
 func (c *Client) sendTestResponseIntegerUint16(ctx context.Context, request string) (res uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16"),
 	}
 
 	// Run stopwatch.
@@ -61291,6 +62708,8 @@ func (c *Client) TestResponseIntegerUint16Array(ctx context.Context, request str
 func (c *Client) sendTestResponseIntegerUint16Array(ctx context.Context, request string) (res []uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16_array"),
 	}
 
 	// Run stopwatch.
@@ -61363,6 +62782,8 @@ func (c *Client) TestResponseIntegerUint16ArrayArray(ctx context.Context, reques
 func (c *Client) sendTestResponseIntegerUint16ArrayArray(ctx context.Context, request string) (res [][]uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16_array_array"),
 	}
 
 	// Run stopwatch.
@@ -61435,6 +62856,8 @@ func (c *Client) TestResponseIntegerUint16Nullable(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUint16Nullable(ctx context.Context, request string) (res NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -61507,6 +62930,8 @@ func (c *Client) TestResponseIntegerUint16NullableArray(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUint16NullableArray(ctx context.Context, request string) (res []NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -61579,6 +63004,8 @@ func (c *Client) TestResponseIntegerUint16NullableArrayArray(ctx context.Context
 func (c *Client) sendTestResponseIntegerUint16NullableArrayArray(ctx context.Context, request string) (res [][]NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint16_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -61651,6 +63078,8 @@ func (c *Client) TestResponseIntegerUint32(ctx context.Context, request string) 
 func (c *Client) sendTestResponseIntegerUint32(ctx context.Context, request string) (res uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32"),
 	}
 
 	// Run stopwatch.
@@ -61723,6 +63152,8 @@ func (c *Client) TestResponseIntegerUint32Array(ctx context.Context, request str
 func (c *Client) sendTestResponseIntegerUint32Array(ctx context.Context, request string) (res []uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32_array"),
 	}
 
 	// Run stopwatch.
@@ -61795,6 +63226,8 @@ func (c *Client) TestResponseIntegerUint32ArrayArray(ctx context.Context, reques
 func (c *Client) sendTestResponseIntegerUint32ArrayArray(ctx context.Context, request string) (res [][]uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -61867,6 +63300,8 @@ func (c *Client) TestResponseIntegerUint32Nullable(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUint32Nullable(ctx context.Context, request string) (res NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -61939,6 +63374,8 @@ func (c *Client) TestResponseIntegerUint32NullableArray(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUint32NullableArray(ctx context.Context, request string) (res []NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -62011,6 +63448,8 @@ func (c *Client) TestResponseIntegerUint32NullableArrayArray(ctx context.Context
 func (c *Client) sendTestResponseIntegerUint32NullableArrayArray(ctx context.Context, request string) (res [][]NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -62083,6 +63522,8 @@ func (c *Client) TestResponseIntegerUint64(ctx context.Context, request string) 
 func (c *Client) sendTestResponseIntegerUint64(ctx context.Context, request string) (res uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64"),
 	}
 
 	// Run stopwatch.
@@ -62155,6 +63596,8 @@ func (c *Client) TestResponseIntegerUint64Array(ctx context.Context, request str
 func (c *Client) sendTestResponseIntegerUint64Array(ctx context.Context, request string) (res []uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64_array"),
 	}
 
 	// Run stopwatch.
@@ -62227,6 +63670,8 @@ func (c *Client) TestResponseIntegerUint64ArrayArray(ctx context.Context, reques
 func (c *Client) sendTestResponseIntegerUint64ArrayArray(ctx context.Context, request string) (res [][]uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -62299,6 +63744,8 @@ func (c *Client) TestResponseIntegerUint64Nullable(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUint64Nullable(ctx context.Context, request string) (res NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -62371,6 +63818,8 @@ func (c *Client) TestResponseIntegerUint64NullableArray(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUint64NullableArray(ctx context.Context, request string) (res []NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -62443,6 +63892,8 @@ func (c *Client) TestResponseIntegerUint64NullableArrayArray(ctx context.Context
 func (c *Client) sendTestResponseIntegerUint64NullableArrayArray(ctx context.Context, request string) (res [][]NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -62515,6 +63966,8 @@ func (c *Client) TestResponseIntegerUint8(ctx context.Context, request string) (
 func (c *Client) sendTestResponseIntegerUint8(ctx context.Context, request string) (res uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8"),
 	}
 
 	// Run stopwatch.
@@ -62587,6 +64040,8 @@ func (c *Client) TestResponseIntegerUint8Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseIntegerUint8Array(ctx context.Context, request string) (res []uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8_array"),
 	}
 
 	// Run stopwatch.
@@ -62659,6 +64114,8 @@ func (c *Client) TestResponseIntegerUint8ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseIntegerUint8ArrayArray(ctx context.Context, request string) (res [][]uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8_array_array"),
 	}
 
 	// Run stopwatch.
@@ -62731,6 +64188,8 @@ func (c *Client) TestResponseIntegerUint8Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerUint8Nullable(ctx context.Context, request string) (res NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -62803,6 +64262,8 @@ func (c *Client) TestResponseIntegerUint8NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerUint8NullableArray(ctx context.Context, request string) (res []NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -62875,6 +64336,8 @@ func (c *Client) TestResponseIntegerUint8NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseIntegerUint8NullableArrayArray(ctx context.Context, request string) (res [][]NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint8_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -62947,6 +64410,8 @@ func (c *Client) TestResponseIntegerUintArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseIntegerUintArray(ctx context.Context, request string) (res []uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint_array"),
 	}
 
 	// Run stopwatch.
@@ -63019,6 +64484,8 @@ func (c *Client) TestResponseIntegerUintArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUintArrayArray(ctx context.Context, request string) (res [][]uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint_array_array"),
 	}
 
 	// Run stopwatch.
@@ -63091,6 +64558,8 @@ func (c *Client) TestResponseIntegerUintNullable(ctx context.Context, request st
 func (c *Client) sendTestResponseIntegerUintNullable(ctx context.Context, request string) (res NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -63163,6 +64632,8 @@ func (c *Client) TestResponseIntegerUintNullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseIntegerUintNullableArray(ctx context.Context, request string) (res []NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -63235,6 +64706,8 @@ func (c *Client) TestResponseIntegerUintNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseIntegerUintNullableArrayArray(ctx context.Context, request string) (res [][]NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_uint_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -63307,6 +64780,8 @@ func (c *Client) TestResponseIntegerUnix(ctx context.Context, request string) (t
 func (c *Client) sendTestResponseIntegerUnix(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix"),
 	}
 
 	// Run stopwatch.
@@ -63379,6 +64854,8 @@ func (c *Client) TestResponseIntegerUnixArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseIntegerUnixArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix_array"),
 	}
 
 	// Run stopwatch.
@@ -63451,6 +64928,8 @@ func (c *Client) TestResponseIntegerUnixArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUnixArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix_array_array"),
 	}
 
 	// Run stopwatch.
@@ -63523,6 +65002,8 @@ func (c *Client) TestResponseIntegerUnixMicro(ctx context.Context, request strin
 func (c *Client) sendTestResponseIntegerUnixMicro(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -63595,6 +65076,8 @@ func (c *Client) TestResponseIntegerUnixMicroArray(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUnixMicroArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro_array"),
 	}
 
 	// Run stopwatch.
@@ -63667,6 +65150,8 @@ func (c *Client) TestResponseIntegerUnixMicroArrayArray(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUnixMicroArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro_array_array"),
 	}
 
 	// Run stopwatch.
@@ -63739,6 +65224,8 @@ func (c *Client) TestResponseIntegerUnixMicroNullable(ctx context.Context, reque
 func (c *Client) sendTestResponseIntegerUnixMicroNullable(ctx context.Context, request string) (res NilUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -63811,6 +65298,8 @@ func (c *Client) TestResponseIntegerUnixMicroNullableArray(ctx context.Context, 
 func (c *Client) sendTestResponseIntegerUnixMicroNullableArray(ctx context.Context, request string) (res []NilUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -63883,6 +65372,8 @@ func (c *Client) TestResponseIntegerUnixMicroNullableArrayArray(ctx context.Cont
 func (c *Client) sendTestResponseIntegerUnixMicroNullableArrayArray(ctx context.Context, request string) (res [][]NilUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-micro_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -63955,6 +65446,8 @@ func (c *Client) TestResponseIntegerUnixMilli(ctx context.Context, request strin
 func (c *Client) sendTestResponseIntegerUnixMilli(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -64027,6 +65520,8 @@ func (c *Client) TestResponseIntegerUnixMilliArray(ctx context.Context, request 
 func (c *Client) sendTestResponseIntegerUnixMilliArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli_array"),
 	}
 
 	// Run stopwatch.
@@ -64099,6 +65594,8 @@ func (c *Client) TestResponseIntegerUnixMilliArrayArray(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUnixMilliArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli_array_array"),
 	}
 
 	// Run stopwatch.
@@ -64171,6 +65668,8 @@ func (c *Client) TestResponseIntegerUnixMilliNullable(ctx context.Context, reque
 func (c *Client) sendTestResponseIntegerUnixMilliNullable(ctx context.Context, request string) (res NilUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -64243,6 +65742,8 @@ func (c *Client) TestResponseIntegerUnixMilliNullableArray(ctx context.Context, 
 func (c *Client) sendTestResponseIntegerUnixMilliNullableArray(ctx context.Context, request string) (res []NilUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -64315,6 +65816,8 @@ func (c *Client) TestResponseIntegerUnixMilliNullableArrayArray(ctx context.Cont
 func (c *Client) sendTestResponseIntegerUnixMilliNullableArrayArray(ctx context.Context, request string) (res [][]NilUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-milli_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -64387,6 +65890,8 @@ func (c *Client) TestResponseIntegerUnixNano(ctx context.Context, request string
 func (c *Client) sendTestResponseIntegerUnixNano(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -64459,6 +65964,8 @@ func (c *Client) TestResponseIntegerUnixNanoArray(ctx context.Context, request s
 func (c *Client) sendTestResponseIntegerUnixNanoArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano_array"),
 	}
 
 	// Run stopwatch.
@@ -64531,6 +66038,8 @@ func (c *Client) TestResponseIntegerUnixNanoArrayArray(ctx context.Context, requ
 func (c *Client) sendTestResponseIntegerUnixNanoArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano_array_array"),
 	}
 
 	// Run stopwatch.
@@ -64603,6 +66112,8 @@ func (c *Client) TestResponseIntegerUnixNanoNullable(ctx context.Context, reques
 func (c *Client) sendTestResponseIntegerUnixNanoNullable(ctx context.Context, request string) (res NilUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -64675,6 +66186,8 @@ func (c *Client) TestResponseIntegerUnixNanoNullableArray(ctx context.Context, r
 func (c *Client) sendTestResponseIntegerUnixNanoNullableArray(ctx context.Context, request string) (res []NilUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -64747,6 +66260,8 @@ func (c *Client) TestResponseIntegerUnixNanoNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestResponseIntegerUnixNanoNullableArrayArray(ctx context.Context, request string) (res [][]NilUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-nano_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -64819,6 +66334,8 @@ func (c *Client) TestResponseIntegerUnixNullable(ctx context.Context, request st
 func (c *Client) sendTestResponseIntegerUnixNullable(ctx context.Context, request string) (res NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -64891,6 +66408,8 @@ func (c *Client) TestResponseIntegerUnixNullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseIntegerUnixNullableArray(ctx context.Context, request string) (res []NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -64963,6 +66482,8 @@ func (c *Client) TestResponseIntegerUnixNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseIntegerUnixNullableArrayArray(ctx context.Context, request string) (res [][]NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -65035,6 +66556,8 @@ func (c *Client) TestResponseIntegerUnixSeconds(ctx context.Context, request str
 func (c *Client) sendTestResponseIntegerUnixSeconds(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -65107,6 +66630,8 @@ func (c *Client) TestResponseIntegerUnixSecondsArray(ctx context.Context, reques
 func (c *Client) sendTestResponseIntegerUnixSecondsArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds_array"),
 	}
 
 	// Run stopwatch.
@@ -65179,6 +66704,8 @@ func (c *Client) TestResponseIntegerUnixSecondsArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseIntegerUnixSecondsArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds_array_array"),
 	}
 
 	// Run stopwatch.
@@ -65251,6 +66778,8 @@ func (c *Client) TestResponseIntegerUnixSecondsNullable(ctx context.Context, req
 func (c *Client) sendTestResponseIntegerUnixSecondsNullable(ctx context.Context, request string) (res NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -65323,6 +66852,8 @@ func (c *Client) TestResponseIntegerUnixSecondsNullableArray(ctx context.Context
 func (c *Client) sendTestResponseIntegerUnixSecondsNullableArray(ctx context.Context, request string) (res []NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -65395,6 +66926,8 @@ func (c *Client) TestResponseIntegerUnixSecondsNullableArrayArray(ctx context.Co
 func (c *Client) sendTestResponseIntegerUnixSecondsNullableArrayArray(ctx context.Context, request string) (res [][]NilUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_integer_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_integer_unix-seconds_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -65467,6 +67000,8 @@ func (c *Client) TestResponseNull(ctx context.Context, request string) (struct{}
 func (c *Client) sendTestResponseNull(ctx context.Context, request string) (res struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null"),
 	}
 
 	// Run stopwatch.
@@ -65539,6 +67074,8 @@ func (c *Client) TestResponseNullArray(ctx context.Context, request string) ([]s
 func (c *Client) sendTestResponseNullArray(ctx context.Context, request string) (res []struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null_array"),
 	}
 
 	// Run stopwatch.
@@ -65611,6 +67148,8 @@ func (c *Client) TestResponseNullArrayArray(ctx context.Context, request string)
 func (c *Client) sendTestResponseNullArrayArray(ctx context.Context, request string) (res [][]struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null_array_array"),
 	}
 
 	// Run stopwatch.
@@ -65683,6 +67222,8 @@ func (c *Client) TestResponseNullNullable(ctx context.Context, request string) (
 func (c *Client) sendTestResponseNullNullable(ctx context.Context, request string) (res struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null_nullable"),
 	}
 
 	// Run stopwatch.
@@ -65755,6 +67296,8 @@ func (c *Client) TestResponseNullNullableArray(ctx context.Context, request stri
 func (c *Client) sendTestResponseNullNullableArray(ctx context.Context, request string) (res []struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -65827,6 +67370,8 @@ func (c *Client) TestResponseNullNullableArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseNullNullableArrayArray(ctx context.Context, request string) (res [][]struct{}, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_null_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_null_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -65899,6 +67444,8 @@ func (c *Client) TestResponseNumber(ctx context.Context, request string) (float6
 func (c *Client) sendTestResponseNumber(ctx context.Context, request string) (res float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number"),
 	}
 
 	// Run stopwatch.
@@ -65971,6 +67518,8 @@ func (c *Client) TestResponseNumberArray(ctx context.Context, request string) ([
 func (c *Client) sendTestResponseNumberArray(ctx context.Context, request string) (res []float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_array"),
 	}
 
 	// Run stopwatch.
@@ -66043,6 +67592,8 @@ func (c *Client) TestResponseNumberArrayArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseNumberArrayArray(ctx context.Context, request string) (res [][]float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_array_array"),
 	}
 
 	// Run stopwatch.
@@ -66115,6 +67666,8 @@ func (c *Client) TestResponseNumberDouble(ctx context.Context, request string) (
 func (c *Client) sendTestResponseNumberDouble(ctx context.Context, request string) (res float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double"),
 	}
 
 	// Run stopwatch.
@@ -66187,6 +67740,8 @@ func (c *Client) TestResponseNumberDoubleArray(ctx context.Context, request stri
 func (c *Client) sendTestResponseNumberDoubleArray(ctx context.Context, request string) (res []float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double_array"),
 	}
 
 	// Run stopwatch.
@@ -66259,6 +67814,8 @@ func (c *Client) TestResponseNumberDoubleArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseNumberDoubleArrayArray(ctx context.Context, request string) (res [][]float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double_array_array"),
 	}
 
 	// Run stopwatch.
@@ -66331,6 +67888,8 @@ func (c *Client) TestResponseNumberDoubleNullable(ctx context.Context, request s
 func (c *Client) sendTestResponseNumberDoubleNullable(ctx context.Context, request string) (res NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double_nullable"),
 	}
 
 	// Run stopwatch.
@@ -66403,6 +67962,8 @@ func (c *Client) TestResponseNumberDoubleNullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseNumberDoubleNullableArray(ctx context.Context, request string) (res []NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -66475,6 +68036,8 @@ func (c *Client) TestResponseNumberDoubleNullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseNumberDoubleNullableArrayArray(ctx context.Context, request string) (res [][]NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_double_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_double_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -66547,6 +68110,8 @@ func (c *Client) TestResponseNumberFloat(ctx context.Context, request string) (f
 func (c *Client) sendTestResponseNumberFloat(ctx context.Context, request string) (res float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float"),
 	}
 
 	// Run stopwatch.
@@ -66619,6 +68184,8 @@ func (c *Client) TestResponseNumberFloatArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseNumberFloatArray(ctx context.Context, request string) (res []float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float_array"),
 	}
 
 	// Run stopwatch.
@@ -66691,6 +68258,8 @@ func (c *Client) TestResponseNumberFloatArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseNumberFloatArrayArray(ctx context.Context, request string) (res [][]float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float_array_array"),
 	}
 
 	// Run stopwatch.
@@ -66763,6 +68332,8 @@ func (c *Client) TestResponseNumberFloatNullable(ctx context.Context, request st
 func (c *Client) sendTestResponseNumberFloatNullable(ctx context.Context, request string) (res NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float_nullable"),
 	}
 
 	// Run stopwatch.
@@ -66835,6 +68406,8 @@ func (c *Client) TestResponseNumberFloatNullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseNumberFloatNullableArray(ctx context.Context, request string) (res []NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -66907,6 +68480,8 @@ func (c *Client) TestResponseNumberFloatNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseNumberFloatNullableArrayArray(ctx context.Context, request string) (res [][]NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_float_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_float_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -66979,6 +68554,8 @@ func (c *Client) TestResponseNumberInt32(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseNumberInt32(ctx context.Context, request string) (res int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32"),
 	}
 
 	// Run stopwatch.
@@ -67051,6 +68628,8 @@ func (c *Client) TestResponseNumberInt32Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseNumberInt32Array(ctx context.Context, request string) (res []int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -67123,6 +68702,8 @@ func (c *Client) TestResponseNumberInt32ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseNumberInt32ArrayArray(ctx context.Context, request string) (res [][]int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -67195,6 +68776,8 @@ func (c *Client) TestResponseNumberInt32Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseNumberInt32Nullable(ctx context.Context, request string) (res NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -67267,6 +68850,8 @@ func (c *Client) TestResponseNumberInt32NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseNumberInt32NullableArray(ctx context.Context, request string) (res []NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -67339,6 +68924,8 @@ func (c *Client) TestResponseNumberInt32NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseNumberInt32NullableArrayArray(ctx context.Context, request string) (res [][]NilInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -67411,6 +68998,8 @@ func (c *Client) TestResponseNumberInt64(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseNumberInt64(ctx context.Context, request string) (res int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64"),
 	}
 
 	// Run stopwatch.
@@ -67483,6 +69072,8 @@ func (c *Client) TestResponseNumberInt64Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseNumberInt64Array(ctx context.Context, request string) (res []int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -67555,6 +69146,8 @@ func (c *Client) TestResponseNumberInt64ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseNumberInt64ArrayArray(ctx context.Context, request string) (res [][]int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -67627,6 +69220,8 @@ func (c *Client) TestResponseNumberInt64Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseNumberInt64Nullable(ctx context.Context, request string) (res NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -67699,6 +69294,8 @@ func (c *Client) TestResponseNumberInt64NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseNumberInt64NullableArray(ctx context.Context, request string) (res []NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -67771,6 +69368,8 @@ func (c *Client) TestResponseNumberInt64NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseNumberInt64NullableArrayArray(ctx context.Context, request string) (res [][]NilInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_int64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -67843,6 +69442,8 @@ func (c *Client) TestResponseNumberNullable(ctx context.Context, request string)
 func (c *Client) sendTestResponseNumberNullable(ctx context.Context, request string) (res NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_nullable"),
 	}
 
 	// Run stopwatch.
@@ -67915,6 +69516,8 @@ func (c *Client) TestResponseNumberNullableArray(ctx context.Context, request st
 func (c *Client) sendTestResponseNumberNullableArray(ctx context.Context, request string) (res []NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -67987,6 +69590,8 @@ func (c *Client) TestResponseNumberNullableArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseNumberNullableArrayArray(ctx context.Context, request string) (res [][]NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_number_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_number_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -68059,6 +69664,8 @@ func (c *Client) TestResponseString(ctx context.Context, request string) (string
 func (c *Client) sendTestResponseString(ctx context.Context, request string) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string"),
 	}
 
 	// Run stopwatch.
@@ -68131,6 +69738,8 @@ func (c *Client) TestResponseStringArray(ctx context.Context, request string) ([
 func (c *Client) sendTestResponseStringArray(ctx context.Context, request string) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_array"),
 	}
 
 	// Run stopwatch.
@@ -68203,6 +69812,8 @@ func (c *Client) TestResponseStringArrayArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringArrayArray(ctx context.Context, request string) (res [][]string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_array_array"),
 	}
 
 	// Run stopwatch.
@@ -68275,6 +69886,8 @@ func (c *Client) TestResponseStringBase64(ctx context.Context, request string) (
 func (c *Client) sendTestResponseStringBase64(ctx context.Context, request string) (res []byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64"),
 	}
 
 	// Run stopwatch.
@@ -68347,6 +69960,8 @@ func (c *Client) TestResponseStringBase64Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringBase64Array(ctx context.Context, request string) (res [][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64_array"),
 	}
 
 	// Run stopwatch.
@@ -68419,6 +70034,8 @@ func (c *Client) TestResponseStringBase64ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringBase64ArrayArray(ctx context.Context, request string) (res [][][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -68491,6 +70108,8 @@ func (c *Client) TestResponseStringBase64Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseStringBase64Nullable(ctx context.Context, request string) (res []byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -68563,6 +70182,8 @@ func (c *Client) TestResponseStringBase64NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringBase64NullableArray(ctx context.Context, request string) (res [][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -68635,6 +70256,8 @@ func (c *Client) TestResponseStringBase64NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseStringBase64NullableArrayArray(ctx context.Context, request string) (res [][][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_base64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_base64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -68707,6 +70330,8 @@ func (c *Client) TestResponseStringBinary(ctx context.Context, request string) (
 func (c *Client) sendTestResponseStringBinary(ctx context.Context, request string) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary"),
 	}
 
 	// Run stopwatch.
@@ -68779,6 +70404,8 @@ func (c *Client) TestResponseStringBinaryArray(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringBinaryArray(ctx context.Context, request string) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary_array"),
 	}
 
 	// Run stopwatch.
@@ -68851,6 +70478,8 @@ func (c *Client) TestResponseStringBinaryArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringBinaryArrayArray(ctx context.Context, request string) (res [][]string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary_array_array"),
 	}
 
 	// Run stopwatch.
@@ -68923,6 +70552,8 @@ func (c *Client) TestResponseStringBinaryNullable(ctx context.Context, request s
 func (c *Client) sendTestResponseStringBinaryNullable(ctx context.Context, request string) (res NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary_nullable"),
 	}
 
 	// Run stopwatch.
@@ -68995,6 +70626,8 @@ func (c *Client) TestResponseStringBinaryNullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringBinaryNullableArray(ctx context.Context, request string) (res []NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -69067,6 +70700,8 @@ func (c *Client) TestResponseStringBinaryNullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseStringBinaryNullableArrayArray(ctx context.Context, request string) (res [][]NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_binary_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_binary_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -69139,6 +70774,8 @@ func (c *Client) TestResponseStringByte(ctx context.Context, request string) ([]
 func (c *Client) sendTestResponseStringByte(ctx context.Context, request string) (res []byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte"),
 	}
 
 	// Run stopwatch.
@@ -69211,6 +70848,8 @@ func (c *Client) TestResponseStringByteArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringByteArray(ctx context.Context, request string) (res [][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte_array"),
 	}
 
 	// Run stopwatch.
@@ -69283,6 +70922,8 @@ func (c *Client) TestResponseStringByteArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringByteArrayArray(ctx context.Context, request string) (res [][][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte_array_array"),
 	}
 
 	// Run stopwatch.
@@ -69355,6 +70996,8 @@ func (c *Client) TestResponseStringByteNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringByteNullable(ctx context.Context, request string) (res []byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte_nullable"),
 	}
 
 	// Run stopwatch.
@@ -69427,6 +71070,8 @@ func (c *Client) TestResponseStringByteNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringByteNullableArray(ctx context.Context, request string) (res [][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -69499,6 +71144,8 @@ func (c *Client) TestResponseStringByteNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringByteNullableArrayArray(ctx context.Context, request string) (res [][][]byte, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_byte_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_byte_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -69571,6 +71218,8 @@ func (c *Client) TestResponseStringDate(ctx context.Context, request string) (ti
 func (c *Client) sendTestResponseStringDate(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date"),
 	}
 
 	// Run stopwatch.
@@ -69643,6 +71292,8 @@ func (c *Client) TestResponseStringDateArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringDateArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date_array"),
 	}
 
 	// Run stopwatch.
@@ -69715,6 +71366,8 @@ func (c *Client) TestResponseStringDateArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringDateArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date_array_array"),
 	}
 
 	// Run stopwatch.
@@ -69787,6 +71440,8 @@ func (c *Client) TestResponseStringDateNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringDateNullable(ctx context.Context, request string) (res NilDate, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date_nullable"),
 	}
 
 	// Run stopwatch.
@@ -69859,6 +71514,8 @@ func (c *Client) TestResponseStringDateNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringDateNullableArray(ctx context.Context, request string) (res []NilDate, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -69931,6 +71588,8 @@ func (c *Client) TestResponseStringDateNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringDateNullableArrayArray(ctx context.Context, request string) (res [][]NilDate, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -70003,6 +71662,8 @@ func (c *Client) TestResponseStringDateTime(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringDateTime(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time"),
 	}
 
 	// Run stopwatch.
@@ -70075,6 +71736,8 @@ func (c *Client) TestResponseStringDateTimeArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringDateTimeArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time_array"),
 	}
 
 	// Run stopwatch.
@@ -70147,6 +71810,8 @@ func (c *Client) TestResponseStringDateTimeArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringDateTimeArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time_array_array"),
 	}
 
 	// Run stopwatch.
@@ -70219,6 +71884,8 @@ func (c *Client) TestResponseStringDateTimeNullable(ctx context.Context, request
 func (c *Client) sendTestResponseStringDateTimeNullable(ctx context.Context, request string) (res NilDateTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -70291,6 +71958,8 @@ func (c *Client) TestResponseStringDateTimeNullableArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringDateTimeNullableArray(ctx context.Context, request string) (res []NilDateTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -70363,6 +72032,8 @@ func (c *Client) TestResponseStringDateTimeNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestResponseStringDateTimeNullableArrayArray(ctx context.Context, request string) (res [][]NilDateTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_date-time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_date-time_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -70435,6 +72106,8 @@ func (c *Client) TestResponseStringDuration(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringDuration(ctx context.Context, request string) (res time.Duration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration"),
 	}
 
 	// Run stopwatch.
@@ -70507,6 +72180,8 @@ func (c *Client) TestResponseStringDurationArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringDurationArray(ctx context.Context, request string) (res []time.Duration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration_array"),
 	}
 
 	// Run stopwatch.
@@ -70579,6 +72254,8 @@ func (c *Client) TestResponseStringDurationArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringDurationArrayArray(ctx context.Context, request string) (res [][]time.Duration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration_array_array"),
 	}
 
 	// Run stopwatch.
@@ -70651,6 +72328,8 @@ func (c *Client) TestResponseStringDurationNullable(ctx context.Context, request
 func (c *Client) sendTestResponseStringDurationNullable(ctx context.Context, request string) (res NilDuration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration_nullable"),
 	}
 
 	// Run stopwatch.
@@ -70723,6 +72402,8 @@ func (c *Client) TestResponseStringDurationNullableArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringDurationNullableArray(ctx context.Context, request string) (res []NilDuration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -70795,6 +72476,8 @@ func (c *Client) TestResponseStringDurationNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestResponseStringDurationNullableArrayArray(ctx context.Context, request string) (res [][]NilDuration, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_duration_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_duration_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -70867,6 +72550,8 @@ func (c *Client) TestResponseStringEmail(ctx context.Context, request string) (s
 func (c *Client) sendTestResponseStringEmail(ctx context.Context, request string) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email"),
 	}
 
 	// Run stopwatch.
@@ -70939,6 +72624,8 @@ func (c *Client) TestResponseStringEmailArray(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringEmailArray(ctx context.Context, request string) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email_array"),
 	}
 
 	// Run stopwatch.
@@ -71011,6 +72698,8 @@ func (c *Client) TestResponseStringEmailArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringEmailArrayArray(ctx context.Context, request string) (res [][]string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email_array_array"),
 	}
 
 	// Run stopwatch.
@@ -71083,6 +72772,8 @@ func (c *Client) TestResponseStringEmailNullable(ctx context.Context, request st
 func (c *Client) sendTestResponseStringEmailNullable(ctx context.Context, request string) (res NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email_nullable"),
 	}
 
 	// Run stopwatch.
@@ -71155,6 +72846,8 @@ func (c *Client) TestResponseStringEmailNullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringEmailNullableArray(ctx context.Context, request string) (res []NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -71227,6 +72920,8 @@ func (c *Client) TestResponseStringEmailNullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseStringEmailNullableArrayArray(ctx context.Context, request string) (res [][]NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_email_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_email_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -71299,6 +72994,8 @@ func (c *Client) TestResponseStringFloat32(ctx context.Context, request string) 
 func (c *Client) sendTestResponseStringFloat32(ctx context.Context, request string) (res float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32"),
 	}
 
 	// Run stopwatch.
@@ -71371,6 +73068,8 @@ func (c *Client) TestResponseStringFloat32Array(ctx context.Context, request str
 func (c *Client) sendTestResponseStringFloat32Array(ctx context.Context, request string) (res []float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32_array"),
 	}
 
 	// Run stopwatch.
@@ -71443,6 +73142,8 @@ func (c *Client) TestResponseStringFloat32ArrayArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringFloat32ArrayArray(ctx context.Context, request string) (res [][]float32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -71515,6 +73216,8 @@ func (c *Client) TestResponseStringFloat32Nullable(ctx context.Context, request 
 func (c *Client) sendTestResponseStringFloat32Nullable(ctx context.Context, request string) (res NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -71587,6 +73290,8 @@ func (c *Client) TestResponseStringFloat32NullableArray(ctx context.Context, req
 func (c *Client) sendTestResponseStringFloat32NullableArray(ctx context.Context, request string) (res []NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -71659,6 +73364,8 @@ func (c *Client) TestResponseStringFloat32NullableArrayArray(ctx context.Context
 func (c *Client) sendTestResponseStringFloat32NullableArrayArray(ctx context.Context, request string) (res [][]NilFloat32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -71731,6 +73438,8 @@ func (c *Client) TestResponseStringFloat64(ctx context.Context, request string) 
 func (c *Client) sendTestResponseStringFloat64(ctx context.Context, request string) (res float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64"),
 	}
 
 	// Run stopwatch.
@@ -71803,6 +73512,8 @@ func (c *Client) TestResponseStringFloat64Array(ctx context.Context, request str
 func (c *Client) sendTestResponseStringFloat64Array(ctx context.Context, request string) (res []float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64_array"),
 	}
 
 	// Run stopwatch.
@@ -71875,6 +73586,8 @@ func (c *Client) TestResponseStringFloat64ArrayArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringFloat64ArrayArray(ctx context.Context, request string) (res [][]float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -71947,6 +73660,8 @@ func (c *Client) TestResponseStringFloat64Nullable(ctx context.Context, request 
 func (c *Client) sendTestResponseStringFloat64Nullable(ctx context.Context, request string) (res NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -72019,6 +73734,8 @@ func (c *Client) TestResponseStringFloat64NullableArray(ctx context.Context, req
 func (c *Client) sendTestResponseStringFloat64NullableArray(ctx context.Context, request string) (res []NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -72091,6 +73808,8 @@ func (c *Client) TestResponseStringFloat64NullableArrayArray(ctx context.Context
 func (c *Client) sendTestResponseStringFloat64NullableArrayArray(ctx context.Context, request string) (res [][]NilFloat64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_float64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_float64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -72163,6 +73882,8 @@ func (c *Client) TestResponseStringHostname(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringHostname(ctx context.Context, request string) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname"),
 	}
 
 	// Run stopwatch.
@@ -72235,6 +73956,8 @@ func (c *Client) TestResponseStringHostnameArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringHostnameArray(ctx context.Context, request string) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname_array"),
 	}
 
 	// Run stopwatch.
@@ -72307,6 +74030,8 @@ func (c *Client) TestResponseStringHostnameArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringHostnameArrayArray(ctx context.Context, request string) (res [][]string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname_array_array"),
 	}
 
 	// Run stopwatch.
@@ -72379,6 +74104,8 @@ func (c *Client) TestResponseStringHostnameNullable(ctx context.Context, request
 func (c *Client) sendTestResponseStringHostnameNullable(ctx context.Context, request string) (res NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname_nullable"),
 	}
 
 	// Run stopwatch.
@@ -72451,6 +74178,8 @@ func (c *Client) TestResponseStringHostnameNullableArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringHostnameNullableArray(ctx context.Context, request string) (res []NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -72523,6 +74252,8 @@ func (c *Client) TestResponseStringHostnameNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestResponseStringHostnameNullableArrayArray(ctx context.Context, request string) (res [][]NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_hostname_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_hostname_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -72595,6 +74326,8 @@ func (c *Client) TestResponseStringIP(ctx context.Context, request string) (neti
 func (c *Client) sendTestResponseStringIP(ctx context.Context, request string) (res netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip"),
 	}
 
 	// Run stopwatch.
@@ -72667,6 +74400,8 @@ func (c *Client) TestResponseStringIPArray(ctx context.Context, request string) 
 func (c *Client) sendTestResponseStringIPArray(ctx context.Context, request string) (res []netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip_array"),
 	}
 
 	// Run stopwatch.
@@ -72739,6 +74474,8 @@ func (c *Client) TestResponseStringIPArrayArray(ctx context.Context, request str
 func (c *Client) sendTestResponseStringIPArrayArray(ctx context.Context, request string) (res [][]netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip_array_array"),
 	}
 
 	// Run stopwatch.
@@ -72811,6 +74548,8 @@ func (c *Client) TestResponseStringIPNullable(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringIPNullable(ctx context.Context, request string) (res NilIP, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip_nullable"),
 	}
 
 	// Run stopwatch.
@@ -72883,6 +74622,8 @@ func (c *Client) TestResponseStringIPNullableArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringIPNullableArray(ctx context.Context, request string) (res []NilIP, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -72955,6 +74696,8 @@ func (c *Client) TestResponseStringIPNullableArrayArray(ctx context.Context, req
 func (c *Client) sendTestResponseStringIPNullableArrayArray(ctx context.Context, request string) (res [][]NilIP, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ip_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ip_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -73027,6 +74770,8 @@ func (c *Client) TestResponseStringInt(ctx context.Context, request string) (int
 func (c *Client) sendTestResponseStringInt(ctx context.Context, request string) (res int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int"),
 	}
 
 	// Run stopwatch.
@@ -73099,6 +74844,8 @@ func (c *Client) TestResponseStringInt16(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseStringInt16(ctx context.Context, request string) (res int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16"),
 	}
 
 	// Run stopwatch.
@@ -73171,6 +74918,8 @@ func (c *Client) TestResponseStringInt16Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringInt16Array(ctx context.Context, request string) (res []int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16_array"),
 	}
 
 	// Run stopwatch.
@@ -73243,6 +74992,8 @@ func (c *Client) TestResponseStringInt16ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringInt16ArrayArray(ctx context.Context, request string) (res [][]int16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16_array_array"),
 	}
 
 	// Run stopwatch.
@@ -73315,6 +75066,8 @@ func (c *Client) TestResponseStringInt16Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseStringInt16Nullable(ctx context.Context, request string) (res NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -73387,6 +75140,8 @@ func (c *Client) TestResponseStringInt16NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringInt16NullableArray(ctx context.Context, request string) (res []NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -73459,6 +75214,8 @@ func (c *Client) TestResponseStringInt16NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseStringInt16NullableArrayArray(ctx context.Context, request string) (res [][]NilInt16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int16_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -73531,6 +75288,8 @@ func (c *Client) TestResponseStringInt32(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseStringInt32(ctx context.Context, request string) (res int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32"),
 	}
 
 	// Run stopwatch.
@@ -73603,6 +75362,8 @@ func (c *Client) TestResponseStringInt32Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringInt32Array(ctx context.Context, request string) (res []int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32_array"),
 	}
 
 	// Run stopwatch.
@@ -73675,6 +75436,8 @@ func (c *Client) TestResponseStringInt32ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringInt32ArrayArray(ctx context.Context, request string) (res [][]int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -73747,6 +75510,8 @@ func (c *Client) TestResponseStringInt32Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseStringInt32Nullable(ctx context.Context, request string) (res NilStringInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -73819,6 +75584,8 @@ func (c *Client) TestResponseStringInt32NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringInt32NullableArray(ctx context.Context, request string) (res []NilStringInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -73891,6 +75658,8 @@ func (c *Client) TestResponseStringInt32NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseStringInt32NullableArrayArray(ctx context.Context, request string) (res [][]NilStringInt32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -73963,6 +75732,8 @@ func (c *Client) TestResponseStringInt64(ctx context.Context, request string) (i
 func (c *Client) sendTestResponseStringInt64(ctx context.Context, request string) (res int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64"),
 	}
 
 	// Run stopwatch.
@@ -74035,6 +75806,8 @@ func (c *Client) TestResponseStringInt64Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringInt64Array(ctx context.Context, request string) (res []int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64_array"),
 	}
 
 	// Run stopwatch.
@@ -74107,6 +75880,8 @@ func (c *Client) TestResponseStringInt64ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringInt64ArrayArray(ctx context.Context, request string) (res [][]int64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -74179,6 +75954,8 @@ func (c *Client) TestResponseStringInt64Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseStringInt64Nullable(ctx context.Context, request string) (res NilStringInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -74251,6 +76028,8 @@ func (c *Client) TestResponseStringInt64NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringInt64NullableArray(ctx context.Context, request string) (res []NilStringInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -74323,6 +76102,8 @@ func (c *Client) TestResponseStringInt64NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseStringInt64NullableArrayArray(ctx context.Context, request string) (res [][]NilStringInt64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -74395,6 +76176,8 @@ func (c *Client) TestResponseStringInt8(ctx context.Context, request string) (in
 func (c *Client) sendTestResponseStringInt8(ctx context.Context, request string) (res int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8"),
 	}
 
 	// Run stopwatch.
@@ -74467,6 +76250,8 @@ func (c *Client) TestResponseStringInt8Array(ctx context.Context, request string
 func (c *Client) sendTestResponseStringInt8Array(ctx context.Context, request string) (res []int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8_array"),
 	}
 
 	// Run stopwatch.
@@ -74539,6 +76324,8 @@ func (c *Client) TestResponseStringInt8ArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringInt8ArrayArray(ctx context.Context, request string) (res [][]int8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8_array_array"),
 	}
 
 	// Run stopwatch.
@@ -74611,6 +76398,8 @@ func (c *Client) TestResponseStringInt8Nullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringInt8Nullable(ctx context.Context, request string) (res NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -74683,6 +76472,8 @@ func (c *Client) TestResponseStringInt8NullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringInt8NullableArray(ctx context.Context, request string) (res []NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -74755,6 +76546,8 @@ func (c *Client) TestResponseStringInt8NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringInt8NullableArrayArray(ctx context.Context, request string) (res [][]NilInt8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int8_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -74827,6 +76620,8 @@ func (c *Client) TestResponseStringIntArray(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringIntArray(ctx context.Context, request string) (res []int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int_array"),
 	}
 
 	// Run stopwatch.
@@ -74899,6 +76694,8 @@ func (c *Client) TestResponseStringIntArrayArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringIntArrayArray(ctx context.Context, request string) (res [][]int, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int_array_array"),
 	}
 
 	// Run stopwatch.
@@ -74971,6 +76768,8 @@ func (c *Client) TestResponseStringIntNullable(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringIntNullable(ctx context.Context, request string) (res NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int_nullable"),
 	}
 
 	// Run stopwatch.
@@ -75043,6 +76842,8 @@ func (c *Client) TestResponseStringIntNullableArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringIntNullableArray(ctx context.Context, request string) (res []NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -75115,6 +76916,8 @@ func (c *Client) TestResponseStringIntNullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringIntNullableArrayArray(ctx context.Context, request string) (res [][]NilInt, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_int_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_int_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -75187,6 +76990,8 @@ func (c *Client) TestResponseStringIpv4(ctx context.Context, request string) (ne
 func (c *Client) sendTestResponseStringIpv4(ctx context.Context, request string) (res netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4"),
 	}
 
 	// Run stopwatch.
@@ -75259,6 +77064,8 @@ func (c *Client) TestResponseStringIpv4Array(ctx context.Context, request string
 func (c *Client) sendTestResponseStringIpv4Array(ctx context.Context, request string) (res []netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4_array"),
 	}
 
 	// Run stopwatch.
@@ -75331,6 +77138,8 @@ func (c *Client) TestResponseStringIpv4ArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringIpv4ArrayArray(ctx context.Context, request string) (res [][]netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4_array_array"),
 	}
 
 	// Run stopwatch.
@@ -75403,6 +77212,8 @@ func (c *Client) TestResponseStringIpv4Nullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringIpv4Nullable(ctx context.Context, request string) (res NilIPv4, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4_nullable"),
 	}
 
 	// Run stopwatch.
@@ -75475,6 +77286,8 @@ func (c *Client) TestResponseStringIpv4NullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringIpv4NullableArray(ctx context.Context, request string) (res []NilIPv4, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -75547,6 +77360,8 @@ func (c *Client) TestResponseStringIpv4NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringIpv4NullableArrayArray(ctx context.Context, request string) (res [][]NilIPv4, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv4_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv4_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -75619,6 +77434,8 @@ func (c *Client) TestResponseStringIpv6(ctx context.Context, request string) (ne
 func (c *Client) sendTestResponseStringIpv6(ctx context.Context, request string) (res netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6"),
 	}
 
 	// Run stopwatch.
@@ -75691,6 +77508,8 @@ func (c *Client) TestResponseStringIpv6Array(ctx context.Context, request string
 func (c *Client) sendTestResponseStringIpv6Array(ctx context.Context, request string) (res []netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6_array"),
 	}
 
 	// Run stopwatch.
@@ -75763,6 +77582,8 @@ func (c *Client) TestResponseStringIpv6ArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringIpv6ArrayArray(ctx context.Context, request string) (res [][]netip.Addr, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6_array_array"),
 	}
 
 	// Run stopwatch.
@@ -75835,6 +77656,8 @@ func (c *Client) TestResponseStringIpv6Nullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringIpv6Nullable(ctx context.Context, request string) (res NilIPv6, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6_nullable"),
 	}
 
 	// Run stopwatch.
@@ -75907,6 +77730,8 @@ func (c *Client) TestResponseStringIpv6NullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringIpv6NullableArray(ctx context.Context, request string) (res []NilIPv6, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -75979,6 +77804,8 @@ func (c *Client) TestResponseStringIpv6NullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringIpv6NullableArrayArray(ctx context.Context, request string) (res [][]NilIPv6, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_ipv6_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_ipv6_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -76051,6 +77878,8 @@ func (c *Client) TestResponseStringNullable(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringNullable(ctx context.Context, request string) (res NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_nullable"),
 	}
 
 	// Run stopwatch.
@@ -76123,6 +77952,8 @@ func (c *Client) TestResponseStringNullableArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringNullableArray(ctx context.Context, request string) (res []NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -76195,6 +78026,8 @@ func (c *Client) TestResponseStringNullableArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringNullableArrayArray(ctx context.Context, request string) (res [][]NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -76267,6 +78100,8 @@ func (c *Client) TestResponseStringPassword(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringPassword(ctx context.Context, request string) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password"),
 	}
 
 	// Run stopwatch.
@@ -76339,6 +78174,8 @@ func (c *Client) TestResponseStringPasswordArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringPasswordArray(ctx context.Context, request string) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password_array"),
 	}
 
 	// Run stopwatch.
@@ -76411,6 +78248,8 @@ func (c *Client) TestResponseStringPasswordArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringPasswordArrayArray(ctx context.Context, request string) (res [][]string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password_array_array"),
 	}
 
 	// Run stopwatch.
@@ -76483,6 +78322,8 @@ func (c *Client) TestResponseStringPasswordNullable(ctx context.Context, request
 func (c *Client) sendTestResponseStringPasswordNullable(ctx context.Context, request string) (res NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password_nullable"),
 	}
 
 	// Run stopwatch.
@@ -76555,6 +78396,8 @@ func (c *Client) TestResponseStringPasswordNullableArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringPasswordNullableArray(ctx context.Context, request string) (res []NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -76627,6 +78470,8 @@ func (c *Client) TestResponseStringPasswordNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestResponseStringPasswordNullableArrayArray(ctx context.Context, request string) (res [][]NilString, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_password_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_password_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -76699,6 +78544,8 @@ func (c *Client) TestResponseStringTime(ctx context.Context, request string) (ti
 func (c *Client) sendTestResponseStringTime(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time"),
 	}
 
 	// Run stopwatch.
@@ -76771,6 +78618,8 @@ func (c *Client) TestResponseStringTimeArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringTimeArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time_array"),
 	}
 
 	// Run stopwatch.
@@ -76843,6 +78692,8 @@ func (c *Client) TestResponseStringTimeArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringTimeArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time_array_array"),
 	}
 
 	// Run stopwatch.
@@ -76915,6 +78766,8 @@ func (c *Client) TestResponseStringTimeNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringTimeNullable(ctx context.Context, request string) (res NilTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time_nullable"),
 	}
 
 	// Run stopwatch.
@@ -76987,6 +78840,8 @@ func (c *Client) TestResponseStringTimeNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringTimeNullableArray(ctx context.Context, request string) (res []NilTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -77059,6 +78914,8 @@ func (c *Client) TestResponseStringTimeNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringTimeNullableArrayArray(ctx context.Context, request string) (res [][]NilTime, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_time_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_time_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -77131,6 +78988,8 @@ func (c *Client) TestResponseStringURI(ctx context.Context, request string) (url
 func (c *Client) sendTestResponseStringURI(ctx context.Context, request string) (res url.URL, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri"),
 	}
 
 	// Run stopwatch.
@@ -77203,6 +79062,8 @@ func (c *Client) TestResponseStringURIArray(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringURIArray(ctx context.Context, request string) (res []url.URL, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri_array"),
 	}
 
 	// Run stopwatch.
@@ -77275,6 +79136,8 @@ func (c *Client) TestResponseStringURIArrayArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringURIArrayArray(ctx context.Context, request string) (res [][]url.URL, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri_array_array"),
 	}
 
 	// Run stopwatch.
@@ -77347,6 +79210,8 @@ func (c *Client) TestResponseStringURINullable(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringURINullable(ctx context.Context, request string) (res NilURI, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri_nullable"),
 	}
 
 	// Run stopwatch.
@@ -77419,6 +79284,8 @@ func (c *Client) TestResponseStringURINullableArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringURINullableArray(ctx context.Context, request string) (res []NilURI, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -77491,6 +79358,8 @@ func (c *Client) TestResponseStringURINullableArrayArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringURINullableArrayArray(ctx context.Context, request string) (res [][]NilURI, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uri_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uri_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -77563,6 +79432,8 @@ func (c *Client) TestResponseStringUUID(ctx context.Context, request string) (uu
 func (c *Client) sendTestResponseStringUUID(ctx context.Context, request string) (res uuid.UUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid"),
 	}
 
 	// Run stopwatch.
@@ -77635,6 +79506,8 @@ func (c *Client) TestResponseStringUUIDArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringUUIDArray(ctx context.Context, request string) (res []uuid.UUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid_array"),
 	}
 
 	// Run stopwatch.
@@ -77707,6 +79580,8 @@ func (c *Client) TestResponseStringUUIDArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUUIDArrayArray(ctx context.Context, request string) (res [][]uuid.UUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid_array_array"),
 	}
 
 	// Run stopwatch.
@@ -77779,6 +79654,8 @@ func (c *Client) TestResponseStringUUIDNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringUUIDNullable(ctx context.Context, request string) (res NilUUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid_nullable"),
 	}
 
 	// Run stopwatch.
@@ -77851,6 +79728,8 @@ func (c *Client) TestResponseStringUUIDNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringUUIDNullableArray(ctx context.Context, request string) (res []NilUUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -77923,6 +79802,8 @@ func (c *Client) TestResponseStringUUIDNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringUUIDNullableArrayArray(ctx context.Context, request string) (res [][]NilUUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uuid_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uuid_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -77995,6 +79876,8 @@ func (c *Client) TestResponseStringUint(ctx context.Context, request string) (ui
 func (c *Client) sendTestResponseStringUint(ctx context.Context, request string) (res uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint"),
 	}
 
 	// Run stopwatch.
@@ -78067,6 +79950,8 @@ func (c *Client) TestResponseStringUint16(ctx context.Context, request string) (
 func (c *Client) sendTestResponseStringUint16(ctx context.Context, request string) (res uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16"),
 	}
 
 	// Run stopwatch.
@@ -78139,6 +80024,8 @@ func (c *Client) TestResponseStringUint16Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringUint16Array(ctx context.Context, request string) (res []uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16_array"),
 	}
 
 	// Run stopwatch.
@@ -78211,6 +80098,8 @@ func (c *Client) TestResponseStringUint16ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringUint16ArrayArray(ctx context.Context, request string) (res [][]uint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16_array_array"),
 	}
 
 	// Run stopwatch.
@@ -78283,6 +80172,8 @@ func (c *Client) TestResponseStringUint16Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUint16Nullable(ctx context.Context, request string) (res NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16_nullable"),
 	}
 
 	// Run stopwatch.
@@ -78355,6 +80246,8 @@ func (c *Client) TestResponseStringUint16NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUint16NullableArray(ctx context.Context, request string) (res []NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -78427,6 +80320,8 @@ func (c *Client) TestResponseStringUint16NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseStringUint16NullableArrayArray(ctx context.Context, request string) (res [][]NilUint16, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint16_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint16_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -78499,6 +80394,8 @@ func (c *Client) TestResponseStringUint32(ctx context.Context, request string) (
 func (c *Client) sendTestResponseStringUint32(ctx context.Context, request string) (res uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32"),
 	}
 
 	// Run stopwatch.
@@ -78571,6 +80468,8 @@ func (c *Client) TestResponseStringUint32Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringUint32Array(ctx context.Context, request string) (res []uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32_array"),
 	}
 
 	// Run stopwatch.
@@ -78643,6 +80542,8 @@ func (c *Client) TestResponseStringUint32ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringUint32ArrayArray(ctx context.Context, request string) (res [][]uint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32_array_array"),
 	}
 
 	// Run stopwatch.
@@ -78715,6 +80616,8 @@ func (c *Client) TestResponseStringUint32Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUint32Nullable(ctx context.Context, request string) (res NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32_nullable"),
 	}
 
 	// Run stopwatch.
@@ -78787,6 +80690,8 @@ func (c *Client) TestResponseStringUint32NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUint32NullableArray(ctx context.Context, request string) (res []NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -78859,6 +80764,8 @@ func (c *Client) TestResponseStringUint32NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseStringUint32NullableArrayArray(ctx context.Context, request string) (res [][]NilUint32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint32_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint32_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -78931,6 +80838,8 @@ func (c *Client) TestResponseStringUint64(ctx context.Context, request string) (
 func (c *Client) sendTestResponseStringUint64(ctx context.Context, request string) (res uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64"),
 	}
 
 	// Run stopwatch.
@@ -79003,6 +80912,8 @@ func (c *Client) TestResponseStringUint64Array(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringUint64Array(ctx context.Context, request string) (res []uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64_array"),
 	}
 
 	// Run stopwatch.
@@ -79075,6 +80986,8 @@ func (c *Client) TestResponseStringUint64ArrayArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringUint64ArrayArray(ctx context.Context, request string) (res [][]uint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64_array_array"),
 	}
 
 	// Run stopwatch.
@@ -79147,6 +81060,8 @@ func (c *Client) TestResponseStringUint64Nullable(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUint64Nullable(ctx context.Context, request string) (res NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64_nullable"),
 	}
 
 	// Run stopwatch.
@@ -79219,6 +81134,8 @@ func (c *Client) TestResponseStringUint64NullableArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUint64NullableArray(ctx context.Context, request string) (res []NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -79291,6 +81208,8 @@ func (c *Client) TestResponseStringUint64NullableArrayArray(ctx context.Context,
 func (c *Client) sendTestResponseStringUint64NullableArrayArray(ctx context.Context, request string) (res [][]NilUint64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint64_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint64_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -79363,6 +81282,8 @@ func (c *Client) TestResponseStringUint8(ctx context.Context, request string) (u
 func (c *Client) sendTestResponseStringUint8(ctx context.Context, request string) (res uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8"),
 	}
 
 	// Run stopwatch.
@@ -79435,6 +81356,8 @@ func (c *Client) TestResponseStringUint8Array(ctx context.Context, request strin
 func (c *Client) sendTestResponseStringUint8Array(ctx context.Context, request string) (res []uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8_array"),
 	}
 
 	// Run stopwatch.
@@ -79507,6 +81430,8 @@ func (c *Client) TestResponseStringUint8ArrayArray(ctx context.Context, request 
 func (c *Client) sendTestResponseStringUint8ArrayArray(ctx context.Context, request string) (res [][]uint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8_array_array"),
 	}
 
 	// Run stopwatch.
@@ -79579,6 +81504,8 @@ func (c *Client) TestResponseStringUint8Nullable(ctx context.Context, request st
 func (c *Client) sendTestResponseStringUint8Nullable(ctx context.Context, request string) (res NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8_nullable"),
 	}
 
 	// Run stopwatch.
@@ -79651,6 +81578,8 @@ func (c *Client) TestResponseStringUint8NullableArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringUint8NullableArray(ctx context.Context, request string) (res []NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -79723,6 +81652,8 @@ func (c *Client) TestResponseStringUint8NullableArrayArray(ctx context.Context, 
 func (c *Client) sendTestResponseStringUint8NullableArrayArray(ctx context.Context, request string) (res [][]NilUint8, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint8_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint8_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -79795,6 +81726,8 @@ func (c *Client) TestResponseStringUintArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringUintArray(ctx context.Context, request string) (res []uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint_array"),
 	}
 
 	// Run stopwatch.
@@ -79867,6 +81800,8 @@ func (c *Client) TestResponseStringUintArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUintArrayArray(ctx context.Context, request string) (res [][]uint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint_array_array"),
 	}
 
 	// Run stopwatch.
@@ -79939,6 +81874,8 @@ func (c *Client) TestResponseStringUintNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringUintNullable(ctx context.Context, request string) (res NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint_nullable"),
 	}
 
 	// Run stopwatch.
@@ -80011,6 +81948,8 @@ func (c *Client) TestResponseStringUintNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringUintNullableArray(ctx context.Context, request string) (res []NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -80083,6 +82022,8 @@ func (c *Client) TestResponseStringUintNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringUintNullableArrayArray(ctx context.Context, request string) (res [][]NilUint, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_uint_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_uint_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -80155,6 +82096,8 @@ func (c *Client) TestResponseStringUnix(ctx context.Context, request string) (ti
 func (c *Client) sendTestResponseStringUnix(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix"),
 	}
 
 	// Run stopwatch.
@@ -80227,6 +82170,8 @@ func (c *Client) TestResponseStringUnixArray(ctx context.Context, request string
 func (c *Client) sendTestResponseStringUnixArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix_array"),
 	}
 
 	// Run stopwatch.
@@ -80299,6 +82244,8 @@ func (c *Client) TestResponseStringUnixArrayArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUnixArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix_array_array"),
 	}
 
 	// Run stopwatch.
@@ -80371,6 +82318,8 @@ func (c *Client) TestResponseStringUnixMicro(ctx context.Context, request string
 func (c *Client) sendTestResponseStringUnixMicro(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro"),
 	}
 
 	// Run stopwatch.
@@ -80443,6 +82392,8 @@ func (c *Client) TestResponseStringUnixMicroArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUnixMicroArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro_array"),
 	}
 
 	// Run stopwatch.
@@ -80515,6 +82466,8 @@ func (c *Client) TestResponseStringUnixMicroArrayArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUnixMicroArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro_array_array"),
 	}
 
 	// Run stopwatch.
@@ -80587,6 +82540,8 @@ func (c *Client) TestResponseStringUnixMicroNullable(ctx context.Context, reques
 func (c *Client) sendTestResponseStringUnixMicroNullable(ctx context.Context, request string) (res NilStringUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro_nullable"),
 	}
 
 	// Run stopwatch.
@@ -80659,6 +82614,8 @@ func (c *Client) TestResponseStringUnixMicroNullableArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringUnixMicroNullableArray(ctx context.Context, request string) (res []NilStringUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -80731,6 +82688,8 @@ func (c *Client) TestResponseStringUnixMicroNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestResponseStringUnixMicroNullableArrayArray(ctx context.Context, request string) (res [][]NilStringUnixMicro, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-micro_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-micro_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -80803,6 +82762,8 @@ func (c *Client) TestResponseStringUnixMilli(ctx context.Context, request string
 func (c *Client) sendTestResponseStringUnixMilli(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli"),
 	}
 
 	// Run stopwatch.
@@ -80875,6 +82836,8 @@ func (c *Client) TestResponseStringUnixMilliArray(ctx context.Context, request s
 func (c *Client) sendTestResponseStringUnixMilliArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli_array"),
 	}
 
 	// Run stopwatch.
@@ -80947,6 +82910,8 @@ func (c *Client) TestResponseStringUnixMilliArrayArray(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUnixMilliArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli_array_array"),
 	}
 
 	// Run stopwatch.
@@ -81019,6 +82984,8 @@ func (c *Client) TestResponseStringUnixMilliNullable(ctx context.Context, reques
 func (c *Client) sendTestResponseStringUnixMilliNullable(ctx context.Context, request string) (res NilStringUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli_nullable"),
 	}
 
 	// Run stopwatch.
@@ -81091,6 +83058,8 @@ func (c *Client) TestResponseStringUnixMilliNullableArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringUnixMilliNullableArray(ctx context.Context, request string) (res []NilStringUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -81163,6 +83132,8 @@ func (c *Client) TestResponseStringUnixMilliNullableArrayArray(ctx context.Conte
 func (c *Client) sendTestResponseStringUnixMilliNullableArrayArray(ctx context.Context, request string) (res [][]NilStringUnixMilli, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-milli_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-milli_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -81235,6 +83206,8 @@ func (c *Client) TestResponseStringUnixNano(ctx context.Context, request string)
 func (c *Client) sendTestResponseStringUnixNano(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano"),
 	}
 
 	// Run stopwatch.
@@ -81307,6 +83280,8 @@ func (c *Client) TestResponseStringUnixNanoArray(ctx context.Context, request st
 func (c *Client) sendTestResponseStringUnixNanoArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano_array"),
 	}
 
 	// Run stopwatch.
@@ -81379,6 +83354,8 @@ func (c *Client) TestResponseStringUnixNanoArrayArray(ctx context.Context, reque
 func (c *Client) sendTestResponseStringUnixNanoArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano_array_array"),
 	}
 
 	// Run stopwatch.
@@ -81451,6 +83428,8 @@ func (c *Client) TestResponseStringUnixNanoNullable(ctx context.Context, request
 func (c *Client) sendTestResponseStringUnixNanoNullable(ctx context.Context, request string) (res NilStringUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano_nullable"),
 	}
 
 	// Run stopwatch.
@@ -81523,6 +83502,8 @@ func (c *Client) TestResponseStringUnixNanoNullableArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringUnixNanoNullableArray(ctx context.Context, request string) (res []NilStringUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -81595,6 +83576,8 @@ func (c *Client) TestResponseStringUnixNanoNullableArrayArray(ctx context.Contex
 func (c *Client) sendTestResponseStringUnixNanoNullableArrayArray(ctx context.Context, request string) (res [][]NilStringUnixNano, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-nano_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-nano_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -81667,6 +83650,8 @@ func (c *Client) TestResponseStringUnixNullable(ctx context.Context, request str
 func (c *Client) sendTestResponseStringUnixNullable(ctx context.Context, request string) (res NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix_nullable"),
 	}
 
 	// Run stopwatch.
@@ -81739,6 +83724,8 @@ func (c *Client) TestResponseStringUnixNullableArray(ctx context.Context, reques
 func (c *Client) sendTestResponseStringUnixNullableArray(ctx context.Context, request string) (res []NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -81811,6 +83798,8 @@ func (c *Client) TestResponseStringUnixNullableArrayArray(ctx context.Context, r
 func (c *Client) sendTestResponseStringUnixNullableArrayArray(ctx context.Context, request string) (res [][]NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix_nullable_array_array"),
 	}
 
 	// Run stopwatch.
@@ -81883,6 +83872,8 @@ func (c *Client) TestResponseStringUnixSeconds(ctx context.Context, request stri
 func (c *Client) sendTestResponseStringUnixSeconds(ctx context.Context, request string) (res time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds"),
 	}
 
 	// Run stopwatch.
@@ -81955,6 +83946,8 @@ func (c *Client) TestResponseStringUnixSecondsArray(ctx context.Context, request
 func (c *Client) sendTestResponseStringUnixSecondsArray(ctx context.Context, request string) (res []time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds_array"),
 	}
 
 	// Run stopwatch.
@@ -82027,6 +84020,8 @@ func (c *Client) TestResponseStringUnixSecondsArrayArray(ctx context.Context, re
 func (c *Client) sendTestResponseStringUnixSecondsArrayArray(ctx context.Context, request string) (res [][]time.Time, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds_array_array"),
 	}
 
 	// Run stopwatch.
@@ -82099,6 +84094,8 @@ func (c *Client) TestResponseStringUnixSecondsNullable(ctx context.Context, requ
 func (c *Client) sendTestResponseStringUnixSecondsNullable(ctx context.Context, request string) (res NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds_nullable"),
 	}
 
 	// Run stopwatch.
@@ -82171,6 +84168,8 @@ func (c *Client) TestResponseStringUnixSecondsNullableArray(ctx context.Context,
 func (c *Client) sendTestResponseStringUnixSecondsNullableArray(ctx context.Context, request string) (res []NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds_nullable_array"),
 	}
 
 	// Run stopwatch.
@@ -82243,6 +84242,8 @@ func (c *Client) TestResponseStringUnixSecondsNullableArrayArray(ctx context.Con
 func (c *Client) sendTestResponseStringUnixSecondsNullableArrayArray(ctx context.Context, request string) (res [][]NilStringUnixSeconds, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("test_response_string_unix-seconds_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_unix-seconds_nullable_array_array"),
 	}
 
 	// Run stopwatch.

--- a/examples/ex_tinkoff/oas_client_gen.go
+++ b/examples/ex_tinkoff/oas_client_gen.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
 	ht "github.com/ogen-go/ogen/http"
@@ -81,7 +83,10 @@ func (c *Client) MarketBondsGet(ctx context.Context) (MarketBondsGetRes, error) 
 }
 
 func (c *Client) sendMarketBondsGet(ctx context.Context) (res MarketBondsGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/bonds"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -96,6 +101,7 @@ func (c *Client) sendMarketBondsGet(ctx context.Context) (res MarketBondsGetRes,
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketBondsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -182,7 +188,10 @@ func (c *Client) MarketCandlesGet(ctx context.Context, params MarketCandlesGetPa
 }
 
 func (c *Client) sendMarketCandlesGet(ctx context.Context, params MarketCandlesGetParams) (res MarketCandlesGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/candles"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -197,6 +206,7 @@ func (c *Client) sendMarketCandlesGet(ctx context.Context, params MarketCandlesG
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketCandlesGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -343,7 +353,10 @@ func (c *Client) MarketCurrenciesGet(ctx context.Context) (MarketCurrenciesGetRe
 }
 
 func (c *Client) sendMarketCurrenciesGet(ctx context.Context) (res MarketCurrenciesGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/currencies"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -358,6 +371,7 @@ func (c *Client) sendMarketCurrenciesGet(ctx context.Context) (res MarketCurrenc
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketCurrenciesGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -444,7 +458,10 @@ func (c *Client) MarketEtfsGet(ctx context.Context) (MarketEtfsGetRes, error) {
 }
 
 func (c *Client) sendMarketEtfsGet(ctx context.Context) (res MarketEtfsGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/etfs"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -459,6 +476,7 @@ func (c *Client) sendMarketEtfsGet(ctx context.Context) (res MarketEtfsGetRes, e
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketEtfsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -545,7 +563,10 @@ func (c *Client) MarketOrderbookGet(ctx context.Context, params MarketOrderbookG
 }
 
 func (c *Client) sendMarketOrderbookGet(ctx context.Context, params MarketOrderbookGetParams) (res MarketOrderbookGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/orderbook"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -560,6 +581,7 @@ func (c *Client) sendMarketOrderbookGet(ctx context.Context, params MarketOrderb
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketOrderbookGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -678,7 +700,10 @@ func (c *Client) MarketSearchByFigiGet(ctx context.Context, params MarketSearchB
 }
 
 func (c *Client) sendMarketSearchByFigiGet(ctx context.Context, params MarketSearchByFigiGetParams) (res MarketSearchByFigiGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/search/by-figi"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -693,6 +718,7 @@ func (c *Client) sendMarketSearchByFigiGet(ctx context.Context, params MarketSea
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketSearchByFigiGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -797,7 +823,10 @@ func (c *Client) MarketSearchByTickerGet(ctx context.Context, params MarketSearc
 }
 
 func (c *Client) sendMarketSearchByTickerGet(ctx context.Context, params MarketSearchByTickerGetParams) (res MarketSearchByTickerGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/search/by-ticker"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -812,6 +841,7 @@ func (c *Client) sendMarketSearchByTickerGet(ctx context.Context, params MarketS
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketSearchByTickerGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -916,7 +946,10 @@ func (c *Client) MarketStocksGet(ctx context.Context) (MarketStocksGetRes, error
 }
 
 func (c *Client) sendMarketStocksGet(ctx context.Context) (res MarketStocksGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/stocks"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -931,6 +964,7 @@ func (c *Client) sendMarketStocksGet(ctx context.Context) (res MarketStocksGetRe
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "MarketStocksGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1017,7 +1051,10 @@ func (c *Client) OperationsGet(ctx context.Context, params OperationsGetParams) 
 }
 
 func (c *Client) sendOperationsGet(ctx context.Context, params OperationsGetParams) (res OperationsGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/operations"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1032,6 +1069,7 @@ func (c *Client) sendOperationsGet(ctx context.Context, params OperationsGetPara
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "OperationsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1184,7 +1222,10 @@ func (c *Client) OrdersCancelPost(ctx context.Context, params OrdersCancelPostPa
 }
 
 func (c *Client) sendOrdersCancelPost(ctx context.Context, params OrdersCancelPostParams) (res OrdersCancelPostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/cancel"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1199,6 +1240,7 @@ func (c *Client) sendOrdersCancelPost(ctx context.Context, params OrdersCancelPo
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "OrdersCancelPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1320,7 +1362,10 @@ func (c *Client) OrdersGet(ctx context.Context, params OrdersGetParams) (OrdersG
 }
 
 func (c *Client) sendOrdersGet(ctx context.Context, params OrdersGetParams) (res OrdersGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orders"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1335,6 +1380,7 @@ func (c *Client) sendOrdersGet(ctx context.Context, params OrdersGetParams) (res
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "OrdersGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1442,7 +1488,10 @@ func (c *Client) OrdersLimitOrderPost(ctx context.Context, request *LimitOrderRe
 }
 
 func (c *Client) sendOrdersLimitOrderPost(ctx context.Context, request *LimitOrderRequest, params OrdersLimitOrderPostParams) (res OrdersLimitOrderPostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/limit-order"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if err := request.Validate(); err != nil {
@@ -1466,6 +1515,7 @@ func (c *Client) sendOrdersLimitOrderPost(ctx context.Context, request *LimitOrd
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "OrdersLimitOrderPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1590,7 +1640,10 @@ func (c *Client) OrdersMarketOrderPost(ctx context.Context, request *MarketOrder
 }
 
 func (c *Client) sendOrdersMarketOrderPost(ctx context.Context, request *MarketOrderRequest, params OrdersMarketOrderPostParams) (res OrdersMarketOrderPostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/market-order"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if err := request.Validate(); err != nil {
@@ -1614,6 +1667,7 @@ func (c *Client) sendOrdersMarketOrderPost(ctx context.Context, request *MarketO
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "OrdersMarketOrderPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1738,7 +1792,10 @@ func (c *Client) PortfolioCurrenciesGet(ctx context.Context, params PortfolioCur
 }
 
 func (c *Client) sendPortfolioCurrenciesGet(ctx context.Context, params PortfolioCurrenciesGetParams) (res PortfolioCurrenciesGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/portfolio/currencies"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1753,6 +1810,7 @@ func (c *Client) sendPortfolioCurrenciesGet(ctx context.Context, params Portfoli
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PortfolioCurrenciesGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1860,7 +1918,10 @@ func (c *Client) PortfolioGet(ctx context.Context, params PortfolioGetParams) (P
 }
 
 func (c *Client) sendPortfolioGet(ctx context.Context, params PortfolioGetParams) (res PortfolioGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/portfolio"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1875,6 +1936,7 @@ func (c *Client) sendPortfolioGet(ctx context.Context, params PortfolioGetParams
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PortfolioGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1982,7 +2044,10 @@ func (c *Client) SandboxClearPost(ctx context.Context, params SandboxClearPostPa
 }
 
 func (c *Client) sendSandboxClearPost(ctx context.Context, params SandboxClearPostParams) (res SandboxClearPostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/clear"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1997,6 +2062,7 @@ func (c *Client) sendSandboxClearPost(ctx context.Context, params SandboxClearPo
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "SandboxClearPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2104,7 +2170,10 @@ func (c *Client) SandboxCurrenciesBalancePost(ctx context.Context, request *Sand
 }
 
 func (c *Client) sendSandboxCurrenciesBalancePost(ctx context.Context, request *SandboxSetCurrencyBalanceRequest, params SandboxCurrenciesBalancePostParams) (res SandboxCurrenciesBalancePostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/currencies/balance"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if err := request.Validate(); err != nil {
@@ -2128,6 +2197,7 @@ func (c *Client) sendSandboxCurrenciesBalancePost(ctx context.Context, request *
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "SandboxCurrenciesBalancePost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2238,7 +2308,10 @@ func (c *Client) SandboxPositionsBalancePost(ctx context.Context, request *Sandb
 }
 
 func (c *Client) sendSandboxPositionsBalancePost(ctx context.Context, request *SandboxSetPositionBalanceRequest, params SandboxPositionsBalancePostParams) (res SandboxPositionsBalancePostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/positions/balance"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if err := request.Validate(); err != nil {
@@ -2262,6 +2335,7 @@ func (c *Client) sendSandboxPositionsBalancePost(ctx context.Context, request *S
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "SandboxPositionsBalancePost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2372,7 +2446,10 @@ func (c *Client) SandboxRegisterPost(ctx context.Context, request OptSandboxRegi
 }
 
 func (c *Client) sendSandboxRegisterPost(ctx context.Context, request OptSandboxRegisterRequest) (res SandboxRegisterPostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/register"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -2403,6 +2480,7 @@ func (c *Client) sendSandboxRegisterPost(ctx context.Context, request OptSandbox
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "SandboxRegisterPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2492,7 +2570,10 @@ func (c *Client) SandboxRemovePost(ctx context.Context, params SandboxRemovePost
 }
 
 func (c *Client) sendSandboxRemovePost(ctx context.Context, params SandboxRemovePostParams) (res SandboxRemovePostRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/remove"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -2507,6 +2588,7 @@ func (c *Client) sendSandboxRemovePost(ctx context.Context, params SandboxRemove
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "SandboxRemovePost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2614,7 +2696,10 @@ func (c *Client) UserAccountsGet(ctx context.Context) (UserAccountsGetRes, error
 }
 
 func (c *Client) sendUserAccountsGet(ctx context.Context) (res UserAccountsGetRes, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/accounts"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -2629,6 +2714,7 @@ func (c *Client) sendUserAccountsGet(ctx context.Context) (res UserAccountsGetRe
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "UserAccountsGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.

--- a/examples/ex_tinkoff/oas_handlers_gen.go
+++ b/examples/ex_tinkoff/oas_handlers_gen.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -21,10 +23,14 @@ import (
 //
 // GET /market/bonds
 func (s *Server) handleMarketBondsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/bonds"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketBondsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -148,10 +154,14 @@ func (s *Server) handleMarketBondsGetRequest(args [0]string, argsEscaped bool, w
 //
 // GET /market/candles
 func (s *Server) handleMarketCandlesGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/candles"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketCandlesGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -302,10 +312,14 @@ func (s *Server) handleMarketCandlesGetRequest(args [0]string, argsEscaped bool,
 //
 // GET /market/currencies
 func (s *Server) handleMarketCurrenciesGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/currencies"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketCurrenciesGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -429,10 +443,14 @@ func (s *Server) handleMarketCurrenciesGetRequest(args [0]string, argsEscaped bo
 //
 // GET /market/etfs
 func (s *Server) handleMarketEtfsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/etfs"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketEtfsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -556,10 +574,14 @@ func (s *Server) handleMarketEtfsGetRequest(args [0]string, argsEscaped bool, w 
 //
 // GET /market/orderbook
 func (s *Server) handleMarketOrderbookGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/orderbook"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketOrderbookGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -702,10 +724,14 @@ func (s *Server) handleMarketOrderbookGetRequest(args [0]string, argsEscaped boo
 //
 // GET /market/search/by-figi
 func (s *Server) handleMarketSearchByFigiGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/search/by-figi"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketSearchByFigiGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -844,10 +870,14 @@ func (s *Server) handleMarketSearchByFigiGetRequest(args [0]string, argsEscaped 
 //
 // GET /market/search/by-ticker
 func (s *Server) handleMarketSearchByTickerGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/search/by-ticker"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketSearchByTickerGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -986,10 +1016,14 @@ func (s *Server) handleMarketSearchByTickerGetRequest(args [0]string, argsEscape
 //
 // GET /market/stocks
 func (s *Server) handleMarketStocksGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/market/stocks"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "MarketStocksGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1113,10 +1147,14 @@ func (s *Server) handleMarketStocksGetRequest(args [0]string, argsEscaped bool, 
 //
 // GET /operations
 func (s *Server) handleOperationsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/operations"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "OperationsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1267,10 +1305,14 @@ func (s *Server) handleOperationsGetRequest(args [0]string, argsEscaped bool, w 
 //
 // POST /orders/cancel
 func (s *Server) handleOrdersCancelPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/cancel"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "OrdersCancelPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1413,10 +1455,14 @@ func (s *Server) handleOrdersCancelPostRequest(args [0]string, argsEscaped bool,
 //
 // GET /orders
 func (s *Server) handleOrdersGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/orders"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "OrdersGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1555,10 +1601,14 @@ func (s *Server) handleOrdersGetRequest(args [0]string, argsEscaped bool, w http
 //
 // POST /orders/limit-order
 func (s *Server) handleOrdersLimitOrderPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/limit-order"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "OrdersLimitOrderPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1716,10 +1766,14 @@ func (s *Server) handleOrdersLimitOrderPostRequest(args [0]string, argsEscaped b
 //
 // POST /orders/market-order
 func (s *Server) handleOrdersMarketOrderPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/orders/market-order"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "OrdersMarketOrderPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1877,10 +1931,14 @@ func (s *Server) handleOrdersMarketOrderPostRequest(args [0]string, argsEscaped 
 //
 // GET /portfolio/currencies
 func (s *Server) handlePortfolioCurrenciesGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/portfolio/currencies"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PortfolioCurrenciesGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2019,10 +2077,14 @@ func (s *Server) handlePortfolioCurrenciesGetRequest(args [0]string, argsEscaped
 //
 // GET /portfolio
 func (s *Server) handlePortfolioGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/portfolio"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PortfolioGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2161,10 +2223,14 @@ func (s *Server) handlePortfolioGetRequest(args [0]string, argsEscaped bool, w h
 //
 // POST /sandbox/clear
 func (s *Server) handleSandboxClearPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/clear"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "SandboxClearPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2303,10 +2369,14 @@ func (s *Server) handleSandboxClearPostRequest(args [0]string, argsEscaped bool,
 //
 // POST /sandbox/currencies/balance
 func (s *Server) handleSandboxCurrenciesBalancePostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/currencies/balance"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "SandboxCurrenciesBalancePost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2460,10 +2530,14 @@ func (s *Server) handleSandboxCurrenciesBalancePostRequest(args [0]string, argsE
 //
 // POST /sandbox/positions/balance
 func (s *Server) handleSandboxPositionsBalancePostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/positions/balance"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "SandboxPositionsBalancePost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2617,10 +2691,14 @@ func (s *Server) handleSandboxPositionsBalancePostRequest(args [0]string, argsEs
 //
 // POST /sandbox/register
 func (s *Server) handleSandboxRegisterPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/register"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "SandboxRegisterPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2759,10 +2837,14 @@ func (s *Server) handleSandboxRegisterPostRequest(args [0]string, argsEscaped bo
 //
 // POST /sandbox/remove
 func (s *Server) handleSandboxRemovePostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/sandbox/remove"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "SandboxRemovePost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2901,10 +2983,14 @@ func (s *Server) handleSandboxRemovePostRequest(args [0]string, argsEscaped bool
 //
 // GET /user/accounts
 func (s *Server) handleUserAccountsGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/user/accounts"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "UserAccountsGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/gen/_template/client.tmpl
+++ b/gen/_template/client.tmpl
@@ -124,11 +124,16 @@ func (c *{{ if $op.WebhookInfo }}Webhook{{ end }}Client) send{{ $op.Name }}(ctx 
 	{{- if $op.Params }}, params {{ $op.Name }}Params {{ end }}) (res {{ $op.Responses.GoType }}, err error) {
 
 	{{- $hasOTELAttrs := false }}
-	{{- with $attrs := $op.OTELAttributes }}
+	{{- $ogenAttrs := $op.OTELAttributes }}
+	{{- if or $ogenAttrs (not $op.WebhookInfo) }}
 	{{- $hasOTELAttrs = true }}
 	otelAttrs := []attribute.KeyValue{
-		{{- range $attr := $attrs }}
+		{{- range $attr := $ogenAttrs }}
 		{{ $attr.String }},
+		{{- end }}
+		{{- if not $op.WebhookInfo }}
+		semconv.HTTPMethodKey.String({{ upper $op.Spec.HTTPMethod | quote }}),
+		semconv.HTTPRouteKey.String({{ quote $op.Spec.Path }}),
 		{{- end }}
 	}
 	{{- else }}

--- a/gen/_template/handlers.tmpl
+++ b/gen/_template/handlers.tmpl
@@ -23,14 +23,15 @@
 {{- template "godoc_op" $op }}
 func (s *{{ if $op.WebhookInfo }}Webhook{{ end }}Server) handle{{ $op.Name }}Request(args [{{ $op.PathParamsCount }}]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	{{- $hasOTELAttrs := false }}
-	{{- with $attrs := $op.OTELAttributes }}
+	{{- $ogenAttrs := $op.OTELAttributes }}
+	{{- if or $ogenAttrs (not $op.WebhookInfo) }}
 	{{- $hasOTELAttrs = true }}
 	otelAttrs := []attribute.KeyValue{
-		{{- range $attr := $attrs }}
+		{{- range $attr := $ogenAttrs }}
 		{{ $attr.String }},
 		{{- end }}
 		{{- if not $op.WebhookInfo }}
-		semconv.HTTPMethodKey.String("{{ upper $op.Spec.HTTPMethod }}"),
+		semconv.HTTPMethodKey.String({{ upper $op.Spec.HTTPMethod | quote }}),
 		semconv.HTTPRouteKey.String({{ quote $op.Spec.Path }}),
 		{{- end }}
 	}

--- a/internal/integration/referenced_path_item/oas_client_gen.go
+++ b/internal/integration/referenced_path_item/oas_client_gen.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/uri"
@@ -75,7 +77,10 @@ func (c *Client) FooGet(ctx context.Context) (string, error) {
 }
 
 func (c *Client) sendFooGet(ctx context.Context) (res string, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/foo"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -90,6 +95,7 @@ func (c *Client) sendFooGet(ctx context.Context) (res string, err error) {
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "FooGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.

--- a/internal/integration/referenced_path_item/oas_handlers_gen.go
+++ b/internal/integration/referenced_path_item/oas_handlers_gen.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/middleware"
 )
@@ -18,10 +20,14 @@ import (
 //
 // GET /foo
 func (s *Server) handleFooGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/foo"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "FooGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/sample_api/oas_client_gen.go
+++ b/internal/integration/sample_api/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -86,6 +87,8 @@ func (c *Client) DataGetFormat(ctx context.Context, params DataGetFormatParams) 
 func (c *Client) sendDataGetFormat(ctx context.Context, params DataGetFormatParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGetFormat"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/name/{id}/{foo}1234{bar}-{baz}!{kek}"),
 	}
 
 	// Run stopwatch.
@@ -249,6 +252,8 @@ func (c *Client) DefaultTest(ctx context.Context, request *DefaultTest, params D
 func (c *Client) sendDefaultTest(ctx context.Context, request *DefaultTest, params DefaultTestParams) (res int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("defaultTest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/defaultTest"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -353,6 +358,8 @@ func (c *Client) ErrorGet(ctx context.Context) (*ErrorStatusCode, error) {
 func (c *Client) sendErrorGet(ctx context.Context) (res *ErrorStatusCode, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("errorGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/error"),
 	}
 
 	// Run stopwatch.
@@ -424,6 +431,8 @@ func (c *Client) FoobarGet(ctx context.Context, params FoobarGetParams) (FoobarG
 func (c *Client) sendFoobarGet(ctx context.Context, params FoobarGetParams) (res FoobarGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("foobarGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/foobar"),
 	}
 
 	// Run stopwatch.
@@ -527,6 +536,8 @@ func (c *Client) FoobarPost(ctx context.Context, request OptPet) (FoobarPostRes,
 func (c *Client) sendFoobarPost(ctx context.Context, request OptPet) (res FoobarPostRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("foobarPost"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/foobar"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -613,7 +624,10 @@ func (c *Client) FoobarPut(ctx context.Context) (*FoobarPutDef, error) {
 }
 
 func (c *Client) sendFoobarPut(ctx context.Context) (res *FoobarPutDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/foobar"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -628,6 +642,7 @@ func (c *Client) sendFoobarPut(ctx context.Context) (res *FoobarPutDef, err erro
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "FoobarPut",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -681,6 +696,8 @@ func (c *Client) NoAdditionalPropertiesTest(ctx context.Context) (*NoAdditionalP
 func (c *Client) sendNoAdditionalPropertiesTest(ctx context.Context) (res *NoAdditionalPropertiesTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("noAdditionalPropertiesTest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/noAdditionalPropertiesTest"),
 	}
 
 	// Run stopwatch.
@@ -750,6 +767,8 @@ func (c *Client) NullableDefaultResponse(ctx context.Context) (*NilIntStatusCode
 func (c *Client) sendNullableDefaultResponse(ctx context.Context) (res *NilIntStatusCode, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("nullableDefaultResponse"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/nullableDefaultResponse"),
 	}
 
 	// Run stopwatch.
@@ -819,6 +838,8 @@ func (c *Client) OneofBug(ctx context.Context, request *OneOfBugs) error {
 func (c *Client) sendOneofBug(ctx context.Context, request *OneOfBugs) (res *OneofBugOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oneofBug"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/oneofBug"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -898,7 +919,10 @@ func (c *Client) PatternRecursiveMapGet(ctx context.Context) (PatternRecursiveMa
 }
 
 func (c *Client) sendPatternRecursiveMapGet(ctx context.Context) (res PatternRecursiveMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/patternRecursiveMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -913,6 +937,7 @@ func (c *Client) sendPatternRecursiveMapGet(ctx context.Context) (res PatternRec
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PatternRecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -968,6 +993,8 @@ func (c *Client) PetCreate(ctx context.Context, request OptPet) (*Pet, error) {
 func (c *Client) sendPetCreate(ctx context.Context, request OptPet) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petCreate"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1058,6 +1085,8 @@ func (c *Client) PetFriendsNamesByID(ctx context.Context, params PetFriendsNames
 func (c *Client) sendPetFriendsNamesByID(ctx context.Context, params PetFriendsNamesByIDParams) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petFriendsNamesByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/friendNames/{id}"),
 	}
 
 	// Run stopwatch.
@@ -1147,6 +1176,8 @@ func (c *Client) PetGet(ctx context.Context, params PetGetParams) (PetGetRes, er
 func (c *Client) sendPetGet(ctx context.Context, params PetGetParams) (res PetGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet"),
 	}
 
 	// Run stopwatch.
@@ -1293,6 +1324,8 @@ func (c *Client) PetGetAvatarByID(ctx context.Context, params PetGetAvatarByIDPa
 func (c *Client) sendPetGetAvatarByID(ctx context.Context, params PetGetAvatarByIDParams) (res PetGetAvatarByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetAvatarByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1382,6 +1415,8 @@ func (c *Client) PetGetAvatarByName(ctx context.Context, params PetGetAvatarByNa
 func (c *Client) sendPetGetAvatarByName(ctx context.Context, params PetGetAvatarByNameParams) (res PetGetAvatarByNameRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetAvatarByName"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/{name}/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1472,6 +1507,8 @@ func (c *Client) PetGetByName(ctx context.Context, params PetGetByNameParams) (*
 func (c *Client) sendPetGetByName(ctx context.Context, params PetGetByNameParams) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetByName"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/{name}"),
 	}
 
 	// Run stopwatch.
@@ -1561,6 +1598,8 @@ func (c *Client) PetNameByID(ctx context.Context, params PetNameByIDParams) (str
 func (c *Client) sendPetNameByID(ctx context.Context, params PetNameByIDParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petNameByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/name/{id}"),
 	}
 
 	// Run stopwatch.
@@ -1646,7 +1685,10 @@ func (c *Client) PetUpdateNameAliasPost(ctx context.Context, request OptPetName)
 }
 
 func (c *Client) sendPetUpdateNameAliasPost(ctx context.Context, request OptPetName) (res *PetUpdateNameAliasPostDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateNameAlias"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -1677,6 +1719,7 @@ func (c *Client) sendPetUpdateNameAliasPost(ctx context.Context, request OptPetN
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PetUpdateNameAliasPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1731,7 +1774,10 @@ func (c *Client) PetUpdateNamePost(ctx context.Context, request OptString) (*Pet
 }
 
 func (c *Client) sendPetUpdateNamePost(ctx context.Context, request OptString) (res *PetUpdateNamePostDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateName"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -1770,6 +1816,7 @@ func (c *Client) sendPetUpdateNamePost(ctx context.Context, request OptString) (
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PetUpdateNamePost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1828,6 +1875,8 @@ func (c *Client) PetUploadAvatarByID(ctx context.Context, request PetUploadAvata
 func (c *Client) sendPetUploadAvatarByID(ctx context.Context, request PetUploadAvatarByIDReq, params PetUploadAvatarByIDParams) (res PetUploadAvatarByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petUploadAvatarByID"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1916,7 +1965,10 @@ func (c *Client) RecursiveArrayGet(ctx context.Context) (RecursiveArray, error) 
 }
 
 func (c *Client) sendRecursiveArrayGet(ctx context.Context) (res RecursiveArray, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveArray"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1931,6 +1983,7 @@ func (c *Client) sendRecursiveArrayGet(ctx context.Context) (res RecursiveArray,
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "RecursiveArrayGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1982,7 +2035,10 @@ func (c *Client) RecursiveMapGet(ctx context.Context) (*RecursiveMap, error) {
 }
 
 func (c *Client) sendRecursiveMapGet(ctx context.Context) (res *RecursiveMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1997,6 +2053,7 @@ func (c *Client) sendRecursiveMapGet(ctx context.Context) (res *RecursiveMap, er
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "RecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2050,6 +2107,8 @@ func (c *Client) SecurityTest(ctx context.Context) (string, error) {
 func (c *Client) sendSecurityTest(ctx context.Context) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("securityTest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/securityTest"),
 	}
 
 	// Run stopwatch.
@@ -2150,7 +2209,10 @@ func (c *Client) StringIntMapGet(ctx context.Context) (*StringIntMap, error) {
 }
 
 func (c *Client) sendStringIntMapGet(ctx context.Context) (res *StringIntMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/stringIntMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -2165,6 +2227,7 @@ func (c *Client) sendStringIntMapGet(ctx context.Context) (res *StringIntMap, er
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "StringIntMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2218,6 +2281,8 @@ func (c *Client) TestFloatValidation(ctx context.Context, request *TestFloatVali
 func (c *Client) sendTestFloatValidation(ctx context.Context, request *TestFloatValidation) (res *TestFloatValidationOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testFloatValidation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testFloatValidation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2299,6 +2364,8 @@ func (c *Client) TestInlineOneof(ctx context.Context) (*TestInlineOneOf, error) 
 func (c *Client) sendTestInlineOneof(ctx context.Context) (res *TestInlineOneOf, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testInlineOneof"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testInlineOneof"),
 	}
 
 	// Run stopwatch.
@@ -2368,6 +2435,8 @@ func (c *Client) TestNullableOneofs(ctx context.Context) (TestNullableOneofsRes,
 func (c *Client) sendTestNullableOneofs(ctx context.Context) (res TestNullableOneofsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testNullableOneofs"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testNullableOneofs"),
 	}
 
 	// Run stopwatch.
@@ -2437,6 +2506,8 @@ func (c *Client) TestTuple(ctx context.Context) (*TupleTest, error) {
 func (c *Client) sendTestTuple(ctx context.Context) (res *TupleTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testTuple"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testTuple"),
 	}
 
 	// Run stopwatch.
@@ -2506,6 +2577,8 @@ func (c *Client) TestTupleNamed(ctx context.Context) (*TupleNamedTest, error) {
 func (c *Client) sendTestTupleNamed(ctx context.Context) (res *TupleNamedTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testTupleNamed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testTupleNamed"),
 	}
 
 	// Run stopwatch.
@@ -2575,6 +2648,8 @@ func (c *Client) TestUniqueItems(ctx context.Context) (*UniqueItemsTest, error) 
 func (c *Client) sendTestUniqueItems(ctx context.Context) (res *UniqueItemsTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testUniqueItems"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testUniqueItems"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/sample_api/oas_handlers_gen.go
+++ b/internal/integration/sample_api/oas_handlers_gen.go
@@ -551,10 +551,14 @@ func (s *Server) handleFoobarPostRequest(args [0]string, argsEscaped bool, w htt
 //
 // PUT /foobar
 func (s *Server) handleFoobarPutRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/foobar"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "FoobarPut",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -893,10 +897,14 @@ func (s *Server) handleOneofBugRequest(args [0]string, argsEscaped bool, w http.
 //
 // GET /patternRecursiveMap
 func (s *Server) handlePatternRecursiveMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/patternRecursiveMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PatternRecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1703,10 +1711,14 @@ func (s *Server) handlePetNameByIDRequest(args [1]string, argsEscaped bool, w ht
 //
 // POST /pet/updateNameAlias
 func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateNameAlias"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PetUpdateNameAliasPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1799,10 +1811,14 @@ func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, argsEscaped
 //
 // POST /pet/updateName
 func (s *Server) handlePetUpdateNamePostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateName"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PetUpdateNamePost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2013,10 +2029,14 @@ func (s *Server) handlePetUploadAvatarByIDRequest(args [0]string, argsEscaped bo
 //
 // GET /recursiveArray
 func (s *Server) handleRecursiveArrayGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveArray"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "RecursiveArrayGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2090,10 +2110,14 @@ func (s *Server) handleRecursiveArrayGetRequest(args [0]string, argsEscaped bool
 //
 // GET /recursiveMap
 func (s *Server) handleRecursiveMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "RecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2297,10 +2321,14 @@ func (s *Server) handleSecurityTestRequest(args [0]string, argsEscaped bool, w h
 //
 // GET /stringIntMap
 func (s *Server) handleStringIntMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/stringIntMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "StringIntMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/sample_api_nc/oas_handlers_gen.go
+++ b/internal/integration/sample_api_nc/oas_handlers_gen.go
@@ -551,10 +551,14 @@ func (s *Server) handleFoobarPostRequest(args [0]string, argsEscaped bool, w htt
 //
 // PUT /foobar
 func (s *Server) handleFoobarPutRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/foobar"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "FoobarPut",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -893,10 +897,14 @@ func (s *Server) handleOneofBugRequest(args [0]string, argsEscaped bool, w http.
 //
 // GET /patternRecursiveMap
 func (s *Server) handlePatternRecursiveMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/patternRecursiveMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PatternRecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1703,10 +1711,14 @@ func (s *Server) handlePetNameByIDRequest(args [1]string, argsEscaped bool, w ht
 //
 // POST /pet/updateNameAlias
 func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateNameAlias"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PetUpdateNameAliasPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -1799,10 +1811,14 @@ func (s *Server) handlePetUpdateNameAliasPostRequest(args [0]string, argsEscaped
 //
 // POST /pet/updateName
 func (s *Server) handlePetUpdateNamePostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateName"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PetUpdateNamePost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2013,10 +2029,14 @@ func (s *Server) handlePetUploadAvatarByIDRequest(args [0]string, argsEscaped bo
 //
 // GET /recursiveArray
 func (s *Server) handleRecursiveArrayGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveArray"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "RecursiveArrayGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2090,10 +2110,14 @@ func (s *Server) handleRecursiveArrayGetRequest(args [0]string, argsEscaped bool
 //
 // GET /recursiveMap
 func (s *Server) handleRecursiveMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "RecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -2297,10 +2321,14 @@ func (s *Server) handleSecurityTestRequest(args [0]string, argsEscaped bool, w h
 //
 // GET /stringIntMap
 func (s *Server) handleStringIntMapGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/stringIntMap"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "StringIntMapGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/sample_api_ns/oas_client_gen.go
+++ b/internal/integration/sample_api_ns/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -82,6 +83,8 @@ func (c *Client) DataGetFormat(ctx context.Context, params DataGetFormatParams) 
 func (c *Client) sendDataGetFormat(ctx context.Context, params DataGetFormatParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGetFormat"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/name/{id}/{foo}1234{bar}-{baz}!{kek}"),
 	}
 
 	// Run stopwatch.
@@ -245,6 +248,8 @@ func (c *Client) DefaultTest(ctx context.Context, request *DefaultTest, params D
 func (c *Client) sendDefaultTest(ctx context.Context, request *DefaultTest, params DefaultTestParams) (res int32, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("defaultTest"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/defaultTest"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -349,6 +354,8 @@ func (c *Client) ErrorGet(ctx context.Context) (*ErrorStatusCode, error) {
 func (c *Client) sendErrorGet(ctx context.Context) (res *ErrorStatusCode, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("errorGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/error"),
 	}
 
 	// Run stopwatch.
@@ -420,6 +427,8 @@ func (c *Client) FoobarGet(ctx context.Context, params FoobarGetParams) (FoobarG
 func (c *Client) sendFoobarGet(ctx context.Context, params FoobarGetParams) (res FoobarGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("foobarGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/foobar"),
 	}
 
 	// Run stopwatch.
@@ -523,6 +532,8 @@ func (c *Client) FoobarPost(ctx context.Context, request OptPet) (FoobarPostRes,
 func (c *Client) sendFoobarPost(ctx context.Context, request OptPet) (res FoobarPostRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("foobarPost"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/foobar"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -609,7 +620,10 @@ func (c *Client) FoobarPut(ctx context.Context) (*FoobarPutDef, error) {
 }
 
 func (c *Client) sendFoobarPut(ctx context.Context) (res *FoobarPutDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("PUT"),
+		semconv.HTTPRouteKey.String("/foobar"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -624,6 +638,7 @@ func (c *Client) sendFoobarPut(ctx context.Context) (res *FoobarPutDef, err erro
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "FoobarPut",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -677,6 +692,8 @@ func (c *Client) NoAdditionalPropertiesTest(ctx context.Context) (*NoAdditionalP
 func (c *Client) sendNoAdditionalPropertiesTest(ctx context.Context) (res *NoAdditionalPropertiesTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("noAdditionalPropertiesTest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/noAdditionalPropertiesTest"),
 	}
 
 	// Run stopwatch.
@@ -746,6 +763,8 @@ func (c *Client) NullableDefaultResponse(ctx context.Context) (*NilIntStatusCode
 func (c *Client) sendNullableDefaultResponse(ctx context.Context) (res *NilIntStatusCode, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("nullableDefaultResponse"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/nullableDefaultResponse"),
 	}
 
 	// Run stopwatch.
@@ -815,6 +834,8 @@ func (c *Client) OneofBug(ctx context.Context, request *OneOfBugs) error {
 func (c *Client) sendOneofBug(ctx context.Context, request *OneOfBugs) (res *OneofBugOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oneofBug"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/oneofBug"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -894,7 +915,10 @@ func (c *Client) PatternRecursiveMapGet(ctx context.Context) (PatternRecursiveMa
 }
 
 func (c *Client) sendPatternRecursiveMapGet(ctx context.Context) (res PatternRecursiveMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/patternRecursiveMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -909,6 +933,7 @@ func (c *Client) sendPatternRecursiveMapGet(ctx context.Context) (res PatternRec
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PatternRecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -964,6 +989,8 @@ func (c *Client) PetCreate(ctx context.Context, request OptPet) (*Pet, error) {
 func (c *Client) sendPetCreate(ctx context.Context, request OptPet) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petCreate"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -1054,6 +1081,8 @@ func (c *Client) PetFriendsNamesByID(ctx context.Context, params PetFriendsNames
 func (c *Client) sendPetFriendsNamesByID(ctx context.Context, params PetFriendsNamesByIDParams) (res []string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petFriendsNamesByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/friendNames/{id}"),
 	}
 
 	// Run stopwatch.
@@ -1143,6 +1172,8 @@ func (c *Client) PetGet(ctx context.Context, params PetGetParams) (PetGetRes, er
 func (c *Client) sendPetGet(ctx context.Context, params PetGetParams) (res PetGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet"),
 	}
 
 	// Run stopwatch.
@@ -1289,6 +1320,8 @@ func (c *Client) PetGetAvatarByID(ctx context.Context, params PetGetAvatarByIDPa
 func (c *Client) sendPetGetAvatarByID(ctx context.Context, params PetGetAvatarByIDParams) (res PetGetAvatarByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetAvatarByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1378,6 +1411,8 @@ func (c *Client) PetGetAvatarByName(ctx context.Context, params PetGetAvatarByNa
 func (c *Client) sendPetGetAvatarByName(ctx context.Context, params PetGetAvatarByNameParams) (res PetGetAvatarByNameRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetAvatarByName"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/{name}/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1468,6 +1503,8 @@ func (c *Client) PetGetByName(ctx context.Context, params PetGetByNameParams) (*
 func (c *Client) sendPetGetByName(ctx context.Context, params PetGetByNameParams) (res *Pet, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petGetByName"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/{name}"),
 	}
 
 	// Run stopwatch.
@@ -1557,6 +1594,8 @@ func (c *Client) PetNameByID(ctx context.Context, params PetNameByIDParams) (str
 func (c *Client) sendPetNameByID(ctx context.Context, params PetNameByIDParams) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petNameByID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pet/name/{id}"),
 	}
 
 	// Run stopwatch.
@@ -1642,7 +1681,10 @@ func (c *Client) PetUpdateNameAliasPost(ctx context.Context, request OptPetName)
 }
 
 func (c *Client) sendPetUpdateNameAliasPost(ctx context.Context, request OptPetName) (res *PetUpdateNameAliasPostDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateNameAlias"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -1673,6 +1715,7 @@ func (c *Client) sendPetUpdateNameAliasPost(ctx context.Context, request OptPetN
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PetUpdateNameAliasPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1727,7 +1770,10 @@ func (c *Client) PetUpdateNamePost(ctx context.Context, request OptString) (*Pet
 }
 
 func (c *Client) sendPetUpdateNamePost(ctx context.Context, request OptString) (res *PetUpdateNamePostDef, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/updateName"),
+	}
 	// Validate request before sending.
 	if err := func() error {
 		if value, ok := request.Get(); ok {
@@ -1766,6 +1812,7 @@ func (c *Client) sendPetUpdateNamePost(ctx context.Context, request OptString) (
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PetUpdateNamePost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1824,6 +1871,8 @@ func (c *Client) PetUploadAvatarByID(ctx context.Context, request PetUploadAvata
 func (c *Client) sendPetUploadAvatarByID(ctx context.Context, request PetUploadAvatarByIDReq, params PetUploadAvatarByIDParams) (res PetUploadAvatarByIDRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("petUploadAvatarByID"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/pet/avatar"),
 	}
 
 	// Run stopwatch.
@@ -1912,7 +1961,10 @@ func (c *Client) RecursiveArrayGet(ctx context.Context) (RecursiveArray, error) 
 }
 
 func (c *Client) sendRecursiveArrayGet(ctx context.Context) (res RecursiveArray, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveArray"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1927,6 +1979,7 @@ func (c *Client) sendRecursiveArrayGet(ctx context.Context) (res RecursiveArray,
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "RecursiveArrayGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -1978,7 +2031,10 @@ func (c *Client) RecursiveMapGet(ctx context.Context) (*RecursiveMap, error) {
 }
 
 func (c *Client) sendRecursiveMapGet(ctx context.Context) (res *RecursiveMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/recursiveMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -1993,6 +2049,7 @@ func (c *Client) sendRecursiveMapGet(ctx context.Context) (res *RecursiveMap, er
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "RecursiveMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2046,6 +2103,8 @@ func (c *Client) SecurityTest(ctx context.Context) (string, error) {
 func (c *Client) sendSecurityTest(ctx context.Context) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("securityTest"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/securityTest"),
 	}
 
 	// Run stopwatch.
@@ -2146,7 +2205,10 @@ func (c *Client) StringIntMapGet(ctx context.Context) (*StringIntMap, error) {
 }
 
 func (c *Client) sendStringIntMapGet(ctx context.Context) (res *StringIntMap, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/stringIntMap"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -2161,6 +2223,7 @@ func (c *Client) sendStringIntMapGet(ctx context.Context) (res *StringIntMap, er
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "StringIntMapGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -2214,6 +2277,8 @@ func (c *Client) TestFloatValidation(ctx context.Context, request *TestFloatVali
 func (c *Client) sendTestFloatValidation(ctx context.Context, request *TestFloatValidation) (res *TestFloatValidationOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testFloatValidation"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testFloatValidation"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -2295,6 +2360,8 @@ func (c *Client) TestInlineOneof(ctx context.Context) (*TestInlineOneOf, error) 
 func (c *Client) sendTestInlineOneof(ctx context.Context) (res *TestInlineOneOf, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testInlineOneof"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testInlineOneof"),
 	}
 
 	// Run stopwatch.
@@ -2364,6 +2431,8 @@ func (c *Client) TestNullableOneofs(ctx context.Context) (TestNullableOneofsRes,
 func (c *Client) sendTestNullableOneofs(ctx context.Context) (res TestNullableOneofsRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testNullableOneofs"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testNullableOneofs"),
 	}
 
 	// Run stopwatch.
@@ -2433,6 +2502,8 @@ func (c *Client) TestTuple(ctx context.Context) (*TupleTest, error) {
 func (c *Client) sendTestTuple(ctx context.Context) (res *TupleTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testTuple"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testTuple"),
 	}
 
 	// Run stopwatch.
@@ -2502,6 +2573,8 @@ func (c *Client) TestTupleNamed(ctx context.Context) (*TupleNamedTest, error) {
 func (c *Client) sendTestTupleNamed(ctx context.Context) (res *TupleNamedTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testTupleNamed"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testTupleNamed"),
 	}
 
 	// Run stopwatch.
@@ -2571,6 +2644,8 @@ func (c *Client) TestUniqueItems(ctx context.Context) (*UniqueItemsTest, error) 
 func (c *Client) sendTestUniqueItems(ctx context.Context) (res *UniqueItemsTest, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testUniqueItems"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/testUniqueItems"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/sample_err/oas_client_gen.go
+++ b/internal/integration/sample_err/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -85,6 +86,8 @@ func (c *Client) DataCreate(ctx context.Context, request OptData) (*Data, error)
 func (c *Client) sendDataCreate(ctx context.Context, request OptData) (res *Data, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataCreate"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/data"),
 	}
 
 	// Run stopwatch.
@@ -159,6 +162,8 @@ func (c *Client) DataGet(ctx context.Context) (*Data, error) {
 func (c *Client) sendDataGet(ctx context.Context) (res *Data, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("dataGet"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/data"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/techempower/oas_client_gen.go
+++ b/internal/integration/techempower/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -87,6 +88,8 @@ func (c *Client) Caching(ctx context.Context, params CachingParams) (WorldObject
 func (c *Client) sendCaching(ctx context.Context, params CachingParams) (res WorldObjects, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("Caching"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/cached-worlds"),
 	}
 
 	// Run stopwatch.
@@ -177,6 +180,8 @@ func (c *Client) DB(ctx context.Context) (*WorldObject, error) {
 func (c *Client) sendDB(ctx context.Context) (res *WorldObject, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("DB"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/db"),
 	}
 
 	// Run stopwatch.
@@ -250,6 +255,8 @@ func (c *Client) JSON(ctx context.Context) (*HelloWorld, error) {
 func (c *Client) sendJSON(ctx context.Context) (res *HelloWorld, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("json"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/json"),
 	}
 
 	// Run stopwatch.
@@ -324,6 +331,8 @@ func (c *Client) Queries(ctx context.Context, params QueriesParams) (WorldObject
 func (c *Client) sendQueries(ctx context.Context, params QueriesParams) (res WorldObjects, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("Queries"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/queries"),
 	}
 
 	// Run stopwatch.
@@ -415,6 +424,8 @@ func (c *Client) Updates(ctx context.Context, params UpdatesParams) (WorldObject
 func (c *Client) sendUpdates(ctx context.Context, params UpdatesParams) (res WorldObjects, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("Updates"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/updates"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_allof/oas_client_gen.go
+++ b/internal/integration/test_allof/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -82,6 +83,8 @@ func (c *Client) NullableStrings(ctx context.Context, request NilString) error {
 func (c *Client) sendNullableStrings(ctx context.Context, request NilString) (res *NullableStringsOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("nullableStrings"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/nullableStrings"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -180,6 +183,8 @@ func (c *Client) ObjectsWithConflictingArrayProperty(ctx context.Context, reques
 func (c *Client) sendObjectsWithConflictingArrayProperty(ctx context.Context, request *ObjectsWithConflictingArrayPropertyReq) (res *ObjectsWithConflictingArrayPropertyOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("objectsWithConflictingArrayProperty"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/objectsWithConflictingArrayProperty"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -263,6 +268,8 @@ func (c *Client) ObjectsWithConflictingProperties(ctx context.Context, request *
 func (c *Client) sendObjectsWithConflictingProperties(ctx context.Context, request *ObjectsWithConflictingPropertiesReq) (res *ObjectsWithConflictingPropertiesOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("objectsWithConflictingProperties"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/objectsWithConflictingProperties"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -346,6 +353,8 @@ func (c *Client) ReferencedAllof(ctx context.Context, request ReferencedAllofReq
 func (c *Client) sendReferencedAllof(ctx context.Context, request ReferencedAllofReq) (res *ReferencedAllofOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("referencedAllof"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/referencedAllof"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {
@@ -443,6 +452,8 @@ func (c *Client) ReferencedAllofOptional(ctx context.Context, request Referenced
 func (c *Client) sendReferencedAllofOptional(ctx context.Context, request ReferencedAllofOptionalReq) (res *ReferencedAllofOptionalOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("referencedAllofOptional"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/referencedAllofOptional"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {
@@ -542,6 +553,8 @@ func (c *Client) SimpleInteger(ctx context.Context, request int) error {
 func (c *Client) sendSimpleInteger(ctx context.Context, request int) (res *SimpleIntegerOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("simpleInteger"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/simpleInteger"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -634,6 +647,8 @@ func (c *Client) SimpleObjects(ctx context.Context, request *SimpleObjectsReq) e
 func (c *Client) sendSimpleObjects(ctx context.Context, request *SimpleObjectsReq) (res *SimpleObjectsOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("simpleObjects"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/simpleObjects"),
 	}
 
 	// Run stopwatch.
@@ -706,6 +721,8 @@ func (c *Client) StringsNotype(ctx context.Context, request NilString) error {
 func (c *Client) sendStringsNotype(ctx context.Context, request NilString) (res *StringsNotypeOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("stringsNotype"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/stringsNotype"),
 	}
 	// Validate request before sending.
 	if err := func() error {

--- a/internal/integration/test_anyof/oas_client_gen.go
+++ b/internal/integration/test_anyof/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -79,6 +80,8 @@ func (c *Client) IntegerNumber(ctx context.Context) (*IntegerNumber, error) {
 func (c *Client) sendIntegerNumber(ctx context.Context) (res *IntegerNumber, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("integerNumber"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/integerNumber"),
 	}
 
 	// Run stopwatch.
@@ -148,6 +151,8 @@ func (c *Client) JaegerAnyOf(ctx context.Context) (*JaegerAnyOf, error) {
 func (c *Client) sendJaegerAnyOf(ctx context.Context) (res *JaegerAnyOf, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("jaegerAnyOf"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/jaegerAnyOf"),
 	}
 
 	// Run stopwatch.
@@ -217,6 +222,8 @@ func (c *Client) OneUUID(ctx context.Context) (*OneUUID, error) {
 func (c *Client) sendOneUUID(ctx context.Context) (res *OneUUID, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("oneUUID"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/oneUUID"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_customformats/oas_client_gen.go
+++ b/internal/integration/test_customformats/oas_client_gen.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/uri"
@@ -75,7 +77,10 @@ func (c *Client) EventPost(ctx context.Context, request any) (any, error) {
 }
 
 func (c *Client) sendEventPost(ctx context.Context, request any) (res any, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/event"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -90,6 +95,7 @@ func (c *Client) sendEventPost(ctx context.Context, request any) (res any, err e
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "EventPost",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -144,7 +150,10 @@ func (c *Client) PhoneGet(ctx context.Context, request *User, params PhoneGetPar
 }
 
 func (c *Client) sendPhoneGet(ctx context.Context, request *User, params PhoneGetParams) (res *User, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/phone"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -159,6 +168,7 @@ func (c *Client) sendPhoneGet(ctx context.Context, request *User, params PhoneGe
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "PhoneGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.

--- a/internal/integration/test_customformats/oas_handlers_gen.go
+++ b/internal/integration/test_customformats/oas_handlers_gen.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -19,10 +21,14 @@ import (
 //
 // POST /event
 func (s *Server) handleEventPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/event"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "EventPost",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()
@@ -115,10 +121,14 @@ func (s *Server) handleEventPostRequest(args [0]string, argsEscaped bool, w http
 //
 // GET /phone
 func (s *Server) handlePhoneGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/phone"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "PhoneGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/test_enum_naming/oas_client_gen.go
+++ b/internal/integration/test_enum_naming/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -81,6 +82,8 @@ func (c *Client) ProbeLiveness(ctx context.Context) (*ProbeLivenessOK, error) {
 func (c *Client) sendProbeLiveness(ctx context.Context) (res *ProbeLivenessOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("probeLiveness"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/healthz"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_form/oas_client_gen.go
+++ b/internal/integration/test_form/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -79,6 +80,8 @@ func (c *Client) OnlyForm(ctx context.Context, request *OnlyFormReq) error {
 func (c *Client) sendOnlyForm(ctx context.Context, request *OnlyFormReq) (res *OnlyFormOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("onlyForm"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/onlyForm"),
 	}
 
 	// Run stopwatch.
@@ -151,6 +154,8 @@ func (c *Client) OnlyMultipartFile(ctx context.Context, request *OnlyMultipartFi
 func (c *Client) sendOnlyMultipartFile(ctx context.Context, request *OnlyMultipartFileReq) (res *OnlyMultipartFileOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("onlyMultipartFile"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/onlyMultipartFile"),
 	}
 
 	// Run stopwatch.
@@ -223,6 +228,8 @@ func (c *Client) OnlyMultipartForm(ctx context.Context, request *OnlyMultipartFo
 func (c *Client) sendOnlyMultipartForm(ctx context.Context, request *OnlyMultipartFormReq) (res *OnlyMultipartFormOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("onlyMultipartForm"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/onlyMultipartForm"),
 	}
 
 	// Run stopwatch.
@@ -295,6 +302,8 @@ func (c *Client) TestFormURLEncoded(ctx context.Context, request *TestForm) erro
 func (c *Client) sendTestFormURLEncoded(ctx context.Context, request *TestForm) (res *TestFormURLEncodedOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testFormURLEncoded"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testFormURLEncoded"),
 	}
 
 	// Run stopwatch.
@@ -367,6 +376,8 @@ func (c *Client) TestMultipart(ctx context.Context, request *TestFormMultipart) 
 func (c *Client) sendTestMultipart(ctx context.Context, request *TestFormMultipart) (res *TestMultipartOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testMultipart"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testMultipart"),
 	}
 
 	// Run stopwatch.
@@ -439,6 +450,8 @@ func (c *Client) TestMultipartUpload(ctx context.Context, request *TestMultipart
 func (c *Client) sendTestMultipartUpload(ctx context.Context, request *TestMultipartUploadReq) (res *TestMultipartUploadOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testMultipartUpload"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testMultipartUpload"),
 	}
 	// Validate request before sending.
 	if err := func() error {
@@ -520,6 +533,8 @@ func (c *Client) TestReuseFormOptionalSchema(ctx context.Context, request OptSha
 func (c *Client) sendTestReuseFormOptionalSchema(ctx context.Context, request OptSharedRequestMultipart) (res *TestReuseFormOptionalSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testReuseFormOptionalSchema"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testReuseFormOptionalSchema"),
 	}
 
 	// Run stopwatch.
@@ -592,6 +607,8 @@ func (c *Client) TestReuseFormSchema(ctx context.Context, request *SharedRequest
 func (c *Client) sendTestReuseFormSchema(ctx context.Context, request *SharedRequestMultipart) (res *TestReuseFormSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testReuseFormSchema"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testReuseFormSchema"),
 	}
 
 	// Run stopwatch.
@@ -664,6 +681,8 @@ func (c *Client) TestShareFormSchema(ctx context.Context, request TestShareFormS
 func (c *Client) sendTestShareFormSchema(ctx context.Context, request TestShareFormSchemaReq) (res *TestShareFormSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("testShareFormSchema"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/testShareFormSchema"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {

--- a/internal/integration/test_http_requests/oas_client_gen.go
+++ b/internal/integration/test_http_requests/oas_client_gen.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -81,6 +82,8 @@ func (c *Client) AllRequestBodies(ctx context.Context, request AllRequestBodiesR
 func (c *Client) sendAllRequestBodies(ctx context.Context, request AllRequestBodiesReq) (res AllRequestBodiesOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("allRequestBodies"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/allRequestBodies"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {
@@ -168,6 +171,8 @@ func (c *Client) AllRequestBodiesOptional(ctx context.Context, request AllReques
 func (c *Client) sendAllRequestBodiesOptional(ctx context.Context, request AllRequestBodiesOptionalReq) (res AllRequestBodiesOptionalOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("allRequestBodiesOptional"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/allRequestBodiesOptional"),
 	}
 	// Validate request before sending.
 	switch request := request.(type) {
@@ -257,6 +262,8 @@ func (c *Client) Base64Request(ctx context.Context, request Base64RequestReq) (B
 func (c *Client) sendBase64Request(ctx context.Context, request Base64RequestReq) (res Base64RequestOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("base64Request"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/base64Request"),
 	}
 
 	// Run stopwatch.
@@ -329,6 +336,8 @@ func (c *Client) MaskContentType(ctx context.Context, request *MaskContentTypeRe
 func (c *Client) sendMaskContentType(ctx context.Context, request *MaskContentTypeReqWithContentType) (res *MaskResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("maskContentType"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/maskContentType"),
 	}
 
 	// Run stopwatch.
@@ -401,6 +410,8 @@ func (c *Client) MaskContentTypeOptional(ctx context.Context, request *MaskConte
 func (c *Client) sendMaskContentTypeOptional(ctx context.Context, request *MaskContentTypeOptionalReqWithContentType) (res *MaskResponse, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("maskContentTypeOptional"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/maskContentTypeOptional"),
 	}
 
 	// Run stopwatch.
@@ -473,6 +484,8 @@ func (c *Client) StreamJSON(ctx context.Context, request []float64) (float64, er
 func (c *Client) sendStreamJSON(ctx context.Context, request []float64) (res float64, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("streamJSON"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/streamJSON"),
 	}
 	// Validate request before sending.
 	if err := func() error {

--- a/internal/integration/test_http_responses/oas_client_gen.go
+++ b/internal/integration/test_http_responses/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -80,6 +81,8 @@ func (c *Client) AnyContentTypeBinaryStringSchema(ctx context.Context) (AnyConte
 func (c *Client) sendAnyContentTypeBinaryStringSchema(ctx context.Context) (res AnyContentTypeBinaryStringSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("anyContentTypeBinaryStringSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/anyContentTypeBinaryStringSchema"),
 	}
 
 	// Run stopwatch.
@@ -149,6 +152,8 @@ func (c *Client) AnyContentTypeBinaryStringSchemaDefault(ctx context.Context) (*
 func (c *Client) sendAnyContentTypeBinaryStringSchemaDefault(ctx context.Context) (res *AnyContentTypeBinaryStringSchemaDefaultDefStatusCode, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("anyContentTypeBinaryStringSchemaDefault"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/anyContentTypeBinaryStringSchemaDefault"),
 	}
 
 	// Run stopwatch.
@@ -218,6 +223,8 @@ func (c *Client) Combined(ctx context.Context, params CombinedParams) (CombinedR
 func (c *Client) sendCombined(ctx context.Context, params CombinedParams) (res CombinedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("combined"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/combined"),
 	}
 
 	// Run stopwatch.
@@ -305,6 +312,8 @@ func (c *Client) Headers200(ctx context.Context) (*Headers200OK, error) {
 func (c *Client) sendHeaders200(ctx context.Context) (res *Headers200OK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headers200"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headers200"),
 	}
 
 	// Run stopwatch.
@@ -374,6 +383,8 @@ func (c *Client) HeadersCombined(ctx context.Context, params HeadersCombinedPara
 func (c *Client) sendHeadersCombined(ctx context.Context, params HeadersCombinedParams) (res HeadersCombinedRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headersCombined"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headersCombined"),
 	}
 
 	// Run stopwatch.
@@ -461,6 +472,8 @@ func (c *Client) HeadersDefault(ctx context.Context) (*HeadersDefaultDef, error)
 func (c *Client) sendHeadersDefault(ctx context.Context) (res *HeadersDefaultDef, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headersDefault"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headersDefault"),
 	}
 
 	// Run stopwatch.
@@ -530,6 +543,8 @@ func (c *Client) HeadersJSON(ctx context.Context) (*HeadersJSONOK, error) {
 func (c *Client) sendHeadersJSON(ctx context.Context) (res *HeadersJSONOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headersJSON"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headersJSON"),
 	}
 
 	// Run stopwatch.
@@ -599,6 +614,8 @@ func (c *Client) HeadersPattern(ctx context.Context) (*HeadersPattern4XX, error)
 func (c *Client) sendHeadersPattern(ctx context.Context) (res *HeadersPattern4XX, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headersPattern"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headersPattern"),
 	}
 
 	// Run stopwatch.
@@ -671,6 +688,8 @@ func (c *Client) IntersectPatternCode(ctx context.Context, params IntersectPatte
 func (c *Client) sendIntersectPatternCode(ctx context.Context, params IntersectPatternCodeParams) (res IntersectPatternCodeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("intersectPatternCode"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/intersectPatternCode"),
 	}
 
 	// Run stopwatch.
@@ -758,6 +777,8 @@ func (c *Client) MultipleGenericResponses(ctx context.Context) (MultipleGenericR
 func (c *Client) sendMultipleGenericResponses(ctx context.Context) (res MultipleGenericResponsesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("multipleGenericResponses"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/multipleGenericResponses"),
 	}
 
 	// Run stopwatch.
@@ -827,6 +848,8 @@ func (c *Client) OctetStreamBinaryStringSchema(ctx context.Context) (OctetStream
 func (c *Client) sendOctetStreamBinaryStringSchema(ctx context.Context) (res OctetStreamBinaryStringSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("octetStreamBinaryStringSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/octetStreamBinaryStringSchema"),
 	}
 
 	// Run stopwatch.
@@ -896,6 +919,8 @@ func (c *Client) OctetStreamEmptySchema(ctx context.Context) (OctetStreamEmptySc
 func (c *Client) sendOctetStreamEmptySchema(ctx context.Context) (res OctetStreamEmptySchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("octetStreamEmptySchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/octetStreamEmptySchema"),
 	}
 
 	// Run stopwatch.
@@ -967,6 +992,8 @@ func (c *Client) OptionalHeaders(ctx context.Context) (*OptionalHeadersOK, error
 func (c *Client) sendOptionalHeaders(ctx context.Context) (res *OptionalHeadersOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("optionalHeaders"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/optionalHeaders"),
 	}
 
 	// Run stopwatch.
@@ -1036,6 +1063,8 @@ func (c *Client) StreamJSON(ctx context.Context, params StreamJSONParams) (Strea
 func (c *Client) sendStreamJSON(ctx context.Context, params StreamJSONParams) (res StreamJSONRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("streamJSON"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/streamJSON"),
 	}
 
 	// Run stopwatch.
@@ -1123,6 +1152,8 @@ func (c *Client) TextPlainBinaryStringSchema(ctx context.Context) (TextPlainBina
 func (c *Client) sendTextPlainBinaryStringSchema(ctx context.Context) (res TextPlainBinaryStringSchemaOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("textPlainBinaryStringSchema"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/textPlainBinaryStringSchema"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_naming_extensions/oas_client_gen.go
+++ b/internal/integration/test_naming_extensions/oas_client_gen.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/uri"
@@ -75,7 +77,10 @@ func (c *Client) HealthzGet(ctx context.Context) (*Person, error) {
 }
 
 func (c *Client) sendHealthzGet(ctx context.Context) (res *Person, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/healthz"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -90,6 +95,7 @@ func (c *Client) sendHealthzGet(ctx context.Context) (res *Person, err error) {
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "HealthzGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.

--- a/internal/integration/test_naming_extensions/oas_handlers_gen.go
+++ b/internal/integration/test_naming_extensions/oas_handlers_gen.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/middleware"
 )
@@ -18,10 +20,14 @@ import (
 //
 // GET /healthz
 func (s *Server) handleHealthzGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/healthz"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "HealthzGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/test_parameters/oas_client_gen.go
+++ b/internal/integration/test_parameters/oas_client_gen.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -79,7 +80,10 @@ func (c *Client) ComplicatedParameterNameGet(ctx context.Context, params Complic
 }
 
 func (c *Client) sendComplicatedParameterNameGet(ctx context.Context, params ComplicatedParameterNameGetParams) (res *ComplicatedParameterNameGetOK, err error) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/complicatedParameterName"),
+	}
 
 	// Run stopwatch.
 	startTime := time.Now()
@@ -94,6 +98,7 @@ func (c *Client) sendComplicatedParameterNameGet(ctx context.Context, params Com
 
 	// Start a span for this request.
 	ctx, span := c.cfg.Tracer.Start(ctx, "ComplicatedParameterNameGet",
+		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
 	// Track stage for error reporting.
@@ -221,6 +226,8 @@ func (c *Client) ContentParameters(ctx context.Context, params ContentParameters
 func (c *Client) sendContentParameters(ctx context.Context, params ContentParametersParams) (res *ContentParameters, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("contentParameters"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/contentParameters/{path}"),
 	}
 
 	// Run stopwatch.
@@ -374,6 +381,8 @@ func (c *Client) CookieParameter(ctx context.Context, params CookieParameterPara
 func (c *Client) sendCookieParameter(ctx context.Context, params CookieParameterParams) (res *Value, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("cookieParameter"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/cookieParameter"),
 	}
 
 	// Run stopwatch.
@@ -461,6 +470,8 @@ func (c *Client) HeaderParameter(ctx context.Context, params HeaderParameterPara
 func (c *Client) sendHeaderParameter(ctx context.Context, params HeaderParameterParams) (res *Value, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("headerParameter"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/headerParameter"),
 	}
 
 	// Run stopwatch.
@@ -544,6 +555,8 @@ func (c *Client) ObjectCookieParameter(ctx context.Context, params ObjectCookieP
 func (c *Client) sendObjectCookieParameter(ctx context.Context, params ObjectCookieParameterParams) (res *OneLevelObject, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("objectCookieParameter"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/objectCookieParameter"),
 	}
 
 	// Run stopwatch.
@@ -629,6 +642,8 @@ func (c *Client) ObjectQueryParameter(ctx context.Context, params ObjectQueryPar
 func (c *Client) sendObjectQueryParameter(ctx context.Context, params ObjectQueryParameterParams) (res *ObjectQueryParameterOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("objectQueryParameter"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/objectQueryParameter"),
 	}
 
 	// Run stopwatch.
@@ -738,6 +753,8 @@ func (c *Client) PathParameter(ctx context.Context, params PathParameterParams) 
 func (c *Client) sendPathParameter(ctx context.Context, params PathParameterParams) (res *Value, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("pathParameter"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/pathParameter/{value}"),
 	}
 
 	// Run stopwatch.
@@ -827,6 +844,8 @@ func (c *Client) SameName(ctx context.Context, params SameNameParams) error {
 func (c *Client) sendSameName(ctx context.Context, params SameNameParams) (res *SameNameOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("sameName"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/same_name/{param}"),
 	}
 
 	// Run stopwatch.
@@ -934,6 +953,8 @@ func (c *Client) SimilarNames(ctx context.Context, params SimilarNamesParams) er
 func (c *Client) sendSimilarNames(ctx context.Context, params SimilarNamesParams) (res *SimilarNamesOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("similarNames"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/similarNames"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_parameters/oas_handlers_gen.go
+++ b/internal/integration/test_parameters/oas_handlers_gen.go
@@ -22,10 +22,14 @@ import (
 //
 // GET /complicatedParameterName
 func (s *Server) handleComplicatedParameterNameGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	var otelAttrs []attribute.KeyValue
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/complicatedParameterName"),
+	}
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), "ComplicatedParameterNameGet",
+		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
 	defer span.End()

--- a/internal/integration/test_security/oas_client_gen.go
+++ b/internal/integration/test_security/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -82,6 +83,8 @@ func (c *Client) DisjointSecurity(ctx context.Context) error {
 func (c *Client) sendDisjointSecurity(ctx context.Context) (res *DisjointSecurityOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("disjointSecurity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/disjointSecurity"),
 	}
 
 	// Run stopwatch.
@@ -218,6 +221,8 @@ func (c *Client) IntersectSecurity(ctx context.Context) error {
 func (c *Client) sendIntersectSecurity(ctx context.Context) (res *IntersectSecurityOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("intersectSecurity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/intersectSecurity"),
 	}
 
 	// Run stopwatch.
@@ -343,6 +348,8 @@ func (c *Client) OptionalSecurity(ctx context.Context) error {
 func (c *Client) sendOptionalSecurity(ctx context.Context) (res *OptionalSecurityOK, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("optionalSecurity"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/optionalSecurity"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_servers/oas_client_gen.go
+++ b/internal/integration/test_servers/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -85,6 +86,8 @@ func (c *Client) ProbeLiveness(ctx context.Context) (string, error) {
 func (c *Client) sendProbeLiveness(ctx context.Context) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("probeLiveness"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/healthz"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_single_endpoint/oas_client_gen.go
+++ b/internal/integration/test_single_endpoint/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	ht "github.com/ogen-go/ogen/http"
@@ -85,6 +86,8 @@ func (c *Client) ProbeLiveness(ctx context.Context) (string, error) {
 func (c *Client) sendProbeLiveness(ctx context.Context) (res string, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("probeLiveness"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/healthz"),
 	}
 
 	// Run stopwatch.

--- a/internal/integration/test_webhooks/oas_client_gen.go
+++ b/internal/integration/test_webhooks/oas_client_gen.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ogen-go/ogen/conv"
@@ -84,6 +85,8 @@ func (c *Client) PublishEvent(ctx context.Context, request OptEvent) (*Event, er
 func (c *Client) sendPublishEvent(ctx context.Context, request OptEvent) (res *Event, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("publishEvent"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/event"),
 	}
 
 	// Run stopwatch.


### PR DESCRIPTION
Fixes #1030