### PR TITLE
feat(security): added option to exclude sec requirement 

### DIFF
--- a/examples/ex_k8s/oas_security_gen.go
+++ b/examples/ex_k8s/oas_security_gen.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -41,7 +43,9 @@ func (s *Server) securityBearerToken(ctx context.Context, operationName string, 
 	}
 	t.APIKey = value
 	rctx, err := s.sec.HandleBearerToken(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/examples/ex_oauth2/oas_security_gen.go
+++ b/examples/ex_oauth2/oas_security_gen.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -55,7 +57,9 @@ func (s *Server) securityOAuth2(ctx context.Context, operationName string, req *
 	t.Token = token
 	t.Scopes = oauth2Scopes[operationName]
 	rctx, err := s.sec.HandleOAuth2(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/examples/ex_tinkoff/oas_security_gen.go
+++ b/examples/ex_tinkoff/oas_security_gen.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -39,7 +41,9 @@ func (s *Server) securitySSOAuth(ctx context.Context, operationName string, req 
 	}
 	t.Token = token
 	rctx, err := s.sec.HandleSSOAuth(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/gen/_template/security.tmpl
+++ b/gen/_template/security.tmpl
@@ -97,7 +97,9 @@ func (s *Server) security{{ $s.Type.Name }}(ctx context.Context, operationName s
         {{ errorf "unexpected security %q:%q" $s.Kind $s.Format }}
 	{{- end }}
 	rctx, err := s.sec.Handle{{ $s.Type.Name }}(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/internal/integration/sample_api/oas_security_gen.go
+++ b/internal/integration/sample_api/oas_security_gen.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -40,7 +42,9 @@ func (s *Server) securityAPIKey(ctx context.Context, operationName string, req *
 	}
 	t.APIKey = value
 	rctx, err := s.sec.HandleAPIKey(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/internal/integration/sample_api_nc/oas_security_gen.go
+++ b/internal/integration/sample_api_nc/oas_security_gen.go
@@ -6,6 +6,10 @@ import (
 	"context"
 	"net/http"
 	"strings"
+
+	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -38,7 +42,9 @@ func (s *Server) securityAPIKey(ctx context.Context, operationName string, req *
 	}
 	t.APIKey = value
 	rctx, err := s.sec.HandleAPIKey(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/internal/integration/test_security/oas_security_gen.go
+++ b/internal/integration/test_security/oas_security_gen.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-faster/errors"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // SecurityHandler is handler for security parameters.
@@ -51,7 +53,9 @@ func (s *Server) securityBasicAuth(ctx context.Context, operationName string, re
 	t.Username = username
 	t.Password = password
 	rctx, err := s.sec.HandleBasicAuth(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err
@@ -64,7 +68,9 @@ func (s *Server) securityBearerToken(ctx context.Context, operationName string, 
 	}
 	t.Token = token
 	rctx, err := s.sec.HandleBearerToken(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err
@@ -83,7 +89,9 @@ func (s *Server) securityCookieKey(ctx context.Context, operationName string, re
 	}
 	t.APIKey = value
 	rctx, err := s.sec.HandleCookieKey(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err
@@ -97,7 +105,9 @@ func (s *Server) securityHeaderKey(ctx context.Context, operationName string, re
 	}
 	t.APIKey = value
 	rctx, err := s.sec.HandleHeaderKey(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err
@@ -112,7 +122,9 @@ func (s *Server) securityQueryKey(ctx context.Context, operationName string, req
 	value := q.Get(parameterName)
 	t.APIKey = value
 	rctx, err := s.sec.HandleQueryKey(ctx, operationName, t)
-	if err != nil {
+	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
+		return nil, false, nil
+	} else if err != nil {
 		return nil, false, err
 	}
 	return rctx, true, err

--- a/ogenerrors/security.go
+++ b/ogenerrors/security.go
@@ -6,5 +6,7 @@ var (
 	// ErrSecurityRequirementIsNotSatisfied is returned when security requirement is not satisfied.
 	ErrSecurityRequirementIsNotSatisfied = errors.New("security requirement is not satisfied")
 	// ErrSkipClientSecurity is guard error to exclude security scheme from client request.
-	ErrSkipClientSecurity = errors.New("skip security")
+	ErrSkipClientSecurity = errors.New("skip client security")
+	// ErrSkipServerSecurity is guard error to exclude security scheme from server request.
+	ErrSkipServerSecurity = errors.New("skip server security")
 )


### PR DESCRIPTION
Added option to exclude security requirement for handlers.

This is useful in case you want to have multiple security providers with the same data.
For an example if you want to use both `apikey` and `oauth` security providers on one endpoint you want to check structure of a token first. If it starts with Bearer you want to skip bearer validation and just enforce the oauth validation.