### PR TITLE
feat: add 'mac' primitive for 'net.HardwareAddr' (MAC)

### DIFF
--- a/_testdata/positive/format_gen.json
+++ b/_testdata/positive/format_gen.json
@@ -843,6 +843,27 @@
 						}
 					},
 					{
+						"name": "string_mac",
+						"in": "query",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "mac"
+						}
+					},
+					{
+						"name": "string_mac_array",
+						"in": "query",
+						"required": true,
+						"schema": {
+							"type": "array",
+							"items": {
+								"type": "string",
+								"format": "mac"
+							}
+						}
+					},
+					{
 						"name": "string_password",
 						"in": "query",
 						"required": true,
@@ -1482,6 +1503,13 @@
 											"format": "ipv6"
 										}
 									},
+									"required_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac"
+										}
+									},
 									"required_array_string_password": {
 										"type": "array",
 										"items": {
@@ -1995,6 +2023,16 @@
 											}
 										}
 									},
+									"required_double_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
+											}
+										}
+									},
 									"required_double_array_string_password": {
 										"type": "array",
 										"items": {
@@ -2290,6 +2328,10 @@
 									"required_string_ipv6": {
 										"type": "string",
 										"format": "ipv6"
+									},
+									"required_string_mac": {
+										"type": "string",
+										"format": "mac"
 									},
 									"required_string_password": {
 										"type": "string",
@@ -2632,6 +2674,13 @@
 										"items": {
 											"type": "string",
 											"format": "ipv6"
+										}
+									},
+									"optional_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac"
 										}
 									},
 									"optional_array_string_password": {
@@ -3147,6 +3196,16 @@
 											}
 										}
 									},
+									"optional_double_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
+											}
+										}
+									},
 									"optional_double_array_string_password": {
 										"type": "array",
 										"items": {
@@ -3443,6 +3502,10 @@
 										"type": "string",
 										"format": "ipv6"
 									},
+									"optional_string_mac": {
+										"type": "string",
+										"format": "mac"
+									},
 									"optional_string_password": {
 										"type": "string",
 										"format": "password"
@@ -3544,6 +3607,7 @@
 									"required_array_string_ip",
 									"required_array_string_ipv4",
 									"required_array_string_ipv6",
+									"required_array_string_mac",
 									"required_array_string_password",
 									"required_array_string_time",
 									"required_array_string_uint",
@@ -3601,6 +3665,7 @@
 									"required_double_array_string_ip",
 									"required_double_array_string_ipv4",
 									"required_double_array_string_ipv6",
+									"required_double_array_string_mac",
 									"required_double_array_string_password",
 									"required_double_array_string_time",
 									"required_double_array_string_uint",
@@ -3655,6 +3720,7 @@
 									"required_string_ip",
 									"required_string_ipv4",
 									"required_string_ipv6",
+									"required_string_mac",
 									"required_string_password",
 									"required_string_time",
 									"required_string_uint",
@@ -7228,6 +7294,13 @@
 											"format": "ipv6"
 										}
 									},
+									"required_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac"
+										}
+									},
 									"required_array_string_password": {
 										"type": "array",
 										"items": {
@@ -7741,6 +7814,16 @@
 											}
 										}
 									},
+									"required_double_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
+											}
+										}
+									},
 									"required_double_array_string_password": {
 										"type": "array",
 										"items": {
@@ -8036,6 +8119,10 @@
 									"required_string_ipv6": {
 										"type": "string",
 										"format": "ipv6"
+									},
+									"required_string_mac": {
+										"type": "string",
+										"format": "mac"
 									},
 									"required_string_password": {
 										"type": "string",
@@ -8378,6 +8465,13 @@
 										"items": {
 											"type": "string",
 											"format": "ipv6"
+										}
+									},
+									"optional_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac"
 										}
 									},
 									"optional_array_string_password": {
@@ -8893,6 +8987,16 @@
 											}
 										}
 									},
+									"optional_double_array_string_mac": {
+										"type": "array",
+										"items": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
+											}
+										}
+									},
 									"optional_double_array_string_password": {
 										"type": "array",
 										"items": {
@@ -9189,6 +9293,10 @@
 										"type": "string",
 										"format": "ipv6"
 									},
+									"optional_string_mac": {
+										"type": "string",
+										"format": "mac"
+									},
 									"optional_string_password": {
 										"type": "string",
 										"format": "password"
@@ -9290,6 +9398,7 @@
 									"required_array_string_ip",
 									"required_array_string_ipv4",
 									"required_array_string_ipv6",
+									"required_array_string_mac",
 									"required_array_string_password",
 									"required_array_string_time",
 									"required_array_string_uint",
@@ -9347,6 +9456,7 @@
 									"required_double_array_string_ip",
 									"required_double_array_string_ipv4",
 									"required_double_array_string_ipv6",
+									"required_double_array_string_mac",
 									"required_double_array_string_password",
 									"required_double_array_string_time",
 									"required_double_array_string_uint",
@@ -9401,6 +9511,7 @@
 									"required_string_ip",
 									"required_string_ipv4",
 									"required_string_ipv6",
+									"required_string_mac",
 									"required_string_password",
 									"required_string_time",
 									"required_string_uint",
@@ -15596,6 +15707,159 @@
 				}
 			}
 		},
+		"/test_request_required_string_mac": {
+			"post": {
+				"operationId": "test_request_required_string_mac",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "string",
+								"format": "mac"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_required_string_mac_array": {
+			"post": {
+				"operationId": "test_request_required_string_mac_array",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"format": "mac"
+								}
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_required_string_mac_array_array": {
+			"post": {
+				"operationId": "test_request_required_string_mac_array_array",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac"
+									}
+								}
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_required_string_mac_nullable": {
+			"post": {
+				"operationId": "test_request_required_string_mac_nullable",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "string",
+								"format": "mac",
+								"nullable": true
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_required_string_mac_nullable_array": {
+			"post": {
+				"operationId": "test_request_required_string_mac_nullable_array",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"format": "mac",
+									"nullable": true
+								}
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_required_string_mac_nullable_array_array": {
+			"post": {
+				"operationId": "test_request_required_string_mac_nullable_array_array",
+				"requestBody": {
+					"description": "Required request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac",
+										"nullable": true
+									}
+								}
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
 		"/test_request_required_string_nullable": {
 			"post": {
 				"operationId": "test_request_required_string_nullable",
@@ -20528,6 +20792,153 @@
 				}
 			}
 		},
+		"/test_request_string_mac": {
+			"post": {
+				"operationId": "test_request_string_mac",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "string",
+								"format": "mac"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_string_mac_array": {
+			"post": {
+				"operationId": "test_request_string_mac_array",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"format": "mac"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_string_mac_array_array": {
+			"post": {
+				"operationId": "test_request_string_mac_array_array",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac"
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_string_mac_nullable": {
+			"post": {
+				"operationId": "test_request_string_mac_nullable",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "string",
+								"format": "mac",
+								"nullable": true
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_string_mac_nullable_array": {
+			"post": {
+				"operationId": "test_request_string_mac_nullable_array",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"format": "mac",
+									"nullable": true
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
+		"/test_request_string_mac_nullable_array_array": {
+			"post": {
+				"operationId": "test_request_string_mac_nullable_array_array",
+				"requestBody": {
+					"description": "Optional request body",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac",
+										"nullable": true
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/error"
+					}
+				}
+			}
+		},
 		"/test_request_string_nullable": {
 			"post": {
 				"operationId": "test_request_string_nullable",
@@ -22997,6 +23408,13 @@
 												"format": "ipv6"
 											}
 										},
+										"required_array_string_mac": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
+											}
+										},
 										"required_array_string_password": {
 											"type": "array",
 											"items": {
@@ -23510,6 +23928,16 @@
 												}
 											}
 										},
+										"required_double_array_string_mac": {
+											"type": "array",
+											"items": {
+												"type": "array",
+												"items": {
+													"type": "string",
+													"format": "mac"
+												}
+											}
+										},
 										"required_double_array_string_password": {
 											"type": "array",
 											"items": {
@@ -23805,6 +24233,10 @@
 										"required_string_ipv6": {
 											"type": "string",
 											"format": "ipv6"
+										},
+										"required_string_mac": {
+											"type": "string",
+											"format": "mac"
 										},
 										"required_string_password": {
 											"type": "string",
@@ -24147,6 +24579,13 @@
 											"items": {
 												"type": "string",
 												"format": "ipv6"
+											}
+										},
+										"optional_array_string_mac": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "mac"
 											}
 										},
 										"optional_array_string_password": {
@@ -24662,6 +25101,16 @@
 												}
 											}
 										},
+										"optional_double_array_string_mac": {
+											"type": "array",
+											"items": {
+												"type": "array",
+												"items": {
+													"type": "string",
+													"format": "mac"
+												}
+											}
+										},
 										"optional_double_array_string_password": {
 											"type": "array",
 											"items": {
@@ -24958,6 +25407,10 @@
 											"type": "string",
 											"format": "ipv6"
 										},
+										"optional_string_mac": {
+											"type": "string",
+											"format": "mac"
+										},
 										"optional_string_password": {
 											"type": "string",
 											"format": "password"
@@ -25059,6 +25512,7 @@
 										"required_array_string_ip",
 										"required_array_string_ipv4",
 										"required_array_string_ipv6",
+										"required_array_string_mac",
 										"required_array_string_password",
 										"required_array_string_time",
 										"required_array_string_uint",
@@ -25116,6 +25570,7 @@
 										"required_double_array_string_ip",
 										"required_double_array_string_ipv4",
 										"required_double_array_string_ipv6",
+										"required_double_array_string_mac",
 										"required_double_array_string_password",
 										"required_double_array_string_time",
 										"required_double_array_string_uint",
@@ -25170,6 +25625,7 @@
 										"required_string_ip",
 										"required_string_ipv4",
 										"required_string_ipv6",
+										"required_string_mac",
 										"required_string_password",
 										"required_string_time",
 										"required_string_uint",
@@ -31107,6 +31563,153 @@
 										"items": {
 											"type": "string",
 											"format": "ipv6",
+											"nullable": true
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac": {
+			"post": {
+				"operationId": "test_response_string_mac",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string",
+									"format": "mac"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac_array": {
+			"post": {
+				"operationId": "test_response_string_mac_array",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac_array_array": {
+			"post": {
+				"operationId": "test_response_string_mac_array_array",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac_nullable": {
+			"post": {
+				"operationId": "test_response_string_mac_nullable",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string",
+									"format": "mac",
+									"nullable": true
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac_nullable_array": {
+			"post": {
+				"operationId": "test_response_string_mac_nullable_array",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"format": "mac",
+										"nullable": true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test_response_string_mac_nullable_array_array": {
+			"post": {
+				"operationId": "test_response_string_mac_nullable_array_array",
+				"requestBody": {
+					"$ref": "#/components/requestBodies/defaultBody"
+				},
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"format": "mac",
 											"nullable": true
 										}
 									}

--- a/conv/decode.go
+++ b/conv/decode.go
@@ -1,6 +1,7 @@
 package conv
 
 import (
+	"net"
 	"net/netip"
 	"net/url"
 	"strconv"
@@ -126,6 +127,10 @@ func ToUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
 }
 
+func ToMAC(s string) (net.HardwareAddr, error) {
+	return net.ParseMAC(s)
+}
+
 func ToAddr(s string) (netip.Addr, error) {
 	return netip.ParseAddr(s)
 }
@@ -244,4 +249,8 @@ func ToBoolArray(a []string) ([]bool, error) {
 
 func ToUUIDArray(a []string) ([]uuid.UUID, error) {
 	return decodeArray(a, ToUUID)
+}
+
+func ToMACArray(a []string) ([]net.HardwareAddr, error) {
+	return decodeArray(a, ToMAC)
 }

--- a/conv/encode.go
+++ b/conv/encode.go
@@ -1,6 +1,7 @@
 package conv
 
 import (
+	"net"
 	"net/netip"
 	"net/url"
 	"strconv"
@@ -41,6 +42,8 @@ func UnixMilliToString(v time.Time) string   { return StringInt64ToString(v.Unix
 func DurationToString(v time.Duration) string { return v.String() }
 
 func UUIDToString(v uuid.UUID) string { return v.String() }
+
+func MACToString(v net.HardwareAddr) string { return v.String() }
 
 func AddrToString(v netip.Addr) string { return v.String() }
 
@@ -103,4 +106,8 @@ func BoolArrayToString(vs []bool) []string {
 
 func UUIDArrayToString(vs []uuid.UUID) []string {
 	return encodeArray(vs, UUIDToString)
+}
+
+func MACArrayToString(vs []net.HardwareAddr) []string {
+	return encodeArray(vs, MACToString)
 }

--- a/examples/ex_test_format/oas_client_gen.go
+++ b/examples/ex_test_format/oas_client_gen.go
@@ -5688,7 +5688,7 @@ func (c *Client) sendTestQueryParameter(ctx context.Context, request string, par
 		}
 
 		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
-			return e.EncodeValue(conv.HardwareAddrToString(params.StringMAC))
+			return e.EncodeValue(conv.MACToString(params.StringMAC))
 		}); err != nil {
 			return res, errors.Wrap(err, "encode query")
 		}
@@ -5705,7 +5705,7 @@ func (c *Client) sendTestQueryParameter(ctx context.Context, request string, par
 			return e.EncodeArray(func(e uri.Encoder) error {
 				for i, item := range params.StringMACArray {
 					if err := func() error {
-						return e.EncodeValue(conv.HardwareAddrToString(item))
+						return e.EncodeValue(conv.MACToString(item))
 					}(); err != nil {
 						return errors.Wrapf(err, "[%d]", i)
 					}

--- a/examples/ex_test_format/oas_client_gen.go
+++ b/examples/ex_test_format/oas_client_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"net/url"
 	"strings"
@@ -1554,6 +1555,30 @@ type Invoker interface {
 	//
 	// POST /test_request_required_string_ipv6_nullable_array_array
 	TestRequestRequiredStringIpv6NullableArrayArray(ctx context.Context, request [][]NilIPv6) (*Error, error)
+	// TestRequestRequiredStringMAC invokes test_request_required_string_mac operation.
+	//
+	// POST /test_request_required_string_mac
+	TestRequestRequiredStringMAC(ctx context.Context, request net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACArray invokes test_request_required_string_mac_array operation.
+	//
+	// POST /test_request_required_string_mac_array
+	TestRequestRequiredStringMACArray(ctx context.Context, request []net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACArrayArray invokes test_request_required_string_mac_array_array operation.
+	//
+	// POST /test_request_required_string_mac_array_array
+	TestRequestRequiredStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullable invokes test_request_required_string_mac_nullable operation.
+	//
+	// POST /test_request_required_string_mac_nullable
+	TestRequestRequiredStringMACNullable(ctx context.Context, request NilHardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullableArray invokes test_request_required_string_mac_nullable_array operation.
+	//
+	// POST /test_request_required_string_mac_nullable_array
+	TestRequestRequiredStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullableArrayArray invokes test_request_required_string_mac_nullable_array_array operation.
+	//
+	// POST /test_request_required_string_mac_nullable_array_array
+	TestRequestRequiredStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (*Error, error)
 	// TestRequestRequiredStringNullable invokes test_request_required_string_nullable operation.
 	//
 	// POST /test_request_required_string_nullable
@@ -2346,6 +2371,30 @@ type Invoker interface {
 	//
 	// POST /test_request_string_ipv6_nullable_array_array
 	TestRequestStringIpv6NullableArrayArray(ctx context.Context, request [][]NilIPv6) (*Error, error)
+	// TestRequestStringMAC invokes test_request_string_mac operation.
+	//
+	// POST /test_request_string_mac
+	TestRequestStringMAC(ctx context.Context, request OptHardwareAddr) (*Error, error)
+	// TestRequestStringMACArray invokes test_request_string_mac_array operation.
+	//
+	// POST /test_request_string_mac_array
+	TestRequestStringMACArray(ctx context.Context, request []net.HardwareAddr) (*Error, error)
+	// TestRequestStringMACArrayArray invokes test_request_string_mac_array_array operation.
+	//
+	// POST /test_request_string_mac_array_array
+	TestRequestStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (*Error, error)
+	// TestRequestStringMACNullable invokes test_request_string_mac_nullable operation.
+	//
+	// POST /test_request_string_mac_nullable
+	TestRequestStringMACNullable(ctx context.Context, request OptNilHardwareAddr) (*Error, error)
+	// TestRequestStringMACNullableArray invokes test_request_string_mac_nullable_array operation.
+	//
+	// POST /test_request_string_mac_nullable_array
+	TestRequestStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (*Error, error)
+	// TestRequestStringMACNullableArrayArray invokes test_request_string_mac_nullable_array_array operation.
+	//
+	// POST /test_request_string_mac_nullable_array_array
+	TestRequestStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (*Error, error)
 	// TestRequestStringNullable invokes test_request_string_nullable operation.
 	//
 	// POST /test_request_string_nullable
@@ -3678,6 +3727,30 @@ type Invoker interface {
 	//
 	// POST /test_response_string_ipv6_nullable_array_array
 	TestResponseStringIpv6NullableArrayArray(ctx context.Context, request string) ([][]NilIPv6, error)
+	// TestResponseStringMAC invokes test_response_string_mac operation.
+	//
+	// POST /test_response_string_mac
+	TestResponseStringMAC(ctx context.Context, request string) (net.HardwareAddr, error)
+	// TestResponseStringMACArray invokes test_response_string_mac_array operation.
+	//
+	// POST /test_response_string_mac_array
+	TestResponseStringMACArray(ctx context.Context, request string) ([]net.HardwareAddr, error)
+	// TestResponseStringMACArrayArray invokes test_response_string_mac_array_array operation.
+	//
+	// POST /test_response_string_mac_array_array
+	TestResponseStringMACArrayArray(ctx context.Context, request string) ([][]net.HardwareAddr, error)
+	// TestResponseStringMACNullable invokes test_response_string_mac_nullable operation.
+	//
+	// POST /test_response_string_mac_nullable
+	TestResponseStringMACNullable(ctx context.Context, request string) (NilHardwareAddr, error)
+	// TestResponseStringMACNullableArray invokes test_response_string_mac_nullable_array operation.
+	//
+	// POST /test_response_string_mac_nullable_array
+	TestResponseStringMACNullableArray(ctx context.Context, request string) ([]NilHardwareAddr, error)
+	// TestResponseStringMACNullableArrayArray invokes test_response_string_mac_nullable_array_array operation.
+	//
+	// POST /test_response_string_mac_nullable_array_array
+	TestResponseStringMACNullableArrayArray(ctx context.Context, request string) ([][]NilHardwareAddr, error)
 	// TestResponseStringNullable invokes test_response_string_nullable operation.
 	//
 	// POST /test_response_string_nullable
@@ -5596,6 +5669,43 @@ func (c *Client) sendTestQueryParameter(ctx context.Context, request string, par
 				for i, item := range params.StringIpv6Array {
 					if err := func() error {
 						return e.EncodeValue(conv.AddrToString(item))
+					}(); err != nil {
+						return errors.Wrapf(err, "[%d]", i)
+					}
+				}
+				return nil
+			})
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "string_mac" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "string_mac",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeValue(conv.HardwareAddrToString(params.StringMAC))
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "string_mac_array" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "string_mac_array",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeArray(func(e uri.Encoder) error {
+				for i, item := range params.StringMACArray {
+					if err := func() error {
+						return e.EncodeValue(conv.HardwareAddrToString(item))
 					}(); err != nil {
 						return errors.Wrapf(err, "[%d]", i)
 					}
@@ -33964,6 +34074,444 @@ func (c *Client) sendTestRequestRequiredStringIpv6NullableArrayArray(ctx context
 	return result, nil
 }
 
+// TestRequestRequiredStringMAC invokes test_request_required_string_mac operation.
+//
+// POST /test_request_required_string_mac
+func (c *Client) TestRequestRequiredStringMAC(ctx context.Context, request net.HardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMAC(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMAC(ctx context.Context, request net.HardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestRequiredStringMACArray invokes test_request_required_string_mac_array operation.
+//
+// POST /test_request_required_string_mac_array
+func (c *Client) TestRequestRequiredStringMACArray(ctx context.Context, request []net.HardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMACArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMACArray(ctx context.Context, request []net.HardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestRequiredStringMACArrayArray invokes test_request_required_string_mac_array_array operation.
+//
+// POST /test_request_required_string_mac_array_array
+func (c *Client) TestRequestRequiredStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMACArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestRequiredStringMACNullable invokes test_request_required_string_mac_nullable operation.
+//
+// POST /test_request_required_string_mac_nullable
+func (c *Client) TestRequestRequiredStringMACNullable(ctx context.Context, request NilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMACNullable(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMACNullable(ctx context.Context, request NilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac_nullable"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACNullableRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACNullableResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestRequiredStringMACNullableArray invokes test_request_required_string_mac_nullable_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array
+func (c *Client) TestRequestRequiredStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMACNullableArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac_nullable_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACNullableArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACNullableArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestRequiredStringMACNullableArrayArray invokes test_request_required_string_mac_nullable_array_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array_array
+func (c *Client) TestRequestRequiredStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestRequiredStringMACNullableArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestRequiredStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestRequiredStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_required_string_mac_nullable_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestRequiredStringMACNullableArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestRequiredStringMACNullableArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
 // TestRequestRequiredStringNullable invokes test_request_required_string_nullable operation.
 //
 // POST /test_request_required_string_nullable
@@ -48411,6 +48959,444 @@ func (c *Client) sendTestRequestStringIpv6NullableArrayArray(ctx context.Context
 
 	stage = "DecodeResponse"
 	result, err := decodeTestRequestStringIpv6NullableArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMAC invokes test_request_string_mac operation.
+//
+// POST /test_request_string_mac
+func (c *Client) TestRequestStringMAC(ctx context.Context, request OptHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMAC(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMAC(ctx context.Context, request OptHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMACArray invokes test_request_string_mac_array operation.
+//
+// POST /test_request_string_mac_array
+func (c *Client) TestRequestStringMACArray(ctx context.Context, request []net.HardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMACArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMACArray(ctx context.Context, request []net.HardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMACArrayArray invokes test_request_string_mac_array_array operation.
+//
+// POST /test_request_string_mac_array_array
+func (c *Client) TestRequestStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMACArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMACArrayArray(ctx context.Context, request [][]net.HardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMACNullable invokes test_request_string_mac_nullable operation.
+//
+// POST /test_request_string_mac_nullable
+func (c *Client) TestRequestStringMACNullable(ctx context.Context, request OptNilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMACNullable(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMACNullable(ctx context.Context, request OptNilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac_nullable"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACNullableRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACNullableResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMACNullableArray invokes test_request_string_mac_nullable_array operation.
+//
+// POST /test_request_string_mac_nullable_array
+func (c *Client) TestRequestStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMACNullableArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMACNullableArray(ctx context.Context, request []NilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac_nullable_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACNullableArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACNullableArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestRequestStringMACNullableArrayArray invokes test_request_string_mac_nullable_array_array operation.
+//
+// POST /test_request_string_mac_nullable_array_array
+func (c *Client) TestRequestStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (*Error, error) {
+	res, err := c.sendTestRequestStringMACNullableArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestRequestStringMACNullableArrayArray(ctx context.Context, request [][]NilHardwareAddr) (res *Error, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestRequestStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_request_string_mac_nullable_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestRequestStringMACNullableArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestRequestStringMACNullableArrayArrayResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -72720,6 +73706,444 @@ func (c *Client) sendTestResponseStringIpv6NullableArrayArray(ctx context.Contex
 
 	stage = "DecodeResponse"
 	result, err := decodeTestResponseStringIpv6NullableArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMAC invokes test_response_string_mac operation.
+//
+// POST /test_response_string_mac
+func (c *Client) TestResponseStringMAC(ctx context.Context, request string) (net.HardwareAddr, error) {
+	res, err := c.sendTestResponseStringMAC(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMAC(ctx context.Context, request string) (res net.HardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMACArray invokes test_response_string_mac_array operation.
+//
+// POST /test_response_string_mac_array
+func (c *Client) TestResponseStringMACArray(ctx context.Context, request string) ([]net.HardwareAddr, error) {
+	res, err := c.sendTestResponseStringMACArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMACArray(ctx context.Context, request string) (res []net.HardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMACArrayArray invokes test_response_string_mac_array_array operation.
+//
+// POST /test_response_string_mac_array_array
+func (c *Client) TestResponseStringMACArrayArray(ctx context.Context, request string) ([][]net.HardwareAddr, error) {
+	res, err := c.sendTestResponseStringMACArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMACArrayArray(ctx context.Context, request string) (res [][]net.HardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACArrayArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMACNullable invokes test_response_string_mac_nullable operation.
+//
+// POST /test_response_string_mac_nullable
+func (c *Client) TestResponseStringMACNullable(ctx context.Context, request string) (NilHardwareAddr, error) {
+	res, err := c.sendTestResponseStringMACNullable(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMACNullable(ctx context.Context, request string) (res NilHardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac_nullable"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACNullableRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACNullableResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMACNullableArray invokes test_response_string_mac_nullable_array operation.
+//
+// POST /test_response_string_mac_nullable_array
+func (c *Client) TestResponseStringMACNullableArray(ctx context.Context, request string) ([]NilHardwareAddr, error) {
+	res, err := c.sendTestResponseStringMACNullableArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMACNullableArray(ctx context.Context, request string) (res []NilHardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac_nullable_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACNullableArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACNullableArrayResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// TestResponseStringMACNullableArrayArray invokes test_response_string_mac_nullable_array_array operation.
+//
+// POST /test_response_string_mac_nullable_array_array
+func (c *Client) TestResponseStringMACNullableArrayArray(ctx context.Context, request string) ([][]NilHardwareAddr, error) {
+	res, err := c.sendTestResponseStringMACNullableArrayArray(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendTestResponseStringMACNullableArrayArray(ctx context.Context, request string) (res [][]NilHardwareAddr, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable_array_array"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "TestResponseStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/test_response_string_mac_nullable_array_array"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeTestResponseStringMACNullableArrayArrayRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeTestResponseStringMACNullableArrayArrayResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/examples/ex_test_format/oas_faker_gen.go
+++ b/examples/ex_test_format/oas_faker_gen.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"net"
 	"net/netip"
 	"net/url"
 	"time"
@@ -52,6 +53,11 @@ func (s *NilFloat32) SetFake() {
 
 // SetFake set fake values.
 func (s *NilFloat64) SetFake() {
+	s.Null = true
+}
+
+// SetFake set fake values.
+func (s *NilHardwareAddr) SetFake() {
 	s.Null = true
 }
 
@@ -295,6 +301,15 @@ func (s *OptFloat64) SetFake() {
 }
 
 // SetFake set fake values.
+func (s *OptHardwareAddr) SetFake() {
+	var elem net.HardwareAddr
+	{
+		elem = net.ParseMAC("11:22:33:44:55:66")
+	}
+	s.SetTo(elem)
+}
+
+// SetFake set fake values.
 func (s *OptIP) SetFake() {
 	var elem netip.Addr
 	{
@@ -404,6 +419,12 @@ func (s *OptNilFloat32) SetFake() {
 
 // SetFake set fake values.
 func (s *OptNilFloat64) SetFake() {
+	s.Null = true
+	s.Set = true
+}
+
+// SetFake set fake values.
+func (s *OptNilHardwareAddr) SetFake() {
 	s.Null = true
 	s.Set = true
 }
@@ -1426,6 +1447,18 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.RequiredArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem string
@@ -2397,6 +2430,25 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.RequiredDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -2859,6 +2911,11 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	{
 		{
 			s.RequiredStringIpv6 = netip.MustParseAddr("::1")
+		}
+	}
+	{
+		{
+			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
 		}
 	}
 	{
@@ -3437,6 +3494,18 @@ func (s *TestRequestFormatTestReq) SetFake() {
 					elem = netip.MustParseAddr("::1")
 				}
 				s.OptionalArrayStringIpv6 = append(s.OptionalArrayStringIpv6, elem)
+			}
+		}
+	}
+	{
+		{
+			s.OptionalArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
 		}
 	}
@@ -4413,6 +4482,25 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.OptionalDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.OptionalDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -4875,6 +4963,11 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	{
 		{
 			s.OptionalStringIpv6.SetFake()
+		}
+	}
+	{
+		{
+			s.OptionalStringMAC.SetFake()
 		}
 	}
 	{
@@ -5466,6 +5559,18 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.RequiredArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem string
@@ -6437,6 +6542,25 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.RequiredDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -6899,6 +7023,11 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	{
 		{
 			s.RequiredStringIpv6 = netip.MustParseAddr("::1")
+		}
+	}
+	{
+		{
+			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
 		}
 	}
 	{
@@ -7477,6 +7606,18 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 					elem = netip.MustParseAddr("::1")
 				}
 				s.OptionalArrayStringIpv6 = append(s.OptionalArrayStringIpv6, elem)
+			}
+		}
+	}
+	{
+		{
+			s.OptionalArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
 		}
 	}
@@ -8453,6 +8594,25 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	}
 	{
 		{
+			s.OptionalDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.OptionalDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -8915,6 +9075,11 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	{
 		{
 			s.OptionalStringIpv6.SetFake()
+		}
+	}
+	{
+		{
+			s.OptionalStringMAC.SetFake()
 		}
 	}
 	{
@@ -9506,6 +9671,18 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	}
 	{
 		{
+			s.RequiredArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem string
@@ -10477,6 +10654,25 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	}
 	{
 		{
+			s.RequiredDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.RequiredDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -10939,6 +11135,11 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	{
 		{
 			s.RequiredStringIpv6 = netip.MustParseAddr("::1")
+		}
+	}
+	{
+		{
+			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
 		}
 	}
 	{
@@ -11517,6 +11718,18 @@ func (s *TestResponseFormatTestOK) SetFake() {
 					elem = netip.MustParseAddr("::1")
 				}
 				s.OptionalArrayStringIpv6 = append(s.OptionalArrayStringIpv6, elem)
+			}
+		}
+	}
+	{
+		{
+			s.OptionalArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem net.HardwareAddr
+				{
+					elem = net.ParseMAC("11:22:33:44:55:66")
+				}
+				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
 		}
 	}
@@ -12493,6 +12706,25 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	}
 	{
 		{
+			s.OptionalDoubleArrayStringMAC = nil
+			for i := 0; i < 0; i++ {
+				var elem []net.HardwareAddr
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem net.HardwareAddr
+						{
+							elemElem = net.ParseMAC("11:22:33:44:55:66")
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+			}
+		}
+	}
+	{
+		{
 			s.OptionalDoubleArrayStringPassword = nil
 			for i := 0; i < 0; i++ {
 				var elem []string
@@ -12955,6 +13187,11 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	{
 		{
 			s.OptionalStringIpv6.SetFake()
+		}
+	}
+	{
+		{
+			s.OptionalStringMAC.SetFake()
 		}
 	}
 	{

--- a/examples/ex_test_format/oas_faker_gen.go
+++ b/examples/ex_test_format/oas_faker_gen.go
@@ -304,7 +304,7 @@ func (s *OptFloat64) SetFake() {
 func (s *OptHardwareAddr) SetFake() {
 	var elem net.HardwareAddr
 	{
-		elem = net.ParseMAC("11:22:33:44:55:66")
+		elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 	}
 	s.SetTo(elem)
 }
@@ -1451,7 +1451,7 @@ func (s *TestRequestFormatTestReq) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
 			}
@@ -2438,7 +2438,7 @@ func (s *TestRequestFormatTestReq) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}
@@ -2915,7 +2915,7 @@ func (s *TestRequestFormatTestReq) SetFake() {
 	}
 	{
 		{
-			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
+			s.RequiredStringMAC = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 		}
 	}
 	{
@@ -3503,7 +3503,7 @@ func (s *TestRequestFormatTestReq) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
@@ -4490,7 +4490,7 @@ func (s *TestRequestFormatTestReq) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}
@@ -5563,7 +5563,7 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
 			}
@@ -6550,7 +6550,7 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}
@@ -7027,7 +7027,7 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 	}
 	{
 		{
-			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
+			s.RequiredStringMAC = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 		}
 	}
 	{
@@ -7615,7 +7615,7 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
@@ -8602,7 +8602,7 @@ func (s *TestRequestRequiredFormatTestReq) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}
@@ -9675,7 +9675,7 @@ func (s *TestResponseFormatTestOK) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
 			}
@@ -10662,7 +10662,7 @@ func (s *TestResponseFormatTestOK) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}
@@ -11139,7 +11139,7 @@ func (s *TestResponseFormatTestOK) SetFake() {
 	}
 	{
 		{
-			s.RequiredStringMAC = net.ParseMAC("11:22:33:44:55:66")
+			s.RequiredStringMAC = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 		}
 	}
 	{
@@ -11727,7 +11727,7 @@ func (s *TestResponseFormatTestOK) SetFake() {
 			for i := 0; i < 0; i++ {
 				var elem net.HardwareAddr
 				{
-					elem = net.ParseMAC("11:22:33:44:55:66")
+					elem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 				}
 				s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
 			}
@@ -12714,7 +12714,7 @@ func (s *TestResponseFormatTestOK) SetFake() {
 					for i := 0; i < 0; i++ {
 						var elemElem net.HardwareAddr
 						{
-							elemElem = net.ParseMAC("11:22:33:44:55:66")
+							elemElem = net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
 						}
 						elem = append(elem, elemElem)
 					}

--- a/examples/ex_test_format/oas_handlers_gen.go
+++ b/examples/ex_test_format/oas_handlers_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -419,6 +420,14 @@ func (s *Server) handleTestQueryParameterRequest(args [0]string, argsEscaped boo
 					Name: "string_ipv6_array",
 					In:   "query",
 				}: params.StringIpv6Array,
+				{
+					Name: "string_mac",
+					In:   "query",
+				}: params.StringMAC,
+				{
+					Name: "string_mac_array",
+					In:   "query",
+				}: params.StringMACArray,
 				{
 					Name: "string_password",
 					In:   "query",
@@ -40195,6 +40204,630 @@ func (s *Server) handleTestRequestRequiredStringIpv6NullableArrayArrayRequest(ar
 	}
 }
 
+// handleTestRequestRequiredStringMACRequest handles test_request_required_string_mac operation.
+//
+// POST /test_request_required_string_mac
+func (s *Server) handleTestRequestRequiredStringMACRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMAC",
+			ID:   "test_request_required_string_mac",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMAC",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = net.HardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMAC(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMAC(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestRequiredStringMACArrayRequest handles test_request_required_string_mac_array operation.
+//
+// POST /test_request_required_string_mac_array
+func (s *Server) handleTestRequestRequiredStringMACArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMACArray",
+			ID:   "test_request_required_string_mac_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMACArray",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = []net.HardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMACArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMACArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestRequiredStringMACArrayArrayRequest handles test_request_required_string_mac_array_array operation.
+//
+// POST /test_request_required_string_mac_array_array
+func (s *Server) handleTestRequestRequiredStringMACArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMACArrayArray",
+			ID:   "test_request_required_string_mac_array_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMACArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = [][]net.HardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMACArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMACArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestRequiredStringMACNullableRequest handles test_request_required_string_mac_nullable operation.
+//
+// POST /test_request_required_string_mac_nullable
+func (s *Server) handleTestRequestRequiredStringMACNullableRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMACNullable",
+			ID:   "test_request_required_string_mac_nullable",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACNullableRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMACNullable",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac_nullable",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = NilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMACNullable(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMACNullable(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACNullableResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestRequiredStringMACNullableArrayRequest handles test_request_required_string_mac_nullable_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array
+func (s *Server) handleTestRequestRequiredStringMACNullableArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMACNullableArray",
+			ID:   "test_request_required_string_mac_nullable_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACNullableArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMACNullableArray",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac_nullable_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = []NilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMACNullableArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMACNullableArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACNullableArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestRequiredStringMACNullableArrayArrayRequest handles test_request_required_string_mac_nullable_array_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array_array
+func (s *Server) handleTestRequestRequiredStringMACNullableArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_required_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_required_string_mac_nullable_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestRequiredStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestRequiredStringMACNullableArrayArray",
+			ID:   "test_request_required_string_mac_nullable_array_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestRequiredStringMACNullableArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestRequiredStringMACNullableArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_request_required_string_mac_nullable_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = [][]NilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestRequiredStringMACNullableArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestRequiredStringMACNullableArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestRequiredStringMACNullableArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleTestRequestRequiredStringNullableRequest handles test_request_required_string_nullable operation.
 //
 // POST /test_request_required_string_nullable
@@ -60779,6 +61412,630 @@ func (s *Server) handleTestRequestStringIpv6NullableArrayArrayRequest(args [0]st
 	}
 
 	if err := encodeTestRequestStringIpv6NullableArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACRequest handles test_request_string_mac operation.
+//
+// POST /test_request_string_mac
+func (s *Server) handleTestRequestStringMACRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMAC",
+			ID:   "test_request_string_mac",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMAC",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = OptHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMAC(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMAC(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACArrayRequest handles test_request_string_mac_array operation.
+//
+// POST /test_request_string_mac_array
+func (s *Server) handleTestRequestStringMACArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMACArray",
+			ID:   "test_request_string_mac_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMACArray",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = []net.HardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMACArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMACArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACArrayArrayRequest handles test_request_string_mac_array_array operation.
+//
+// POST /test_request_string_mac_array_array
+func (s *Server) handleTestRequestStringMACArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMACArrayArray",
+			ID:   "test_request_string_mac_array_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMACArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = [][]net.HardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMACArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMACArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACNullableRequest handles test_request_string_mac_nullable operation.
+//
+// POST /test_request_string_mac_nullable
+func (s *Server) handleTestRequestStringMACNullableRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMACNullable",
+			ID:   "test_request_string_mac_nullable",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACNullableRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMACNullable",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac_nullable",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = OptNilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMACNullable(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMACNullable(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACNullableResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACNullableArrayRequest handles test_request_string_mac_nullable_array operation.
+//
+// POST /test_request_string_mac_nullable_array
+func (s *Server) handleTestRequestStringMACNullableArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMACNullableArray",
+			ID:   "test_request_string_mac_nullable_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACNullableArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMACNullableArray",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac_nullable_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = []NilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMACNullableArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMACNullableArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACNullableArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestRequestStringMACNullableArrayArrayRequest handles test_request_string_mac_nullable_array_array operation.
+//
+// POST /test_request_string_mac_nullable_array_array
+func (s *Server) handleTestRequestStringMACNullableArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_request_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_request_string_mac_nullable_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestRequestStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestRequestStringMACNullableArrayArray",
+			ID:   "test_request_string_mac_nullable_array_array",
+		}
+	)
+	request, close, err := s.decodeTestRequestStringMACNullableArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response *Error
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestRequestStringMACNullableArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_request_string_mac_nullable_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = [][]NilHardwareAddr
+			Params   = struct{}
+			Response = *Error
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestRequestStringMACNullableArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestRequestStringMACNullableArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestRequestStringMACNullableArrayArrayResponse(response, w, span); err != nil {
 		recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -95411,6 +96668,630 @@ func (s *Server) handleTestResponseStringIpv6NullableArrayArrayRequest(args [0]s
 	}
 
 	if err := encodeTestResponseStringIpv6NullableArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACRequest handles test_response_string_mac operation.
+//
+// POST /test_response_string_mac
+func (s *Server) handleTestResponseStringMACRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMAC",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMAC",
+			ID:   "test_response_string_mac",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response net.HardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMAC",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = net.HardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMAC(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMAC(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACArrayRequest handles test_response_string_mac_array operation.
+//
+// POST /test_response_string_mac_array
+func (s *Server) handleTestResponseStringMACArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMACArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMACArray",
+			ID:   "test_response_string_mac_array",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response []net.HardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMACArray",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = []net.HardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMACArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMACArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACArrayArrayRequest handles test_response_string_mac_array_array operation.
+//
+// POST /test_response_string_mac_array_array
+func (s *Server) handleTestResponseStringMACArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMACArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMACArrayArray",
+			ID:   "test_response_string_mac_array_array",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response [][]net.HardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMACArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = [][]net.HardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMACArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMACArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACArrayArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACNullableRequest handles test_response_string_mac_nullable operation.
+//
+// POST /test_response_string_mac_nullable
+func (s *Server) handleTestResponseStringMACNullableRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMACNullable",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMACNullable",
+			ID:   "test_response_string_mac_nullable",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACNullableRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response NilHardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMACNullable",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac_nullable",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = NilHardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMACNullable(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMACNullable(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACNullableResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACNullableArrayRequest handles test_response_string_mac_nullable_array operation.
+//
+// POST /test_response_string_mac_nullable_array
+func (s *Server) handleTestResponseStringMACNullableArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMACNullableArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMACNullableArray",
+			ID:   "test_response_string_mac_nullable_array",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACNullableArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response []NilHardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMACNullableArray",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac_nullable_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = []NilHardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMACNullableArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMACNullableArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACNullableArrayResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleTestResponseStringMACNullableArrayArrayRequest handles test_response_string_mac_nullable_array_array operation.
+//
+// POST /test_response_string_mac_nullable_array_array
+func (s *Server) handleTestResponseStringMACNullableArrayArrayRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("test_response_string_mac_nullable_array_array"),
+		semconv.HTTPMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/test_response_string_mac_nullable_array_array"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "TestResponseStringMACNullableArrayArray",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "TestResponseStringMACNullableArrayArray",
+			ID:   "test_response_string_mac_nullable_array_array",
+		}
+	)
+	request, close, err := s.decodeTestResponseStringMACNullableArrayArrayRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response [][]NilHardwareAddr
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "TestResponseStringMACNullableArrayArray",
+			OperationSummary: "",
+			OperationID:      "test_response_string_mac_nullable_array_array",
+			Body:             request,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = string
+			Params   = struct{}
+			Response = [][]NilHardwareAddr
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.TestResponseStringMACNullableArrayArray(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.TestResponseStringMACNullableArrayArray(ctx, request)
+	}
+	if err != nil {
+		recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeTestResponseStringMACNullableArrayArrayResponse(response, w, span); err != nil {
 		recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)

--- a/examples/ex_test_format/oas_json_gen.go
+++ b/examples/ex_test_format/oas_json_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"math/bits"
+	"net"
 	"net/netip"
 	"net/url"
 	"strconv"
@@ -369,6 +370,52 @@ func (s NilFloat64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *NilFloat64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes net.HardwareAddr as json.
+func (o NilHardwareAddr) Encode(e *jx.Encoder) {
+	if o.Null {
+		e.Null()
+		return
+	}
+	json.EncodeMAC(e, o.Value)
+}
+
+// Decode decodes net.HardwareAddr from json.
+func (o *NilHardwareAddr) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode NilHardwareAddr to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v net.HardwareAddr
+		o.Value = v
+		o.Null = true
+		return nil
+	}
+	o.Null = false
+	v, err := json.DecodeMAC(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s NilHardwareAddr) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *NilHardwareAddr) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -2285,6 +2332,41 @@ func (s *OptFloat64) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes net.HardwareAddr as json.
+func (o OptHardwareAddr) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	json.EncodeMAC(e, o.Value)
+}
+
+// Decode decodes net.HardwareAddr from json.
+func (o *OptHardwareAddr) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptHardwareAddr to nil")
+	}
+	o.Set = true
+	v, err := json.DecodeMAC(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptHardwareAddr) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptHardwareAddr) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes netip.Addr as json.
 func (o OptIP) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -2918,6 +3000,57 @@ func (s OptNilFloat64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptNilFloat64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes net.HardwareAddr as json.
+func (o OptNilHardwareAddr) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	json.EncodeMAC(e, o.Value)
+}
+
+// Decode decodes net.HardwareAddr from json.
+func (o *OptNilHardwareAddr) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilHardwareAddr to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v net.HardwareAddr
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	v, err := json.DecodeMAC(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilHardwareAddr) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilHardwareAddr) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -6289,6 +6422,14 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredArrayStringMAC {
+			json.EncodeMAC(e, elem)
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredArrayStringPassword {
@@ -6912,6 +7053,18 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_double_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredDoubleArrayStringMAC {
+			e.ArrStart()
+			for _, elem := range elem {
+				json.EncodeMAC(e, elem)
+			}
+			e.ArrEnd()
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_double_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredDoubleArrayStringPassword {
@@ -7239,6 +7392,10 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 	{
 		e.FieldStart("required_string_ipv6")
 		json.EncodeIPv6(e, s.RequiredStringIpv6)
+	}
+	{
+		e.FieldStart("required_string_mac")
+		json.EncodeMAC(e, s.RequiredStringMAC)
 	}
 	{
 		e.FieldStart("required_string_password")
@@ -7721,6 +7878,16 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 			e.ArrStart()
 			for _, elem := range s.OptionalArrayStringIpv6 {
 				json.EncodeIPv6(e, elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.OptionalArrayStringMAC != nil {
+			e.FieldStart("optional_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalArrayStringMAC {
+				json.EncodeMAC(e, elem)
 			}
 			e.ArrEnd()
 		}
@@ -8463,6 +8630,20 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalDoubleArrayStringMAC != nil {
+			e.FieldStart("optional_double_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalDoubleArrayStringMAC {
+				e.ArrStart()
+				for _, elem := range elem {
+					json.EncodeMAC(e, elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		if s.OptionalDoubleArrayStringPassword != nil {
 			e.FieldStart("optional_double_array_string_password")
 			e.ArrStart()
@@ -8895,6 +9076,12 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalStringMAC.Set {
+			e.FieldStart("optional_string_mac")
+			s.OptionalStringMAC.Encode(e)
+		}
+	}
+	{
 		if s.OptionalStringPassword.Set {
 			e.FieldStart("optional_string_password")
 			s.OptionalStringPassword.Encode(e)
@@ -8980,7 +9167,7 @@ func (s *TestRequestFormatTestReq) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfTestRequestFormatTestReq = [336]string{
+var jsonFieldsNameOfTestRequestFormatTestReq = [342]string{
 	0:   "required_any",
 	1:   "required_array_any",
 	2:   "required_array_boolean",
@@ -9024,299 +9211,305 @@ var jsonFieldsNameOfTestRequestFormatTestReq = [336]string{
 	40:  "required_array_string_ip",
 	41:  "required_array_string_ipv4",
 	42:  "required_array_string_ipv6",
-	43:  "required_array_string_password",
-	44:  "required_array_string_time",
-	45:  "required_array_string_uint",
-	46:  "required_array_string_uint16",
-	47:  "required_array_string_uint32",
-	48:  "required_array_string_uint64",
-	49:  "required_array_string_uint8",
-	50:  "required_array_string_unix",
-	51:  "required_array_string_unix-micro",
-	52:  "required_array_string_unix-milli",
-	53:  "required_array_string_unix-nano",
-	54:  "required_array_string_unix-seconds",
-	55:  "required_array_string_uri",
-	56:  "required_array_string_uuid",
-	57:  "required_boolean",
-	58:  "required_double_array_any",
-	59:  "required_double_array_boolean",
-	60:  "required_double_array_integer",
-	61:  "required_double_array_integer_int16",
-	62:  "required_double_array_integer_int32",
-	63:  "required_double_array_integer_int64",
-	64:  "required_double_array_integer_int8",
-	65:  "required_double_array_integer_uint",
-	66:  "required_double_array_integer_uint16",
-	67:  "required_double_array_integer_uint32",
-	68:  "required_double_array_integer_uint64",
-	69:  "required_double_array_integer_uint8",
-	70:  "required_double_array_integer_unix",
-	71:  "required_double_array_integer_unix-micro",
-	72:  "required_double_array_integer_unix-milli",
-	73:  "required_double_array_integer_unix-nano",
-	74:  "required_double_array_integer_unix-seconds",
-	75:  "required_double_array_null",
-	76:  "required_double_array_number",
-	77:  "required_double_array_number_double",
-	78:  "required_double_array_number_float",
-	79:  "required_double_array_number_int32",
-	80:  "required_double_array_number_int64",
-	81:  "required_double_array_string",
-	82:  "required_double_array_string_base64",
-	83:  "required_double_array_string_binary",
-	84:  "required_double_array_string_byte",
-	85:  "required_double_array_string_date",
-	86:  "required_double_array_string_date-time",
-	87:  "required_double_array_string_duration",
-	88:  "required_double_array_string_email",
-	89:  "required_double_array_string_float32",
-	90:  "required_double_array_string_float64",
-	91:  "required_double_array_string_hostname",
-	92:  "required_double_array_string_int",
-	93:  "required_double_array_string_int16",
-	94:  "required_double_array_string_int32",
-	95:  "required_double_array_string_int64",
-	96:  "required_double_array_string_int8",
-	97:  "required_double_array_string_ip",
-	98:  "required_double_array_string_ipv4",
-	99:  "required_double_array_string_ipv6",
-	100: "required_double_array_string_password",
-	101: "required_double_array_string_time",
-	102: "required_double_array_string_uint",
-	103: "required_double_array_string_uint16",
-	104: "required_double_array_string_uint32",
-	105: "required_double_array_string_uint64",
-	106: "required_double_array_string_uint8",
-	107: "required_double_array_string_unix",
-	108: "required_double_array_string_unix-micro",
-	109: "required_double_array_string_unix-milli",
-	110: "required_double_array_string_unix-nano",
-	111: "required_double_array_string_unix-seconds",
-	112: "required_double_array_string_uri",
-	113: "required_double_array_string_uuid",
-	114: "required_integer",
-	115: "required_integer_int16",
-	116: "required_integer_int32",
-	117: "required_integer_int64",
-	118: "required_integer_int8",
-	119: "required_integer_uint",
-	120: "required_integer_uint16",
-	121: "required_integer_uint32",
-	122: "required_integer_uint64",
-	123: "required_integer_uint8",
-	124: "required_integer_unix",
-	125: "required_integer_unix-micro",
-	126: "required_integer_unix-milli",
-	127: "required_integer_unix-nano",
-	128: "required_integer_unix-seconds",
-	129: "required_null",
-	130: "required_number",
-	131: "required_number_double",
-	132: "required_number_float",
-	133: "required_number_int32",
-	134: "required_number_int64",
-	135: "required_string",
-	136: "required_string_base64",
-	137: "required_string_binary",
-	138: "required_string_byte",
-	139: "required_string_date",
-	140: "required_string_date-time",
-	141: "required_string_duration",
-	142: "required_string_email",
-	143: "required_string_float32",
-	144: "required_string_float64",
-	145: "required_string_hostname",
-	146: "required_string_int",
-	147: "required_string_int16",
-	148: "required_string_int32",
-	149: "required_string_int64",
-	150: "required_string_int8",
-	151: "required_string_ip",
-	152: "required_string_ipv4",
-	153: "required_string_ipv6",
-	154: "required_string_password",
-	155: "required_string_time",
-	156: "required_string_uint",
-	157: "required_string_uint16",
-	158: "required_string_uint32",
-	159: "required_string_uint64",
-	160: "required_string_uint8",
-	161: "required_string_unix",
-	162: "required_string_unix-micro",
-	163: "required_string_unix-milli",
-	164: "required_string_unix-nano",
-	165: "required_string_unix-seconds",
-	166: "required_string_uri",
-	167: "required_string_uuid",
-	168: "optional_any",
-	169: "optional_array_any",
-	170: "optional_array_boolean",
-	171: "optional_array_integer",
-	172: "optional_array_integer_int16",
-	173: "optional_array_integer_int32",
-	174: "optional_array_integer_int64",
-	175: "optional_array_integer_int8",
-	176: "optional_array_integer_uint",
-	177: "optional_array_integer_uint16",
-	178: "optional_array_integer_uint32",
-	179: "optional_array_integer_uint64",
-	180: "optional_array_integer_uint8",
-	181: "optional_array_integer_unix",
-	182: "optional_array_integer_unix-micro",
-	183: "optional_array_integer_unix-milli",
-	184: "optional_array_integer_unix-nano",
-	185: "optional_array_integer_unix-seconds",
-	186: "optional_array_null",
-	187: "optional_array_number",
-	188: "optional_array_number_double",
-	189: "optional_array_number_float",
-	190: "optional_array_number_int32",
-	191: "optional_array_number_int64",
-	192: "optional_array_string",
-	193: "optional_array_string_base64",
-	194: "optional_array_string_binary",
-	195: "optional_array_string_byte",
-	196: "optional_array_string_date",
-	197: "optional_array_string_date-time",
-	198: "optional_array_string_duration",
-	199: "optional_array_string_email",
-	200: "optional_array_string_float32",
-	201: "optional_array_string_float64",
-	202: "optional_array_string_hostname",
-	203: "optional_array_string_int",
-	204: "optional_array_string_int16",
-	205: "optional_array_string_int32",
-	206: "optional_array_string_int64",
-	207: "optional_array_string_int8",
-	208: "optional_array_string_ip",
-	209: "optional_array_string_ipv4",
-	210: "optional_array_string_ipv6",
-	211: "optional_array_string_password",
-	212: "optional_array_string_time",
-	213: "optional_array_string_uint",
-	214: "optional_array_string_uint16",
-	215: "optional_array_string_uint32",
-	216: "optional_array_string_uint64",
-	217: "optional_array_string_uint8",
-	218: "optional_array_string_unix",
-	219: "optional_array_string_unix-micro",
-	220: "optional_array_string_unix-milli",
-	221: "optional_array_string_unix-nano",
-	222: "optional_array_string_unix-seconds",
-	223: "optional_array_string_uri",
-	224: "optional_array_string_uuid",
-	225: "optional_boolean",
-	226: "optional_double_array_any",
-	227: "optional_double_array_boolean",
-	228: "optional_double_array_integer",
-	229: "optional_double_array_integer_int16",
-	230: "optional_double_array_integer_int32",
-	231: "optional_double_array_integer_int64",
-	232: "optional_double_array_integer_int8",
-	233: "optional_double_array_integer_uint",
-	234: "optional_double_array_integer_uint16",
-	235: "optional_double_array_integer_uint32",
-	236: "optional_double_array_integer_uint64",
-	237: "optional_double_array_integer_uint8",
-	238: "optional_double_array_integer_unix",
-	239: "optional_double_array_integer_unix-micro",
-	240: "optional_double_array_integer_unix-milli",
-	241: "optional_double_array_integer_unix-nano",
-	242: "optional_double_array_integer_unix-seconds",
-	243: "optional_double_array_null",
-	244: "optional_double_array_number",
-	245: "optional_double_array_number_double",
-	246: "optional_double_array_number_float",
-	247: "optional_double_array_number_int32",
-	248: "optional_double_array_number_int64",
-	249: "optional_double_array_string",
-	250: "optional_double_array_string_base64",
-	251: "optional_double_array_string_binary",
-	252: "optional_double_array_string_byte",
-	253: "optional_double_array_string_date",
-	254: "optional_double_array_string_date-time",
-	255: "optional_double_array_string_duration",
-	256: "optional_double_array_string_email",
-	257: "optional_double_array_string_float32",
-	258: "optional_double_array_string_float64",
-	259: "optional_double_array_string_hostname",
-	260: "optional_double_array_string_int",
-	261: "optional_double_array_string_int16",
-	262: "optional_double_array_string_int32",
-	263: "optional_double_array_string_int64",
-	264: "optional_double_array_string_int8",
-	265: "optional_double_array_string_ip",
-	266: "optional_double_array_string_ipv4",
-	267: "optional_double_array_string_ipv6",
-	268: "optional_double_array_string_password",
-	269: "optional_double_array_string_time",
-	270: "optional_double_array_string_uint",
-	271: "optional_double_array_string_uint16",
-	272: "optional_double_array_string_uint32",
-	273: "optional_double_array_string_uint64",
-	274: "optional_double_array_string_uint8",
-	275: "optional_double_array_string_unix",
-	276: "optional_double_array_string_unix-micro",
-	277: "optional_double_array_string_unix-milli",
-	278: "optional_double_array_string_unix-nano",
-	279: "optional_double_array_string_unix-seconds",
-	280: "optional_double_array_string_uri",
-	281: "optional_double_array_string_uuid",
-	282: "optional_integer",
-	283: "optional_integer_int16",
-	284: "optional_integer_int32",
-	285: "optional_integer_int64",
-	286: "optional_integer_int8",
-	287: "optional_integer_uint",
-	288: "optional_integer_uint16",
-	289: "optional_integer_uint32",
-	290: "optional_integer_uint64",
-	291: "optional_integer_uint8",
-	292: "optional_integer_unix",
-	293: "optional_integer_unix-micro",
-	294: "optional_integer_unix-milli",
-	295: "optional_integer_unix-nano",
-	296: "optional_integer_unix-seconds",
-	297: "optional_null",
-	298: "optional_number",
-	299: "optional_number_double",
-	300: "optional_number_float",
-	301: "optional_number_int32",
-	302: "optional_number_int64",
-	303: "optional_string",
-	304: "optional_string_base64",
-	305: "optional_string_binary",
-	306: "optional_string_byte",
-	307: "optional_string_date",
-	308: "optional_string_date-time",
-	309: "optional_string_duration",
-	310: "optional_string_email",
-	311: "optional_string_float32",
-	312: "optional_string_float64",
-	313: "optional_string_hostname",
-	314: "optional_string_int",
-	315: "optional_string_int16",
-	316: "optional_string_int32",
-	317: "optional_string_int64",
-	318: "optional_string_int8",
-	319: "optional_string_ip",
-	320: "optional_string_ipv4",
-	321: "optional_string_ipv6",
-	322: "optional_string_password",
-	323: "optional_string_time",
-	324: "optional_string_uint",
-	325: "optional_string_uint16",
-	326: "optional_string_uint32",
-	327: "optional_string_uint64",
-	328: "optional_string_uint8",
-	329: "optional_string_unix",
-	330: "optional_string_unix-micro",
-	331: "optional_string_unix-milli",
-	332: "optional_string_unix-nano",
-	333: "optional_string_unix-seconds",
-	334: "optional_string_uri",
-	335: "optional_string_uuid",
+	43:  "required_array_string_mac",
+	44:  "required_array_string_password",
+	45:  "required_array_string_time",
+	46:  "required_array_string_uint",
+	47:  "required_array_string_uint16",
+	48:  "required_array_string_uint32",
+	49:  "required_array_string_uint64",
+	50:  "required_array_string_uint8",
+	51:  "required_array_string_unix",
+	52:  "required_array_string_unix-micro",
+	53:  "required_array_string_unix-milli",
+	54:  "required_array_string_unix-nano",
+	55:  "required_array_string_unix-seconds",
+	56:  "required_array_string_uri",
+	57:  "required_array_string_uuid",
+	58:  "required_boolean",
+	59:  "required_double_array_any",
+	60:  "required_double_array_boolean",
+	61:  "required_double_array_integer",
+	62:  "required_double_array_integer_int16",
+	63:  "required_double_array_integer_int32",
+	64:  "required_double_array_integer_int64",
+	65:  "required_double_array_integer_int8",
+	66:  "required_double_array_integer_uint",
+	67:  "required_double_array_integer_uint16",
+	68:  "required_double_array_integer_uint32",
+	69:  "required_double_array_integer_uint64",
+	70:  "required_double_array_integer_uint8",
+	71:  "required_double_array_integer_unix",
+	72:  "required_double_array_integer_unix-micro",
+	73:  "required_double_array_integer_unix-milli",
+	74:  "required_double_array_integer_unix-nano",
+	75:  "required_double_array_integer_unix-seconds",
+	76:  "required_double_array_null",
+	77:  "required_double_array_number",
+	78:  "required_double_array_number_double",
+	79:  "required_double_array_number_float",
+	80:  "required_double_array_number_int32",
+	81:  "required_double_array_number_int64",
+	82:  "required_double_array_string",
+	83:  "required_double_array_string_base64",
+	84:  "required_double_array_string_binary",
+	85:  "required_double_array_string_byte",
+	86:  "required_double_array_string_date",
+	87:  "required_double_array_string_date-time",
+	88:  "required_double_array_string_duration",
+	89:  "required_double_array_string_email",
+	90:  "required_double_array_string_float32",
+	91:  "required_double_array_string_float64",
+	92:  "required_double_array_string_hostname",
+	93:  "required_double_array_string_int",
+	94:  "required_double_array_string_int16",
+	95:  "required_double_array_string_int32",
+	96:  "required_double_array_string_int64",
+	97:  "required_double_array_string_int8",
+	98:  "required_double_array_string_ip",
+	99:  "required_double_array_string_ipv4",
+	100: "required_double_array_string_ipv6",
+	101: "required_double_array_string_mac",
+	102: "required_double_array_string_password",
+	103: "required_double_array_string_time",
+	104: "required_double_array_string_uint",
+	105: "required_double_array_string_uint16",
+	106: "required_double_array_string_uint32",
+	107: "required_double_array_string_uint64",
+	108: "required_double_array_string_uint8",
+	109: "required_double_array_string_unix",
+	110: "required_double_array_string_unix-micro",
+	111: "required_double_array_string_unix-milli",
+	112: "required_double_array_string_unix-nano",
+	113: "required_double_array_string_unix-seconds",
+	114: "required_double_array_string_uri",
+	115: "required_double_array_string_uuid",
+	116: "required_integer",
+	117: "required_integer_int16",
+	118: "required_integer_int32",
+	119: "required_integer_int64",
+	120: "required_integer_int8",
+	121: "required_integer_uint",
+	122: "required_integer_uint16",
+	123: "required_integer_uint32",
+	124: "required_integer_uint64",
+	125: "required_integer_uint8",
+	126: "required_integer_unix",
+	127: "required_integer_unix-micro",
+	128: "required_integer_unix-milli",
+	129: "required_integer_unix-nano",
+	130: "required_integer_unix-seconds",
+	131: "required_null",
+	132: "required_number",
+	133: "required_number_double",
+	134: "required_number_float",
+	135: "required_number_int32",
+	136: "required_number_int64",
+	137: "required_string",
+	138: "required_string_base64",
+	139: "required_string_binary",
+	140: "required_string_byte",
+	141: "required_string_date",
+	142: "required_string_date-time",
+	143: "required_string_duration",
+	144: "required_string_email",
+	145: "required_string_float32",
+	146: "required_string_float64",
+	147: "required_string_hostname",
+	148: "required_string_int",
+	149: "required_string_int16",
+	150: "required_string_int32",
+	151: "required_string_int64",
+	152: "required_string_int8",
+	153: "required_string_ip",
+	154: "required_string_ipv4",
+	155: "required_string_ipv6",
+	156: "required_string_mac",
+	157: "required_string_password",
+	158: "required_string_time",
+	159: "required_string_uint",
+	160: "required_string_uint16",
+	161: "required_string_uint32",
+	162: "required_string_uint64",
+	163: "required_string_uint8",
+	164: "required_string_unix",
+	165: "required_string_unix-micro",
+	166: "required_string_unix-milli",
+	167: "required_string_unix-nano",
+	168: "required_string_unix-seconds",
+	169: "required_string_uri",
+	170: "required_string_uuid",
+	171: "optional_any",
+	172: "optional_array_any",
+	173: "optional_array_boolean",
+	174: "optional_array_integer",
+	175: "optional_array_integer_int16",
+	176: "optional_array_integer_int32",
+	177: "optional_array_integer_int64",
+	178: "optional_array_integer_int8",
+	179: "optional_array_integer_uint",
+	180: "optional_array_integer_uint16",
+	181: "optional_array_integer_uint32",
+	182: "optional_array_integer_uint64",
+	183: "optional_array_integer_uint8",
+	184: "optional_array_integer_unix",
+	185: "optional_array_integer_unix-micro",
+	186: "optional_array_integer_unix-milli",
+	187: "optional_array_integer_unix-nano",
+	188: "optional_array_integer_unix-seconds",
+	189: "optional_array_null",
+	190: "optional_array_number",
+	191: "optional_array_number_double",
+	192: "optional_array_number_float",
+	193: "optional_array_number_int32",
+	194: "optional_array_number_int64",
+	195: "optional_array_string",
+	196: "optional_array_string_base64",
+	197: "optional_array_string_binary",
+	198: "optional_array_string_byte",
+	199: "optional_array_string_date",
+	200: "optional_array_string_date-time",
+	201: "optional_array_string_duration",
+	202: "optional_array_string_email",
+	203: "optional_array_string_float32",
+	204: "optional_array_string_float64",
+	205: "optional_array_string_hostname",
+	206: "optional_array_string_int",
+	207: "optional_array_string_int16",
+	208: "optional_array_string_int32",
+	209: "optional_array_string_int64",
+	210: "optional_array_string_int8",
+	211: "optional_array_string_ip",
+	212: "optional_array_string_ipv4",
+	213: "optional_array_string_ipv6",
+	214: "optional_array_string_mac",
+	215: "optional_array_string_password",
+	216: "optional_array_string_time",
+	217: "optional_array_string_uint",
+	218: "optional_array_string_uint16",
+	219: "optional_array_string_uint32",
+	220: "optional_array_string_uint64",
+	221: "optional_array_string_uint8",
+	222: "optional_array_string_unix",
+	223: "optional_array_string_unix-micro",
+	224: "optional_array_string_unix-milli",
+	225: "optional_array_string_unix-nano",
+	226: "optional_array_string_unix-seconds",
+	227: "optional_array_string_uri",
+	228: "optional_array_string_uuid",
+	229: "optional_boolean",
+	230: "optional_double_array_any",
+	231: "optional_double_array_boolean",
+	232: "optional_double_array_integer",
+	233: "optional_double_array_integer_int16",
+	234: "optional_double_array_integer_int32",
+	235: "optional_double_array_integer_int64",
+	236: "optional_double_array_integer_int8",
+	237: "optional_double_array_integer_uint",
+	238: "optional_double_array_integer_uint16",
+	239: "optional_double_array_integer_uint32",
+	240: "optional_double_array_integer_uint64",
+	241: "optional_double_array_integer_uint8",
+	242: "optional_double_array_integer_unix",
+	243: "optional_double_array_integer_unix-micro",
+	244: "optional_double_array_integer_unix-milli",
+	245: "optional_double_array_integer_unix-nano",
+	246: "optional_double_array_integer_unix-seconds",
+	247: "optional_double_array_null",
+	248: "optional_double_array_number",
+	249: "optional_double_array_number_double",
+	250: "optional_double_array_number_float",
+	251: "optional_double_array_number_int32",
+	252: "optional_double_array_number_int64",
+	253: "optional_double_array_string",
+	254: "optional_double_array_string_base64",
+	255: "optional_double_array_string_binary",
+	256: "optional_double_array_string_byte",
+	257: "optional_double_array_string_date",
+	258: "optional_double_array_string_date-time",
+	259: "optional_double_array_string_duration",
+	260: "optional_double_array_string_email",
+	261: "optional_double_array_string_float32",
+	262: "optional_double_array_string_float64",
+	263: "optional_double_array_string_hostname",
+	264: "optional_double_array_string_int",
+	265: "optional_double_array_string_int16",
+	266: "optional_double_array_string_int32",
+	267: "optional_double_array_string_int64",
+	268: "optional_double_array_string_int8",
+	269: "optional_double_array_string_ip",
+	270: "optional_double_array_string_ipv4",
+	271: "optional_double_array_string_ipv6",
+	272: "optional_double_array_string_mac",
+	273: "optional_double_array_string_password",
+	274: "optional_double_array_string_time",
+	275: "optional_double_array_string_uint",
+	276: "optional_double_array_string_uint16",
+	277: "optional_double_array_string_uint32",
+	278: "optional_double_array_string_uint64",
+	279: "optional_double_array_string_uint8",
+	280: "optional_double_array_string_unix",
+	281: "optional_double_array_string_unix-micro",
+	282: "optional_double_array_string_unix-milli",
+	283: "optional_double_array_string_unix-nano",
+	284: "optional_double_array_string_unix-seconds",
+	285: "optional_double_array_string_uri",
+	286: "optional_double_array_string_uuid",
+	287: "optional_integer",
+	288: "optional_integer_int16",
+	289: "optional_integer_int32",
+	290: "optional_integer_int64",
+	291: "optional_integer_int8",
+	292: "optional_integer_uint",
+	293: "optional_integer_uint16",
+	294: "optional_integer_uint32",
+	295: "optional_integer_uint64",
+	296: "optional_integer_uint8",
+	297: "optional_integer_unix",
+	298: "optional_integer_unix-micro",
+	299: "optional_integer_unix-milli",
+	300: "optional_integer_unix-nano",
+	301: "optional_integer_unix-seconds",
+	302: "optional_null",
+	303: "optional_number",
+	304: "optional_number_double",
+	305: "optional_number_float",
+	306: "optional_number_int32",
+	307: "optional_number_int64",
+	308: "optional_string",
+	309: "optional_string_base64",
+	310: "optional_string_binary",
+	311: "optional_string_byte",
+	312: "optional_string_date",
+	313: "optional_string_date-time",
+	314: "optional_string_duration",
+	315: "optional_string_email",
+	316: "optional_string_float32",
+	317: "optional_string_float64",
+	318: "optional_string_hostname",
+	319: "optional_string_int",
+	320: "optional_string_int16",
+	321: "optional_string_int32",
+	322: "optional_string_int64",
+	323: "optional_string_int8",
+	324: "optional_string_ip",
+	325: "optional_string_ipv4",
+	326: "optional_string_ipv6",
+	327: "optional_string_mac",
+	328: "optional_string_password",
+	329: "optional_string_time",
+	330: "optional_string_uint",
+	331: "optional_string_uint16",
+	332: "optional_string_uint32",
+	333: "optional_string_uint64",
+	334: "optional_string_uint8",
+	335: "optional_string_unix",
+	336: "optional_string_unix-micro",
+	337: "optional_string_unix-milli",
+	338: "optional_string_unix-nano",
+	339: "optional_string_unix-seconds",
+	340: "optional_string_uri",
+	341: "optional_string_uuid",
 }
 
 // Decode decodes TestRequestFormatTestReq from json.
@@ -9324,7 +9517,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode TestRequestFormatTestReq to nil")
 	}
-	var requiredBitSet [42]uint8
+	var requiredBitSet [43]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -10178,8 +10371,28 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_array_string_ipv6\"")
 			}
-		case "required_array_string_password":
+		case "required_array_string_mac":
 			requiredBitSet[5] |= 1 << 3
+			if err := func() error {
+				s.RequiredArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_array_string_mac\"")
+			}
+		case "required_array_string_password":
+			requiredBitSet[5] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringPassword = make([]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10199,7 +10412,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_password\"")
 			}
 		case "required_array_string_time":
-			requiredBitSet[5] |= 1 << 4
+			requiredBitSet[5] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringTime = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10219,7 +10432,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_time\"")
 			}
 		case "required_array_string_uint":
-			requiredBitSet[5] |= 1 << 5
+			requiredBitSet[5] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUint = make([]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10239,7 +10452,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint\"")
 			}
 		case "required_array_string_uint16":
-			requiredBitSet[5] |= 1 << 6
+			requiredBitSet[5] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUint16 = make([]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10259,7 +10472,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint16\"")
 			}
 		case "required_array_string_uint32":
-			requiredBitSet[5] |= 1 << 7
+			requiredBitSet[6] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringUint32 = make([]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10279,7 +10492,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint32\"")
 			}
 		case "required_array_string_uint64":
-			requiredBitSet[6] |= 1 << 0
+			requiredBitSet[6] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUint64 = make([]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10299,7 +10512,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint64\"")
 			}
 		case "required_array_string_uint8":
-			requiredBitSet[6] |= 1 << 1
+			requiredBitSet[6] |= 1 << 2
 			if err := func() error {
 				s.RequiredArrayStringUint8 = make([]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10319,7 +10532,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint8\"")
 			}
 		case "required_array_string_unix":
-			requiredBitSet[6] |= 1 << 2
+			requiredBitSet[6] |= 1 << 3
 			if err := func() error {
 				s.RequiredArrayStringUnix = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10339,7 +10552,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix\"")
 			}
 		case "required_array_string_unix-micro":
-			requiredBitSet[6] |= 1 << 3
+			requiredBitSet[6] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMicro = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10359,7 +10572,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-micro\"")
 			}
 		case "required_array_string_unix-milli":
-			requiredBitSet[6] |= 1 << 4
+			requiredBitSet[6] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMilli = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10379,7 +10592,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-milli\"")
 			}
 		case "required_array_string_unix-nano":
-			requiredBitSet[6] |= 1 << 5
+			requiredBitSet[6] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusNano = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10399,7 +10612,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-nano\"")
 			}
 		case "required_array_string_unix-seconds":
-			requiredBitSet[6] |= 1 << 6
+			requiredBitSet[6] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusSeconds = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10419,7 +10632,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-seconds\"")
 			}
 		case "required_array_string_uri":
-			requiredBitSet[6] |= 1 << 7
+			requiredBitSet[7] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringURI = make([]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10439,7 +10652,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uri\"")
 			}
 		case "required_array_string_uuid":
-			requiredBitSet[7] |= 1 << 0
+			requiredBitSet[7] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUUID = make([]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10459,7 +10672,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uuid\"")
 			}
 		case "required_boolean":
-			requiredBitSet[7] |= 1 << 1
+			requiredBitSet[7] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.RequiredBoolean = bool(v)
@@ -10471,7 +10684,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_boolean\"")
 			}
 		case "required_double_array_any":
-			requiredBitSet[7] |= 1 << 2
+			requiredBitSet[7] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayAny = make([][]jx.Raw, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10499,7 +10712,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_any\"")
 			}
 		case "required_double_array_boolean":
-			requiredBitSet[7] |= 1 << 3
+			requiredBitSet[7] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayBoolean = make([][]bool, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10527,7 +10740,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_boolean\"")
 			}
 		case "required_double_array_integer":
-			requiredBitSet[7] |= 1 << 4
+			requiredBitSet[7] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayInteger = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10555,7 +10768,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer\"")
 			}
 		case "required_double_array_integer_int16":
-			requiredBitSet[7] |= 1 << 5
+			requiredBitSet[7] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10583,7 +10796,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int16\"")
 			}
 		case "required_double_array_integer_int32":
-			requiredBitSet[7] |= 1 << 6
+			requiredBitSet[7] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10611,7 +10824,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int32\"")
 			}
 		case "required_double_array_integer_int64":
-			requiredBitSet[7] |= 1 << 7
+			requiredBitSet[8] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10639,7 +10852,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int64\"")
 			}
 		case "required_double_array_integer_int8":
-			requiredBitSet[8] |= 1 << 0
+			requiredBitSet[8] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10667,7 +10880,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int8\"")
 			}
 		case "required_double_array_integer_uint":
-			requiredBitSet[8] |= 1 << 1
+			requiredBitSet[8] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10695,7 +10908,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint\"")
 			}
 		case "required_double_array_integer_uint16":
-			requiredBitSet[8] |= 1 << 2
+			requiredBitSet[8] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10723,7 +10936,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint16\"")
 			}
 		case "required_double_array_integer_uint32":
-			requiredBitSet[8] |= 1 << 3
+			requiredBitSet[8] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10751,7 +10964,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint32\"")
 			}
 		case "required_double_array_integer_uint64":
-			requiredBitSet[8] |= 1 << 4
+			requiredBitSet[8] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10779,7 +10992,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint64\"")
 			}
 		case "required_double_array_integer_uint8":
-			requiredBitSet[8] |= 1 << 5
+			requiredBitSet[8] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10807,7 +11020,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint8\"")
 			}
 		case "required_double_array_integer_unix":
-			requiredBitSet[8] |= 1 << 6
+			requiredBitSet[8] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10835,7 +11048,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix\"")
 			}
 		case "required_double_array_integer_unix-micro":
-			requiredBitSet[8] |= 1 << 7
+			requiredBitSet[9] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10863,7 +11076,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-micro\"")
 			}
 		case "required_double_array_integer_unix-milli":
-			requiredBitSet[9] |= 1 << 0
+			requiredBitSet[9] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10891,7 +11104,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-milli\"")
 			}
 		case "required_double_array_integer_unix-nano":
-			requiredBitSet[9] |= 1 << 1
+			requiredBitSet[9] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10919,7 +11132,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-nano\"")
 			}
 		case "required_double_array_integer_unix-seconds":
-			requiredBitSet[9] |= 1 << 2
+			requiredBitSet[9] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10947,7 +11160,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-seconds\"")
 			}
 		case "required_double_array_null":
-			requiredBitSet[9] |= 1 << 3
+			requiredBitSet[9] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayNull = make([][]struct{}, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -10973,7 +11186,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_null\"")
 			}
 		case "required_double_array_number":
-			requiredBitSet[9] |= 1 << 4
+			requiredBitSet[9] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayNumber = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11001,7 +11214,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number\"")
 			}
 		case "required_double_array_number_double":
-			requiredBitSet[9] |= 1 << 5
+			requiredBitSet[9] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayNumberDouble = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11029,7 +11242,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_double\"")
 			}
 		case "required_double_array_number_float":
-			requiredBitSet[9] |= 1 << 6
+			requiredBitSet[9] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayNumberFloat = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11057,7 +11270,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_float\"")
 			}
 		case "required_double_array_number_int32":
-			requiredBitSet[9] |= 1 << 7
+			requiredBitSet[10] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11085,7 +11298,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int32\"")
 			}
 		case "required_double_array_number_int64":
-			requiredBitSet[10] |= 1 << 0
+			requiredBitSet[10] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11113,7 +11326,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int64\"")
 			}
 		case "required_double_array_string":
-			requiredBitSet[10] |= 1 << 1
+			requiredBitSet[10] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayString = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11141,7 +11354,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string\"")
 			}
 		case "required_double_array_string_base64":
-			requiredBitSet[10] |= 1 << 2
+			requiredBitSet[10] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringBase64 = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11169,7 +11382,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_base64\"")
 			}
 		case "required_double_array_string_binary":
-			requiredBitSet[10] |= 1 << 3
+			requiredBitSet[10] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringBinary = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11197,7 +11410,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_binary\"")
 			}
 		case "required_double_array_string_byte":
-			requiredBitSet[10] |= 1 << 4
+			requiredBitSet[10] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringByte = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11225,7 +11438,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_byte\"")
 			}
 		case "required_double_array_string_date":
-			requiredBitSet[10] |= 1 << 5
+			requiredBitSet[10] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringDate = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11253,7 +11466,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date\"")
 			}
 		case "required_double_array_string_date-time":
-			requiredBitSet[10] |= 1 << 6
+			requiredBitSet[10] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringDateMinusTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11281,7 +11494,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date-time\"")
 			}
 		case "required_double_array_string_duration":
-			requiredBitSet[10] |= 1 << 7
+			requiredBitSet[11] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringDuration = make([][]time.Duration, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11309,7 +11522,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_duration\"")
 			}
 		case "required_double_array_string_email":
-			requiredBitSet[11] |= 1 << 0
+			requiredBitSet[11] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringEmail = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11337,7 +11550,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_email\"")
 			}
 		case "required_double_array_string_float32":
-			requiredBitSet[11] |= 1 << 1
+			requiredBitSet[11] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat32 = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11365,7 +11578,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float32\"")
 			}
 		case "required_double_array_string_float64":
-			requiredBitSet[11] |= 1 << 2
+			requiredBitSet[11] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat64 = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11393,7 +11606,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float64\"")
 			}
 		case "required_double_array_string_hostname":
-			requiredBitSet[11] |= 1 << 3
+			requiredBitSet[11] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringHostname = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11421,7 +11634,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_hostname\"")
 			}
 		case "required_double_array_string_int":
-			requiredBitSet[11] |= 1 << 4
+			requiredBitSet[11] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11449,7 +11662,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int\"")
 			}
 		case "required_double_array_string_int16":
-			requiredBitSet[11] |= 1 << 5
+			requiredBitSet[11] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11477,7 +11690,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int16\"")
 			}
 		case "required_double_array_string_int32":
-			requiredBitSet[11] |= 1 << 6
+			requiredBitSet[11] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11505,7 +11718,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int32\"")
 			}
 		case "required_double_array_string_int64":
-			requiredBitSet[11] |= 1 << 7
+			requiredBitSet[12] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11533,7 +11746,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int64\"")
 			}
 		case "required_double_array_string_int8":
-			requiredBitSet[12] |= 1 << 0
+			requiredBitSet[12] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11561,7 +11774,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int8\"")
 			}
 		case "required_double_array_string_ip":
-			requiredBitSet[12] |= 1 << 1
+			requiredBitSet[12] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringIP = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11589,7 +11802,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ip\"")
 			}
 		case "required_double_array_string_ipv4":
-			requiredBitSet[12] |= 1 << 2
+			requiredBitSet[12] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv4 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11617,7 +11830,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv4\"")
 			}
 		case "required_double_array_string_ipv6":
-			requiredBitSet[12] |= 1 << 3
+			requiredBitSet[12] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv6 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11644,8 +11857,36 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv6\"")
 			}
+		case "required_double_array_string_mac":
+			requiredBitSet[12] |= 1 << 5
+			if err := func() error {
+				s.RequiredDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_double_array_string_mac\"")
+			}
 		case "required_double_array_string_password":
-			requiredBitSet[12] |= 1 << 4
+			requiredBitSet[12] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringPassword = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11673,7 +11914,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_password\"")
 			}
 		case "required_double_array_string_time":
-			requiredBitSet[12] |= 1 << 5
+			requiredBitSet[12] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11701,7 +11942,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_time\"")
 			}
 		case "required_double_array_string_uint":
-			requiredBitSet[12] |= 1 << 6
+			requiredBitSet[13] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11729,7 +11970,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint\"")
 			}
 		case "required_double_array_string_uint16":
-			requiredBitSet[12] |= 1 << 7
+			requiredBitSet[13] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11757,7 +11998,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint16\"")
 			}
 		case "required_double_array_string_uint32":
-			requiredBitSet[13] |= 1 << 0
+			requiredBitSet[13] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11785,7 +12026,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint32\"")
 			}
 		case "required_double_array_string_uint64":
-			requiredBitSet[13] |= 1 << 1
+			requiredBitSet[13] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11813,7 +12054,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint64\"")
 			}
 		case "required_double_array_string_uint8":
-			requiredBitSet[13] |= 1 << 2
+			requiredBitSet[13] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11841,7 +12082,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint8\"")
 			}
 		case "required_double_array_string_unix":
-			requiredBitSet[13] |= 1 << 3
+			requiredBitSet[13] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11869,7 +12110,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix\"")
 			}
 		case "required_double_array_string_unix-micro":
-			requiredBitSet[13] |= 1 << 4
+			requiredBitSet[13] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11897,7 +12138,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-micro\"")
 			}
 		case "required_double_array_string_unix-milli":
-			requiredBitSet[13] |= 1 << 5
+			requiredBitSet[13] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11925,7 +12166,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-milli\"")
 			}
 		case "required_double_array_string_unix-nano":
-			requiredBitSet[13] |= 1 << 6
+			requiredBitSet[14] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11953,7 +12194,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-nano\"")
 			}
 		case "required_double_array_string_unix-seconds":
-			requiredBitSet[13] |= 1 << 7
+			requiredBitSet[14] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -11981,7 +12222,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-seconds\"")
 			}
 		case "required_double_array_string_uri":
-			requiredBitSet[14] |= 1 << 0
+			requiredBitSet[14] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringURI = make([][]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -12009,7 +12250,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uri\"")
 			}
 		case "required_double_array_string_uuid":
-			requiredBitSet[14] |= 1 << 1
+			requiredBitSet[14] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUUID = make([][]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -12037,7 +12278,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uuid\"")
 			}
 		case "required_integer":
-			requiredBitSet[14] |= 1 << 2
+			requiredBitSet[14] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.RequiredInteger = int(v)
@@ -12049,7 +12290,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer\"")
 			}
 		case "required_integer_int16":
-			requiredBitSet[14] |= 1 << 3
+			requiredBitSet[14] |= 1 << 5
 			if err := func() error {
 				v, err := d.Int16()
 				s.RequiredIntegerInt16 = int16(v)
@@ -12061,7 +12302,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int16\"")
 			}
 		case "required_integer_int32":
-			requiredBitSet[14] |= 1 << 4
+			requiredBitSet[14] |= 1 << 6
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredIntegerInt32 = int32(v)
@@ -12073,7 +12314,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int32\"")
 			}
 		case "required_integer_int64":
-			requiredBitSet[14] |= 1 << 5
+			requiredBitSet[14] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredIntegerInt64 = int64(v)
@@ -12085,7 +12326,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int64\"")
 			}
 		case "required_integer_int8":
-			requiredBitSet[14] |= 1 << 6
+			requiredBitSet[15] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int8()
 				s.RequiredIntegerInt8 = int8(v)
@@ -12097,7 +12338,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int8\"")
 			}
 		case "required_integer_uint":
-			requiredBitSet[14] |= 1 << 7
+			requiredBitSet[15] |= 1 << 1
 			if err := func() error {
 				v, err := d.UInt()
 				s.RequiredIntegerUint = uint(v)
@@ -12109,7 +12350,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint\"")
 			}
 		case "required_integer_uint16":
-			requiredBitSet[15] |= 1 << 0
+			requiredBitSet[15] |= 1 << 2
 			if err := func() error {
 				v, err := d.UInt16()
 				s.RequiredIntegerUint16 = uint16(v)
@@ -12121,7 +12362,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint16\"")
 			}
 		case "required_integer_uint32":
-			requiredBitSet[15] |= 1 << 1
+			requiredBitSet[15] |= 1 << 3
 			if err := func() error {
 				v, err := d.UInt32()
 				s.RequiredIntegerUint32 = uint32(v)
@@ -12133,7 +12374,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint32\"")
 			}
 		case "required_integer_uint64":
-			requiredBitSet[15] |= 1 << 2
+			requiredBitSet[15] |= 1 << 4
 			if err := func() error {
 				v, err := d.UInt64()
 				s.RequiredIntegerUint64 = uint64(v)
@@ -12145,7 +12386,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint64\"")
 			}
 		case "required_integer_uint8":
-			requiredBitSet[15] |= 1 << 3
+			requiredBitSet[15] |= 1 << 5
 			if err := func() error {
 				v, err := d.UInt8()
 				s.RequiredIntegerUint8 = uint8(v)
@@ -12157,7 +12398,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint8\"")
 			}
 		case "required_integer_unix":
-			requiredBitSet[15] |= 1 << 4
+			requiredBitSet[15] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnix = v
@@ -12169,7 +12410,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix\"")
 			}
 		case "required_integer_unix-micro":
-			requiredBitSet[15] |= 1 << 5
+			requiredBitSet[15] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeUnixMicro(d)
 				s.RequiredIntegerUnixMinusMicro = v
@@ -12181,7 +12422,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-micro\"")
 			}
 		case "required_integer_unix-milli":
-			requiredBitSet[15] |= 1 << 6
+			requiredBitSet[16] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeUnixMilli(d)
 				s.RequiredIntegerUnixMinusMilli = v
@@ -12193,7 +12434,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-milli\"")
 			}
 		case "required_integer_unix-nano":
-			requiredBitSet[15] |= 1 << 7
+			requiredBitSet[16] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeUnixNano(d)
 				s.RequiredIntegerUnixMinusNano = v
@@ -12205,7 +12446,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-nano\"")
 			}
 		case "required_integer_unix-seconds":
-			requiredBitSet[16] |= 1 << 0
+			requiredBitSet[16] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnixMinusSeconds = v
@@ -12217,7 +12458,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-seconds\"")
 			}
 		case "required_null":
-			requiredBitSet[16] |= 1 << 1
+			requiredBitSet[16] |= 1 << 3
 			if err := func() error {
 				if err := d.Null(); err != nil {
 					return err
@@ -12227,7 +12468,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_null\"")
 			}
 		case "required_number":
-			requiredBitSet[16] |= 1 << 2
+			requiredBitSet[16] |= 1 << 4
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumber = float64(v)
@@ -12239,7 +12480,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number\"")
 			}
 		case "required_number_double":
-			requiredBitSet[16] |= 1 << 3
+			requiredBitSet[16] |= 1 << 5
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumberDouble = float64(v)
@@ -12251,7 +12492,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_double\"")
 			}
 		case "required_number_float":
-			requiredBitSet[16] |= 1 << 4
+			requiredBitSet[16] |= 1 << 6
 			if err := func() error {
 				v, err := d.Float32()
 				s.RequiredNumberFloat = float32(v)
@@ -12263,7 +12504,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_float\"")
 			}
 		case "required_number_int32":
-			requiredBitSet[16] |= 1 << 5
+			requiredBitSet[16] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredNumberInt32 = int32(v)
@@ -12275,7 +12516,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int32\"")
 			}
 		case "required_number_int64":
-			requiredBitSet[16] |= 1 << 6
+			requiredBitSet[17] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredNumberInt64 = int64(v)
@@ -12287,7 +12528,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int64\"")
 			}
 		case "required_string":
-			requiredBitSet[16] |= 1 << 7
+			requiredBitSet[17] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredString = string(v)
@@ -12299,7 +12540,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string\"")
 			}
 		case "required_string_base64":
-			requiredBitSet[17] |= 1 << 0
+			requiredBitSet[17] |= 1 << 2
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringBase64 = []byte(v)
@@ -12311,7 +12552,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_base64\"")
 			}
 		case "required_string_binary":
-			requiredBitSet[17] |= 1 << 1
+			requiredBitSet[17] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringBinary = string(v)
@@ -12323,7 +12564,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_binary\"")
 			}
 		case "required_string_byte":
-			requiredBitSet[17] |= 1 << 2
+			requiredBitSet[17] |= 1 << 4
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringByte = []byte(v)
@@ -12335,7 +12576,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_byte\"")
 			}
 		case "required_string_date":
-			requiredBitSet[17] |= 1 << 3
+			requiredBitSet[17] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeDate(d)
 				s.RequiredStringDate = v
@@ -12347,7 +12588,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date\"")
 			}
 		case "required_string_date-time":
-			requiredBitSet[17] |= 1 << 4
+			requiredBitSet[17] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.RequiredStringDateMinusTime = v
@@ -12359,7 +12600,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date-time\"")
 			}
 		case "required_string_duration":
-			requiredBitSet[17] |= 1 << 5
+			requiredBitSet[17] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDuration(d)
 				s.RequiredStringDuration = v
@@ -12371,7 +12612,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_duration\"")
 			}
 		case "required_string_email":
-			requiredBitSet[17] |= 1 << 6
+			requiredBitSet[18] |= 1 << 0
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringEmail = string(v)
@@ -12383,7 +12624,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_email\"")
 			}
 		case "required_string_float32":
-			requiredBitSet[17] |= 1 << 7
+			requiredBitSet[18] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringFloat32(d)
 				s.RequiredStringFloat32 = v
@@ -12395,7 +12636,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float32\"")
 			}
 		case "required_string_float64":
-			requiredBitSet[18] |= 1 << 0
+			requiredBitSet[18] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringFloat64(d)
 				s.RequiredStringFloat64 = v
@@ -12407,7 +12648,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float64\"")
 			}
 		case "required_string_hostname":
-			requiredBitSet[18] |= 1 << 1
+			requiredBitSet[18] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringHostname = string(v)
@@ -12419,7 +12660,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_hostname\"")
 			}
 		case "required_string_int":
-			requiredBitSet[18] |= 1 << 2
+			requiredBitSet[18] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringInt(d)
 				s.RequiredStringInt = v
@@ -12431,7 +12672,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int\"")
 			}
 		case "required_string_int16":
-			requiredBitSet[18] |= 1 << 3
+			requiredBitSet[18] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringInt16(d)
 				s.RequiredStringInt16 = v
@@ -12443,7 +12684,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int16\"")
 			}
 		case "required_string_int32":
-			requiredBitSet[18] |= 1 << 4
+			requiredBitSet[18] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringInt32(d)
 				s.RequiredStringInt32 = v
@@ -12455,7 +12696,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int32\"")
 			}
 		case "required_string_int64":
-			requiredBitSet[18] |= 1 << 5
+			requiredBitSet[18] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringInt64(d)
 				s.RequiredStringInt64 = v
@@ -12467,7 +12708,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int64\"")
 			}
 		case "required_string_int8":
-			requiredBitSet[18] |= 1 << 6
+			requiredBitSet[19] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringInt8(d)
 				s.RequiredStringInt8 = v
@@ -12479,7 +12720,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int8\"")
 			}
 		case "required_string_ip":
-			requiredBitSet[18] |= 1 << 7
+			requiredBitSet[19] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeIP(d)
 				s.RequiredStringIP = v
@@ -12491,7 +12732,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ip\"")
 			}
 		case "required_string_ipv4":
-			requiredBitSet[19] |= 1 << 0
+			requiredBitSet[19] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeIPv4(d)
 				s.RequiredStringIpv4 = v
@@ -12503,7 +12744,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ipv4\"")
 			}
 		case "required_string_ipv6":
-			requiredBitSet[19] |= 1 << 1
+			requiredBitSet[19] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeIPv6(d)
 				s.RequiredStringIpv6 = v
@@ -12514,8 +12755,20 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_string_ipv6\"")
 			}
+		case "required_string_mac":
+			requiredBitSet[19] |= 1 << 4
+			if err := func() error {
+				v, err := json.DecodeMAC(d)
+				s.RequiredStringMAC = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_string_mac\"")
+			}
 		case "required_string_password":
-			requiredBitSet[19] |= 1 << 2
+			requiredBitSet[19] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringPassword = string(v)
@@ -12527,7 +12780,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_password\"")
 			}
 		case "required_string_time":
-			requiredBitSet[19] |= 1 << 3
+			requiredBitSet[19] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeTime(d)
 				s.RequiredStringTime = v
@@ -12539,7 +12792,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_time\"")
 			}
 		case "required_string_uint":
-			requiredBitSet[19] |= 1 << 4
+			requiredBitSet[19] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUint(d)
 				s.RequiredStringUint = v
@@ -12551,7 +12804,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint\"")
 			}
 		case "required_string_uint16":
-			requiredBitSet[19] |= 1 << 5
+			requiredBitSet[20] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUint16(d)
 				s.RequiredStringUint16 = v
@@ -12563,7 +12816,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint16\"")
 			}
 		case "required_string_uint32":
-			requiredBitSet[19] |= 1 << 6
+			requiredBitSet[20] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringUint32(d)
 				s.RequiredStringUint32 = v
@@ -12575,7 +12828,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint32\"")
 			}
 		case "required_string_uint64":
-			requiredBitSet[19] |= 1 << 7
+			requiredBitSet[20] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringUint64(d)
 				s.RequiredStringUint64 = v
@@ -12587,7 +12840,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint64\"")
 			}
 		case "required_string_uint8":
-			requiredBitSet[20] |= 1 << 0
+			requiredBitSet[20] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeStringUint8(d)
 				s.RequiredStringUint8 = v
@@ -12599,7 +12852,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint8\"")
 			}
 		case "required_string_unix":
-			requiredBitSet[20] |= 1 << 1
+			requiredBitSet[20] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnix = v
@@ -12611,7 +12864,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix\"")
 			}
 		case "required_string_unix-micro":
-			requiredBitSet[20] |= 1 << 2
+			requiredBitSet[20] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringUnixMicro(d)
 				s.RequiredStringUnixMinusMicro = v
@@ -12623,7 +12876,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-micro\"")
 			}
 		case "required_string_unix-milli":
-			requiredBitSet[20] |= 1 << 3
+			requiredBitSet[20] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringUnixMilli(d)
 				s.RequiredStringUnixMinusMilli = v
@@ -12635,7 +12888,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-milli\"")
 			}
 		case "required_string_unix-nano":
-			requiredBitSet[20] |= 1 << 4
+			requiredBitSet[20] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUnixNano(d)
 				s.RequiredStringUnixMinusNano = v
@@ -12647,7 +12900,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-nano\"")
 			}
 		case "required_string_unix-seconds":
-			requiredBitSet[20] |= 1 << 5
+			requiredBitSet[21] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnixMinusSeconds = v
@@ -12659,7 +12912,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-seconds\"")
 			}
 		case "required_string_uri":
-			requiredBitSet[20] |= 1 << 6
+			requiredBitSet[21] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.RequiredStringURI = v
@@ -12671,7 +12924,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uri\"")
 			}
 		case "required_string_uuid":
-			requiredBitSet[20] |= 1 << 7
+			requiredBitSet[21] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.RequiredStringUUID = v
@@ -13488,6 +13741,25 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_array_string_ipv6\"")
+			}
+		case "optional_array_string_mac":
+			if err := func() error {
+				s.OptionalArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_array_string_mac\"")
 			}
 		case "optional_array_string_password":
 			if err := func() error {
@@ -14897,6 +15169,33 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_double_array_string_ipv6\"")
 			}
+		case "optional_double_array_string_mac":
+			if err := func() error {
+				s.OptionalDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_double_array_string_mac\"")
+			}
 		case "optional_double_array_string_password":
 			if err := func() error {
 				s.OptionalDoubleArrayStringPassword = make([][]string, 0)
@@ -15677,6 +15976,16 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_string_ipv6\"")
 			}
+		case "optional_string_mac":
+			if err := func() error {
+				s.OptionalStringMAC.Reset()
+				if err := s.OptionalStringMAC.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_string_mac\"")
+			}
 		case "optional_string_password":
 			if err := func() error {
 				s.OptionalStringPassword.Reset()
@@ -15826,7 +16135,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [42]uint8{
+	for i, mask := range [43]uint8{
 		0b11111111,
 		0b11111111,
 		0b11111111,
@@ -15848,6 +16157,7 @@ func (s *TestRequestFormatTestReq) Decode(d *jx.Decoder) error {
 		0b11111111,
 		0b11111111,
 		0b11111111,
+		0b00000111,
 		0b00000000,
 		0b00000000,
 		0b00000000,
@@ -16313,6 +16623,14 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredArrayStringMAC {
+			json.EncodeMAC(e, elem)
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredArrayStringPassword {
@@ -16936,6 +17254,18 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_double_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredDoubleArrayStringMAC {
+			e.ArrStart()
+			for _, elem := range elem {
+				json.EncodeMAC(e, elem)
+			}
+			e.ArrEnd()
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_double_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredDoubleArrayStringPassword {
@@ -17263,6 +17593,10 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 	{
 		e.FieldStart("required_string_ipv6")
 		json.EncodeIPv6(e, s.RequiredStringIpv6)
+	}
+	{
+		e.FieldStart("required_string_mac")
+		json.EncodeMAC(e, s.RequiredStringMAC)
 	}
 	{
 		e.FieldStart("required_string_password")
@@ -17745,6 +18079,16 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 			e.ArrStart()
 			for _, elem := range s.OptionalArrayStringIpv6 {
 				json.EncodeIPv6(e, elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.OptionalArrayStringMAC != nil {
+			e.FieldStart("optional_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalArrayStringMAC {
+				json.EncodeMAC(e, elem)
 			}
 			e.ArrEnd()
 		}
@@ -18487,6 +18831,20 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalDoubleArrayStringMAC != nil {
+			e.FieldStart("optional_double_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalDoubleArrayStringMAC {
+				e.ArrStart()
+				for _, elem := range elem {
+					json.EncodeMAC(e, elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		if s.OptionalDoubleArrayStringPassword != nil {
 			e.FieldStart("optional_double_array_string_password")
 			e.ArrStart()
@@ -18919,6 +19277,12 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalStringMAC.Set {
+			e.FieldStart("optional_string_mac")
+			s.OptionalStringMAC.Encode(e)
+		}
+	}
+	{
 		if s.OptionalStringPassword.Set {
 			e.FieldStart("optional_string_password")
 			s.OptionalStringPassword.Encode(e)
@@ -19004,7 +19368,7 @@ func (s *TestRequestRequiredFormatTestReq) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfTestRequestRequiredFormatTestReq = [336]string{
+var jsonFieldsNameOfTestRequestRequiredFormatTestReq = [342]string{
 	0:   "required_any",
 	1:   "required_array_any",
 	2:   "required_array_boolean",
@@ -19048,299 +19412,305 @@ var jsonFieldsNameOfTestRequestRequiredFormatTestReq = [336]string{
 	40:  "required_array_string_ip",
 	41:  "required_array_string_ipv4",
 	42:  "required_array_string_ipv6",
-	43:  "required_array_string_password",
-	44:  "required_array_string_time",
-	45:  "required_array_string_uint",
-	46:  "required_array_string_uint16",
-	47:  "required_array_string_uint32",
-	48:  "required_array_string_uint64",
-	49:  "required_array_string_uint8",
-	50:  "required_array_string_unix",
-	51:  "required_array_string_unix-micro",
-	52:  "required_array_string_unix-milli",
-	53:  "required_array_string_unix-nano",
-	54:  "required_array_string_unix-seconds",
-	55:  "required_array_string_uri",
-	56:  "required_array_string_uuid",
-	57:  "required_boolean",
-	58:  "required_double_array_any",
-	59:  "required_double_array_boolean",
-	60:  "required_double_array_integer",
-	61:  "required_double_array_integer_int16",
-	62:  "required_double_array_integer_int32",
-	63:  "required_double_array_integer_int64",
-	64:  "required_double_array_integer_int8",
-	65:  "required_double_array_integer_uint",
-	66:  "required_double_array_integer_uint16",
-	67:  "required_double_array_integer_uint32",
-	68:  "required_double_array_integer_uint64",
-	69:  "required_double_array_integer_uint8",
-	70:  "required_double_array_integer_unix",
-	71:  "required_double_array_integer_unix-micro",
-	72:  "required_double_array_integer_unix-milli",
-	73:  "required_double_array_integer_unix-nano",
-	74:  "required_double_array_integer_unix-seconds",
-	75:  "required_double_array_null",
-	76:  "required_double_array_number",
-	77:  "required_double_array_number_double",
-	78:  "required_double_array_number_float",
-	79:  "required_double_array_number_int32",
-	80:  "required_double_array_number_int64",
-	81:  "required_double_array_string",
-	82:  "required_double_array_string_base64",
-	83:  "required_double_array_string_binary",
-	84:  "required_double_array_string_byte",
-	85:  "required_double_array_string_date",
-	86:  "required_double_array_string_date-time",
-	87:  "required_double_array_string_duration",
-	88:  "required_double_array_string_email",
-	89:  "required_double_array_string_float32",
-	90:  "required_double_array_string_float64",
-	91:  "required_double_array_string_hostname",
-	92:  "required_double_array_string_int",
-	93:  "required_double_array_string_int16",
-	94:  "required_double_array_string_int32",
-	95:  "required_double_array_string_int64",
-	96:  "required_double_array_string_int8",
-	97:  "required_double_array_string_ip",
-	98:  "required_double_array_string_ipv4",
-	99:  "required_double_array_string_ipv6",
-	100: "required_double_array_string_password",
-	101: "required_double_array_string_time",
-	102: "required_double_array_string_uint",
-	103: "required_double_array_string_uint16",
-	104: "required_double_array_string_uint32",
-	105: "required_double_array_string_uint64",
-	106: "required_double_array_string_uint8",
-	107: "required_double_array_string_unix",
-	108: "required_double_array_string_unix-micro",
-	109: "required_double_array_string_unix-milli",
-	110: "required_double_array_string_unix-nano",
-	111: "required_double_array_string_unix-seconds",
-	112: "required_double_array_string_uri",
-	113: "required_double_array_string_uuid",
-	114: "required_integer",
-	115: "required_integer_int16",
-	116: "required_integer_int32",
-	117: "required_integer_int64",
-	118: "required_integer_int8",
-	119: "required_integer_uint",
-	120: "required_integer_uint16",
-	121: "required_integer_uint32",
-	122: "required_integer_uint64",
-	123: "required_integer_uint8",
-	124: "required_integer_unix",
-	125: "required_integer_unix-micro",
-	126: "required_integer_unix-milli",
-	127: "required_integer_unix-nano",
-	128: "required_integer_unix-seconds",
-	129: "required_null",
-	130: "required_number",
-	131: "required_number_double",
-	132: "required_number_float",
-	133: "required_number_int32",
-	134: "required_number_int64",
-	135: "required_string",
-	136: "required_string_base64",
-	137: "required_string_binary",
-	138: "required_string_byte",
-	139: "required_string_date",
-	140: "required_string_date-time",
-	141: "required_string_duration",
-	142: "required_string_email",
-	143: "required_string_float32",
-	144: "required_string_float64",
-	145: "required_string_hostname",
-	146: "required_string_int",
-	147: "required_string_int16",
-	148: "required_string_int32",
-	149: "required_string_int64",
-	150: "required_string_int8",
-	151: "required_string_ip",
-	152: "required_string_ipv4",
-	153: "required_string_ipv6",
-	154: "required_string_password",
-	155: "required_string_time",
-	156: "required_string_uint",
-	157: "required_string_uint16",
-	158: "required_string_uint32",
-	159: "required_string_uint64",
-	160: "required_string_uint8",
-	161: "required_string_unix",
-	162: "required_string_unix-micro",
-	163: "required_string_unix-milli",
-	164: "required_string_unix-nano",
-	165: "required_string_unix-seconds",
-	166: "required_string_uri",
-	167: "required_string_uuid",
-	168: "optional_any",
-	169: "optional_array_any",
-	170: "optional_array_boolean",
-	171: "optional_array_integer",
-	172: "optional_array_integer_int16",
-	173: "optional_array_integer_int32",
-	174: "optional_array_integer_int64",
-	175: "optional_array_integer_int8",
-	176: "optional_array_integer_uint",
-	177: "optional_array_integer_uint16",
-	178: "optional_array_integer_uint32",
-	179: "optional_array_integer_uint64",
-	180: "optional_array_integer_uint8",
-	181: "optional_array_integer_unix",
-	182: "optional_array_integer_unix-micro",
-	183: "optional_array_integer_unix-milli",
-	184: "optional_array_integer_unix-nano",
-	185: "optional_array_integer_unix-seconds",
-	186: "optional_array_null",
-	187: "optional_array_number",
-	188: "optional_array_number_double",
-	189: "optional_array_number_float",
-	190: "optional_array_number_int32",
-	191: "optional_array_number_int64",
-	192: "optional_array_string",
-	193: "optional_array_string_base64",
-	194: "optional_array_string_binary",
-	195: "optional_array_string_byte",
-	196: "optional_array_string_date",
-	197: "optional_array_string_date-time",
-	198: "optional_array_string_duration",
-	199: "optional_array_string_email",
-	200: "optional_array_string_float32",
-	201: "optional_array_string_float64",
-	202: "optional_array_string_hostname",
-	203: "optional_array_string_int",
-	204: "optional_array_string_int16",
-	205: "optional_array_string_int32",
-	206: "optional_array_string_int64",
-	207: "optional_array_string_int8",
-	208: "optional_array_string_ip",
-	209: "optional_array_string_ipv4",
-	210: "optional_array_string_ipv6",
-	211: "optional_array_string_password",
-	212: "optional_array_string_time",
-	213: "optional_array_string_uint",
-	214: "optional_array_string_uint16",
-	215: "optional_array_string_uint32",
-	216: "optional_array_string_uint64",
-	217: "optional_array_string_uint8",
-	218: "optional_array_string_unix",
-	219: "optional_array_string_unix-micro",
-	220: "optional_array_string_unix-milli",
-	221: "optional_array_string_unix-nano",
-	222: "optional_array_string_unix-seconds",
-	223: "optional_array_string_uri",
-	224: "optional_array_string_uuid",
-	225: "optional_boolean",
-	226: "optional_double_array_any",
-	227: "optional_double_array_boolean",
-	228: "optional_double_array_integer",
-	229: "optional_double_array_integer_int16",
-	230: "optional_double_array_integer_int32",
-	231: "optional_double_array_integer_int64",
-	232: "optional_double_array_integer_int8",
-	233: "optional_double_array_integer_uint",
-	234: "optional_double_array_integer_uint16",
-	235: "optional_double_array_integer_uint32",
-	236: "optional_double_array_integer_uint64",
-	237: "optional_double_array_integer_uint8",
-	238: "optional_double_array_integer_unix",
-	239: "optional_double_array_integer_unix-micro",
-	240: "optional_double_array_integer_unix-milli",
-	241: "optional_double_array_integer_unix-nano",
-	242: "optional_double_array_integer_unix-seconds",
-	243: "optional_double_array_null",
-	244: "optional_double_array_number",
-	245: "optional_double_array_number_double",
-	246: "optional_double_array_number_float",
-	247: "optional_double_array_number_int32",
-	248: "optional_double_array_number_int64",
-	249: "optional_double_array_string",
-	250: "optional_double_array_string_base64",
-	251: "optional_double_array_string_binary",
-	252: "optional_double_array_string_byte",
-	253: "optional_double_array_string_date",
-	254: "optional_double_array_string_date-time",
-	255: "optional_double_array_string_duration",
-	256: "optional_double_array_string_email",
-	257: "optional_double_array_string_float32",
-	258: "optional_double_array_string_float64",
-	259: "optional_double_array_string_hostname",
-	260: "optional_double_array_string_int",
-	261: "optional_double_array_string_int16",
-	262: "optional_double_array_string_int32",
-	263: "optional_double_array_string_int64",
-	264: "optional_double_array_string_int8",
-	265: "optional_double_array_string_ip",
-	266: "optional_double_array_string_ipv4",
-	267: "optional_double_array_string_ipv6",
-	268: "optional_double_array_string_password",
-	269: "optional_double_array_string_time",
-	270: "optional_double_array_string_uint",
-	271: "optional_double_array_string_uint16",
-	272: "optional_double_array_string_uint32",
-	273: "optional_double_array_string_uint64",
-	274: "optional_double_array_string_uint8",
-	275: "optional_double_array_string_unix",
-	276: "optional_double_array_string_unix-micro",
-	277: "optional_double_array_string_unix-milli",
-	278: "optional_double_array_string_unix-nano",
-	279: "optional_double_array_string_unix-seconds",
-	280: "optional_double_array_string_uri",
-	281: "optional_double_array_string_uuid",
-	282: "optional_integer",
-	283: "optional_integer_int16",
-	284: "optional_integer_int32",
-	285: "optional_integer_int64",
-	286: "optional_integer_int8",
-	287: "optional_integer_uint",
-	288: "optional_integer_uint16",
-	289: "optional_integer_uint32",
-	290: "optional_integer_uint64",
-	291: "optional_integer_uint8",
-	292: "optional_integer_unix",
-	293: "optional_integer_unix-micro",
-	294: "optional_integer_unix-milli",
-	295: "optional_integer_unix-nano",
-	296: "optional_integer_unix-seconds",
-	297: "optional_null",
-	298: "optional_number",
-	299: "optional_number_double",
-	300: "optional_number_float",
-	301: "optional_number_int32",
-	302: "optional_number_int64",
-	303: "optional_string",
-	304: "optional_string_base64",
-	305: "optional_string_binary",
-	306: "optional_string_byte",
-	307: "optional_string_date",
-	308: "optional_string_date-time",
-	309: "optional_string_duration",
-	310: "optional_string_email",
-	311: "optional_string_float32",
-	312: "optional_string_float64",
-	313: "optional_string_hostname",
-	314: "optional_string_int",
-	315: "optional_string_int16",
-	316: "optional_string_int32",
-	317: "optional_string_int64",
-	318: "optional_string_int8",
-	319: "optional_string_ip",
-	320: "optional_string_ipv4",
-	321: "optional_string_ipv6",
-	322: "optional_string_password",
-	323: "optional_string_time",
-	324: "optional_string_uint",
-	325: "optional_string_uint16",
-	326: "optional_string_uint32",
-	327: "optional_string_uint64",
-	328: "optional_string_uint8",
-	329: "optional_string_unix",
-	330: "optional_string_unix-micro",
-	331: "optional_string_unix-milli",
-	332: "optional_string_unix-nano",
-	333: "optional_string_unix-seconds",
-	334: "optional_string_uri",
-	335: "optional_string_uuid",
+	43:  "required_array_string_mac",
+	44:  "required_array_string_password",
+	45:  "required_array_string_time",
+	46:  "required_array_string_uint",
+	47:  "required_array_string_uint16",
+	48:  "required_array_string_uint32",
+	49:  "required_array_string_uint64",
+	50:  "required_array_string_uint8",
+	51:  "required_array_string_unix",
+	52:  "required_array_string_unix-micro",
+	53:  "required_array_string_unix-milli",
+	54:  "required_array_string_unix-nano",
+	55:  "required_array_string_unix-seconds",
+	56:  "required_array_string_uri",
+	57:  "required_array_string_uuid",
+	58:  "required_boolean",
+	59:  "required_double_array_any",
+	60:  "required_double_array_boolean",
+	61:  "required_double_array_integer",
+	62:  "required_double_array_integer_int16",
+	63:  "required_double_array_integer_int32",
+	64:  "required_double_array_integer_int64",
+	65:  "required_double_array_integer_int8",
+	66:  "required_double_array_integer_uint",
+	67:  "required_double_array_integer_uint16",
+	68:  "required_double_array_integer_uint32",
+	69:  "required_double_array_integer_uint64",
+	70:  "required_double_array_integer_uint8",
+	71:  "required_double_array_integer_unix",
+	72:  "required_double_array_integer_unix-micro",
+	73:  "required_double_array_integer_unix-milli",
+	74:  "required_double_array_integer_unix-nano",
+	75:  "required_double_array_integer_unix-seconds",
+	76:  "required_double_array_null",
+	77:  "required_double_array_number",
+	78:  "required_double_array_number_double",
+	79:  "required_double_array_number_float",
+	80:  "required_double_array_number_int32",
+	81:  "required_double_array_number_int64",
+	82:  "required_double_array_string",
+	83:  "required_double_array_string_base64",
+	84:  "required_double_array_string_binary",
+	85:  "required_double_array_string_byte",
+	86:  "required_double_array_string_date",
+	87:  "required_double_array_string_date-time",
+	88:  "required_double_array_string_duration",
+	89:  "required_double_array_string_email",
+	90:  "required_double_array_string_float32",
+	91:  "required_double_array_string_float64",
+	92:  "required_double_array_string_hostname",
+	93:  "required_double_array_string_int",
+	94:  "required_double_array_string_int16",
+	95:  "required_double_array_string_int32",
+	96:  "required_double_array_string_int64",
+	97:  "required_double_array_string_int8",
+	98:  "required_double_array_string_ip",
+	99:  "required_double_array_string_ipv4",
+	100: "required_double_array_string_ipv6",
+	101: "required_double_array_string_mac",
+	102: "required_double_array_string_password",
+	103: "required_double_array_string_time",
+	104: "required_double_array_string_uint",
+	105: "required_double_array_string_uint16",
+	106: "required_double_array_string_uint32",
+	107: "required_double_array_string_uint64",
+	108: "required_double_array_string_uint8",
+	109: "required_double_array_string_unix",
+	110: "required_double_array_string_unix-micro",
+	111: "required_double_array_string_unix-milli",
+	112: "required_double_array_string_unix-nano",
+	113: "required_double_array_string_unix-seconds",
+	114: "required_double_array_string_uri",
+	115: "required_double_array_string_uuid",
+	116: "required_integer",
+	117: "required_integer_int16",
+	118: "required_integer_int32",
+	119: "required_integer_int64",
+	120: "required_integer_int8",
+	121: "required_integer_uint",
+	122: "required_integer_uint16",
+	123: "required_integer_uint32",
+	124: "required_integer_uint64",
+	125: "required_integer_uint8",
+	126: "required_integer_unix",
+	127: "required_integer_unix-micro",
+	128: "required_integer_unix-milli",
+	129: "required_integer_unix-nano",
+	130: "required_integer_unix-seconds",
+	131: "required_null",
+	132: "required_number",
+	133: "required_number_double",
+	134: "required_number_float",
+	135: "required_number_int32",
+	136: "required_number_int64",
+	137: "required_string",
+	138: "required_string_base64",
+	139: "required_string_binary",
+	140: "required_string_byte",
+	141: "required_string_date",
+	142: "required_string_date-time",
+	143: "required_string_duration",
+	144: "required_string_email",
+	145: "required_string_float32",
+	146: "required_string_float64",
+	147: "required_string_hostname",
+	148: "required_string_int",
+	149: "required_string_int16",
+	150: "required_string_int32",
+	151: "required_string_int64",
+	152: "required_string_int8",
+	153: "required_string_ip",
+	154: "required_string_ipv4",
+	155: "required_string_ipv6",
+	156: "required_string_mac",
+	157: "required_string_password",
+	158: "required_string_time",
+	159: "required_string_uint",
+	160: "required_string_uint16",
+	161: "required_string_uint32",
+	162: "required_string_uint64",
+	163: "required_string_uint8",
+	164: "required_string_unix",
+	165: "required_string_unix-micro",
+	166: "required_string_unix-milli",
+	167: "required_string_unix-nano",
+	168: "required_string_unix-seconds",
+	169: "required_string_uri",
+	170: "required_string_uuid",
+	171: "optional_any",
+	172: "optional_array_any",
+	173: "optional_array_boolean",
+	174: "optional_array_integer",
+	175: "optional_array_integer_int16",
+	176: "optional_array_integer_int32",
+	177: "optional_array_integer_int64",
+	178: "optional_array_integer_int8",
+	179: "optional_array_integer_uint",
+	180: "optional_array_integer_uint16",
+	181: "optional_array_integer_uint32",
+	182: "optional_array_integer_uint64",
+	183: "optional_array_integer_uint8",
+	184: "optional_array_integer_unix",
+	185: "optional_array_integer_unix-micro",
+	186: "optional_array_integer_unix-milli",
+	187: "optional_array_integer_unix-nano",
+	188: "optional_array_integer_unix-seconds",
+	189: "optional_array_null",
+	190: "optional_array_number",
+	191: "optional_array_number_double",
+	192: "optional_array_number_float",
+	193: "optional_array_number_int32",
+	194: "optional_array_number_int64",
+	195: "optional_array_string",
+	196: "optional_array_string_base64",
+	197: "optional_array_string_binary",
+	198: "optional_array_string_byte",
+	199: "optional_array_string_date",
+	200: "optional_array_string_date-time",
+	201: "optional_array_string_duration",
+	202: "optional_array_string_email",
+	203: "optional_array_string_float32",
+	204: "optional_array_string_float64",
+	205: "optional_array_string_hostname",
+	206: "optional_array_string_int",
+	207: "optional_array_string_int16",
+	208: "optional_array_string_int32",
+	209: "optional_array_string_int64",
+	210: "optional_array_string_int8",
+	211: "optional_array_string_ip",
+	212: "optional_array_string_ipv4",
+	213: "optional_array_string_ipv6",
+	214: "optional_array_string_mac",
+	215: "optional_array_string_password",
+	216: "optional_array_string_time",
+	217: "optional_array_string_uint",
+	218: "optional_array_string_uint16",
+	219: "optional_array_string_uint32",
+	220: "optional_array_string_uint64",
+	221: "optional_array_string_uint8",
+	222: "optional_array_string_unix",
+	223: "optional_array_string_unix-micro",
+	224: "optional_array_string_unix-milli",
+	225: "optional_array_string_unix-nano",
+	226: "optional_array_string_unix-seconds",
+	227: "optional_array_string_uri",
+	228: "optional_array_string_uuid",
+	229: "optional_boolean",
+	230: "optional_double_array_any",
+	231: "optional_double_array_boolean",
+	232: "optional_double_array_integer",
+	233: "optional_double_array_integer_int16",
+	234: "optional_double_array_integer_int32",
+	235: "optional_double_array_integer_int64",
+	236: "optional_double_array_integer_int8",
+	237: "optional_double_array_integer_uint",
+	238: "optional_double_array_integer_uint16",
+	239: "optional_double_array_integer_uint32",
+	240: "optional_double_array_integer_uint64",
+	241: "optional_double_array_integer_uint8",
+	242: "optional_double_array_integer_unix",
+	243: "optional_double_array_integer_unix-micro",
+	244: "optional_double_array_integer_unix-milli",
+	245: "optional_double_array_integer_unix-nano",
+	246: "optional_double_array_integer_unix-seconds",
+	247: "optional_double_array_null",
+	248: "optional_double_array_number",
+	249: "optional_double_array_number_double",
+	250: "optional_double_array_number_float",
+	251: "optional_double_array_number_int32",
+	252: "optional_double_array_number_int64",
+	253: "optional_double_array_string",
+	254: "optional_double_array_string_base64",
+	255: "optional_double_array_string_binary",
+	256: "optional_double_array_string_byte",
+	257: "optional_double_array_string_date",
+	258: "optional_double_array_string_date-time",
+	259: "optional_double_array_string_duration",
+	260: "optional_double_array_string_email",
+	261: "optional_double_array_string_float32",
+	262: "optional_double_array_string_float64",
+	263: "optional_double_array_string_hostname",
+	264: "optional_double_array_string_int",
+	265: "optional_double_array_string_int16",
+	266: "optional_double_array_string_int32",
+	267: "optional_double_array_string_int64",
+	268: "optional_double_array_string_int8",
+	269: "optional_double_array_string_ip",
+	270: "optional_double_array_string_ipv4",
+	271: "optional_double_array_string_ipv6",
+	272: "optional_double_array_string_mac",
+	273: "optional_double_array_string_password",
+	274: "optional_double_array_string_time",
+	275: "optional_double_array_string_uint",
+	276: "optional_double_array_string_uint16",
+	277: "optional_double_array_string_uint32",
+	278: "optional_double_array_string_uint64",
+	279: "optional_double_array_string_uint8",
+	280: "optional_double_array_string_unix",
+	281: "optional_double_array_string_unix-micro",
+	282: "optional_double_array_string_unix-milli",
+	283: "optional_double_array_string_unix-nano",
+	284: "optional_double_array_string_unix-seconds",
+	285: "optional_double_array_string_uri",
+	286: "optional_double_array_string_uuid",
+	287: "optional_integer",
+	288: "optional_integer_int16",
+	289: "optional_integer_int32",
+	290: "optional_integer_int64",
+	291: "optional_integer_int8",
+	292: "optional_integer_uint",
+	293: "optional_integer_uint16",
+	294: "optional_integer_uint32",
+	295: "optional_integer_uint64",
+	296: "optional_integer_uint8",
+	297: "optional_integer_unix",
+	298: "optional_integer_unix-micro",
+	299: "optional_integer_unix-milli",
+	300: "optional_integer_unix-nano",
+	301: "optional_integer_unix-seconds",
+	302: "optional_null",
+	303: "optional_number",
+	304: "optional_number_double",
+	305: "optional_number_float",
+	306: "optional_number_int32",
+	307: "optional_number_int64",
+	308: "optional_string",
+	309: "optional_string_base64",
+	310: "optional_string_binary",
+	311: "optional_string_byte",
+	312: "optional_string_date",
+	313: "optional_string_date-time",
+	314: "optional_string_duration",
+	315: "optional_string_email",
+	316: "optional_string_float32",
+	317: "optional_string_float64",
+	318: "optional_string_hostname",
+	319: "optional_string_int",
+	320: "optional_string_int16",
+	321: "optional_string_int32",
+	322: "optional_string_int64",
+	323: "optional_string_int8",
+	324: "optional_string_ip",
+	325: "optional_string_ipv4",
+	326: "optional_string_ipv6",
+	327: "optional_string_mac",
+	328: "optional_string_password",
+	329: "optional_string_time",
+	330: "optional_string_uint",
+	331: "optional_string_uint16",
+	332: "optional_string_uint32",
+	333: "optional_string_uint64",
+	334: "optional_string_uint8",
+	335: "optional_string_unix",
+	336: "optional_string_unix-micro",
+	337: "optional_string_unix-milli",
+	338: "optional_string_unix-nano",
+	339: "optional_string_unix-seconds",
+	340: "optional_string_uri",
+	341: "optional_string_uuid",
 }
 
 // Decode decodes TestRequestRequiredFormatTestReq from json.
@@ -19348,7 +19718,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode TestRequestRequiredFormatTestReq to nil")
 	}
-	var requiredBitSet [42]uint8
+	var requiredBitSet [43]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -20202,8 +20572,28 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_array_string_ipv6\"")
 			}
-		case "required_array_string_password":
+		case "required_array_string_mac":
 			requiredBitSet[5] |= 1 << 3
+			if err := func() error {
+				s.RequiredArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_array_string_mac\"")
+			}
+		case "required_array_string_password":
+			requiredBitSet[5] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringPassword = make([]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20223,7 +20613,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_password\"")
 			}
 		case "required_array_string_time":
-			requiredBitSet[5] |= 1 << 4
+			requiredBitSet[5] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringTime = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20243,7 +20633,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_time\"")
 			}
 		case "required_array_string_uint":
-			requiredBitSet[5] |= 1 << 5
+			requiredBitSet[5] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUint = make([]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20263,7 +20653,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint\"")
 			}
 		case "required_array_string_uint16":
-			requiredBitSet[5] |= 1 << 6
+			requiredBitSet[5] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUint16 = make([]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20283,7 +20673,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint16\"")
 			}
 		case "required_array_string_uint32":
-			requiredBitSet[5] |= 1 << 7
+			requiredBitSet[6] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringUint32 = make([]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20303,7 +20693,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint32\"")
 			}
 		case "required_array_string_uint64":
-			requiredBitSet[6] |= 1 << 0
+			requiredBitSet[6] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUint64 = make([]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20323,7 +20713,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint64\"")
 			}
 		case "required_array_string_uint8":
-			requiredBitSet[6] |= 1 << 1
+			requiredBitSet[6] |= 1 << 2
 			if err := func() error {
 				s.RequiredArrayStringUint8 = make([]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20343,7 +20733,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint8\"")
 			}
 		case "required_array_string_unix":
-			requiredBitSet[6] |= 1 << 2
+			requiredBitSet[6] |= 1 << 3
 			if err := func() error {
 				s.RequiredArrayStringUnix = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20363,7 +20753,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix\"")
 			}
 		case "required_array_string_unix-micro":
-			requiredBitSet[6] |= 1 << 3
+			requiredBitSet[6] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMicro = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20383,7 +20773,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-micro\"")
 			}
 		case "required_array_string_unix-milli":
-			requiredBitSet[6] |= 1 << 4
+			requiredBitSet[6] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMilli = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20403,7 +20793,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-milli\"")
 			}
 		case "required_array_string_unix-nano":
-			requiredBitSet[6] |= 1 << 5
+			requiredBitSet[6] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusNano = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20423,7 +20813,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-nano\"")
 			}
 		case "required_array_string_unix-seconds":
-			requiredBitSet[6] |= 1 << 6
+			requiredBitSet[6] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusSeconds = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20443,7 +20833,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-seconds\"")
 			}
 		case "required_array_string_uri":
-			requiredBitSet[6] |= 1 << 7
+			requiredBitSet[7] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringURI = make([]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20463,7 +20853,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uri\"")
 			}
 		case "required_array_string_uuid":
-			requiredBitSet[7] |= 1 << 0
+			requiredBitSet[7] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUUID = make([]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20483,7 +20873,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uuid\"")
 			}
 		case "required_boolean":
-			requiredBitSet[7] |= 1 << 1
+			requiredBitSet[7] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.RequiredBoolean = bool(v)
@@ -20495,7 +20885,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_boolean\"")
 			}
 		case "required_double_array_any":
-			requiredBitSet[7] |= 1 << 2
+			requiredBitSet[7] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayAny = make([][]jx.Raw, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20523,7 +20913,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_any\"")
 			}
 		case "required_double_array_boolean":
-			requiredBitSet[7] |= 1 << 3
+			requiredBitSet[7] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayBoolean = make([][]bool, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20551,7 +20941,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_boolean\"")
 			}
 		case "required_double_array_integer":
-			requiredBitSet[7] |= 1 << 4
+			requiredBitSet[7] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayInteger = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20579,7 +20969,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer\"")
 			}
 		case "required_double_array_integer_int16":
-			requiredBitSet[7] |= 1 << 5
+			requiredBitSet[7] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20607,7 +20997,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int16\"")
 			}
 		case "required_double_array_integer_int32":
-			requiredBitSet[7] |= 1 << 6
+			requiredBitSet[7] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20635,7 +21025,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int32\"")
 			}
 		case "required_double_array_integer_int64":
-			requiredBitSet[7] |= 1 << 7
+			requiredBitSet[8] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20663,7 +21053,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int64\"")
 			}
 		case "required_double_array_integer_int8":
-			requiredBitSet[8] |= 1 << 0
+			requiredBitSet[8] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20691,7 +21081,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int8\"")
 			}
 		case "required_double_array_integer_uint":
-			requiredBitSet[8] |= 1 << 1
+			requiredBitSet[8] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20719,7 +21109,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint\"")
 			}
 		case "required_double_array_integer_uint16":
-			requiredBitSet[8] |= 1 << 2
+			requiredBitSet[8] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20747,7 +21137,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint16\"")
 			}
 		case "required_double_array_integer_uint32":
-			requiredBitSet[8] |= 1 << 3
+			requiredBitSet[8] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20775,7 +21165,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint32\"")
 			}
 		case "required_double_array_integer_uint64":
-			requiredBitSet[8] |= 1 << 4
+			requiredBitSet[8] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20803,7 +21193,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint64\"")
 			}
 		case "required_double_array_integer_uint8":
-			requiredBitSet[8] |= 1 << 5
+			requiredBitSet[8] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20831,7 +21221,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint8\"")
 			}
 		case "required_double_array_integer_unix":
-			requiredBitSet[8] |= 1 << 6
+			requiredBitSet[8] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20859,7 +21249,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix\"")
 			}
 		case "required_double_array_integer_unix-micro":
-			requiredBitSet[8] |= 1 << 7
+			requiredBitSet[9] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20887,7 +21277,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-micro\"")
 			}
 		case "required_double_array_integer_unix-milli":
-			requiredBitSet[9] |= 1 << 0
+			requiredBitSet[9] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20915,7 +21305,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-milli\"")
 			}
 		case "required_double_array_integer_unix-nano":
-			requiredBitSet[9] |= 1 << 1
+			requiredBitSet[9] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20943,7 +21333,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-nano\"")
 			}
 		case "required_double_array_integer_unix-seconds":
-			requiredBitSet[9] |= 1 << 2
+			requiredBitSet[9] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20971,7 +21361,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-seconds\"")
 			}
 		case "required_double_array_null":
-			requiredBitSet[9] |= 1 << 3
+			requiredBitSet[9] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayNull = make([][]struct{}, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -20997,7 +21387,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_null\"")
 			}
 		case "required_double_array_number":
-			requiredBitSet[9] |= 1 << 4
+			requiredBitSet[9] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayNumber = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21025,7 +21415,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number\"")
 			}
 		case "required_double_array_number_double":
-			requiredBitSet[9] |= 1 << 5
+			requiredBitSet[9] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayNumberDouble = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21053,7 +21443,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_double\"")
 			}
 		case "required_double_array_number_float":
-			requiredBitSet[9] |= 1 << 6
+			requiredBitSet[9] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayNumberFloat = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21081,7 +21471,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_float\"")
 			}
 		case "required_double_array_number_int32":
-			requiredBitSet[9] |= 1 << 7
+			requiredBitSet[10] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21109,7 +21499,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int32\"")
 			}
 		case "required_double_array_number_int64":
-			requiredBitSet[10] |= 1 << 0
+			requiredBitSet[10] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21137,7 +21527,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int64\"")
 			}
 		case "required_double_array_string":
-			requiredBitSet[10] |= 1 << 1
+			requiredBitSet[10] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayString = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21165,7 +21555,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string\"")
 			}
 		case "required_double_array_string_base64":
-			requiredBitSet[10] |= 1 << 2
+			requiredBitSet[10] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringBase64 = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21193,7 +21583,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_base64\"")
 			}
 		case "required_double_array_string_binary":
-			requiredBitSet[10] |= 1 << 3
+			requiredBitSet[10] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringBinary = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21221,7 +21611,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_binary\"")
 			}
 		case "required_double_array_string_byte":
-			requiredBitSet[10] |= 1 << 4
+			requiredBitSet[10] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringByte = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21249,7 +21639,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_byte\"")
 			}
 		case "required_double_array_string_date":
-			requiredBitSet[10] |= 1 << 5
+			requiredBitSet[10] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringDate = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21277,7 +21667,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date\"")
 			}
 		case "required_double_array_string_date-time":
-			requiredBitSet[10] |= 1 << 6
+			requiredBitSet[10] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringDateMinusTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21305,7 +21695,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date-time\"")
 			}
 		case "required_double_array_string_duration":
-			requiredBitSet[10] |= 1 << 7
+			requiredBitSet[11] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringDuration = make([][]time.Duration, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21333,7 +21723,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_duration\"")
 			}
 		case "required_double_array_string_email":
-			requiredBitSet[11] |= 1 << 0
+			requiredBitSet[11] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringEmail = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21361,7 +21751,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_email\"")
 			}
 		case "required_double_array_string_float32":
-			requiredBitSet[11] |= 1 << 1
+			requiredBitSet[11] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat32 = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21389,7 +21779,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float32\"")
 			}
 		case "required_double_array_string_float64":
-			requiredBitSet[11] |= 1 << 2
+			requiredBitSet[11] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat64 = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21417,7 +21807,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float64\"")
 			}
 		case "required_double_array_string_hostname":
-			requiredBitSet[11] |= 1 << 3
+			requiredBitSet[11] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringHostname = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21445,7 +21835,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_hostname\"")
 			}
 		case "required_double_array_string_int":
-			requiredBitSet[11] |= 1 << 4
+			requiredBitSet[11] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21473,7 +21863,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int\"")
 			}
 		case "required_double_array_string_int16":
-			requiredBitSet[11] |= 1 << 5
+			requiredBitSet[11] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21501,7 +21891,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int16\"")
 			}
 		case "required_double_array_string_int32":
-			requiredBitSet[11] |= 1 << 6
+			requiredBitSet[11] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21529,7 +21919,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int32\"")
 			}
 		case "required_double_array_string_int64":
-			requiredBitSet[11] |= 1 << 7
+			requiredBitSet[12] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21557,7 +21947,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int64\"")
 			}
 		case "required_double_array_string_int8":
-			requiredBitSet[12] |= 1 << 0
+			requiredBitSet[12] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21585,7 +21975,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int8\"")
 			}
 		case "required_double_array_string_ip":
-			requiredBitSet[12] |= 1 << 1
+			requiredBitSet[12] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringIP = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21613,7 +22003,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ip\"")
 			}
 		case "required_double_array_string_ipv4":
-			requiredBitSet[12] |= 1 << 2
+			requiredBitSet[12] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv4 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21641,7 +22031,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv4\"")
 			}
 		case "required_double_array_string_ipv6":
-			requiredBitSet[12] |= 1 << 3
+			requiredBitSet[12] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv6 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21668,8 +22058,36 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv6\"")
 			}
+		case "required_double_array_string_mac":
+			requiredBitSet[12] |= 1 << 5
+			if err := func() error {
+				s.RequiredDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_double_array_string_mac\"")
+			}
 		case "required_double_array_string_password":
-			requiredBitSet[12] |= 1 << 4
+			requiredBitSet[12] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringPassword = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21697,7 +22115,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_password\"")
 			}
 		case "required_double_array_string_time":
-			requiredBitSet[12] |= 1 << 5
+			requiredBitSet[12] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21725,7 +22143,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_time\"")
 			}
 		case "required_double_array_string_uint":
-			requiredBitSet[12] |= 1 << 6
+			requiredBitSet[13] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21753,7 +22171,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint\"")
 			}
 		case "required_double_array_string_uint16":
-			requiredBitSet[12] |= 1 << 7
+			requiredBitSet[13] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21781,7 +22199,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint16\"")
 			}
 		case "required_double_array_string_uint32":
-			requiredBitSet[13] |= 1 << 0
+			requiredBitSet[13] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21809,7 +22227,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint32\"")
 			}
 		case "required_double_array_string_uint64":
-			requiredBitSet[13] |= 1 << 1
+			requiredBitSet[13] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21837,7 +22255,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint64\"")
 			}
 		case "required_double_array_string_uint8":
-			requiredBitSet[13] |= 1 << 2
+			requiredBitSet[13] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21865,7 +22283,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint8\"")
 			}
 		case "required_double_array_string_unix":
-			requiredBitSet[13] |= 1 << 3
+			requiredBitSet[13] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21893,7 +22311,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix\"")
 			}
 		case "required_double_array_string_unix-micro":
-			requiredBitSet[13] |= 1 << 4
+			requiredBitSet[13] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21921,7 +22339,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-micro\"")
 			}
 		case "required_double_array_string_unix-milli":
-			requiredBitSet[13] |= 1 << 5
+			requiredBitSet[13] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21949,7 +22367,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-milli\"")
 			}
 		case "required_double_array_string_unix-nano":
-			requiredBitSet[13] |= 1 << 6
+			requiredBitSet[14] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -21977,7 +22395,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-nano\"")
 			}
 		case "required_double_array_string_unix-seconds":
-			requiredBitSet[13] |= 1 << 7
+			requiredBitSet[14] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -22005,7 +22423,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-seconds\"")
 			}
 		case "required_double_array_string_uri":
-			requiredBitSet[14] |= 1 << 0
+			requiredBitSet[14] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringURI = make([][]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -22033,7 +22451,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uri\"")
 			}
 		case "required_double_array_string_uuid":
-			requiredBitSet[14] |= 1 << 1
+			requiredBitSet[14] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUUID = make([][]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -22061,7 +22479,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uuid\"")
 			}
 		case "required_integer":
-			requiredBitSet[14] |= 1 << 2
+			requiredBitSet[14] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.RequiredInteger = int(v)
@@ -22073,7 +22491,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer\"")
 			}
 		case "required_integer_int16":
-			requiredBitSet[14] |= 1 << 3
+			requiredBitSet[14] |= 1 << 5
 			if err := func() error {
 				v, err := d.Int16()
 				s.RequiredIntegerInt16 = int16(v)
@@ -22085,7 +22503,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int16\"")
 			}
 		case "required_integer_int32":
-			requiredBitSet[14] |= 1 << 4
+			requiredBitSet[14] |= 1 << 6
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredIntegerInt32 = int32(v)
@@ -22097,7 +22515,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int32\"")
 			}
 		case "required_integer_int64":
-			requiredBitSet[14] |= 1 << 5
+			requiredBitSet[14] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredIntegerInt64 = int64(v)
@@ -22109,7 +22527,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int64\"")
 			}
 		case "required_integer_int8":
-			requiredBitSet[14] |= 1 << 6
+			requiredBitSet[15] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int8()
 				s.RequiredIntegerInt8 = int8(v)
@@ -22121,7 +22539,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int8\"")
 			}
 		case "required_integer_uint":
-			requiredBitSet[14] |= 1 << 7
+			requiredBitSet[15] |= 1 << 1
 			if err := func() error {
 				v, err := d.UInt()
 				s.RequiredIntegerUint = uint(v)
@@ -22133,7 +22551,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint\"")
 			}
 		case "required_integer_uint16":
-			requiredBitSet[15] |= 1 << 0
+			requiredBitSet[15] |= 1 << 2
 			if err := func() error {
 				v, err := d.UInt16()
 				s.RequiredIntegerUint16 = uint16(v)
@@ -22145,7 +22563,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint16\"")
 			}
 		case "required_integer_uint32":
-			requiredBitSet[15] |= 1 << 1
+			requiredBitSet[15] |= 1 << 3
 			if err := func() error {
 				v, err := d.UInt32()
 				s.RequiredIntegerUint32 = uint32(v)
@@ -22157,7 +22575,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint32\"")
 			}
 		case "required_integer_uint64":
-			requiredBitSet[15] |= 1 << 2
+			requiredBitSet[15] |= 1 << 4
 			if err := func() error {
 				v, err := d.UInt64()
 				s.RequiredIntegerUint64 = uint64(v)
@@ -22169,7 +22587,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint64\"")
 			}
 		case "required_integer_uint8":
-			requiredBitSet[15] |= 1 << 3
+			requiredBitSet[15] |= 1 << 5
 			if err := func() error {
 				v, err := d.UInt8()
 				s.RequiredIntegerUint8 = uint8(v)
@@ -22181,7 +22599,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint8\"")
 			}
 		case "required_integer_unix":
-			requiredBitSet[15] |= 1 << 4
+			requiredBitSet[15] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnix = v
@@ -22193,7 +22611,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix\"")
 			}
 		case "required_integer_unix-micro":
-			requiredBitSet[15] |= 1 << 5
+			requiredBitSet[15] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeUnixMicro(d)
 				s.RequiredIntegerUnixMinusMicro = v
@@ -22205,7 +22623,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-micro\"")
 			}
 		case "required_integer_unix-milli":
-			requiredBitSet[15] |= 1 << 6
+			requiredBitSet[16] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeUnixMilli(d)
 				s.RequiredIntegerUnixMinusMilli = v
@@ -22217,7 +22635,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-milli\"")
 			}
 		case "required_integer_unix-nano":
-			requiredBitSet[15] |= 1 << 7
+			requiredBitSet[16] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeUnixNano(d)
 				s.RequiredIntegerUnixMinusNano = v
@@ -22229,7 +22647,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-nano\"")
 			}
 		case "required_integer_unix-seconds":
-			requiredBitSet[16] |= 1 << 0
+			requiredBitSet[16] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnixMinusSeconds = v
@@ -22241,7 +22659,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-seconds\"")
 			}
 		case "required_null":
-			requiredBitSet[16] |= 1 << 1
+			requiredBitSet[16] |= 1 << 3
 			if err := func() error {
 				if err := d.Null(); err != nil {
 					return err
@@ -22251,7 +22669,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_null\"")
 			}
 		case "required_number":
-			requiredBitSet[16] |= 1 << 2
+			requiredBitSet[16] |= 1 << 4
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumber = float64(v)
@@ -22263,7 +22681,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number\"")
 			}
 		case "required_number_double":
-			requiredBitSet[16] |= 1 << 3
+			requiredBitSet[16] |= 1 << 5
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumberDouble = float64(v)
@@ -22275,7 +22693,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_double\"")
 			}
 		case "required_number_float":
-			requiredBitSet[16] |= 1 << 4
+			requiredBitSet[16] |= 1 << 6
 			if err := func() error {
 				v, err := d.Float32()
 				s.RequiredNumberFloat = float32(v)
@@ -22287,7 +22705,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_float\"")
 			}
 		case "required_number_int32":
-			requiredBitSet[16] |= 1 << 5
+			requiredBitSet[16] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredNumberInt32 = int32(v)
@@ -22299,7 +22717,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int32\"")
 			}
 		case "required_number_int64":
-			requiredBitSet[16] |= 1 << 6
+			requiredBitSet[17] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredNumberInt64 = int64(v)
@@ -22311,7 +22729,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int64\"")
 			}
 		case "required_string":
-			requiredBitSet[16] |= 1 << 7
+			requiredBitSet[17] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredString = string(v)
@@ -22323,7 +22741,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string\"")
 			}
 		case "required_string_base64":
-			requiredBitSet[17] |= 1 << 0
+			requiredBitSet[17] |= 1 << 2
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringBase64 = []byte(v)
@@ -22335,7 +22753,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_base64\"")
 			}
 		case "required_string_binary":
-			requiredBitSet[17] |= 1 << 1
+			requiredBitSet[17] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringBinary = string(v)
@@ -22347,7 +22765,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_binary\"")
 			}
 		case "required_string_byte":
-			requiredBitSet[17] |= 1 << 2
+			requiredBitSet[17] |= 1 << 4
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringByte = []byte(v)
@@ -22359,7 +22777,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_byte\"")
 			}
 		case "required_string_date":
-			requiredBitSet[17] |= 1 << 3
+			requiredBitSet[17] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeDate(d)
 				s.RequiredStringDate = v
@@ -22371,7 +22789,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date\"")
 			}
 		case "required_string_date-time":
-			requiredBitSet[17] |= 1 << 4
+			requiredBitSet[17] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.RequiredStringDateMinusTime = v
@@ -22383,7 +22801,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date-time\"")
 			}
 		case "required_string_duration":
-			requiredBitSet[17] |= 1 << 5
+			requiredBitSet[17] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDuration(d)
 				s.RequiredStringDuration = v
@@ -22395,7 +22813,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_duration\"")
 			}
 		case "required_string_email":
-			requiredBitSet[17] |= 1 << 6
+			requiredBitSet[18] |= 1 << 0
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringEmail = string(v)
@@ -22407,7 +22825,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_email\"")
 			}
 		case "required_string_float32":
-			requiredBitSet[17] |= 1 << 7
+			requiredBitSet[18] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringFloat32(d)
 				s.RequiredStringFloat32 = v
@@ -22419,7 +22837,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float32\"")
 			}
 		case "required_string_float64":
-			requiredBitSet[18] |= 1 << 0
+			requiredBitSet[18] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringFloat64(d)
 				s.RequiredStringFloat64 = v
@@ -22431,7 +22849,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float64\"")
 			}
 		case "required_string_hostname":
-			requiredBitSet[18] |= 1 << 1
+			requiredBitSet[18] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringHostname = string(v)
@@ -22443,7 +22861,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_hostname\"")
 			}
 		case "required_string_int":
-			requiredBitSet[18] |= 1 << 2
+			requiredBitSet[18] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringInt(d)
 				s.RequiredStringInt = v
@@ -22455,7 +22873,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int\"")
 			}
 		case "required_string_int16":
-			requiredBitSet[18] |= 1 << 3
+			requiredBitSet[18] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringInt16(d)
 				s.RequiredStringInt16 = v
@@ -22467,7 +22885,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int16\"")
 			}
 		case "required_string_int32":
-			requiredBitSet[18] |= 1 << 4
+			requiredBitSet[18] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringInt32(d)
 				s.RequiredStringInt32 = v
@@ -22479,7 +22897,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int32\"")
 			}
 		case "required_string_int64":
-			requiredBitSet[18] |= 1 << 5
+			requiredBitSet[18] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringInt64(d)
 				s.RequiredStringInt64 = v
@@ -22491,7 +22909,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int64\"")
 			}
 		case "required_string_int8":
-			requiredBitSet[18] |= 1 << 6
+			requiredBitSet[19] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringInt8(d)
 				s.RequiredStringInt8 = v
@@ -22503,7 +22921,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int8\"")
 			}
 		case "required_string_ip":
-			requiredBitSet[18] |= 1 << 7
+			requiredBitSet[19] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeIP(d)
 				s.RequiredStringIP = v
@@ -22515,7 +22933,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ip\"")
 			}
 		case "required_string_ipv4":
-			requiredBitSet[19] |= 1 << 0
+			requiredBitSet[19] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeIPv4(d)
 				s.RequiredStringIpv4 = v
@@ -22527,7 +22945,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ipv4\"")
 			}
 		case "required_string_ipv6":
-			requiredBitSet[19] |= 1 << 1
+			requiredBitSet[19] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeIPv6(d)
 				s.RequiredStringIpv6 = v
@@ -22538,8 +22956,20 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_string_ipv6\"")
 			}
+		case "required_string_mac":
+			requiredBitSet[19] |= 1 << 4
+			if err := func() error {
+				v, err := json.DecodeMAC(d)
+				s.RequiredStringMAC = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_string_mac\"")
+			}
 		case "required_string_password":
-			requiredBitSet[19] |= 1 << 2
+			requiredBitSet[19] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringPassword = string(v)
@@ -22551,7 +22981,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_password\"")
 			}
 		case "required_string_time":
-			requiredBitSet[19] |= 1 << 3
+			requiredBitSet[19] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeTime(d)
 				s.RequiredStringTime = v
@@ -22563,7 +22993,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_time\"")
 			}
 		case "required_string_uint":
-			requiredBitSet[19] |= 1 << 4
+			requiredBitSet[19] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUint(d)
 				s.RequiredStringUint = v
@@ -22575,7 +23005,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint\"")
 			}
 		case "required_string_uint16":
-			requiredBitSet[19] |= 1 << 5
+			requiredBitSet[20] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUint16(d)
 				s.RequiredStringUint16 = v
@@ -22587,7 +23017,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint16\"")
 			}
 		case "required_string_uint32":
-			requiredBitSet[19] |= 1 << 6
+			requiredBitSet[20] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringUint32(d)
 				s.RequiredStringUint32 = v
@@ -22599,7 +23029,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint32\"")
 			}
 		case "required_string_uint64":
-			requiredBitSet[19] |= 1 << 7
+			requiredBitSet[20] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringUint64(d)
 				s.RequiredStringUint64 = v
@@ -22611,7 +23041,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint64\"")
 			}
 		case "required_string_uint8":
-			requiredBitSet[20] |= 1 << 0
+			requiredBitSet[20] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeStringUint8(d)
 				s.RequiredStringUint8 = v
@@ -22623,7 +23053,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint8\"")
 			}
 		case "required_string_unix":
-			requiredBitSet[20] |= 1 << 1
+			requiredBitSet[20] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnix = v
@@ -22635,7 +23065,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix\"")
 			}
 		case "required_string_unix-micro":
-			requiredBitSet[20] |= 1 << 2
+			requiredBitSet[20] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringUnixMicro(d)
 				s.RequiredStringUnixMinusMicro = v
@@ -22647,7 +23077,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-micro\"")
 			}
 		case "required_string_unix-milli":
-			requiredBitSet[20] |= 1 << 3
+			requiredBitSet[20] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringUnixMilli(d)
 				s.RequiredStringUnixMinusMilli = v
@@ -22659,7 +23089,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-milli\"")
 			}
 		case "required_string_unix-nano":
-			requiredBitSet[20] |= 1 << 4
+			requiredBitSet[20] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUnixNano(d)
 				s.RequiredStringUnixMinusNano = v
@@ -22671,7 +23101,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-nano\"")
 			}
 		case "required_string_unix-seconds":
-			requiredBitSet[20] |= 1 << 5
+			requiredBitSet[21] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnixMinusSeconds = v
@@ -22683,7 +23113,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-seconds\"")
 			}
 		case "required_string_uri":
-			requiredBitSet[20] |= 1 << 6
+			requiredBitSet[21] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.RequiredStringURI = v
@@ -22695,7 +23125,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uri\"")
 			}
 		case "required_string_uuid":
-			requiredBitSet[20] |= 1 << 7
+			requiredBitSet[21] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.RequiredStringUUID = v
@@ -23512,6 +23942,25 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_array_string_ipv6\"")
+			}
+		case "optional_array_string_mac":
+			if err := func() error {
+				s.OptionalArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_array_string_mac\"")
 			}
 		case "optional_array_string_password":
 			if err := func() error {
@@ -24921,6 +25370,33 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_double_array_string_ipv6\"")
 			}
+		case "optional_double_array_string_mac":
+			if err := func() error {
+				s.OptionalDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_double_array_string_mac\"")
+			}
 		case "optional_double_array_string_password":
 			if err := func() error {
 				s.OptionalDoubleArrayStringPassword = make([][]string, 0)
@@ -25701,6 +26177,16 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_string_ipv6\"")
 			}
+		case "optional_string_mac":
+			if err := func() error {
+				s.OptionalStringMAC.Reset()
+				if err := s.OptionalStringMAC.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_string_mac\"")
+			}
 		case "optional_string_password":
 			if err := func() error {
 				s.OptionalStringPassword.Reset()
@@ -25850,7 +26336,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [42]uint8{
+	for i, mask := range [43]uint8{
 		0b11111111,
 		0b11111111,
 		0b11111111,
@@ -25872,6 +26358,7 @@ func (s *TestRequestRequiredFormatTestReq) Decode(d *jx.Decoder) error {
 		0b11111111,
 		0b11111111,
 		0b11111111,
+		0b00000111,
 		0b00000000,
 		0b00000000,
 		0b00000000,
@@ -26337,6 +26824,14 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredArrayStringMAC {
+			json.EncodeMAC(e, elem)
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredArrayStringPassword {
@@ -26960,6 +27455,18 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 		e.ArrEnd()
 	}
 	{
+		e.FieldStart("required_double_array_string_mac")
+		e.ArrStart()
+		for _, elem := range s.RequiredDoubleArrayStringMAC {
+			e.ArrStart()
+			for _, elem := range elem {
+				json.EncodeMAC(e, elem)
+			}
+			e.ArrEnd()
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("required_double_array_string_password")
 		e.ArrStart()
 		for _, elem := range s.RequiredDoubleArrayStringPassword {
@@ -27287,6 +27794,10 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 	{
 		e.FieldStart("required_string_ipv6")
 		json.EncodeIPv6(e, s.RequiredStringIpv6)
+	}
+	{
+		e.FieldStart("required_string_mac")
+		json.EncodeMAC(e, s.RequiredStringMAC)
 	}
 	{
 		e.FieldStart("required_string_password")
@@ -27769,6 +28280,16 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 			e.ArrStart()
 			for _, elem := range s.OptionalArrayStringIpv6 {
 				json.EncodeIPv6(e, elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.OptionalArrayStringMAC != nil {
+			e.FieldStart("optional_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalArrayStringMAC {
+				json.EncodeMAC(e, elem)
 			}
 			e.ArrEnd()
 		}
@@ -28511,6 +29032,20 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalDoubleArrayStringMAC != nil {
+			e.FieldStart("optional_double_array_string_mac")
+			e.ArrStart()
+			for _, elem := range s.OptionalDoubleArrayStringMAC {
+				e.ArrStart()
+				for _, elem := range elem {
+					json.EncodeMAC(e, elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		if s.OptionalDoubleArrayStringPassword != nil {
 			e.FieldStart("optional_double_array_string_password")
 			e.ArrStart()
@@ -28943,6 +29478,12 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.OptionalStringMAC.Set {
+			e.FieldStart("optional_string_mac")
+			s.OptionalStringMAC.Encode(e)
+		}
+	}
+	{
 		if s.OptionalStringPassword.Set {
 			e.FieldStart("optional_string_password")
 			s.OptionalStringPassword.Encode(e)
@@ -29028,7 +29569,7 @@ func (s *TestResponseFormatTestOK) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfTestResponseFormatTestOK = [336]string{
+var jsonFieldsNameOfTestResponseFormatTestOK = [342]string{
 	0:   "required_any",
 	1:   "required_array_any",
 	2:   "required_array_boolean",
@@ -29072,299 +29613,305 @@ var jsonFieldsNameOfTestResponseFormatTestOK = [336]string{
 	40:  "required_array_string_ip",
 	41:  "required_array_string_ipv4",
 	42:  "required_array_string_ipv6",
-	43:  "required_array_string_password",
-	44:  "required_array_string_time",
-	45:  "required_array_string_uint",
-	46:  "required_array_string_uint16",
-	47:  "required_array_string_uint32",
-	48:  "required_array_string_uint64",
-	49:  "required_array_string_uint8",
-	50:  "required_array_string_unix",
-	51:  "required_array_string_unix-micro",
-	52:  "required_array_string_unix-milli",
-	53:  "required_array_string_unix-nano",
-	54:  "required_array_string_unix-seconds",
-	55:  "required_array_string_uri",
-	56:  "required_array_string_uuid",
-	57:  "required_boolean",
-	58:  "required_double_array_any",
-	59:  "required_double_array_boolean",
-	60:  "required_double_array_integer",
-	61:  "required_double_array_integer_int16",
-	62:  "required_double_array_integer_int32",
-	63:  "required_double_array_integer_int64",
-	64:  "required_double_array_integer_int8",
-	65:  "required_double_array_integer_uint",
-	66:  "required_double_array_integer_uint16",
-	67:  "required_double_array_integer_uint32",
-	68:  "required_double_array_integer_uint64",
-	69:  "required_double_array_integer_uint8",
-	70:  "required_double_array_integer_unix",
-	71:  "required_double_array_integer_unix-micro",
-	72:  "required_double_array_integer_unix-milli",
-	73:  "required_double_array_integer_unix-nano",
-	74:  "required_double_array_integer_unix-seconds",
-	75:  "required_double_array_null",
-	76:  "required_double_array_number",
-	77:  "required_double_array_number_double",
-	78:  "required_double_array_number_float",
-	79:  "required_double_array_number_int32",
-	80:  "required_double_array_number_int64",
-	81:  "required_double_array_string",
-	82:  "required_double_array_string_base64",
-	83:  "required_double_array_string_binary",
-	84:  "required_double_array_string_byte",
-	85:  "required_double_array_string_date",
-	86:  "required_double_array_string_date-time",
-	87:  "required_double_array_string_duration",
-	88:  "required_double_array_string_email",
-	89:  "required_double_array_string_float32",
-	90:  "required_double_array_string_float64",
-	91:  "required_double_array_string_hostname",
-	92:  "required_double_array_string_int",
-	93:  "required_double_array_string_int16",
-	94:  "required_double_array_string_int32",
-	95:  "required_double_array_string_int64",
-	96:  "required_double_array_string_int8",
-	97:  "required_double_array_string_ip",
-	98:  "required_double_array_string_ipv4",
-	99:  "required_double_array_string_ipv6",
-	100: "required_double_array_string_password",
-	101: "required_double_array_string_time",
-	102: "required_double_array_string_uint",
-	103: "required_double_array_string_uint16",
-	104: "required_double_array_string_uint32",
-	105: "required_double_array_string_uint64",
-	106: "required_double_array_string_uint8",
-	107: "required_double_array_string_unix",
-	108: "required_double_array_string_unix-micro",
-	109: "required_double_array_string_unix-milli",
-	110: "required_double_array_string_unix-nano",
-	111: "required_double_array_string_unix-seconds",
-	112: "required_double_array_string_uri",
-	113: "required_double_array_string_uuid",
-	114: "required_integer",
-	115: "required_integer_int16",
-	116: "required_integer_int32",
-	117: "required_integer_int64",
-	118: "required_integer_int8",
-	119: "required_integer_uint",
-	120: "required_integer_uint16",
-	121: "required_integer_uint32",
-	122: "required_integer_uint64",
-	123: "required_integer_uint8",
-	124: "required_integer_unix",
-	125: "required_integer_unix-micro",
-	126: "required_integer_unix-milli",
-	127: "required_integer_unix-nano",
-	128: "required_integer_unix-seconds",
-	129: "required_null",
-	130: "required_number",
-	131: "required_number_double",
-	132: "required_number_float",
-	133: "required_number_int32",
-	134: "required_number_int64",
-	135: "required_string",
-	136: "required_string_base64",
-	137: "required_string_binary",
-	138: "required_string_byte",
-	139: "required_string_date",
-	140: "required_string_date-time",
-	141: "required_string_duration",
-	142: "required_string_email",
-	143: "required_string_float32",
-	144: "required_string_float64",
-	145: "required_string_hostname",
-	146: "required_string_int",
-	147: "required_string_int16",
-	148: "required_string_int32",
-	149: "required_string_int64",
-	150: "required_string_int8",
-	151: "required_string_ip",
-	152: "required_string_ipv4",
-	153: "required_string_ipv6",
-	154: "required_string_password",
-	155: "required_string_time",
-	156: "required_string_uint",
-	157: "required_string_uint16",
-	158: "required_string_uint32",
-	159: "required_string_uint64",
-	160: "required_string_uint8",
-	161: "required_string_unix",
-	162: "required_string_unix-micro",
-	163: "required_string_unix-milli",
-	164: "required_string_unix-nano",
-	165: "required_string_unix-seconds",
-	166: "required_string_uri",
-	167: "required_string_uuid",
-	168: "optional_any",
-	169: "optional_array_any",
-	170: "optional_array_boolean",
-	171: "optional_array_integer",
-	172: "optional_array_integer_int16",
-	173: "optional_array_integer_int32",
-	174: "optional_array_integer_int64",
-	175: "optional_array_integer_int8",
-	176: "optional_array_integer_uint",
-	177: "optional_array_integer_uint16",
-	178: "optional_array_integer_uint32",
-	179: "optional_array_integer_uint64",
-	180: "optional_array_integer_uint8",
-	181: "optional_array_integer_unix",
-	182: "optional_array_integer_unix-micro",
-	183: "optional_array_integer_unix-milli",
-	184: "optional_array_integer_unix-nano",
-	185: "optional_array_integer_unix-seconds",
-	186: "optional_array_null",
-	187: "optional_array_number",
-	188: "optional_array_number_double",
-	189: "optional_array_number_float",
-	190: "optional_array_number_int32",
-	191: "optional_array_number_int64",
-	192: "optional_array_string",
-	193: "optional_array_string_base64",
-	194: "optional_array_string_binary",
-	195: "optional_array_string_byte",
-	196: "optional_array_string_date",
-	197: "optional_array_string_date-time",
-	198: "optional_array_string_duration",
-	199: "optional_array_string_email",
-	200: "optional_array_string_float32",
-	201: "optional_array_string_float64",
-	202: "optional_array_string_hostname",
-	203: "optional_array_string_int",
-	204: "optional_array_string_int16",
-	205: "optional_array_string_int32",
-	206: "optional_array_string_int64",
-	207: "optional_array_string_int8",
-	208: "optional_array_string_ip",
-	209: "optional_array_string_ipv4",
-	210: "optional_array_string_ipv6",
-	211: "optional_array_string_password",
-	212: "optional_array_string_time",
-	213: "optional_array_string_uint",
-	214: "optional_array_string_uint16",
-	215: "optional_array_string_uint32",
-	216: "optional_array_string_uint64",
-	217: "optional_array_string_uint8",
-	218: "optional_array_string_unix",
-	219: "optional_array_string_unix-micro",
-	220: "optional_array_string_unix-milli",
-	221: "optional_array_string_unix-nano",
-	222: "optional_array_string_unix-seconds",
-	223: "optional_array_string_uri",
-	224: "optional_array_string_uuid",
-	225: "optional_boolean",
-	226: "optional_double_array_any",
-	227: "optional_double_array_boolean",
-	228: "optional_double_array_integer",
-	229: "optional_double_array_integer_int16",
-	230: "optional_double_array_integer_int32",
-	231: "optional_double_array_integer_int64",
-	232: "optional_double_array_integer_int8",
-	233: "optional_double_array_integer_uint",
-	234: "optional_double_array_integer_uint16",
-	235: "optional_double_array_integer_uint32",
-	236: "optional_double_array_integer_uint64",
-	237: "optional_double_array_integer_uint8",
-	238: "optional_double_array_integer_unix",
-	239: "optional_double_array_integer_unix-micro",
-	240: "optional_double_array_integer_unix-milli",
-	241: "optional_double_array_integer_unix-nano",
-	242: "optional_double_array_integer_unix-seconds",
-	243: "optional_double_array_null",
-	244: "optional_double_array_number",
-	245: "optional_double_array_number_double",
-	246: "optional_double_array_number_float",
-	247: "optional_double_array_number_int32",
-	248: "optional_double_array_number_int64",
-	249: "optional_double_array_string",
-	250: "optional_double_array_string_base64",
-	251: "optional_double_array_string_binary",
-	252: "optional_double_array_string_byte",
-	253: "optional_double_array_string_date",
-	254: "optional_double_array_string_date-time",
-	255: "optional_double_array_string_duration",
-	256: "optional_double_array_string_email",
-	257: "optional_double_array_string_float32",
-	258: "optional_double_array_string_float64",
-	259: "optional_double_array_string_hostname",
-	260: "optional_double_array_string_int",
-	261: "optional_double_array_string_int16",
-	262: "optional_double_array_string_int32",
-	263: "optional_double_array_string_int64",
-	264: "optional_double_array_string_int8",
-	265: "optional_double_array_string_ip",
-	266: "optional_double_array_string_ipv4",
-	267: "optional_double_array_string_ipv6",
-	268: "optional_double_array_string_password",
-	269: "optional_double_array_string_time",
-	270: "optional_double_array_string_uint",
-	271: "optional_double_array_string_uint16",
-	272: "optional_double_array_string_uint32",
-	273: "optional_double_array_string_uint64",
-	274: "optional_double_array_string_uint8",
-	275: "optional_double_array_string_unix",
-	276: "optional_double_array_string_unix-micro",
-	277: "optional_double_array_string_unix-milli",
-	278: "optional_double_array_string_unix-nano",
-	279: "optional_double_array_string_unix-seconds",
-	280: "optional_double_array_string_uri",
-	281: "optional_double_array_string_uuid",
-	282: "optional_integer",
-	283: "optional_integer_int16",
-	284: "optional_integer_int32",
-	285: "optional_integer_int64",
-	286: "optional_integer_int8",
-	287: "optional_integer_uint",
-	288: "optional_integer_uint16",
-	289: "optional_integer_uint32",
-	290: "optional_integer_uint64",
-	291: "optional_integer_uint8",
-	292: "optional_integer_unix",
-	293: "optional_integer_unix-micro",
-	294: "optional_integer_unix-milli",
-	295: "optional_integer_unix-nano",
-	296: "optional_integer_unix-seconds",
-	297: "optional_null",
-	298: "optional_number",
-	299: "optional_number_double",
-	300: "optional_number_float",
-	301: "optional_number_int32",
-	302: "optional_number_int64",
-	303: "optional_string",
-	304: "optional_string_base64",
-	305: "optional_string_binary",
-	306: "optional_string_byte",
-	307: "optional_string_date",
-	308: "optional_string_date-time",
-	309: "optional_string_duration",
-	310: "optional_string_email",
-	311: "optional_string_float32",
-	312: "optional_string_float64",
-	313: "optional_string_hostname",
-	314: "optional_string_int",
-	315: "optional_string_int16",
-	316: "optional_string_int32",
-	317: "optional_string_int64",
-	318: "optional_string_int8",
-	319: "optional_string_ip",
-	320: "optional_string_ipv4",
-	321: "optional_string_ipv6",
-	322: "optional_string_password",
-	323: "optional_string_time",
-	324: "optional_string_uint",
-	325: "optional_string_uint16",
-	326: "optional_string_uint32",
-	327: "optional_string_uint64",
-	328: "optional_string_uint8",
-	329: "optional_string_unix",
-	330: "optional_string_unix-micro",
-	331: "optional_string_unix-milli",
-	332: "optional_string_unix-nano",
-	333: "optional_string_unix-seconds",
-	334: "optional_string_uri",
-	335: "optional_string_uuid",
+	43:  "required_array_string_mac",
+	44:  "required_array_string_password",
+	45:  "required_array_string_time",
+	46:  "required_array_string_uint",
+	47:  "required_array_string_uint16",
+	48:  "required_array_string_uint32",
+	49:  "required_array_string_uint64",
+	50:  "required_array_string_uint8",
+	51:  "required_array_string_unix",
+	52:  "required_array_string_unix-micro",
+	53:  "required_array_string_unix-milli",
+	54:  "required_array_string_unix-nano",
+	55:  "required_array_string_unix-seconds",
+	56:  "required_array_string_uri",
+	57:  "required_array_string_uuid",
+	58:  "required_boolean",
+	59:  "required_double_array_any",
+	60:  "required_double_array_boolean",
+	61:  "required_double_array_integer",
+	62:  "required_double_array_integer_int16",
+	63:  "required_double_array_integer_int32",
+	64:  "required_double_array_integer_int64",
+	65:  "required_double_array_integer_int8",
+	66:  "required_double_array_integer_uint",
+	67:  "required_double_array_integer_uint16",
+	68:  "required_double_array_integer_uint32",
+	69:  "required_double_array_integer_uint64",
+	70:  "required_double_array_integer_uint8",
+	71:  "required_double_array_integer_unix",
+	72:  "required_double_array_integer_unix-micro",
+	73:  "required_double_array_integer_unix-milli",
+	74:  "required_double_array_integer_unix-nano",
+	75:  "required_double_array_integer_unix-seconds",
+	76:  "required_double_array_null",
+	77:  "required_double_array_number",
+	78:  "required_double_array_number_double",
+	79:  "required_double_array_number_float",
+	80:  "required_double_array_number_int32",
+	81:  "required_double_array_number_int64",
+	82:  "required_double_array_string",
+	83:  "required_double_array_string_base64",
+	84:  "required_double_array_string_binary",
+	85:  "required_double_array_string_byte",
+	86:  "required_double_array_string_date",
+	87:  "required_double_array_string_date-time",
+	88:  "required_double_array_string_duration",
+	89:  "required_double_array_string_email",
+	90:  "required_double_array_string_float32",
+	91:  "required_double_array_string_float64",
+	92:  "required_double_array_string_hostname",
+	93:  "required_double_array_string_int",
+	94:  "required_double_array_string_int16",
+	95:  "required_double_array_string_int32",
+	96:  "required_double_array_string_int64",
+	97:  "required_double_array_string_int8",
+	98:  "required_double_array_string_ip",
+	99:  "required_double_array_string_ipv4",
+	100: "required_double_array_string_ipv6",
+	101: "required_double_array_string_mac",
+	102: "required_double_array_string_password",
+	103: "required_double_array_string_time",
+	104: "required_double_array_string_uint",
+	105: "required_double_array_string_uint16",
+	106: "required_double_array_string_uint32",
+	107: "required_double_array_string_uint64",
+	108: "required_double_array_string_uint8",
+	109: "required_double_array_string_unix",
+	110: "required_double_array_string_unix-micro",
+	111: "required_double_array_string_unix-milli",
+	112: "required_double_array_string_unix-nano",
+	113: "required_double_array_string_unix-seconds",
+	114: "required_double_array_string_uri",
+	115: "required_double_array_string_uuid",
+	116: "required_integer",
+	117: "required_integer_int16",
+	118: "required_integer_int32",
+	119: "required_integer_int64",
+	120: "required_integer_int8",
+	121: "required_integer_uint",
+	122: "required_integer_uint16",
+	123: "required_integer_uint32",
+	124: "required_integer_uint64",
+	125: "required_integer_uint8",
+	126: "required_integer_unix",
+	127: "required_integer_unix-micro",
+	128: "required_integer_unix-milli",
+	129: "required_integer_unix-nano",
+	130: "required_integer_unix-seconds",
+	131: "required_null",
+	132: "required_number",
+	133: "required_number_double",
+	134: "required_number_float",
+	135: "required_number_int32",
+	136: "required_number_int64",
+	137: "required_string",
+	138: "required_string_base64",
+	139: "required_string_binary",
+	140: "required_string_byte",
+	141: "required_string_date",
+	142: "required_string_date-time",
+	143: "required_string_duration",
+	144: "required_string_email",
+	145: "required_string_float32",
+	146: "required_string_float64",
+	147: "required_string_hostname",
+	148: "required_string_int",
+	149: "required_string_int16",
+	150: "required_string_int32",
+	151: "required_string_int64",
+	152: "required_string_int8",
+	153: "required_string_ip",
+	154: "required_string_ipv4",
+	155: "required_string_ipv6",
+	156: "required_string_mac",
+	157: "required_string_password",
+	158: "required_string_time",
+	159: "required_string_uint",
+	160: "required_string_uint16",
+	161: "required_string_uint32",
+	162: "required_string_uint64",
+	163: "required_string_uint8",
+	164: "required_string_unix",
+	165: "required_string_unix-micro",
+	166: "required_string_unix-milli",
+	167: "required_string_unix-nano",
+	168: "required_string_unix-seconds",
+	169: "required_string_uri",
+	170: "required_string_uuid",
+	171: "optional_any",
+	172: "optional_array_any",
+	173: "optional_array_boolean",
+	174: "optional_array_integer",
+	175: "optional_array_integer_int16",
+	176: "optional_array_integer_int32",
+	177: "optional_array_integer_int64",
+	178: "optional_array_integer_int8",
+	179: "optional_array_integer_uint",
+	180: "optional_array_integer_uint16",
+	181: "optional_array_integer_uint32",
+	182: "optional_array_integer_uint64",
+	183: "optional_array_integer_uint8",
+	184: "optional_array_integer_unix",
+	185: "optional_array_integer_unix-micro",
+	186: "optional_array_integer_unix-milli",
+	187: "optional_array_integer_unix-nano",
+	188: "optional_array_integer_unix-seconds",
+	189: "optional_array_null",
+	190: "optional_array_number",
+	191: "optional_array_number_double",
+	192: "optional_array_number_float",
+	193: "optional_array_number_int32",
+	194: "optional_array_number_int64",
+	195: "optional_array_string",
+	196: "optional_array_string_base64",
+	197: "optional_array_string_binary",
+	198: "optional_array_string_byte",
+	199: "optional_array_string_date",
+	200: "optional_array_string_date-time",
+	201: "optional_array_string_duration",
+	202: "optional_array_string_email",
+	203: "optional_array_string_float32",
+	204: "optional_array_string_float64",
+	205: "optional_array_string_hostname",
+	206: "optional_array_string_int",
+	207: "optional_array_string_int16",
+	208: "optional_array_string_int32",
+	209: "optional_array_string_int64",
+	210: "optional_array_string_int8",
+	211: "optional_array_string_ip",
+	212: "optional_array_string_ipv4",
+	213: "optional_array_string_ipv6",
+	214: "optional_array_string_mac",
+	215: "optional_array_string_password",
+	216: "optional_array_string_time",
+	217: "optional_array_string_uint",
+	218: "optional_array_string_uint16",
+	219: "optional_array_string_uint32",
+	220: "optional_array_string_uint64",
+	221: "optional_array_string_uint8",
+	222: "optional_array_string_unix",
+	223: "optional_array_string_unix-micro",
+	224: "optional_array_string_unix-milli",
+	225: "optional_array_string_unix-nano",
+	226: "optional_array_string_unix-seconds",
+	227: "optional_array_string_uri",
+	228: "optional_array_string_uuid",
+	229: "optional_boolean",
+	230: "optional_double_array_any",
+	231: "optional_double_array_boolean",
+	232: "optional_double_array_integer",
+	233: "optional_double_array_integer_int16",
+	234: "optional_double_array_integer_int32",
+	235: "optional_double_array_integer_int64",
+	236: "optional_double_array_integer_int8",
+	237: "optional_double_array_integer_uint",
+	238: "optional_double_array_integer_uint16",
+	239: "optional_double_array_integer_uint32",
+	240: "optional_double_array_integer_uint64",
+	241: "optional_double_array_integer_uint8",
+	242: "optional_double_array_integer_unix",
+	243: "optional_double_array_integer_unix-micro",
+	244: "optional_double_array_integer_unix-milli",
+	245: "optional_double_array_integer_unix-nano",
+	246: "optional_double_array_integer_unix-seconds",
+	247: "optional_double_array_null",
+	248: "optional_double_array_number",
+	249: "optional_double_array_number_double",
+	250: "optional_double_array_number_float",
+	251: "optional_double_array_number_int32",
+	252: "optional_double_array_number_int64",
+	253: "optional_double_array_string",
+	254: "optional_double_array_string_base64",
+	255: "optional_double_array_string_binary",
+	256: "optional_double_array_string_byte",
+	257: "optional_double_array_string_date",
+	258: "optional_double_array_string_date-time",
+	259: "optional_double_array_string_duration",
+	260: "optional_double_array_string_email",
+	261: "optional_double_array_string_float32",
+	262: "optional_double_array_string_float64",
+	263: "optional_double_array_string_hostname",
+	264: "optional_double_array_string_int",
+	265: "optional_double_array_string_int16",
+	266: "optional_double_array_string_int32",
+	267: "optional_double_array_string_int64",
+	268: "optional_double_array_string_int8",
+	269: "optional_double_array_string_ip",
+	270: "optional_double_array_string_ipv4",
+	271: "optional_double_array_string_ipv6",
+	272: "optional_double_array_string_mac",
+	273: "optional_double_array_string_password",
+	274: "optional_double_array_string_time",
+	275: "optional_double_array_string_uint",
+	276: "optional_double_array_string_uint16",
+	277: "optional_double_array_string_uint32",
+	278: "optional_double_array_string_uint64",
+	279: "optional_double_array_string_uint8",
+	280: "optional_double_array_string_unix",
+	281: "optional_double_array_string_unix-micro",
+	282: "optional_double_array_string_unix-milli",
+	283: "optional_double_array_string_unix-nano",
+	284: "optional_double_array_string_unix-seconds",
+	285: "optional_double_array_string_uri",
+	286: "optional_double_array_string_uuid",
+	287: "optional_integer",
+	288: "optional_integer_int16",
+	289: "optional_integer_int32",
+	290: "optional_integer_int64",
+	291: "optional_integer_int8",
+	292: "optional_integer_uint",
+	293: "optional_integer_uint16",
+	294: "optional_integer_uint32",
+	295: "optional_integer_uint64",
+	296: "optional_integer_uint8",
+	297: "optional_integer_unix",
+	298: "optional_integer_unix-micro",
+	299: "optional_integer_unix-milli",
+	300: "optional_integer_unix-nano",
+	301: "optional_integer_unix-seconds",
+	302: "optional_null",
+	303: "optional_number",
+	304: "optional_number_double",
+	305: "optional_number_float",
+	306: "optional_number_int32",
+	307: "optional_number_int64",
+	308: "optional_string",
+	309: "optional_string_base64",
+	310: "optional_string_binary",
+	311: "optional_string_byte",
+	312: "optional_string_date",
+	313: "optional_string_date-time",
+	314: "optional_string_duration",
+	315: "optional_string_email",
+	316: "optional_string_float32",
+	317: "optional_string_float64",
+	318: "optional_string_hostname",
+	319: "optional_string_int",
+	320: "optional_string_int16",
+	321: "optional_string_int32",
+	322: "optional_string_int64",
+	323: "optional_string_int8",
+	324: "optional_string_ip",
+	325: "optional_string_ipv4",
+	326: "optional_string_ipv6",
+	327: "optional_string_mac",
+	328: "optional_string_password",
+	329: "optional_string_time",
+	330: "optional_string_uint",
+	331: "optional_string_uint16",
+	332: "optional_string_uint32",
+	333: "optional_string_uint64",
+	334: "optional_string_uint8",
+	335: "optional_string_unix",
+	336: "optional_string_unix-micro",
+	337: "optional_string_unix-milli",
+	338: "optional_string_unix-nano",
+	339: "optional_string_unix-seconds",
+	340: "optional_string_uri",
+	341: "optional_string_uuid",
 }
 
 // Decode decodes TestResponseFormatTestOK from json.
@@ -29372,7 +29919,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode TestResponseFormatTestOK to nil")
 	}
-	var requiredBitSet [42]uint8
+	var requiredBitSet [43]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -30226,8 +30773,28 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_array_string_ipv6\"")
 			}
-		case "required_array_string_password":
+		case "required_array_string_mac":
 			requiredBitSet[5] |= 1 << 3
+			if err := func() error {
+				s.RequiredArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.RequiredArrayStringMAC = append(s.RequiredArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_array_string_mac\"")
+			}
+		case "required_array_string_password":
+			requiredBitSet[5] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringPassword = make([]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30247,7 +30814,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_password\"")
 			}
 		case "required_array_string_time":
-			requiredBitSet[5] |= 1 << 4
+			requiredBitSet[5] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringTime = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30267,7 +30834,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_time\"")
 			}
 		case "required_array_string_uint":
-			requiredBitSet[5] |= 1 << 5
+			requiredBitSet[5] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUint = make([]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30287,7 +30854,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint\"")
 			}
 		case "required_array_string_uint16":
-			requiredBitSet[5] |= 1 << 6
+			requiredBitSet[5] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUint16 = make([]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30307,7 +30874,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint16\"")
 			}
 		case "required_array_string_uint32":
-			requiredBitSet[5] |= 1 << 7
+			requiredBitSet[6] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringUint32 = make([]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30327,7 +30894,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint32\"")
 			}
 		case "required_array_string_uint64":
-			requiredBitSet[6] |= 1 << 0
+			requiredBitSet[6] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUint64 = make([]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30347,7 +30914,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint64\"")
 			}
 		case "required_array_string_uint8":
-			requiredBitSet[6] |= 1 << 1
+			requiredBitSet[6] |= 1 << 2
 			if err := func() error {
 				s.RequiredArrayStringUint8 = make([]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30367,7 +30934,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uint8\"")
 			}
 		case "required_array_string_unix":
-			requiredBitSet[6] |= 1 << 2
+			requiredBitSet[6] |= 1 << 3
 			if err := func() error {
 				s.RequiredArrayStringUnix = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30387,7 +30954,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix\"")
 			}
 		case "required_array_string_unix-micro":
-			requiredBitSet[6] |= 1 << 3
+			requiredBitSet[6] |= 1 << 4
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMicro = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30407,7 +30974,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-micro\"")
 			}
 		case "required_array_string_unix-milli":
-			requiredBitSet[6] |= 1 << 4
+			requiredBitSet[6] |= 1 << 5
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusMilli = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30427,7 +30994,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-milli\"")
 			}
 		case "required_array_string_unix-nano":
-			requiredBitSet[6] |= 1 << 5
+			requiredBitSet[6] |= 1 << 6
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusNano = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30447,7 +31014,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-nano\"")
 			}
 		case "required_array_string_unix-seconds":
-			requiredBitSet[6] |= 1 << 6
+			requiredBitSet[6] |= 1 << 7
 			if err := func() error {
 				s.RequiredArrayStringUnixMinusSeconds = make([]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30467,7 +31034,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_unix-seconds\"")
 			}
 		case "required_array_string_uri":
-			requiredBitSet[6] |= 1 << 7
+			requiredBitSet[7] |= 1 << 0
 			if err := func() error {
 				s.RequiredArrayStringURI = make([]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30487,7 +31054,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uri\"")
 			}
 		case "required_array_string_uuid":
-			requiredBitSet[7] |= 1 << 0
+			requiredBitSet[7] |= 1 << 1
 			if err := func() error {
 				s.RequiredArrayStringUUID = make([]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30507,7 +31074,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_array_string_uuid\"")
 			}
 		case "required_boolean":
-			requiredBitSet[7] |= 1 << 1
+			requiredBitSet[7] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.RequiredBoolean = bool(v)
@@ -30519,7 +31086,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_boolean\"")
 			}
 		case "required_double_array_any":
-			requiredBitSet[7] |= 1 << 2
+			requiredBitSet[7] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayAny = make([][]jx.Raw, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30547,7 +31114,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_any\"")
 			}
 		case "required_double_array_boolean":
-			requiredBitSet[7] |= 1 << 3
+			requiredBitSet[7] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayBoolean = make([][]bool, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30575,7 +31142,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_boolean\"")
 			}
 		case "required_double_array_integer":
-			requiredBitSet[7] |= 1 << 4
+			requiredBitSet[7] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayInteger = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30603,7 +31170,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer\"")
 			}
 		case "required_double_array_integer_int16":
-			requiredBitSet[7] |= 1 << 5
+			requiredBitSet[7] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30631,7 +31198,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int16\"")
 			}
 		case "required_double_array_integer_int32":
-			requiredBitSet[7] |= 1 << 6
+			requiredBitSet[7] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30659,7 +31226,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int32\"")
 			}
 		case "required_double_array_integer_int64":
-			requiredBitSet[7] |= 1 << 7
+			requiredBitSet[8] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30687,7 +31254,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int64\"")
 			}
 		case "required_double_array_integer_int8":
-			requiredBitSet[8] |= 1 << 0
+			requiredBitSet[8] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30715,7 +31282,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_int8\"")
 			}
 		case "required_double_array_integer_uint":
-			requiredBitSet[8] |= 1 << 1
+			requiredBitSet[8] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30743,7 +31310,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint\"")
 			}
 		case "required_double_array_integer_uint16":
-			requiredBitSet[8] |= 1 << 2
+			requiredBitSet[8] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30771,7 +31338,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint16\"")
 			}
 		case "required_double_array_integer_uint32":
-			requiredBitSet[8] |= 1 << 3
+			requiredBitSet[8] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30799,7 +31366,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint32\"")
 			}
 		case "required_double_array_integer_uint64":
-			requiredBitSet[8] |= 1 << 4
+			requiredBitSet[8] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30827,7 +31394,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint64\"")
 			}
 		case "required_double_array_integer_uint8":
-			requiredBitSet[8] |= 1 << 5
+			requiredBitSet[8] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30855,7 +31422,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_uint8\"")
 			}
 		case "required_double_array_integer_unix":
-			requiredBitSet[8] |= 1 << 6
+			requiredBitSet[8] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30883,7 +31450,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix\"")
 			}
 		case "required_double_array_integer_unix-micro":
-			requiredBitSet[8] |= 1 << 7
+			requiredBitSet[9] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30911,7 +31478,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-micro\"")
 			}
 		case "required_double_array_integer_unix-milli":
-			requiredBitSet[9] |= 1 << 0
+			requiredBitSet[9] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30939,7 +31506,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-milli\"")
 			}
 		case "required_double_array_integer_unix-nano":
-			requiredBitSet[9] |= 1 << 1
+			requiredBitSet[9] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30967,7 +31534,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-nano\"")
 			}
 		case "required_double_array_integer_unix-seconds":
-			requiredBitSet[9] |= 1 << 2
+			requiredBitSet[9] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayIntegerUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30995,7 +31562,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_integer_unix-seconds\"")
 			}
 		case "required_double_array_null":
-			requiredBitSet[9] |= 1 << 3
+			requiredBitSet[9] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayNull = make([][]struct{}, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31021,7 +31588,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_null\"")
 			}
 		case "required_double_array_number":
-			requiredBitSet[9] |= 1 << 4
+			requiredBitSet[9] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayNumber = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31049,7 +31616,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number\"")
 			}
 		case "required_double_array_number_double":
-			requiredBitSet[9] |= 1 << 5
+			requiredBitSet[9] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayNumberDouble = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31077,7 +31644,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_double\"")
 			}
 		case "required_double_array_number_float":
-			requiredBitSet[9] |= 1 << 6
+			requiredBitSet[9] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayNumberFloat = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31105,7 +31672,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_float\"")
 			}
 		case "required_double_array_number_int32":
-			requiredBitSet[9] |= 1 << 7
+			requiredBitSet[10] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31133,7 +31700,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int32\"")
 			}
 		case "required_double_array_number_int64":
-			requiredBitSet[10] |= 1 << 0
+			requiredBitSet[10] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayNumberInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31161,7 +31728,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_number_int64\"")
 			}
 		case "required_double_array_string":
-			requiredBitSet[10] |= 1 << 1
+			requiredBitSet[10] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayString = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31189,7 +31756,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string\"")
 			}
 		case "required_double_array_string_base64":
-			requiredBitSet[10] |= 1 << 2
+			requiredBitSet[10] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringBase64 = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31217,7 +31784,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_base64\"")
 			}
 		case "required_double_array_string_binary":
-			requiredBitSet[10] |= 1 << 3
+			requiredBitSet[10] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringBinary = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31245,7 +31812,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_binary\"")
 			}
 		case "required_double_array_string_byte":
-			requiredBitSet[10] |= 1 << 4
+			requiredBitSet[10] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringByte = make([][][]byte, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31273,7 +31840,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_byte\"")
 			}
 		case "required_double_array_string_date":
-			requiredBitSet[10] |= 1 << 5
+			requiredBitSet[10] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringDate = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31301,7 +31868,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date\"")
 			}
 		case "required_double_array_string_date-time":
-			requiredBitSet[10] |= 1 << 6
+			requiredBitSet[10] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringDateMinusTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31329,7 +31896,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_date-time\"")
 			}
 		case "required_double_array_string_duration":
-			requiredBitSet[10] |= 1 << 7
+			requiredBitSet[11] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringDuration = make([][]time.Duration, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31357,7 +31924,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_duration\"")
 			}
 		case "required_double_array_string_email":
-			requiredBitSet[11] |= 1 << 0
+			requiredBitSet[11] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringEmail = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31385,7 +31952,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_email\"")
 			}
 		case "required_double_array_string_float32":
-			requiredBitSet[11] |= 1 << 1
+			requiredBitSet[11] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat32 = make([][]float32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31413,7 +31980,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float32\"")
 			}
 		case "required_double_array_string_float64":
-			requiredBitSet[11] |= 1 << 2
+			requiredBitSet[11] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringFloat64 = make([][]float64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31441,7 +32008,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_float64\"")
 			}
 		case "required_double_array_string_hostname":
-			requiredBitSet[11] |= 1 << 3
+			requiredBitSet[11] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringHostname = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31469,7 +32036,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_hostname\"")
 			}
 		case "required_double_array_string_int":
-			requiredBitSet[11] |= 1 << 4
+			requiredBitSet[11] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt = make([][]int, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31497,7 +32064,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int\"")
 			}
 		case "required_double_array_string_int16":
-			requiredBitSet[11] |= 1 << 5
+			requiredBitSet[11] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt16 = make([][]int16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31525,7 +32092,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int16\"")
 			}
 		case "required_double_array_string_int32":
-			requiredBitSet[11] |= 1 << 6
+			requiredBitSet[11] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt32 = make([][]int32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31553,7 +32120,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int32\"")
 			}
 		case "required_double_array_string_int64":
-			requiredBitSet[11] |= 1 << 7
+			requiredBitSet[12] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt64 = make([][]int64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31581,7 +32148,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int64\"")
 			}
 		case "required_double_array_string_int8":
-			requiredBitSet[12] |= 1 << 0
+			requiredBitSet[12] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringInt8 = make([][]int8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31609,7 +32176,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_int8\"")
 			}
 		case "required_double_array_string_ip":
-			requiredBitSet[12] |= 1 << 1
+			requiredBitSet[12] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringIP = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31637,7 +32204,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ip\"")
 			}
 		case "required_double_array_string_ipv4":
-			requiredBitSet[12] |= 1 << 2
+			requiredBitSet[12] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv4 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31665,7 +32232,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv4\"")
 			}
 		case "required_double_array_string_ipv6":
-			requiredBitSet[12] |= 1 << 3
+			requiredBitSet[12] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringIpv6 = make([][]netip.Addr, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31692,8 +32259,36 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_double_array_string_ipv6\"")
 			}
+		case "required_double_array_string_mac":
+			requiredBitSet[12] |= 1 << 5
+			if err := func() error {
+				s.RequiredDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.RequiredDoubleArrayStringMAC = append(s.RequiredDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_double_array_string_mac\"")
+			}
 		case "required_double_array_string_password":
-			requiredBitSet[12] |= 1 << 4
+			requiredBitSet[12] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringPassword = make([][]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31721,7 +32316,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_password\"")
 			}
 		case "required_double_array_string_time":
-			requiredBitSet[12] |= 1 << 5
+			requiredBitSet[12] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringTime = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31749,7 +32344,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_time\"")
 			}
 		case "required_double_array_string_uint":
-			requiredBitSet[12] |= 1 << 6
+			requiredBitSet[13] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint = make([][]uint, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31777,7 +32372,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint\"")
 			}
 		case "required_double_array_string_uint16":
-			requiredBitSet[12] |= 1 << 7
+			requiredBitSet[13] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint16 = make([][]uint16, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31805,7 +32400,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint16\"")
 			}
 		case "required_double_array_string_uint32":
-			requiredBitSet[13] |= 1 << 0
+			requiredBitSet[13] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint32 = make([][]uint32, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31833,7 +32428,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint32\"")
 			}
 		case "required_double_array_string_uint64":
-			requiredBitSet[13] |= 1 << 1
+			requiredBitSet[13] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint64 = make([][]uint64, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31861,7 +32456,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint64\"")
 			}
 		case "required_double_array_string_uint8":
-			requiredBitSet[13] |= 1 << 2
+			requiredBitSet[13] |= 1 << 4
 			if err := func() error {
 				s.RequiredDoubleArrayStringUint8 = make([][]uint8, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31889,7 +32484,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uint8\"")
 			}
 		case "required_double_array_string_unix":
-			requiredBitSet[13] |= 1 << 3
+			requiredBitSet[13] |= 1 << 5
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnix = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31917,7 +32512,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix\"")
 			}
 		case "required_double_array_string_unix-micro":
-			requiredBitSet[13] |= 1 << 4
+			requiredBitSet[13] |= 1 << 6
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMicro = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31945,7 +32540,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-micro\"")
 			}
 		case "required_double_array_string_unix-milli":
-			requiredBitSet[13] |= 1 << 5
+			requiredBitSet[13] |= 1 << 7
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusMilli = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -31973,7 +32568,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-milli\"")
 			}
 		case "required_double_array_string_unix-nano":
-			requiredBitSet[13] |= 1 << 6
+			requiredBitSet[14] |= 1 << 0
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusNano = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -32001,7 +32596,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-nano\"")
 			}
 		case "required_double_array_string_unix-seconds":
-			requiredBitSet[13] |= 1 << 7
+			requiredBitSet[14] |= 1 << 1
 			if err := func() error {
 				s.RequiredDoubleArrayStringUnixMinusSeconds = make([][]time.Time, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -32029,7 +32624,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_unix-seconds\"")
 			}
 		case "required_double_array_string_uri":
-			requiredBitSet[14] |= 1 << 0
+			requiredBitSet[14] |= 1 << 2
 			if err := func() error {
 				s.RequiredDoubleArrayStringURI = make([][]url.URL, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -32057,7 +32652,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uri\"")
 			}
 		case "required_double_array_string_uuid":
-			requiredBitSet[14] |= 1 << 1
+			requiredBitSet[14] |= 1 << 3
 			if err := func() error {
 				s.RequiredDoubleArrayStringUUID = make([][]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -32085,7 +32680,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_double_array_string_uuid\"")
 			}
 		case "required_integer":
-			requiredBitSet[14] |= 1 << 2
+			requiredBitSet[14] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.RequiredInteger = int(v)
@@ -32097,7 +32692,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer\"")
 			}
 		case "required_integer_int16":
-			requiredBitSet[14] |= 1 << 3
+			requiredBitSet[14] |= 1 << 5
 			if err := func() error {
 				v, err := d.Int16()
 				s.RequiredIntegerInt16 = int16(v)
@@ -32109,7 +32704,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int16\"")
 			}
 		case "required_integer_int32":
-			requiredBitSet[14] |= 1 << 4
+			requiredBitSet[14] |= 1 << 6
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredIntegerInt32 = int32(v)
@@ -32121,7 +32716,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int32\"")
 			}
 		case "required_integer_int64":
-			requiredBitSet[14] |= 1 << 5
+			requiredBitSet[14] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredIntegerInt64 = int64(v)
@@ -32133,7 +32728,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int64\"")
 			}
 		case "required_integer_int8":
-			requiredBitSet[14] |= 1 << 6
+			requiredBitSet[15] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int8()
 				s.RequiredIntegerInt8 = int8(v)
@@ -32145,7 +32740,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_int8\"")
 			}
 		case "required_integer_uint":
-			requiredBitSet[14] |= 1 << 7
+			requiredBitSet[15] |= 1 << 1
 			if err := func() error {
 				v, err := d.UInt()
 				s.RequiredIntegerUint = uint(v)
@@ -32157,7 +32752,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint\"")
 			}
 		case "required_integer_uint16":
-			requiredBitSet[15] |= 1 << 0
+			requiredBitSet[15] |= 1 << 2
 			if err := func() error {
 				v, err := d.UInt16()
 				s.RequiredIntegerUint16 = uint16(v)
@@ -32169,7 +32764,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint16\"")
 			}
 		case "required_integer_uint32":
-			requiredBitSet[15] |= 1 << 1
+			requiredBitSet[15] |= 1 << 3
 			if err := func() error {
 				v, err := d.UInt32()
 				s.RequiredIntegerUint32 = uint32(v)
@@ -32181,7 +32776,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint32\"")
 			}
 		case "required_integer_uint64":
-			requiredBitSet[15] |= 1 << 2
+			requiredBitSet[15] |= 1 << 4
 			if err := func() error {
 				v, err := d.UInt64()
 				s.RequiredIntegerUint64 = uint64(v)
@@ -32193,7 +32788,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint64\"")
 			}
 		case "required_integer_uint8":
-			requiredBitSet[15] |= 1 << 3
+			requiredBitSet[15] |= 1 << 5
 			if err := func() error {
 				v, err := d.UInt8()
 				s.RequiredIntegerUint8 = uint8(v)
@@ -32205,7 +32800,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_uint8\"")
 			}
 		case "required_integer_unix":
-			requiredBitSet[15] |= 1 << 4
+			requiredBitSet[15] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnix = v
@@ -32217,7 +32812,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix\"")
 			}
 		case "required_integer_unix-micro":
-			requiredBitSet[15] |= 1 << 5
+			requiredBitSet[15] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeUnixMicro(d)
 				s.RequiredIntegerUnixMinusMicro = v
@@ -32229,7 +32824,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-micro\"")
 			}
 		case "required_integer_unix-milli":
-			requiredBitSet[15] |= 1 << 6
+			requiredBitSet[16] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeUnixMilli(d)
 				s.RequiredIntegerUnixMinusMilli = v
@@ -32241,7 +32836,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-milli\"")
 			}
 		case "required_integer_unix-nano":
-			requiredBitSet[15] |= 1 << 7
+			requiredBitSet[16] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeUnixNano(d)
 				s.RequiredIntegerUnixMinusNano = v
@@ -32253,7 +32848,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-nano\"")
 			}
 		case "required_integer_unix-seconds":
-			requiredBitSet[16] |= 1 << 0
+			requiredBitSet[16] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUnixSeconds(d)
 				s.RequiredIntegerUnixMinusSeconds = v
@@ -32265,7 +32860,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_integer_unix-seconds\"")
 			}
 		case "required_null":
-			requiredBitSet[16] |= 1 << 1
+			requiredBitSet[16] |= 1 << 3
 			if err := func() error {
 				if err := d.Null(); err != nil {
 					return err
@@ -32275,7 +32870,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_null\"")
 			}
 		case "required_number":
-			requiredBitSet[16] |= 1 << 2
+			requiredBitSet[16] |= 1 << 4
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumber = float64(v)
@@ -32287,7 +32882,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number\"")
 			}
 		case "required_number_double":
-			requiredBitSet[16] |= 1 << 3
+			requiredBitSet[16] |= 1 << 5
 			if err := func() error {
 				v, err := d.Float64()
 				s.RequiredNumberDouble = float64(v)
@@ -32299,7 +32894,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_double\"")
 			}
 		case "required_number_float":
-			requiredBitSet[16] |= 1 << 4
+			requiredBitSet[16] |= 1 << 6
 			if err := func() error {
 				v, err := d.Float32()
 				s.RequiredNumberFloat = float32(v)
@@ -32311,7 +32906,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_float\"")
 			}
 		case "required_number_int32":
-			requiredBitSet[16] |= 1 << 5
+			requiredBitSet[16] |= 1 << 7
 			if err := func() error {
 				v, err := d.Int32()
 				s.RequiredNumberInt32 = int32(v)
@@ -32323,7 +32918,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int32\"")
 			}
 		case "required_number_int64":
-			requiredBitSet[16] |= 1 << 6
+			requiredBitSet[17] |= 1 << 0
 			if err := func() error {
 				v, err := d.Int64()
 				s.RequiredNumberInt64 = int64(v)
@@ -32335,7 +32930,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_number_int64\"")
 			}
 		case "required_string":
-			requiredBitSet[16] |= 1 << 7
+			requiredBitSet[17] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredString = string(v)
@@ -32347,7 +32942,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string\"")
 			}
 		case "required_string_base64":
-			requiredBitSet[17] |= 1 << 0
+			requiredBitSet[17] |= 1 << 2
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringBase64 = []byte(v)
@@ -32359,7 +32954,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_base64\"")
 			}
 		case "required_string_binary":
-			requiredBitSet[17] |= 1 << 1
+			requiredBitSet[17] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringBinary = string(v)
@@ -32371,7 +32966,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_binary\"")
 			}
 		case "required_string_byte":
-			requiredBitSet[17] |= 1 << 2
+			requiredBitSet[17] |= 1 << 4
 			if err := func() error {
 				v, err := d.Base64()
 				s.RequiredStringByte = []byte(v)
@@ -32383,7 +32978,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_byte\"")
 			}
 		case "required_string_date":
-			requiredBitSet[17] |= 1 << 3
+			requiredBitSet[17] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeDate(d)
 				s.RequiredStringDate = v
@@ -32395,7 +32990,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date\"")
 			}
 		case "required_string_date-time":
-			requiredBitSet[17] |= 1 << 4
+			requiredBitSet[17] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.RequiredStringDateMinusTime = v
@@ -32407,7 +33002,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_date-time\"")
 			}
 		case "required_string_duration":
-			requiredBitSet[17] |= 1 << 5
+			requiredBitSet[17] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDuration(d)
 				s.RequiredStringDuration = v
@@ -32419,7 +33014,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_duration\"")
 			}
 		case "required_string_email":
-			requiredBitSet[17] |= 1 << 6
+			requiredBitSet[18] |= 1 << 0
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringEmail = string(v)
@@ -32431,7 +33026,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_email\"")
 			}
 		case "required_string_float32":
-			requiredBitSet[17] |= 1 << 7
+			requiredBitSet[18] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringFloat32(d)
 				s.RequiredStringFloat32 = v
@@ -32443,7 +33038,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float32\"")
 			}
 		case "required_string_float64":
-			requiredBitSet[18] |= 1 << 0
+			requiredBitSet[18] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringFloat64(d)
 				s.RequiredStringFloat64 = v
@@ -32455,7 +33050,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_float64\"")
 			}
 		case "required_string_hostname":
-			requiredBitSet[18] |= 1 << 1
+			requiredBitSet[18] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringHostname = string(v)
@@ -32467,7 +33062,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_hostname\"")
 			}
 		case "required_string_int":
-			requiredBitSet[18] |= 1 << 2
+			requiredBitSet[18] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringInt(d)
 				s.RequiredStringInt = v
@@ -32479,7 +33074,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int\"")
 			}
 		case "required_string_int16":
-			requiredBitSet[18] |= 1 << 3
+			requiredBitSet[18] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringInt16(d)
 				s.RequiredStringInt16 = v
@@ -32491,7 +33086,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int16\"")
 			}
 		case "required_string_int32":
-			requiredBitSet[18] |= 1 << 4
+			requiredBitSet[18] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringInt32(d)
 				s.RequiredStringInt32 = v
@@ -32503,7 +33098,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int32\"")
 			}
 		case "required_string_int64":
-			requiredBitSet[18] |= 1 << 5
+			requiredBitSet[18] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringInt64(d)
 				s.RequiredStringInt64 = v
@@ -32515,7 +33110,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int64\"")
 			}
 		case "required_string_int8":
-			requiredBitSet[18] |= 1 << 6
+			requiredBitSet[19] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringInt8(d)
 				s.RequiredStringInt8 = v
@@ -32527,7 +33122,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_int8\"")
 			}
 		case "required_string_ip":
-			requiredBitSet[18] |= 1 << 7
+			requiredBitSet[19] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeIP(d)
 				s.RequiredStringIP = v
@@ -32539,7 +33134,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ip\"")
 			}
 		case "required_string_ipv4":
-			requiredBitSet[19] |= 1 << 0
+			requiredBitSet[19] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeIPv4(d)
 				s.RequiredStringIpv4 = v
@@ -32551,7 +33146,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_ipv4\"")
 			}
 		case "required_string_ipv6":
-			requiredBitSet[19] |= 1 << 1
+			requiredBitSet[19] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeIPv6(d)
 				s.RequiredStringIpv6 = v
@@ -32562,8 +33157,20 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"required_string_ipv6\"")
 			}
+		case "required_string_mac":
+			requiredBitSet[19] |= 1 << 4
+			if err := func() error {
+				v, err := json.DecodeMAC(d)
+				s.RequiredStringMAC = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_string_mac\"")
+			}
 		case "required_string_password":
-			requiredBitSet[19] |= 1 << 2
+			requiredBitSet[19] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.RequiredStringPassword = string(v)
@@ -32575,7 +33182,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_password\"")
 			}
 		case "required_string_time":
-			requiredBitSet[19] |= 1 << 3
+			requiredBitSet[19] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeTime(d)
 				s.RequiredStringTime = v
@@ -32587,7 +33194,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_time\"")
 			}
 		case "required_string_uint":
-			requiredBitSet[19] |= 1 << 4
+			requiredBitSet[19] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUint(d)
 				s.RequiredStringUint = v
@@ -32599,7 +33206,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint\"")
 			}
 		case "required_string_uint16":
-			requiredBitSet[19] |= 1 << 5
+			requiredBitSet[20] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUint16(d)
 				s.RequiredStringUint16 = v
@@ -32611,7 +33218,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint16\"")
 			}
 		case "required_string_uint32":
-			requiredBitSet[19] |= 1 << 6
+			requiredBitSet[20] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeStringUint32(d)
 				s.RequiredStringUint32 = v
@@ -32623,7 +33230,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint32\"")
 			}
 		case "required_string_uint64":
-			requiredBitSet[19] |= 1 << 7
+			requiredBitSet[20] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeStringUint64(d)
 				s.RequiredStringUint64 = v
@@ -32635,7 +33242,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint64\"")
 			}
 		case "required_string_uint8":
-			requiredBitSet[20] |= 1 << 0
+			requiredBitSet[20] |= 1 << 3
 			if err := func() error {
 				v, err := json.DecodeStringUint8(d)
 				s.RequiredStringUint8 = v
@@ -32647,7 +33254,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uint8\"")
 			}
 		case "required_string_unix":
-			requiredBitSet[20] |= 1 << 1
+			requiredBitSet[20] |= 1 << 4
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnix = v
@@ -32659,7 +33266,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix\"")
 			}
 		case "required_string_unix-micro":
-			requiredBitSet[20] |= 1 << 2
+			requiredBitSet[20] |= 1 << 5
 			if err := func() error {
 				v, err := json.DecodeStringUnixMicro(d)
 				s.RequiredStringUnixMinusMicro = v
@@ -32671,7 +33278,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-micro\"")
 			}
 		case "required_string_unix-milli":
-			requiredBitSet[20] |= 1 << 3
+			requiredBitSet[20] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeStringUnixMilli(d)
 				s.RequiredStringUnixMinusMilli = v
@@ -32683,7 +33290,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-milli\"")
 			}
 		case "required_string_unix-nano":
-			requiredBitSet[20] |= 1 << 4
+			requiredBitSet[20] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeStringUnixNano(d)
 				s.RequiredStringUnixMinusNano = v
@@ -32695,7 +33302,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-nano\"")
 			}
 		case "required_string_unix-seconds":
-			requiredBitSet[20] |= 1 << 5
+			requiredBitSet[21] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeStringUnixSeconds(d)
 				s.RequiredStringUnixMinusSeconds = v
@@ -32707,7 +33314,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_unix-seconds\"")
 			}
 		case "required_string_uri":
-			requiredBitSet[20] |= 1 << 6
+			requiredBitSet[21] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.RequiredStringURI = v
@@ -32719,7 +33326,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"required_string_uri\"")
 			}
 		case "required_string_uuid":
-			requiredBitSet[20] |= 1 << 7
+			requiredBitSet[21] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.RequiredStringUUID = v
@@ -33536,6 +34143,25 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_array_string_ipv6\"")
+			}
+		case "optional_array_string_mac":
+			if err := func() error {
+				s.OptionalArrayStringMAC = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					s.OptionalArrayStringMAC = append(s.OptionalArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_array_string_mac\"")
 			}
 		case "optional_array_string_password":
 			if err := func() error {
@@ -34945,6 +35571,33 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_double_array_string_ipv6\"")
 			}
+		case "optional_double_array_string_mac":
+			if err := func() error {
+				s.OptionalDoubleArrayStringMAC = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.OptionalDoubleArrayStringMAC = append(s.OptionalDoubleArrayStringMAC, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_double_array_string_mac\"")
+			}
 		case "optional_double_array_string_password":
 			if err := func() error {
 				s.OptionalDoubleArrayStringPassword = make([][]string, 0)
@@ -35725,6 +36378,16 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"optional_string_ipv6\"")
 			}
+		case "optional_string_mac":
+			if err := func() error {
+				s.OptionalStringMAC.Reset()
+				if err := s.OptionalStringMAC.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optional_string_mac\"")
+			}
 		case "optional_string_password":
 			if err := func() error {
 				s.OptionalStringPassword.Reset()
@@ -35874,7 +36537,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [42]uint8{
+	for i, mask := range [43]uint8{
 		0b11111111,
 		0b11111111,
 		0b11111111,
@@ -35896,6 +36559,7 @@ func (s *TestResponseFormatTestOK) Decode(d *jx.Decoder) error {
 		0b11111111,
 		0b11111111,
 		0b11111111,
+		0b00000111,
 		0b00000000,
 		0b00000000,
 		0b00000000,

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -101,6 +102,8 @@ type TestQueryParameterParams struct {
 	StringIpv4Array         []netip.Addr
 	StringIpv6              netip.Addr
 	StringIpv6Array         []netip.Addr
+	StringMAC               net.HardwareAddr
+	StringMACArray          []net.HardwareAddr
 	StringPassword          string
 	StringPasswordArray     []string
 	StringTime              time.Time
@@ -691,6 +694,20 @@ func unpackTestQueryParameterParams(packed middleware.Parameters) (params TestQu
 			In:   "query",
 		}
 		params.StringIpv6Array = packed[key].([]netip.Addr)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "string_mac",
+			In:   "query",
+		}
+		params.StringMAC = packed[key].(net.HardwareAddr)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "string_mac_array",
+			In:   "query",
+		}
+		params.StringMACArray = packed[key].([]net.HardwareAddr)
 	}
 	{
 		key := middleware.ParameterKey{
@@ -4656,6 +4673,95 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "string_ipv6_array",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: string_mac.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "string_mac",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToHardwareAddr(val)
+				if err != nil {
+					return err
+				}
+
+				params.StringMAC = c
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "string_mac",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: string_mac_array.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "string_mac_array",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotStringMACArrayVal net.HardwareAddr
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToHardwareAddr(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotStringMACArrayVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.StringMACArray = append(params.StringMACArray, paramsDotStringMACArrayVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if params.StringMACArray == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "string_mac_array",
 			In:   "query",
 			Err:  err,
 		}

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -4692,7 +4692,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 					return err
 				}
 
-				c, err := conv.ToHardwareAddr(val)
+				c, err := conv.ToMAC(val)
 				if err != nil {
 					return err
 				}
@@ -4731,7 +4731,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 							return err
 						}
 
-						c, err := conv.ToHardwareAddr(val)
+						c, err := conv.ToMAC(val)
 						if err != nil {
 							return err
 						}

--- a/examples/ex_test_format/oas_request_decoders_gen.go
+++ b/examples/ex_test_format/oas_request_decoders_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -32743,6 +32744,504 @@ func (s *Server) decodeTestRequestRequiredStringIpv6NullableArrayArrayRequest(r 
 	}
 }
 
+func (s *Server) decodeTestRequestRequiredStringMACRequest(r *http.Request) (
+	req net.HardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request net.HardwareAddr
+		if err := func() error {
+			v, err := json.DecodeMAC(d)
+			request = v
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestRequiredStringMACArrayRequest(r *http.Request) (
+	req []net.HardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request []net.HardwareAddr
+		if err := func() error {
+			request = make([]net.HardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem net.HardwareAddr
+				v, err := json.DecodeMAC(d)
+				elem = v
+				if err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			if request == nil {
+				return errors.New("nil is invalid value")
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestRequiredStringMACArrayArrayRequest(r *http.Request) (
+	req [][]net.HardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request [][]net.HardwareAddr
+		if err := func() error {
+			request = make([][]net.HardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem []net.HardwareAddr
+				elem = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elemElem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elemElem = v
+					if err != nil {
+						return err
+					}
+					elem = append(elem, elemElem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			if request == nil {
+				return errors.New("nil is invalid value")
+			}
+			var failures []validate.FieldError
+			for i, elem := range request {
+				if err := func() error {
+					if elem == nil {
+						return errors.New("nil is invalid value")
+					}
+					return nil
+				}(); err != nil {
+					failures = append(failures, validate.FieldError{
+						Name:  fmt.Sprintf("[%d]", i),
+						Error: err,
+					})
+				}
+			}
+			if len(failures) > 0 {
+				return &validate.Error{Fields: failures}
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestRequiredStringMACNullableRequest(r *http.Request) (
+	req NilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request NilHardwareAddr
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestRequiredStringMACNullableArrayRequest(r *http.Request) (
+	req []NilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request []NilHardwareAddr
+		if err := func() error {
+			request = make([]NilHardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem NilHardwareAddr
+				if err := elem.Decode(d); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			if request == nil {
+				return errors.New("nil is invalid value")
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestRequiredStringMACNullableArrayArrayRequest(r *http.Request) (
+	req [][]NilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request [][]NilHardwareAddr
+		if err := func() error {
+			request = make([][]NilHardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem []NilHardwareAddr
+				elem = make([]NilHardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elemElem NilHardwareAddr
+					if err := elemElem.Decode(d); err != nil {
+						return err
+					}
+					elem = append(elem, elemElem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			if request == nil {
+				return errors.New("nil is invalid value")
+			}
+			var failures []validate.FieldError
+			for i, elem := range request {
+				if err := func() error {
+					if elem == nil {
+						return errors.New("nil is invalid value")
+					}
+					return nil
+				}(); err != nil {
+					failures = append(failures, validate.FieldError{
+						Name:  fmt.Sprintf("[%d]", i),
+						Error: err,
+					})
+				}
+			}
+			if len(failures) > 0 {
+				return &validate.Error{Fields: failures}
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodeTestRequestRequiredStringNullableRequest(r *http.Request) (
 	req NilString,
 	close func() error,
@@ -49643,6 +50142,500 @@ func (s *Server) decodeTestRequestStringIpv6NullableArrayArrayRequest(r *http.Re
 				elem = make([]NilIPv6, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
 					var elemElem NilIPv6
+					if err := elemElem.Decode(d); err != nil {
+						return err
+					}
+					elem = append(elem, elemElem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			var failures []validate.FieldError
+			for i, elem := range request {
+				if err := func() error {
+					if elem == nil {
+						return errors.New("nil is invalid value")
+					}
+					return nil
+				}(); err != nil {
+					failures = append(failures, validate.FieldError{
+						Name:  fmt.Sprintf("[%d]", i),
+						Error: err,
+					})
+				}
+			}
+			if len(failures) > 0 {
+				return &validate.Error{Fields: failures}
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACRequest(r *http.Request) (
+	req OptHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request OptHardwareAddr
+		if err := func() error {
+			request.Reset()
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACArrayRequest(r *http.Request) (
+	req []net.HardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request []net.HardwareAddr
+		if err := func() error {
+			request = make([]net.HardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem net.HardwareAddr
+				v, err := json.DecodeMAC(d)
+				elem = v
+				if err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACArrayArrayRequest(r *http.Request) (
+	req [][]net.HardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request [][]net.HardwareAddr
+		if err := func() error {
+			request = make([][]net.HardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem []net.HardwareAddr
+				elem = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elemElem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elemElem = v
+					if err != nil {
+						return err
+					}
+					elem = append(elem, elemElem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		if err := func() error {
+			var failures []validate.FieldError
+			for i, elem := range request {
+				if err := func() error {
+					if elem == nil {
+						return errors.New("nil is invalid value")
+					}
+					return nil
+				}(); err != nil {
+					failures = append(failures, validate.FieldError{
+						Name:  fmt.Sprintf("[%d]", i),
+						Error: err,
+					})
+				}
+			}
+			if len(failures) > 0 {
+				return &validate.Error{Fields: failures}
+			}
+			return nil
+		}(); err != nil {
+			return req, close, errors.Wrap(err, "validate")
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACNullableRequest(r *http.Request) (
+	req OptNilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request OptNilHardwareAddr
+		if err := func() error {
+			request.Reset()
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACNullableArrayRequest(r *http.Request) (
+	req []NilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request []NilHardwareAddr
+		if err := func() error {
+			request = make([]NilHardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem NilHardwareAddr
+				if err := elem.Decode(d); err != nil {
+					return err
+				}
+				request = append(request, elem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestRequestStringMACNullableArrayArrayRequest(r *http.Request) (
+	req [][]NilHardwareAddr,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request [][]NilHardwareAddr
+		if err := func() error {
+			request = make([][]NilHardwareAddr, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elem []NilHardwareAddr
+				elem = make([]NilHardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elemElem NilHardwareAddr
 					if err := elemElem.Decode(d); err != nil {
 						return err
 					}
@@ -72783,6 +73776,396 @@ func (s *Server) decodeTestResponseStringIpv6NullableArrayRequest(r *http.Reques
 }
 
 func (s *Server) decodeTestResponseStringIpv6NullableArrayArrayRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACArrayRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACArrayArrayRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACNullableRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACNullableArrayRequest(r *http.Request) (
+	req string,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, validate.ErrBodyRequired
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request string
+		if err := func() error {
+			v, err := d.Str()
+			request = string(v)
+			if err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeTestResponseStringMACNullableArrayArrayRequest(r *http.Request) (
 	req string,
 	close func() error,
 	rerr error,

--- a/examples/ex_test_format/oas_request_encoders_gen.go
+++ b/examples/ex_test_format/oas_request_encoders_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"bytes"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -7326,6 +7327,114 @@ func encodeTestRequestRequiredStringIpv6NullableArrayArrayRequest(
 	return nil
 }
 
+func encodeTestRequestRequiredStringMACRequest(
+	req net.HardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		json.EncodeMAC(e, req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACArrayRequest(
+	req []net.HardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.ArrStart()
+		for _, elem := range req {
+			json.EncodeMAC(e, elem)
+		}
+		e.ArrEnd()
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACArrayArrayRequest(
+	req [][]net.HardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.ArrStart()
+		for _, elem := range req {
+			e.ArrStart()
+			for _, elem := range elem {
+				json.EncodeMAC(e, elem)
+			}
+			e.ArrEnd()
+		}
+		e.ArrEnd()
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableRequest(
+	req NilHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		req.Encode(e)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableArrayRequest(
+	req []NilHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.ArrStart()
+		for _, elem := range req {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableArrayArrayRequest(
+	req [][]NilHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.ArrStart()
+		for _, elem := range req {
+			e.ArrStart()
+			for _, elem := range elem {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+		e.ArrEnd()
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
 func encodeTestRequestRequiredStringNullableRequest(
 	req NilString,
 	r *http.Request,
@@ -11226,6 +11335,134 @@ func encodeTestRequestStringIpv6NullableArrayRequest(
 
 func encodeTestRequestStringIpv6NullableArrayArrayRequest(
 	req [][]NilIPv6,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		if req != nil {
+			e.ArrStart()
+			for _, elem := range req {
+				e.ArrStart()
+				for _, elem := range elem {
+					elem.Encode(e)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACRequest(
+	req OptHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	if !req.Set {
+		// Keep request with empty body if value is not set.
+		return nil
+	}
+	e := new(jx.Encoder)
+	{
+		if req.Set {
+			req.Encode(e)
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACArrayRequest(
+	req []net.HardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		if req != nil {
+			e.ArrStart()
+			for _, elem := range req {
+				json.EncodeMAC(e, elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACArrayArrayRequest(
+	req [][]net.HardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		if req != nil {
+			e.ArrStart()
+			for _, elem := range req {
+				e.ArrStart()
+				for _, elem := range elem {
+					json.EncodeMAC(e, elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACNullableRequest(
+	req OptNilHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	if !req.Set {
+		// Keep request with empty body if value is not set.
+		return nil
+	}
+	e := new(jx.Encoder)
+	{
+		if req.Set {
+			req.Encode(e)
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACNullableArrayRequest(
+	req []NilHardwareAddr,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		if req != nil {
+			e.ArrStart()
+			for _, elem := range req {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestRequestStringMACNullableArrayArrayRequest(
+	req [][]NilHardwareAddr,
 	r *http.Request,
 ) error {
 	const contentType = "application/json"
@@ -16535,6 +16772,90 @@ func encodeTestResponseStringIpv6NullableArrayRequest(
 }
 
 func encodeTestResponseStringIpv6NullableArrayArrayRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACArrayRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACArrayArrayRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACNullableRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACNullableArrayRequest(
+	req string,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		e.Str(req)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
+func encodeTestResponseStringMACNullableArrayArrayRequest(
 	req string,
 	r *http.Request,
 ) error {

--- a/examples/ex_test_format/oas_response_decoders_gen.go
+++ b/examples/ex_test_format/oas_response_decoders_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -15682,6 +15683,252 @@ func decodeTestRequestRequiredStringIpv6NullableArrayArrayResponse(resp *http.Re
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
+func decodeTestRequestRequiredStringMACResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestRequiredStringMACArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestRequiredStringMACArrayArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestRequiredStringMACNullableResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestRequiredStringMACNullableArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestRequiredStringMACNullableArrayArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
 func decodeTestRequestRequiredStringNullableResponse(resp *http.Response) (res *Error, _ error) {
 	switch resp.StatusCode {
 	case 200:
@@ -23760,6 +24007,252 @@ func decodeTestRequestStringIpv6NullableArrayResponse(resp *http.Response) (res 
 }
 
 func decodeTestRequestStringIpv6NullableArrayArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACArrayArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACNullableResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACNullableArrayResponse(resp *http.Response) (res *Error, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestRequestStringMACNullableArrayArrayResponse(resp *http.Response) (res *Error, _ error) {
 	switch resp.StatusCode {
 	case 200:
 		// Code 200.
@@ -43281,6 +43774,376 @@ func decodeTestResponseStringIpv6NullableArrayArrayResponse(resp *http.Response)
 					elem = make([]NilIPv6, 0)
 					if err := d.Arr(func(d *jx.Decoder) error {
 						var elemElem NilIPv6
+						if err := elemElem.Decode(d); err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					response = append(response, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if response == nil {
+					return errors.New("nil is invalid value")
+				}
+				var failures []validate.FieldError
+				for i, elem := range response {
+					if err := func() error {
+						if elem == nil {
+							return errors.New("nil is invalid value")
+						}
+						return nil
+					}(); err != nil {
+						failures = append(failures, validate.FieldError{
+							Name:  fmt.Sprintf("[%d]", i),
+							Error: err,
+						})
+					}
+				}
+				if len(failures) > 0 {
+					return &validate.Error{Fields: failures}
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACResponse(resp *http.Response) (res net.HardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response net.HardwareAddr
+			if err := func() error {
+				v, err := json.DecodeMAC(d)
+				response = v
+				if err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACArrayResponse(resp *http.Response) (res []net.HardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response []net.HardwareAddr
+			if err := func() error {
+				response = make([]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem net.HardwareAddr
+					v, err := json.DecodeMAC(d)
+					elem = v
+					if err != nil {
+						return err
+					}
+					response = append(response, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if response == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACArrayArrayResponse(resp *http.Response) (res [][]net.HardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response [][]net.HardwareAddr
+			if err := func() error {
+				response = make([][]net.HardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []net.HardwareAddr
+					elem = make([]net.HardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem net.HardwareAddr
+						v, err := json.DecodeMAC(d)
+						elemElem = v
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					response = append(response, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if response == nil {
+					return errors.New("nil is invalid value")
+				}
+				var failures []validate.FieldError
+				for i, elem := range response {
+					if err := func() error {
+						if elem == nil {
+							return errors.New("nil is invalid value")
+						}
+						return nil
+					}(); err != nil {
+						failures = append(failures, validate.FieldError{
+							Name:  fmt.Sprintf("[%d]", i),
+							Error: err,
+						})
+					}
+				}
+				if len(failures) > 0 {
+					return &validate.Error{Fields: failures}
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACNullableResponse(resp *http.Response) (res NilHardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response NilHardwareAddr
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACNullableArrayResponse(resp *http.Response) (res []NilHardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response []NilHardwareAddr
+			if err := func() error {
+				response = make([]NilHardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem NilHardwareAddr
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					response = append(response, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if response == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
+func decodeTestResponseStringMACNullableArrayArrayResponse(resp *http.Response) (res [][]NilHardwareAddr, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response [][]NilHardwareAddr
+			if err := func() error {
+				response = make([][]NilHardwareAddr, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []NilHardwareAddr
+					elem = make([]NilHardwareAddr, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem NilHardwareAddr
 						if err := elemElem.Decode(d); err != nil {
 							return err
 						}

--- a/examples/ex_test_format/oas_response_encoders_gen.go
+++ b/examples/ex_test_format/oas_response_encoders_gen.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -5365,6 +5366,90 @@ func encodeTestRequestRequiredStringIpv6NullableArrayArrayResponse(response *Err
 	return nil
 }
 
+func encodeTestRequestRequiredStringMACResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACArrayArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestRequiredStringMACNullableArrayArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
 func encodeTestRequestRequiredStringNullableResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)
@@ -8124,6 +8209,90 @@ func encodeTestRequestStringIpv6NullableArrayResponse(response *Error, w http.Re
 }
 
 func encodeTestRequestStringIpv6NullableArrayArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACArrayArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACNullableResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACNullableArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestRequestStringMACNullableArrayArrayResponse(response *Error, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)
 	span.SetStatus(codes.Ok, http.StatusText(200))
@@ -13758,6 +13927,114 @@ func encodeTestResponseStringIpv6NullableArrayResponse(response []NilIPv6, w htt
 }
 
 func encodeTestResponseStringIpv6NullableArrayArrayResponse(response [][]NilIPv6, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	e.ArrStart()
+	for _, elem := range response {
+		e.ArrStart()
+		for _, elem := range elem {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+	e.ArrEnd()
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACResponse(response net.HardwareAddr, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	json.EncodeMAC(e, response)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACArrayResponse(response []net.HardwareAddr, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	e.ArrStart()
+	for _, elem := range response {
+		json.EncodeMAC(e, elem)
+	}
+	e.ArrEnd()
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACArrayArrayResponse(response [][]net.HardwareAddr, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	e.ArrStart()
+	for _, elem := range response {
+		e.ArrStart()
+		for _, elem := range elem {
+			json.EncodeMAC(e, elem)
+		}
+		e.ArrEnd()
+	}
+	e.ArrEnd()
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACNullableResponse(response NilHardwareAddr, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACNullableArrayResponse(response []NilHardwareAddr, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	e.ArrStart()
+	for _, elem := range response {
+		elem.Encode(e)
+	}
+	e.ArrEnd()
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeTestResponseStringMACNullableArrayArrayResponse(response [][]NilHardwareAddr, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)
 	span.SetStatus(codes.Ok, http.StatusText(200))

--- a/examples/ex_test_format/oas_router_gen.go
+++ b/examples/ex_test_format/oas_router_gen.go
@@ -9562,6 +9562,151 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 
 									elem = origElem
+								case 'm': // Prefix: "mac"
+									origElem := elem
+									if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										switch r.Method {
+										case "POST":
+											s.handleTestRequestRequiredStringMACRequest([0]string{}, elemIsEscaped, w, r)
+										default:
+											s.notAllowed(w, r, "POST")
+										}
+
+										return
+									}
+									switch elem[0] {
+									case '_': // Prefix: "_"
+										origElem := elem
+										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											break
+										}
+										switch elem[0] {
+										case 'a': // Prefix: "array"
+											origElem := elem
+											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch r.Method {
+												case "POST":
+													s.handleTestRequestRequiredStringMACArrayRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													// Leaf node.
+													switch r.Method {
+													case "POST":
+														s.handleTestRequestRequiredStringMACArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+													default:
+														s.notAllowed(w, r, "POST")
+													}
+
+													return
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										case 'n': // Prefix: "nullable"
+											origElem := elem
+											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch r.Method {
+												case "POST":
+													s.handleTestRequestRequiredStringMACNullableRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													switch r.Method {
+													case "POST":
+														s.handleTestRequestRequiredStringMACNullableArrayRequest([0]string{}, elemIsEscaped, w, r)
+													default:
+														s.notAllowed(w, r, "POST")
+													}
+
+													return
+												}
+												switch elem[0] {
+												case '_': // Prefix: "_array"
+													origElem := elem
+													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+														elem = elem[l:]
+													} else {
+														break
+													}
+
+													if len(elem) == 0 {
+														// Leaf node.
+														switch r.Method {
+														case "POST":
+															s.handleTestRequestRequiredStringMACNullableArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+														default:
+															s.notAllowed(w, r, "POST")
+														}
+
+														return
+													}
+
+													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
 								case 'n': // Prefix: "nullable"
 									origElem := elem
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
@@ -14455,6 +14600,151 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 
 													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
+								}
+
+								elem = origElem
+							case 'm': // Prefix: "mac"
+								origElem := elem
+								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								if len(elem) == 0 {
+									switch r.Method {
+									case "POST":
+										s.handleTestRequestStringMACRequest([0]string{}, elemIsEscaped, w, r)
+									default:
+										s.notAllowed(w, r, "POST")
+									}
+
+									return
+								}
+								switch elem[0] {
+								case '_': // Prefix: "_"
+									origElem := elem
+									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										break
+									}
+									switch elem[0] {
+									case 'a': // Prefix: "array"
+										origElem := elem
+										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch r.Method {
+											case "POST":
+												s.handleTestRequestStringMACArrayRequest([0]string{}, elemIsEscaped, w, r)
+											default:
+												s.notAllowed(w, r, "POST")
+											}
+
+											return
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												// Leaf node.
+												switch r.Method {
+												case "POST":
+													s.handleTestRequestStringMACArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									case 'n': // Prefix: "nullable"
+										origElem := elem
+										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch r.Method {
+											case "POST":
+												s.handleTestRequestStringMACNullableRequest([0]string{}, elemIsEscaped, w, r)
+											default:
+												s.notAllowed(w, r, "POST")
+											}
+
+											return
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch r.Method {
+												case "POST":
+													s.handleTestRequestStringMACNullableArrayRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													// Leaf node.
+													switch r.Method {
+													case "POST":
+														s.handleTestRequestStringMACNullableArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+													default:
+														s.notAllowed(w, r, "POST")
+													}
+
+													return
 												}
 
 												elem = origElem
@@ -22718,6 +23008,151 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 
 													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
+								}
+
+								elem = origElem
+							case 'm': // Prefix: "mac"
+								origElem := elem
+								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								if len(elem) == 0 {
+									switch r.Method {
+									case "POST":
+										s.handleTestResponseStringMACRequest([0]string{}, elemIsEscaped, w, r)
+									default:
+										s.notAllowed(w, r, "POST")
+									}
+
+									return
+								}
+								switch elem[0] {
+								case '_': // Prefix: "_"
+									origElem := elem
+									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										break
+									}
+									switch elem[0] {
+									case 'a': // Prefix: "array"
+										origElem := elem
+										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch r.Method {
+											case "POST":
+												s.handleTestResponseStringMACArrayRequest([0]string{}, elemIsEscaped, w, r)
+											default:
+												s.notAllowed(w, r, "POST")
+											}
+
+											return
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												// Leaf node.
+												switch r.Method {
+												case "POST":
+													s.handleTestResponseStringMACArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									case 'n': // Prefix: "nullable"
+										origElem := elem
+										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch r.Method {
+											case "POST":
+												s.handleTestResponseStringMACNullableRequest([0]string{}, elemIsEscaped, w, r)
+											default:
+												s.notAllowed(w, r, "POST")
+											}
+
+											return
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch r.Method {
+												case "POST":
+													s.handleTestResponseStringMACNullableArrayRequest([0]string{}, elemIsEscaped, w, r)
+												default:
+													s.notAllowed(w, r, "POST")
+												}
+
+												return
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													// Leaf node.
+													switch r.Method {
+													case "POST":
+														s.handleTestResponseStringMACNullableArrayArrayRequest([0]string{}, elemIsEscaped, w, r)
+													default:
+														s.notAllowed(w, r, "POST")
+													}
+
+													return
 												}
 
 												elem = origElem
@@ -36010,6 +36445,175 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 
 									elem = origElem
+								case 'm': // Prefix: "mac"
+									origElem := elem
+									if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										switch method {
+										case "POST":
+											r.name = "TestRequestRequiredStringMAC"
+											r.summary = ""
+											r.operationID = "test_request_required_string_mac"
+											r.pathPattern = "/test_request_required_string_mac"
+											r.args = args
+											r.count = 0
+											return r, true
+										default:
+											return
+										}
+									}
+									switch elem[0] {
+									case '_': // Prefix: "_"
+										origElem := elem
+										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											break
+										}
+										switch elem[0] {
+										case 'a': // Prefix: "array"
+											origElem := elem
+											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													r.name = "TestRequestRequiredStringMACArray"
+													r.summary = ""
+													r.operationID = "test_request_required_string_mac_array"
+													r.pathPattern = "/test_request_required_string_mac_array"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													switch method {
+													case "POST":
+														// Leaf: TestRequestRequiredStringMACArrayArray
+														r.name = "TestRequestRequiredStringMACArrayArray"
+														r.summary = ""
+														r.operationID = "test_request_required_string_mac_array_array"
+														r.pathPattern = "/test_request_required_string_mac_array_array"
+														r.args = args
+														r.count = 0
+														return r, true
+													default:
+														return
+													}
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										case 'n': // Prefix: "nullable"
+											origElem := elem
+											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													r.name = "TestRequestRequiredStringMACNullable"
+													r.summary = ""
+													r.operationID = "test_request_required_string_mac_nullable"
+													r.pathPattern = "/test_request_required_string_mac_nullable"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													switch method {
+													case "POST":
+														r.name = "TestRequestRequiredStringMACNullableArray"
+														r.summary = ""
+														r.operationID = "test_request_required_string_mac_nullable_array"
+														r.pathPattern = "/test_request_required_string_mac_nullable_array"
+														r.args = args
+														r.count = 0
+														return r, true
+													default:
+														return
+													}
+												}
+												switch elem[0] {
+												case '_': // Prefix: "_array"
+													origElem := elem
+													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+														elem = elem[l:]
+													} else {
+														break
+													}
+
+													if len(elem) == 0 {
+														switch method {
+														case "POST":
+															// Leaf: TestRequestRequiredStringMACNullableArrayArray
+															r.name = "TestRequestRequiredStringMACNullableArrayArray"
+															r.summary = ""
+															r.operationID = "test_request_required_string_mac_nullable_array_array"
+															r.pathPattern = "/test_request_required_string_mac_nullable_array_array"
+															r.args = args
+															r.count = 0
+															return r, true
+														default:
+															return
+														}
+													}
+
+													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
 								case 'n': // Prefix: "nullable"
 									origElem := elem
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
@@ -41695,6 +42299,175 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 
 													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
+								}
+
+								elem = origElem
+							case 'm': // Prefix: "mac"
+								origElem := elem
+								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								if len(elem) == 0 {
+									switch method {
+									case "POST":
+										r.name = "TestRequestStringMAC"
+										r.summary = ""
+										r.operationID = "test_request_string_mac"
+										r.pathPattern = "/test_request_string_mac"
+										r.args = args
+										r.count = 0
+										return r, true
+									default:
+										return
+									}
+								}
+								switch elem[0] {
+								case '_': // Prefix: "_"
+									origElem := elem
+									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										break
+									}
+									switch elem[0] {
+									case 'a': // Prefix: "array"
+										origElem := elem
+										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch method {
+											case "POST":
+												r.name = "TestRequestStringMACArray"
+												r.summary = ""
+												r.operationID = "test_request_string_mac_array"
+												r.pathPattern = "/test_request_string_mac_array"
+												r.args = args
+												r.count = 0
+												return r, true
+											default:
+												return
+											}
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													// Leaf: TestRequestStringMACArrayArray
+													r.name = "TestRequestStringMACArrayArray"
+													r.summary = ""
+													r.operationID = "test_request_string_mac_array_array"
+													r.pathPattern = "/test_request_string_mac_array_array"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									case 'n': // Prefix: "nullable"
+										origElem := elem
+										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch method {
+											case "POST":
+												r.name = "TestRequestStringMACNullable"
+												r.summary = ""
+												r.operationID = "test_request_string_mac_nullable"
+												r.pathPattern = "/test_request_string_mac_nullable"
+												r.args = args
+												r.count = 0
+												return r, true
+											default:
+												return
+											}
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													r.name = "TestRequestStringMACNullableArray"
+													r.summary = ""
+													r.operationID = "test_request_string_mac_nullable_array"
+													r.pathPattern = "/test_request_string_mac_nullable_array"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													switch method {
+													case "POST":
+														// Leaf: TestRequestStringMACNullableArrayArray
+														r.name = "TestRequestStringMACNullableArrayArray"
+														r.summary = ""
+														r.operationID = "test_request_string_mac_nullable_array_array"
+														r.pathPattern = "/test_request_string_mac_nullable_array_array"
+														r.args = args
+														r.count = 0
+														return r, true
+													default:
+														return
+													}
 												}
 
 												elem = origElem
@@ -51290,6 +52063,175 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 
 													elem = origElem
+												}
+
+												elem = origElem
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									}
+
+									elem = origElem
+								}
+
+								elem = origElem
+							case 'm': // Prefix: "mac"
+								origElem := elem
+								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								if len(elem) == 0 {
+									switch method {
+									case "POST":
+										r.name = "TestResponseStringMAC"
+										r.summary = ""
+										r.operationID = "test_response_string_mac"
+										r.pathPattern = "/test_response_string_mac"
+										r.args = args
+										r.count = 0
+										return r, true
+									default:
+										return
+									}
+								}
+								switch elem[0] {
+								case '_': // Prefix: "_"
+									origElem := elem
+									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										break
+									}
+									switch elem[0] {
+									case 'a': // Prefix: "array"
+										origElem := elem
+										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch method {
+											case "POST":
+												r.name = "TestResponseStringMACArray"
+												r.summary = ""
+												r.operationID = "test_response_string_mac_array"
+												r.pathPattern = "/test_response_string_mac_array"
+												r.args = args
+												r.count = 0
+												return r, true
+											default:
+												return
+											}
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													// Leaf: TestResponseStringMACArrayArray
+													r.name = "TestResponseStringMACArrayArray"
+													r.summary = ""
+													r.operationID = "test_response_string_mac_array_array"
+													r.pathPattern = "/test_response_string_mac_array_array"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+
+											elem = origElem
+										}
+
+										elem = origElem
+									case 'n': // Prefix: "nullable"
+										origElem := elem
+										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
+											elem = elem[l:]
+										} else {
+											break
+										}
+
+										if len(elem) == 0 {
+											switch method {
+											case "POST":
+												r.name = "TestResponseStringMACNullable"
+												r.summary = ""
+												r.operationID = "test_response_string_mac_nullable"
+												r.pathPattern = "/test_response_string_mac_nullable"
+												r.args = args
+												r.count = 0
+												return r, true
+											default:
+												return
+											}
+										}
+										switch elem[0] {
+										case '_': // Prefix: "_array"
+											origElem := elem
+											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+												elem = elem[l:]
+											} else {
+												break
+											}
+
+											if len(elem) == 0 {
+												switch method {
+												case "POST":
+													r.name = "TestResponseStringMACNullableArray"
+													r.summary = ""
+													r.operationID = "test_response_string_mac_nullable_array"
+													r.pathPattern = "/test_response_string_mac_nullable_array"
+													r.args = args
+													r.count = 0
+													return r, true
+												default:
+													return
+												}
+											}
+											switch elem[0] {
+											case '_': // Prefix: "_array"
+												origElem := elem
+												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
+													elem = elem[l:]
+												} else {
+													break
+												}
+
+												if len(elem) == 0 {
+													switch method {
+													case "POST":
+														// Leaf: TestResponseStringMACNullableArrayArray
+														r.name = "TestResponseStringMACNullableArrayArray"
+														r.summary = ""
+														r.operationID = "test_response_string_mac_nullable_array_array"
+														r.pathPattern = "/test_response_string_mac_nullable_array_array"
+														r.args = args
+														r.count = 0
+														return r, true
+													default:
+														return
+													}
 												}
 
 												elem = origElem

--- a/examples/ex_test_format/oas_schemas_gen.go
+++ b/examples/ex_test_format/oas_schemas_gen.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"net"
 	"net/netip"
 	"net/url"
 	"time"
@@ -301,6 +302,51 @@ func (o NilFloat64) Get() (v float64, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o NilFloat64) Or(d float64) float64 {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewNilHardwareAddr returns new NilHardwareAddr with value set to v.
+func NewNilHardwareAddr(v net.HardwareAddr) NilHardwareAddr {
+	return NilHardwareAddr{
+		Value: v,
+	}
+}
+
+// NilHardwareAddr is nullable net.HardwareAddr.
+type NilHardwareAddr struct {
+	Value net.HardwareAddr
+	Null  bool
+}
+
+// SetTo sets value to v.
+func (o *NilHardwareAddr) SetTo(v net.HardwareAddr) {
+	o.Null = false
+	o.Value = v
+}
+
+// IsSet returns true if value is Null.
+func (o NilHardwareAddr) IsNull() bool { return o.Null }
+
+// SetNull sets value to null.
+func (o *NilHardwareAddr) SetToNull() {
+	o.Null = true
+	var v net.HardwareAddr
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o NilHardwareAddr) Get() (v net.HardwareAddr, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o NilHardwareAddr) Or(d net.HardwareAddr) net.HardwareAddr {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2248,6 +2294,52 @@ func (o OptFloat64) Or(d float64) float64 {
 	return d
 }
 
+// NewOptHardwareAddr returns new OptHardwareAddr with value set to v.
+func NewOptHardwareAddr(v net.HardwareAddr) OptHardwareAddr {
+	return OptHardwareAddr{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptHardwareAddr is optional net.HardwareAddr.
+type OptHardwareAddr struct {
+	Value net.HardwareAddr
+	Set   bool
+}
+
+// IsSet returns true if OptHardwareAddr was set.
+func (o OptHardwareAddr) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptHardwareAddr) Reset() {
+	var v net.HardwareAddr
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptHardwareAddr) SetTo(v net.HardwareAddr) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptHardwareAddr) Get() (v net.HardwareAddr, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptHardwareAddr) Or(d net.HardwareAddr) net.HardwareAddr {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptIP returns new OptIP with value set to v.
 func NewOptIP(v netip.Addr) OptIP {
 	return OptIP{
@@ -3051,6 +3143,69 @@ func (o OptNilFloat64) Get() (v float64, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptNilFloat64) Or(d float64) float64 {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilHardwareAddr returns new OptNilHardwareAddr with value set to v.
+func NewOptNilHardwareAddr(v net.HardwareAddr) OptNilHardwareAddr {
+	return OptNilHardwareAddr{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilHardwareAddr is optional nullable net.HardwareAddr.
+type OptNilHardwareAddr struct {
+	Value net.HardwareAddr
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilHardwareAddr was set.
+func (o OptNilHardwareAddr) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilHardwareAddr) Reset() {
+	var v net.HardwareAddr
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilHardwareAddr) SetTo(v net.HardwareAddr) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsSet returns true if value is Null.
+func (o OptNilHardwareAddr) IsNull() bool { return o.Null }
+
+// SetNull sets value to null.
+func (o *OptNilHardwareAddr) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v net.HardwareAddr
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilHardwareAddr) Get() (v net.HardwareAddr, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilHardwareAddr) Or(d net.HardwareAddr) net.HardwareAddr {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -6860,6 +7015,7 @@ type TestRequestFormatTestReq struct {
 	RequiredArrayStringIP                      []netip.Addr         `json:"required_array_string_ip"`
 	RequiredArrayStringIpv4                    []netip.Addr         `json:"required_array_string_ipv4"`
 	RequiredArrayStringIpv6                    []netip.Addr         `json:"required_array_string_ipv6"`
+	RequiredArrayStringMAC                     []net.HardwareAddr   `json:"required_array_string_mac"`
 	RequiredArrayStringPassword                []string             `json:"required_array_string_password"`
 	RequiredArrayStringTime                    []time.Time          `json:"required_array_string_time"`
 	RequiredArrayStringUint                    []uint               `json:"required_array_string_uint"`
@@ -6917,6 +7073,7 @@ type TestRequestFormatTestReq struct {
 	RequiredDoubleArrayStringIP                [][]netip.Addr       `json:"required_double_array_string_ip"`
 	RequiredDoubleArrayStringIpv4              [][]netip.Addr       `json:"required_double_array_string_ipv4"`
 	RequiredDoubleArrayStringIpv6              [][]netip.Addr       `json:"required_double_array_string_ipv6"`
+	RequiredDoubleArrayStringMAC               [][]net.HardwareAddr `json:"required_double_array_string_mac"`
 	RequiredDoubleArrayStringPassword          [][]string           `json:"required_double_array_string_password"`
 	RequiredDoubleArrayStringTime              [][]time.Time        `json:"required_double_array_string_time"`
 	RequiredDoubleArrayStringUint              [][]uint             `json:"required_double_array_string_uint"`
@@ -6971,6 +7128,7 @@ type TestRequestFormatTestReq struct {
 	RequiredStringIP                           netip.Addr           `json:"required_string_ip"`
 	RequiredStringIpv4                         netip.Addr           `json:"required_string_ipv4"`
 	RequiredStringIpv6                         netip.Addr           `json:"required_string_ipv6"`
+	RequiredStringMAC                          net.HardwareAddr     `json:"required_string_mac"`
 	RequiredStringPassword                     string               `json:"required_string_password"`
 	RequiredStringTime                         time.Time            `json:"required_string_time"`
 	RequiredStringUint                         uint                 `json:"required_string_uint"`
@@ -7028,6 +7186,7 @@ type TestRequestFormatTestReq struct {
 	OptionalArrayStringIP                      []netip.Addr         `json:"optional_array_string_ip"`
 	OptionalArrayStringIpv4                    []netip.Addr         `json:"optional_array_string_ipv4"`
 	OptionalArrayStringIpv6                    []netip.Addr         `json:"optional_array_string_ipv6"`
+	OptionalArrayStringMAC                     []net.HardwareAddr   `json:"optional_array_string_mac"`
 	OptionalArrayStringPassword                []string             `json:"optional_array_string_password"`
 	OptionalArrayStringTime                    []time.Time          `json:"optional_array_string_time"`
 	OptionalArrayStringUint                    []uint               `json:"optional_array_string_uint"`
@@ -7085,6 +7244,7 @@ type TestRequestFormatTestReq struct {
 	OptionalDoubleArrayStringIP                [][]netip.Addr       `json:"optional_double_array_string_ip"`
 	OptionalDoubleArrayStringIpv4              [][]netip.Addr       `json:"optional_double_array_string_ipv4"`
 	OptionalDoubleArrayStringIpv6              [][]netip.Addr       `json:"optional_double_array_string_ipv6"`
+	OptionalDoubleArrayStringMAC               [][]net.HardwareAddr `json:"optional_double_array_string_mac"`
 	OptionalDoubleArrayStringPassword          [][]string           `json:"optional_double_array_string_password"`
 	OptionalDoubleArrayStringTime              [][]time.Time        `json:"optional_double_array_string_time"`
 	OptionalDoubleArrayStringUint              [][]uint             `json:"optional_double_array_string_uint"`
@@ -7139,6 +7299,7 @@ type TestRequestFormatTestReq struct {
 	OptionalStringIP                           OptIP                `json:"optional_string_ip"`
 	OptionalStringIpv4                         OptIPv4              `json:"optional_string_ipv4"`
 	OptionalStringIpv6                         OptIPv6              `json:"optional_string_ipv6"`
+	OptionalStringMAC                          OptHardwareAddr      `json:"optional_string_mac"`
 	OptionalStringPassword                     OptString            `json:"optional_string_password"`
 	OptionalStringTime                         OptTime              `json:"optional_string_time"`
 	OptionalStringUint                         OptStringUint        `json:"optional_string_uint"`
@@ -7368,6 +7529,11 @@ func (s *TestRequestFormatTestReq) GetRequiredArrayStringIpv4() []netip.Addr {
 // GetRequiredArrayStringIpv6 returns the value of RequiredArrayStringIpv6.
 func (s *TestRequestFormatTestReq) GetRequiredArrayStringIpv6() []netip.Addr {
 	return s.RequiredArrayStringIpv6
+}
+
+// GetRequiredArrayStringMAC returns the value of RequiredArrayStringMAC.
+func (s *TestRequestFormatTestReq) GetRequiredArrayStringMAC() []net.HardwareAddr {
+	return s.RequiredArrayStringMAC
 }
 
 // GetRequiredArrayStringPassword returns the value of RequiredArrayStringPassword.
@@ -7655,6 +7821,11 @@ func (s *TestRequestFormatTestReq) GetRequiredDoubleArrayStringIpv6() [][]netip.
 	return s.RequiredDoubleArrayStringIpv6
 }
 
+// GetRequiredDoubleArrayStringMAC returns the value of RequiredDoubleArrayStringMAC.
+func (s *TestRequestFormatTestReq) GetRequiredDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.RequiredDoubleArrayStringMAC
+}
+
 // GetRequiredDoubleArrayStringPassword returns the value of RequiredDoubleArrayStringPassword.
 func (s *TestRequestFormatTestReq) GetRequiredDoubleArrayStringPassword() [][]string {
 	return s.RequiredDoubleArrayStringPassword
@@ -7923,6 +8094,11 @@ func (s *TestRequestFormatTestReq) GetRequiredStringIpv4() netip.Addr {
 // GetRequiredStringIpv6 returns the value of RequiredStringIpv6.
 func (s *TestRequestFormatTestReq) GetRequiredStringIpv6() netip.Addr {
 	return s.RequiredStringIpv6
+}
+
+// GetRequiredStringMAC returns the value of RequiredStringMAC.
+func (s *TestRequestFormatTestReq) GetRequiredStringMAC() net.HardwareAddr {
+	return s.RequiredStringMAC
 }
 
 // GetRequiredStringPassword returns the value of RequiredStringPassword.
@@ -8210,6 +8386,11 @@ func (s *TestRequestFormatTestReq) GetOptionalArrayStringIpv6() []netip.Addr {
 	return s.OptionalArrayStringIpv6
 }
 
+// GetOptionalArrayStringMAC returns the value of OptionalArrayStringMAC.
+func (s *TestRequestFormatTestReq) GetOptionalArrayStringMAC() []net.HardwareAddr {
+	return s.OptionalArrayStringMAC
+}
+
 // GetOptionalArrayStringPassword returns the value of OptionalArrayStringPassword.
 func (s *TestRequestFormatTestReq) GetOptionalArrayStringPassword() []string {
 	return s.OptionalArrayStringPassword
@@ -8495,6 +8676,11 @@ func (s *TestRequestFormatTestReq) GetOptionalDoubleArrayStringIpv6() [][]netip.
 	return s.OptionalDoubleArrayStringIpv6
 }
 
+// GetOptionalDoubleArrayStringMAC returns the value of OptionalDoubleArrayStringMAC.
+func (s *TestRequestFormatTestReq) GetOptionalDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.OptionalDoubleArrayStringMAC
+}
+
 // GetOptionalDoubleArrayStringPassword returns the value of OptionalDoubleArrayStringPassword.
 func (s *TestRequestFormatTestReq) GetOptionalDoubleArrayStringPassword() [][]string {
 	return s.OptionalDoubleArrayStringPassword
@@ -8763,6 +8949,11 @@ func (s *TestRequestFormatTestReq) GetOptionalStringIpv4() OptIPv4 {
 // GetOptionalStringIpv6 returns the value of OptionalStringIpv6.
 func (s *TestRequestFormatTestReq) GetOptionalStringIpv6() OptIPv6 {
 	return s.OptionalStringIpv6
+}
+
+// GetOptionalStringMAC returns the value of OptionalStringMAC.
+func (s *TestRequestFormatTestReq) GetOptionalStringMAC() OptHardwareAddr {
+	return s.OptionalStringMAC
 }
 
 // GetOptionalStringPassword returns the value of OptionalStringPassword.
@@ -9050,6 +9241,11 @@ func (s *TestRequestFormatTestReq) SetRequiredArrayStringIpv6(val []netip.Addr) 
 	s.RequiredArrayStringIpv6 = val
 }
 
+// SetRequiredArrayStringMAC sets the value of RequiredArrayStringMAC.
+func (s *TestRequestFormatTestReq) SetRequiredArrayStringMAC(val []net.HardwareAddr) {
+	s.RequiredArrayStringMAC = val
+}
+
 // SetRequiredArrayStringPassword sets the value of RequiredArrayStringPassword.
 func (s *TestRequestFormatTestReq) SetRequiredArrayStringPassword(val []string) {
 	s.RequiredArrayStringPassword = val
@@ -9335,6 +9531,11 @@ func (s *TestRequestFormatTestReq) SetRequiredDoubleArrayStringIpv6(val [][]neti
 	s.RequiredDoubleArrayStringIpv6 = val
 }
 
+// SetRequiredDoubleArrayStringMAC sets the value of RequiredDoubleArrayStringMAC.
+func (s *TestRequestFormatTestReq) SetRequiredDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.RequiredDoubleArrayStringMAC = val
+}
+
 // SetRequiredDoubleArrayStringPassword sets the value of RequiredDoubleArrayStringPassword.
 func (s *TestRequestFormatTestReq) SetRequiredDoubleArrayStringPassword(val [][]string) {
 	s.RequiredDoubleArrayStringPassword = val
@@ -9603,6 +9804,11 @@ func (s *TestRequestFormatTestReq) SetRequiredStringIpv4(val netip.Addr) {
 // SetRequiredStringIpv6 sets the value of RequiredStringIpv6.
 func (s *TestRequestFormatTestReq) SetRequiredStringIpv6(val netip.Addr) {
 	s.RequiredStringIpv6 = val
+}
+
+// SetRequiredStringMAC sets the value of RequiredStringMAC.
+func (s *TestRequestFormatTestReq) SetRequiredStringMAC(val net.HardwareAddr) {
+	s.RequiredStringMAC = val
 }
 
 // SetRequiredStringPassword sets the value of RequiredStringPassword.
@@ -9890,6 +10096,11 @@ func (s *TestRequestFormatTestReq) SetOptionalArrayStringIpv6(val []netip.Addr) 
 	s.OptionalArrayStringIpv6 = val
 }
 
+// SetOptionalArrayStringMAC sets the value of OptionalArrayStringMAC.
+func (s *TestRequestFormatTestReq) SetOptionalArrayStringMAC(val []net.HardwareAddr) {
+	s.OptionalArrayStringMAC = val
+}
+
 // SetOptionalArrayStringPassword sets the value of OptionalArrayStringPassword.
 func (s *TestRequestFormatTestReq) SetOptionalArrayStringPassword(val []string) {
 	s.OptionalArrayStringPassword = val
@@ -10175,6 +10386,11 @@ func (s *TestRequestFormatTestReq) SetOptionalDoubleArrayStringIpv6(val [][]neti
 	s.OptionalDoubleArrayStringIpv6 = val
 }
 
+// SetOptionalDoubleArrayStringMAC sets the value of OptionalDoubleArrayStringMAC.
+func (s *TestRequestFormatTestReq) SetOptionalDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.OptionalDoubleArrayStringMAC = val
+}
+
 // SetOptionalDoubleArrayStringPassword sets the value of OptionalDoubleArrayStringPassword.
 func (s *TestRequestFormatTestReq) SetOptionalDoubleArrayStringPassword(val [][]string) {
 	s.OptionalDoubleArrayStringPassword = val
@@ -10445,6 +10661,11 @@ func (s *TestRequestFormatTestReq) SetOptionalStringIpv6(val OptIPv6) {
 	s.OptionalStringIpv6 = val
 }
 
+// SetOptionalStringMAC sets the value of OptionalStringMAC.
+func (s *TestRequestFormatTestReq) SetOptionalStringMAC(val OptHardwareAddr) {
+	s.OptionalStringMAC = val
+}
+
 // SetOptionalStringPassword sets the value of OptionalStringPassword.
 func (s *TestRequestFormatTestReq) SetOptionalStringPassword(val OptString) {
 	s.OptionalStringPassword = val
@@ -10561,6 +10782,7 @@ type TestRequestRequiredFormatTestReq struct {
 	RequiredArrayStringIP                      []netip.Addr         `json:"required_array_string_ip"`
 	RequiredArrayStringIpv4                    []netip.Addr         `json:"required_array_string_ipv4"`
 	RequiredArrayStringIpv6                    []netip.Addr         `json:"required_array_string_ipv6"`
+	RequiredArrayStringMAC                     []net.HardwareAddr   `json:"required_array_string_mac"`
 	RequiredArrayStringPassword                []string             `json:"required_array_string_password"`
 	RequiredArrayStringTime                    []time.Time          `json:"required_array_string_time"`
 	RequiredArrayStringUint                    []uint               `json:"required_array_string_uint"`
@@ -10618,6 +10840,7 @@ type TestRequestRequiredFormatTestReq struct {
 	RequiredDoubleArrayStringIP                [][]netip.Addr       `json:"required_double_array_string_ip"`
 	RequiredDoubleArrayStringIpv4              [][]netip.Addr       `json:"required_double_array_string_ipv4"`
 	RequiredDoubleArrayStringIpv6              [][]netip.Addr       `json:"required_double_array_string_ipv6"`
+	RequiredDoubleArrayStringMAC               [][]net.HardwareAddr `json:"required_double_array_string_mac"`
 	RequiredDoubleArrayStringPassword          [][]string           `json:"required_double_array_string_password"`
 	RequiredDoubleArrayStringTime              [][]time.Time        `json:"required_double_array_string_time"`
 	RequiredDoubleArrayStringUint              [][]uint             `json:"required_double_array_string_uint"`
@@ -10672,6 +10895,7 @@ type TestRequestRequiredFormatTestReq struct {
 	RequiredStringIP                           netip.Addr           `json:"required_string_ip"`
 	RequiredStringIpv4                         netip.Addr           `json:"required_string_ipv4"`
 	RequiredStringIpv6                         netip.Addr           `json:"required_string_ipv6"`
+	RequiredStringMAC                          net.HardwareAddr     `json:"required_string_mac"`
 	RequiredStringPassword                     string               `json:"required_string_password"`
 	RequiredStringTime                         time.Time            `json:"required_string_time"`
 	RequiredStringUint                         uint                 `json:"required_string_uint"`
@@ -10729,6 +10953,7 @@ type TestRequestRequiredFormatTestReq struct {
 	OptionalArrayStringIP                      []netip.Addr         `json:"optional_array_string_ip"`
 	OptionalArrayStringIpv4                    []netip.Addr         `json:"optional_array_string_ipv4"`
 	OptionalArrayStringIpv6                    []netip.Addr         `json:"optional_array_string_ipv6"`
+	OptionalArrayStringMAC                     []net.HardwareAddr   `json:"optional_array_string_mac"`
 	OptionalArrayStringPassword                []string             `json:"optional_array_string_password"`
 	OptionalArrayStringTime                    []time.Time          `json:"optional_array_string_time"`
 	OptionalArrayStringUint                    []uint               `json:"optional_array_string_uint"`
@@ -10786,6 +11011,7 @@ type TestRequestRequiredFormatTestReq struct {
 	OptionalDoubleArrayStringIP                [][]netip.Addr       `json:"optional_double_array_string_ip"`
 	OptionalDoubleArrayStringIpv4              [][]netip.Addr       `json:"optional_double_array_string_ipv4"`
 	OptionalDoubleArrayStringIpv6              [][]netip.Addr       `json:"optional_double_array_string_ipv6"`
+	OptionalDoubleArrayStringMAC               [][]net.HardwareAddr `json:"optional_double_array_string_mac"`
 	OptionalDoubleArrayStringPassword          [][]string           `json:"optional_double_array_string_password"`
 	OptionalDoubleArrayStringTime              [][]time.Time        `json:"optional_double_array_string_time"`
 	OptionalDoubleArrayStringUint              [][]uint             `json:"optional_double_array_string_uint"`
@@ -10840,6 +11066,7 @@ type TestRequestRequiredFormatTestReq struct {
 	OptionalStringIP                           OptIP                `json:"optional_string_ip"`
 	OptionalStringIpv4                         OptIPv4              `json:"optional_string_ipv4"`
 	OptionalStringIpv6                         OptIPv6              `json:"optional_string_ipv6"`
+	OptionalStringMAC                          OptHardwareAddr      `json:"optional_string_mac"`
 	OptionalStringPassword                     OptString            `json:"optional_string_password"`
 	OptionalStringTime                         OptTime              `json:"optional_string_time"`
 	OptionalStringUint                         OptStringUint        `json:"optional_string_uint"`
@@ -11069,6 +11296,11 @@ func (s *TestRequestRequiredFormatTestReq) GetRequiredArrayStringIpv4() []netip.
 // GetRequiredArrayStringIpv6 returns the value of RequiredArrayStringIpv6.
 func (s *TestRequestRequiredFormatTestReq) GetRequiredArrayStringIpv6() []netip.Addr {
 	return s.RequiredArrayStringIpv6
+}
+
+// GetRequiredArrayStringMAC returns the value of RequiredArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetRequiredArrayStringMAC() []net.HardwareAddr {
+	return s.RequiredArrayStringMAC
 }
 
 // GetRequiredArrayStringPassword returns the value of RequiredArrayStringPassword.
@@ -11356,6 +11588,11 @@ func (s *TestRequestRequiredFormatTestReq) GetRequiredDoubleArrayStringIpv6() []
 	return s.RequiredDoubleArrayStringIpv6
 }
 
+// GetRequiredDoubleArrayStringMAC returns the value of RequiredDoubleArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetRequiredDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.RequiredDoubleArrayStringMAC
+}
+
 // GetRequiredDoubleArrayStringPassword returns the value of RequiredDoubleArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) GetRequiredDoubleArrayStringPassword() [][]string {
 	return s.RequiredDoubleArrayStringPassword
@@ -11624,6 +11861,11 @@ func (s *TestRequestRequiredFormatTestReq) GetRequiredStringIpv4() netip.Addr {
 // GetRequiredStringIpv6 returns the value of RequiredStringIpv6.
 func (s *TestRequestRequiredFormatTestReq) GetRequiredStringIpv6() netip.Addr {
 	return s.RequiredStringIpv6
+}
+
+// GetRequiredStringMAC returns the value of RequiredStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetRequiredStringMAC() net.HardwareAddr {
+	return s.RequiredStringMAC
 }
 
 // GetRequiredStringPassword returns the value of RequiredStringPassword.
@@ -11911,6 +12153,11 @@ func (s *TestRequestRequiredFormatTestReq) GetOptionalArrayStringIpv6() []netip.
 	return s.OptionalArrayStringIpv6
 }
 
+// GetOptionalArrayStringMAC returns the value of OptionalArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetOptionalArrayStringMAC() []net.HardwareAddr {
+	return s.OptionalArrayStringMAC
+}
+
 // GetOptionalArrayStringPassword returns the value of OptionalArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) GetOptionalArrayStringPassword() []string {
 	return s.OptionalArrayStringPassword
@@ -12196,6 +12443,11 @@ func (s *TestRequestRequiredFormatTestReq) GetOptionalDoubleArrayStringIpv6() []
 	return s.OptionalDoubleArrayStringIpv6
 }
 
+// GetOptionalDoubleArrayStringMAC returns the value of OptionalDoubleArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetOptionalDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.OptionalDoubleArrayStringMAC
+}
+
 // GetOptionalDoubleArrayStringPassword returns the value of OptionalDoubleArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) GetOptionalDoubleArrayStringPassword() [][]string {
 	return s.OptionalDoubleArrayStringPassword
@@ -12464,6 +12716,11 @@ func (s *TestRequestRequiredFormatTestReq) GetOptionalStringIpv4() OptIPv4 {
 // GetOptionalStringIpv6 returns the value of OptionalStringIpv6.
 func (s *TestRequestRequiredFormatTestReq) GetOptionalStringIpv6() OptIPv6 {
 	return s.OptionalStringIpv6
+}
+
+// GetOptionalStringMAC returns the value of OptionalStringMAC.
+func (s *TestRequestRequiredFormatTestReq) GetOptionalStringMAC() OptHardwareAddr {
+	return s.OptionalStringMAC
 }
 
 // GetOptionalStringPassword returns the value of OptionalStringPassword.
@@ -12751,6 +13008,11 @@ func (s *TestRequestRequiredFormatTestReq) SetRequiredArrayStringIpv6(val []neti
 	s.RequiredArrayStringIpv6 = val
 }
 
+// SetRequiredArrayStringMAC sets the value of RequiredArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetRequiredArrayStringMAC(val []net.HardwareAddr) {
+	s.RequiredArrayStringMAC = val
+}
+
 // SetRequiredArrayStringPassword sets the value of RequiredArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) SetRequiredArrayStringPassword(val []string) {
 	s.RequiredArrayStringPassword = val
@@ -13036,6 +13298,11 @@ func (s *TestRequestRequiredFormatTestReq) SetRequiredDoubleArrayStringIpv6(val 
 	s.RequiredDoubleArrayStringIpv6 = val
 }
 
+// SetRequiredDoubleArrayStringMAC sets the value of RequiredDoubleArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetRequiredDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.RequiredDoubleArrayStringMAC = val
+}
+
 // SetRequiredDoubleArrayStringPassword sets the value of RequiredDoubleArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) SetRequiredDoubleArrayStringPassword(val [][]string) {
 	s.RequiredDoubleArrayStringPassword = val
@@ -13304,6 +13571,11 @@ func (s *TestRequestRequiredFormatTestReq) SetRequiredStringIpv4(val netip.Addr)
 // SetRequiredStringIpv6 sets the value of RequiredStringIpv6.
 func (s *TestRequestRequiredFormatTestReq) SetRequiredStringIpv6(val netip.Addr) {
 	s.RequiredStringIpv6 = val
+}
+
+// SetRequiredStringMAC sets the value of RequiredStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetRequiredStringMAC(val net.HardwareAddr) {
+	s.RequiredStringMAC = val
 }
 
 // SetRequiredStringPassword sets the value of RequiredStringPassword.
@@ -13591,6 +13863,11 @@ func (s *TestRequestRequiredFormatTestReq) SetOptionalArrayStringIpv6(val []neti
 	s.OptionalArrayStringIpv6 = val
 }
 
+// SetOptionalArrayStringMAC sets the value of OptionalArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetOptionalArrayStringMAC(val []net.HardwareAddr) {
+	s.OptionalArrayStringMAC = val
+}
+
 // SetOptionalArrayStringPassword sets the value of OptionalArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) SetOptionalArrayStringPassword(val []string) {
 	s.OptionalArrayStringPassword = val
@@ -13876,6 +14153,11 @@ func (s *TestRequestRequiredFormatTestReq) SetOptionalDoubleArrayStringIpv6(val 
 	s.OptionalDoubleArrayStringIpv6 = val
 }
 
+// SetOptionalDoubleArrayStringMAC sets the value of OptionalDoubleArrayStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetOptionalDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.OptionalDoubleArrayStringMAC = val
+}
+
 // SetOptionalDoubleArrayStringPassword sets the value of OptionalDoubleArrayStringPassword.
 func (s *TestRequestRequiredFormatTestReq) SetOptionalDoubleArrayStringPassword(val [][]string) {
 	s.OptionalDoubleArrayStringPassword = val
@@ -14146,6 +14428,11 @@ func (s *TestRequestRequiredFormatTestReq) SetOptionalStringIpv6(val OptIPv6) {
 	s.OptionalStringIpv6 = val
 }
 
+// SetOptionalStringMAC sets the value of OptionalStringMAC.
+func (s *TestRequestRequiredFormatTestReq) SetOptionalStringMAC(val OptHardwareAddr) {
+	s.OptionalStringMAC = val
+}
+
 // SetOptionalStringPassword sets the value of OptionalStringPassword.
 func (s *TestRequestRequiredFormatTestReq) SetOptionalStringPassword(val OptString) {
 	s.OptionalStringPassword = val
@@ -14262,6 +14549,7 @@ type TestResponseFormatTestOK struct {
 	RequiredArrayStringIP                      []netip.Addr         `json:"required_array_string_ip"`
 	RequiredArrayStringIpv4                    []netip.Addr         `json:"required_array_string_ipv4"`
 	RequiredArrayStringIpv6                    []netip.Addr         `json:"required_array_string_ipv6"`
+	RequiredArrayStringMAC                     []net.HardwareAddr   `json:"required_array_string_mac"`
 	RequiredArrayStringPassword                []string             `json:"required_array_string_password"`
 	RequiredArrayStringTime                    []time.Time          `json:"required_array_string_time"`
 	RequiredArrayStringUint                    []uint               `json:"required_array_string_uint"`
@@ -14319,6 +14607,7 @@ type TestResponseFormatTestOK struct {
 	RequiredDoubleArrayStringIP                [][]netip.Addr       `json:"required_double_array_string_ip"`
 	RequiredDoubleArrayStringIpv4              [][]netip.Addr       `json:"required_double_array_string_ipv4"`
 	RequiredDoubleArrayStringIpv6              [][]netip.Addr       `json:"required_double_array_string_ipv6"`
+	RequiredDoubleArrayStringMAC               [][]net.HardwareAddr `json:"required_double_array_string_mac"`
 	RequiredDoubleArrayStringPassword          [][]string           `json:"required_double_array_string_password"`
 	RequiredDoubleArrayStringTime              [][]time.Time        `json:"required_double_array_string_time"`
 	RequiredDoubleArrayStringUint              [][]uint             `json:"required_double_array_string_uint"`
@@ -14373,6 +14662,7 @@ type TestResponseFormatTestOK struct {
 	RequiredStringIP                           netip.Addr           `json:"required_string_ip"`
 	RequiredStringIpv4                         netip.Addr           `json:"required_string_ipv4"`
 	RequiredStringIpv6                         netip.Addr           `json:"required_string_ipv6"`
+	RequiredStringMAC                          net.HardwareAddr     `json:"required_string_mac"`
 	RequiredStringPassword                     string               `json:"required_string_password"`
 	RequiredStringTime                         time.Time            `json:"required_string_time"`
 	RequiredStringUint                         uint                 `json:"required_string_uint"`
@@ -14430,6 +14720,7 @@ type TestResponseFormatTestOK struct {
 	OptionalArrayStringIP                      []netip.Addr         `json:"optional_array_string_ip"`
 	OptionalArrayStringIpv4                    []netip.Addr         `json:"optional_array_string_ipv4"`
 	OptionalArrayStringIpv6                    []netip.Addr         `json:"optional_array_string_ipv6"`
+	OptionalArrayStringMAC                     []net.HardwareAddr   `json:"optional_array_string_mac"`
 	OptionalArrayStringPassword                []string             `json:"optional_array_string_password"`
 	OptionalArrayStringTime                    []time.Time          `json:"optional_array_string_time"`
 	OptionalArrayStringUint                    []uint               `json:"optional_array_string_uint"`
@@ -14487,6 +14778,7 @@ type TestResponseFormatTestOK struct {
 	OptionalDoubleArrayStringIP                [][]netip.Addr       `json:"optional_double_array_string_ip"`
 	OptionalDoubleArrayStringIpv4              [][]netip.Addr       `json:"optional_double_array_string_ipv4"`
 	OptionalDoubleArrayStringIpv6              [][]netip.Addr       `json:"optional_double_array_string_ipv6"`
+	OptionalDoubleArrayStringMAC               [][]net.HardwareAddr `json:"optional_double_array_string_mac"`
 	OptionalDoubleArrayStringPassword          [][]string           `json:"optional_double_array_string_password"`
 	OptionalDoubleArrayStringTime              [][]time.Time        `json:"optional_double_array_string_time"`
 	OptionalDoubleArrayStringUint              [][]uint             `json:"optional_double_array_string_uint"`
@@ -14541,6 +14833,7 @@ type TestResponseFormatTestOK struct {
 	OptionalStringIP                           OptIP                `json:"optional_string_ip"`
 	OptionalStringIpv4                         OptIPv4              `json:"optional_string_ipv4"`
 	OptionalStringIpv6                         OptIPv6              `json:"optional_string_ipv6"`
+	OptionalStringMAC                          OptHardwareAddr      `json:"optional_string_mac"`
 	OptionalStringPassword                     OptString            `json:"optional_string_password"`
 	OptionalStringTime                         OptTime              `json:"optional_string_time"`
 	OptionalStringUint                         OptStringUint        `json:"optional_string_uint"`
@@ -14770,6 +15063,11 @@ func (s *TestResponseFormatTestOK) GetRequiredArrayStringIpv4() []netip.Addr {
 // GetRequiredArrayStringIpv6 returns the value of RequiredArrayStringIpv6.
 func (s *TestResponseFormatTestOK) GetRequiredArrayStringIpv6() []netip.Addr {
 	return s.RequiredArrayStringIpv6
+}
+
+// GetRequiredArrayStringMAC returns the value of RequiredArrayStringMAC.
+func (s *TestResponseFormatTestOK) GetRequiredArrayStringMAC() []net.HardwareAddr {
+	return s.RequiredArrayStringMAC
 }
 
 // GetRequiredArrayStringPassword returns the value of RequiredArrayStringPassword.
@@ -15057,6 +15355,11 @@ func (s *TestResponseFormatTestOK) GetRequiredDoubleArrayStringIpv6() [][]netip.
 	return s.RequiredDoubleArrayStringIpv6
 }
 
+// GetRequiredDoubleArrayStringMAC returns the value of RequiredDoubleArrayStringMAC.
+func (s *TestResponseFormatTestOK) GetRequiredDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.RequiredDoubleArrayStringMAC
+}
+
 // GetRequiredDoubleArrayStringPassword returns the value of RequiredDoubleArrayStringPassword.
 func (s *TestResponseFormatTestOK) GetRequiredDoubleArrayStringPassword() [][]string {
 	return s.RequiredDoubleArrayStringPassword
@@ -15325,6 +15628,11 @@ func (s *TestResponseFormatTestOK) GetRequiredStringIpv4() netip.Addr {
 // GetRequiredStringIpv6 returns the value of RequiredStringIpv6.
 func (s *TestResponseFormatTestOK) GetRequiredStringIpv6() netip.Addr {
 	return s.RequiredStringIpv6
+}
+
+// GetRequiredStringMAC returns the value of RequiredStringMAC.
+func (s *TestResponseFormatTestOK) GetRequiredStringMAC() net.HardwareAddr {
+	return s.RequiredStringMAC
 }
 
 // GetRequiredStringPassword returns the value of RequiredStringPassword.
@@ -15612,6 +15920,11 @@ func (s *TestResponseFormatTestOK) GetOptionalArrayStringIpv6() []netip.Addr {
 	return s.OptionalArrayStringIpv6
 }
 
+// GetOptionalArrayStringMAC returns the value of OptionalArrayStringMAC.
+func (s *TestResponseFormatTestOK) GetOptionalArrayStringMAC() []net.HardwareAddr {
+	return s.OptionalArrayStringMAC
+}
+
 // GetOptionalArrayStringPassword returns the value of OptionalArrayStringPassword.
 func (s *TestResponseFormatTestOK) GetOptionalArrayStringPassword() []string {
 	return s.OptionalArrayStringPassword
@@ -15897,6 +16210,11 @@ func (s *TestResponseFormatTestOK) GetOptionalDoubleArrayStringIpv6() [][]netip.
 	return s.OptionalDoubleArrayStringIpv6
 }
 
+// GetOptionalDoubleArrayStringMAC returns the value of OptionalDoubleArrayStringMAC.
+func (s *TestResponseFormatTestOK) GetOptionalDoubleArrayStringMAC() [][]net.HardwareAddr {
+	return s.OptionalDoubleArrayStringMAC
+}
+
 // GetOptionalDoubleArrayStringPassword returns the value of OptionalDoubleArrayStringPassword.
 func (s *TestResponseFormatTestOK) GetOptionalDoubleArrayStringPassword() [][]string {
 	return s.OptionalDoubleArrayStringPassword
@@ -16165,6 +16483,11 @@ func (s *TestResponseFormatTestOK) GetOptionalStringIpv4() OptIPv4 {
 // GetOptionalStringIpv6 returns the value of OptionalStringIpv6.
 func (s *TestResponseFormatTestOK) GetOptionalStringIpv6() OptIPv6 {
 	return s.OptionalStringIpv6
+}
+
+// GetOptionalStringMAC returns the value of OptionalStringMAC.
+func (s *TestResponseFormatTestOK) GetOptionalStringMAC() OptHardwareAddr {
+	return s.OptionalStringMAC
 }
 
 // GetOptionalStringPassword returns the value of OptionalStringPassword.
@@ -16452,6 +16775,11 @@ func (s *TestResponseFormatTestOK) SetRequiredArrayStringIpv6(val []netip.Addr) 
 	s.RequiredArrayStringIpv6 = val
 }
 
+// SetRequiredArrayStringMAC sets the value of RequiredArrayStringMAC.
+func (s *TestResponseFormatTestOK) SetRequiredArrayStringMAC(val []net.HardwareAddr) {
+	s.RequiredArrayStringMAC = val
+}
+
 // SetRequiredArrayStringPassword sets the value of RequiredArrayStringPassword.
 func (s *TestResponseFormatTestOK) SetRequiredArrayStringPassword(val []string) {
 	s.RequiredArrayStringPassword = val
@@ -16737,6 +17065,11 @@ func (s *TestResponseFormatTestOK) SetRequiredDoubleArrayStringIpv6(val [][]neti
 	s.RequiredDoubleArrayStringIpv6 = val
 }
 
+// SetRequiredDoubleArrayStringMAC sets the value of RequiredDoubleArrayStringMAC.
+func (s *TestResponseFormatTestOK) SetRequiredDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.RequiredDoubleArrayStringMAC = val
+}
+
 // SetRequiredDoubleArrayStringPassword sets the value of RequiredDoubleArrayStringPassword.
 func (s *TestResponseFormatTestOK) SetRequiredDoubleArrayStringPassword(val [][]string) {
 	s.RequiredDoubleArrayStringPassword = val
@@ -17005,6 +17338,11 @@ func (s *TestResponseFormatTestOK) SetRequiredStringIpv4(val netip.Addr) {
 // SetRequiredStringIpv6 sets the value of RequiredStringIpv6.
 func (s *TestResponseFormatTestOK) SetRequiredStringIpv6(val netip.Addr) {
 	s.RequiredStringIpv6 = val
+}
+
+// SetRequiredStringMAC sets the value of RequiredStringMAC.
+func (s *TestResponseFormatTestOK) SetRequiredStringMAC(val net.HardwareAddr) {
+	s.RequiredStringMAC = val
 }
 
 // SetRequiredStringPassword sets the value of RequiredStringPassword.
@@ -17292,6 +17630,11 @@ func (s *TestResponseFormatTestOK) SetOptionalArrayStringIpv6(val []netip.Addr) 
 	s.OptionalArrayStringIpv6 = val
 }
 
+// SetOptionalArrayStringMAC sets the value of OptionalArrayStringMAC.
+func (s *TestResponseFormatTestOK) SetOptionalArrayStringMAC(val []net.HardwareAddr) {
+	s.OptionalArrayStringMAC = val
+}
+
 // SetOptionalArrayStringPassword sets the value of OptionalArrayStringPassword.
 func (s *TestResponseFormatTestOK) SetOptionalArrayStringPassword(val []string) {
 	s.OptionalArrayStringPassword = val
@@ -17577,6 +17920,11 @@ func (s *TestResponseFormatTestOK) SetOptionalDoubleArrayStringIpv6(val [][]neti
 	s.OptionalDoubleArrayStringIpv6 = val
 }
 
+// SetOptionalDoubleArrayStringMAC sets the value of OptionalDoubleArrayStringMAC.
+func (s *TestResponseFormatTestOK) SetOptionalDoubleArrayStringMAC(val [][]net.HardwareAddr) {
+	s.OptionalDoubleArrayStringMAC = val
+}
+
 // SetOptionalDoubleArrayStringPassword sets the value of OptionalDoubleArrayStringPassword.
 func (s *TestResponseFormatTestOK) SetOptionalDoubleArrayStringPassword(val [][]string) {
 	s.OptionalDoubleArrayStringPassword = val
@@ -17845,6 +18193,11 @@ func (s *TestResponseFormatTestOK) SetOptionalStringIpv4(val OptIPv4) {
 // SetOptionalStringIpv6 sets the value of OptionalStringIpv6.
 func (s *TestResponseFormatTestOK) SetOptionalStringIpv6(val OptIPv6) {
 	s.OptionalStringIpv6 = val
+}
+
+// SetOptionalStringMAC sets the value of OptionalStringMAC.
+func (s *TestResponseFormatTestOK) SetOptionalStringMAC(val OptHardwareAddr) {
+	s.OptionalStringMAC = val
 }
 
 // SetOptionalStringPassword sets the value of OptionalStringPassword.

--- a/examples/ex_test_format/oas_server_gen.go
+++ b/examples/ex_test_format/oas_server_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"net/url"
 	"time"
@@ -1542,6 +1543,30 @@ type Handler interface {
 	//
 	// POST /test_request_required_string_ipv6_nullable_array_array
 	TestRequestRequiredStringIpv6NullableArrayArray(ctx context.Context, req [][]NilIPv6) (*Error, error)
+	// TestRequestRequiredStringMAC implements test_request_required_string_mac operation.
+	//
+	// POST /test_request_required_string_mac
+	TestRequestRequiredStringMAC(ctx context.Context, req net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACArray implements test_request_required_string_mac_array operation.
+	//
+	// POST /test_request_required_string_mac_array
+	TestRequestRequiredStringMACArray(ctx context.Context, req []net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACArrayArray implements test_request_required_string_mac_array_array operation.
+	//
+	// POST /test_request_required_string_mac_array_array
+	TestRequestRequiredStringMACArrayArray(ctx context.Context, req [][]net.HardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullable implements test_request_required_string_mac_nullable operation.
+	//
+	// POST /test_request_required_string_mac_nullable
+	TestRequestRequiredStringMACNullable(ctx context.Context, req NilHardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullableArray implements test_request_required_string_mac_nullable_array operation.
+	//
+	// POST /test_request_required_string_mac_nullable_array
+	TestRequestRequiredStringMACNullableArray(ctx context.Context, req []NilHardwareAddr) (*Error, error)
+	// TestRequestRequiredStringMACNullableArrayArray implements test_request_required_string_mac_nullable_array_array operation.
+	//
+	// POST /test_request_required_string_mac_nullable_array_array
+	TestRequestRequiredStringMACNullableArrayArray(ctx context.Context, req [][]NilHardwareAddr) (*Error, error)
 	// TestRequestRequiredStringNullable implements test_request_required_string_nullable operation.
 	//
 	// POST /test_request_required_string_nullable
@@ -2334,6 +2359,30 @@ type Handler interface {
 	//
 	// POST /test_request_string_ipv6_nullable_array_array
 	TestRequestStringIpv6NullableArrayArray(ctx context.Context, req [][]NilIPv6) (*Error, error)
+	// TestRequestStringMAC implements test_request_string_mac operation.
+	//
+	// POST /test_request_string_mac
+	TestRequestStringMAC(ctx context.Context, req OptHardwareAddr) (*Error, error)
+	// TestRequestStringMACArray implements test_request_string_mac_array operation.
+	//
+	// POST /test_request_string_mac_array
+	TestRequestStringMACArray(ctx context.Context, req []net.HardwareAddr) (*Error, error)
+	// TestRequestStringMACArrayArray implements test_request_string_mac_array_array operation.
+	//
+	// POST /test_request_string_mac_array_array
+	TestRequestStringMACArrayArray(ctx context.Context, req [][]net.HardwareAddr) (*Error, error)
+	// TestRequestStringMACNullable implements test_request_string_mac_nullable operation.
+	//
+	// POST /test_request_string_mac_nullable
+	TestRequestStringMACNullable(ctx context.Context, req OptNilHardwareAddr) (*Error, error)
+	// TestRequestStringMACNullableArray implements test_request_string_mac_nullable_array operation.
+	//
+	// POST /test_request_string_mac_nullable_array
+	TestRequestStringMACNullableArray(ctx context.Context, req []NilHardwareAddr) (*Error, error)
+	// TestRequestStringMACNullableArrayArray implements test_request_string_mac_nullable_array_array operation.
+	//
+	// POST /test_request_string_mac_nullable_array_array
+	TestRequestStringMACNullableArrayArray(ctx context.Context, req [][]NilHardwareAddr) (*Error, error)
 	// TestRequestStringNullable implements test_request_string_nullable operation.
 	//
 	// POST /test_request_string_nullable
@@ -3666,6 +3715,30 @@ type Handler interface {
 	//
 	// POST /test_response_string_ipv6_nullable_array_array
 	TestResponseStringIpv6NullableArrayArray(ctx context.Context, req string) ([][]NilIPv6, error)
+	// TestResponseStringMAC implements test_response_string_mac operation.
+	//
+	// POST /test_response_string_mac
+	TestResponseStringMAC(ctx context.Context, req string) (net.HardwareAddr, error)
+	// TestResponseStringMACArray implements test_response_string_mac_array operation.
+	//
+	// POST /test_response_string_mac_array
+	TestResponseStringMACArray(ctx context.Context, req string) ([]net.HardwareAddr, error)
+	// TestResponseStringMACArrayArray implements test_response_string_mac_array_array operation.
+	//
+	// POST /test_response_string_mac_array_array
+	TestResponseStringMACArrayArray(ctx context.Context, req string) ([][]net.HardwareAddr, error)
+	// TestResponseStringMACNullable implements test_response_string_mac_nullable operation.
+	//
+	// POST /test_response_string_mac_nullable
+	TestResponseStringMACNullable(ctx context.Context, req string) (NilHardwareAddr, error)
+	// TestResponseStringMACNullableArray implements test_response_string_mac_nullable_array operation.
+	//
+	// POST /test_response_string_mac_nullable_array
+	TestResponseStringMACNullableArray(ctx context.Context, req string) ([]NilHardwareAddr, error)
+	// TestResponseStringMACNullableArrayArray implements test_response_string_mac_nullable_array_array operation.
+	//
+	// POST /test_response_string_mac_nullable_array_array
+	TestResponseStringMACNullableArrayArray(ctx context.Context, req string) ([][]NilHardwareAddr, error)
 	// TestResponseStringNullable implements test_response_string_nullable operation.
 	//
 	// POST /test_response_string_nullable

--- a/examples/ex_test_format/oas_unimplemented_gen.go
+++ b/examples/ex_test_format/oas_unimplemented_gen.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"net/url"
 	"time"
@@ -2693,6 +2694,48 @@ func (UnimplementedHandler) TestRequestRequiredStringIpv6NullableArrayArray(ctx 
 	return r, ht.ErrNotImplemented
 }
 
+// TestRequestRequiredStringMAC implements test_request_required_string_mac operation.
+//
+// POST /test_request_required_string_mac
+func (UnimplementedHandler) TestRequestRequiredStringMAC(ctx context.Context, req net.HardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestRequiredStringMACArray implements test_request_required_string_mac_array operation.
+//
+// POST /test_request_required_string_mac_array
+func (UnimplementedHandler) TestRequestRequiredStringMACArray(ctx context.Context, req []net.HardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestRequiredStringMACArrayArray implements test_request_required_string_mac_array_array operation.
+//
+// POST /test_request_required_string_mac_array_array
+func (UnimplementedHandler) TestRequestRequiredStringMACArrayArray(ctx context.Context, req [][]net.HardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestRequiredStringMACNullable implements test_request_required_string_mac_nullable operation.
+//
+// POST /test_request_required_string_mac_nullable
+func (UnimplementedHandler) TestRequestRequiredStringMACNullable(ctx context.Context, req NilHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestRequiredStringMACNullableArray implements test_request_required_string_mac_nullable_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array
+func (UnimplementedHandler) TestRequestRequiredStringMACNullableArray(ctx context.Context, req []NilHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestRequiredStringMACNullableArrayArray implements test_request_required_string_mac_nullable_array_array operation.
+//
+// POST /test_request_required_string_mac_nullable_array_array
+func (UnimplementedHandler) TestRequestRequiredStringMACNullableArrayArray(ctx context.Context, req [][]NilHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // TestRequestRequiredStringNullable implements test_request_required_string_nullable operation.
 //
 // POST /test_request_required_string_nullable
@@ -4076,6 +4119,48 @@ func (UnimplementedHandler) TestRequestStringIpv6NullableArray(ctx context.Conte
 //
 // POST /test_request_string_ipv6_nullable_array_array
 func (UnimplementedHandler) TestRequestStringIpv6NullableArrayArray(ctx context.Context, req [][]NilIPv6) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMAC implements test_request_string_mac operation.
+//
+// POST /test_request_string_mac
+func (UnimplementedHandler) TestRequestStringMAC(ctx context.Context, req OptHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMACArray implements test_request_string_mac_array operation.
+//
+// POST /test_request_string_mac_array
+func (UnimplementedHandler) TestRequestStringMACArray(ctx context.Context, req []net.HardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMACArrayArray implements test_request_string_mac_array_array operation.
+//
+// POST /test_request_string_mac_array_array
+func (UnimplementedHandler) TestRequestStringMACArrayArray(ctx context.Context, req [][]net.HardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMACNullable implements test_request_string_mac_nullable operation.
+//
+// POST /test_request_string_mac_nullable
+func (UnimplementedHandler) TestRequestStringMACNullable(ctx context.Context, req OptNilHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMACNullableArray implements test_request_string_mac_nullable_array operation.
+//
+// POST /test_request_string_mac_nullable_array
+func (UnimplementedHandler) TestRequestStringMACNullableArray(ctx context.Context, req []NilHardwareAddr) (r *Error, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestRequestStringMACNullableArrayArray implements test_request_string_mac_nullable_array_array operation.
+//
+// POST /test_request_string_mac_nullable_array_array
+func (UnimplementedHandler) TestRequestStringMACNullableArrayArray(ctx context.Context, req [][]NilHardwareAddr) (r *Error, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
@@ -6407,6 +6492,48 @@ func (UnimplementedHandler) TestResponseStringIpv6NullableArray(ctx context.Cont
 //
 // POST /test_response_string_ipv6_nullable_array_array
 func (UnimplementedHandler) TestResponseStringIpv6NullableArrayArray(ctx context.Context, req string) (r [][]NilIPv6, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMAC implements test_response_string_mac operation.
+//
+// POST /test_response_string_mac
+func (UnimplementedHandler) TestResponseStringMAC(ctx context.Context, req string) (r net.HardwareAddr, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMACArray implements test_response_string_mac_array operation.
+//
+// POST /test_response_string_mac_array
+func (UnimplementedHandler) TestResponseStringMACArray(ctx context.Context, req string) (r []net.HardwareAddr, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMACArrayArray implements test_response_string_mac_array_array operation.
+//
+// POST /test_response_string_mac_array_array
+func (UnimplementedHandler) TestResponseStringMACArrayArray(ctx context.Context, req string) (r [][]net.HardwareAddr, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMACNullable implements test_response_string_mac_nullable operation.
+//
+// POST /test_response_string_mac_nullable
+func (UnimplementedHandler) TestResponseStringMACNullable(ctx context.Context, req string) (r NilHardwareAddr, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMACNullableArray implements test_response_string_mac_nullable_array operation.
+//
+// POST /test_response_string_mac_nullable_array
+func (UnimplementedHandler) TestResponseStringMACNullableArray(ctx context.Context, req string) (r []NilHardwareAddr, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// TestResponseStringMACNullableArrayArray implements test_response_string_mac_nullable_array_array operation.
+//
+// POST /test_response_string_mac_nullable_array_array
+func (UnimplementedHandler) TestResponseStringMACNullableArrayArray(ctx context.Context, req string) (r [][]NilHardwareAddr, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/examples/ex_test_format/oas_validators_gen.go
+++ b/examples/ex_test_format/oas_validators_gen.go
@@ -614,6 +614,17 @@ func (s *TestRequestFormatTestReq) Validate() error {
 		})
 	}
 	if err := func() error {
+		if s.RequiredArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_array_string_mac",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
@@ -2075,6 +2086,34 @@ func (s *TestRequestFormatTestReq) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.RequiredDoubleArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.RequiredDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_double_array_string_mac",
 			Error: err,
 		})
 	}
@@ -3936,6 +3975,31 @@ func (s *TestRequestFormatTestReq) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.OptionalDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "optional_double_array_string_mac",
 			Error: err,
 		})
 	}
@@ -5041,6 +5105,17 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 		})
 	}
 	if err := func() error {
+		if s.RequiredArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_array_string_mac",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
@@ -6502,6 +6577,34 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.RequiredDoubleArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.RequiredDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_double_array_string_mac",
 			Error: err,
 		})
 	}
@@ -8363,6 +8466,31 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.OptionalDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "optional_double_array_string_mac",
 			Error: err,
 		})
 	}
@@ -9468,6 +9596,17 @@ func (s *TestResponseFormatTestOK) Validate() error {
 		})
 	}
 	if err := func() error {
+		if s.RequiredArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_array_string_mac",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if s.RequiredArrayStringPassword == nil {
 			return errors.New("nil is invalid value")
 		}
@@ -10929,6 +11068,34 @@ func (s *TestResponseFormatTestOK) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "required_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.RequiredDoubleArrayStringMAC == nil {
+			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.RequiredDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_double_array_string_mac",
 			Error: err,
 		})
 	}
@@ -12790,6 +12957,31 @@ func (s *TestResponseFormatTestOK) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "optional_double_array_string_ipv6",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.OptionalDoubleArrayStringMAC {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "optional_double_array_string_mac",
 			Error: err,
 		})
 	}

--- a/gen/ir/faker.go
+++ b/gen/ir/faker.go
@@ -32,7 +32,7 @@ func (t *Type) FakeValue() string {
 	case UUID:
 		return "uuid.New()"
 	case MAC:
-		return `net.ParseMAC("11:22:33:44:55:66")`
+		return `net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}`
 	case IP:
 		if s := t.Schema; s != nil && s.Format == "ipv6" {
 			return `netip.MustParseAddr("::1")`

--- a/gen/ir/faker.go
+++ b/gen/ir/faker.go
@@ -31,6 +31,8 @@ func (t *Type) FakeValue() string {
 		return "time.Duration(5 * time.Second)"
 	case UUID:
 		return "uuid.New()"
+	case MAC:
+		return `net.ParseMAC("11:22:33:44:55:66")`
 	case IP:
 		if s := t.Schema; s != nil && s.Format == "ipv6" {
 			return `netip.MustParseAddr("::1")`

--- a/gen/ir/json.go
+++ b/gen/ir/json.go
@@ -140,6 +140,8 @@ func (j JSON) Format() string {
 		return "IPv4"
 	case "ipv6":
 		return "IPv6"
+	case "mac":
+		return "MAC"
 	case "uri":
 		return "URI"
 	case "int", "int8", "int16", "int32", "int64",

--- a/gen/ir/json.go
+++ b/gen/ir/json.go
@@ -228,7 +228,7 @@ func jsonType(t *Type) string {
 			return "Number"
 		}
 		return "String"
-	case String, Duration, UUID, IP, URL, ByteSlice:
+	case String, Duration, UUID, MAC, IP, URL, ByteSlice:
 		return "String"
 	case Null:
 		return "Null"

--- a/gen/ir/primitive.go
+++ b/gen/ir/primitive.go
@@ -44,6 +44,8 @@ func (p PrimitiveType) String() string {
 		return "time.Duration"
 	case UUID:
 		return "uuid.UUID"
+	case MAC:
+		return "net.HardwareAddr"
 	case IP:
 		return "netip.Addr"
 	case URL:
@@ -83,6 +85,7 @@ const (
 	Time
 	Duration
 	UUID
+	MAC
 	IP
 	URL
 	File

--- a/gen/ir/template_helpers.go
+++ b/gen/ir/template_helpers.go
@@ -52,6 +52,8 @@ func (t Type) uriFormat() string {
 			return naming.Capitalize(f)
 		case "date-time":
 			return "DateTime"
+		case "mac":
+			return "MAC"
 		case "int8",
 			"int16",
 			"int32",

--- a/gen/ir/template_helpers.go
+++ b/gen/ir/template_helpers.go
@@ -22,7 +22,7 @@ func (t *Type) EncodeFn() string {
 		Float32, Float64,
 		String, Bool:
 		return naming.Capitalize(t.Primitive.String())
-	case UUID, Time, IP, Duration, URL:
+	case UUID, Time, MAC, IP, Duration, URL:
 		return naming.AfterDot(t.Primitive.String())
 	default:
 		return ""

--- a/gen/schema_gen_primitive.go
+++ b/gen/schema_gen_primitive.go
@@ -197,6 +197,7 @@ func TypeFormatMapping() map[jsonschema.SchemaType]map[string]ir.PrimitiveType {
 			"time":      ir.Time,
 			"duration":  ir.Duration,
 			"uuid":      ir.UUID,
+			"mac":       ir.MAC,
 			"ip":        ir.IP,
 			"ipv4":      ir.IP,
 			"ipv6":      ir.IP,

--- a/json/mac.go
+++ b/json/mac.go
@@ -1,0 +1,21 @@
+package json
+
+import (
+	"net"
+
+	"github.com/go-faster/jx"
+)
+
+// DecodeMAC decodes net.HardwareAddr.
+func DecodeMAC(d *jx.Decoder) (net.HardwareAddr, error) {
+	raw, err := d.Str()
+	if err != nil {
+		return nil, err
+	}
+	return net.ParseMAC(raw)
+}
+
+// EncodeMAC encodes net.HardwareAddr.
+func EncodeMAC(e *jx.Encoder, v net.HardwareAddr) {
+	e.Str(v.String())
+}

--- a/json/mac_test.go
+++ b/json/mac_test.go
@@ -1,0 +1,78 @@
+package json
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkEncodeMAC(b *testing.B) {
+	mac, err := net.ParseMAC("00:11:22:33:44:55")
+	require.NoError(b, err)
+
+	e := jx.GetEncoder()
+	// Preallocate internal buffer.
+	EncodeMAC(e, mac)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		EncodeMAC(e, mac)
+	}
+}
+
+func BenchmarkDecodeMAC(b *testing.B) {
+	data := []byte(`"00:11:22:33:44:55"`)
+	d := jx.GetDecoder()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var (
+		mac net.HardwareAddr
+		err error
+	)
+	for i := 0; i < b.N; i++ {
+		d.ResetBytes(data)
+		mac, err = DecodeMAC(d)
+	}
+	require.NoError(b, err)
+	_ = mac
+}
+
+func TestMAC(t *testing.T) {
+	mac := func(s string) net.HardwareAddr {
+		m, err := net.ParseMAC(s)
+		require.NoError(t, err)
+		return m
+	}
+	tests := []struct {
+		input   string
+		wantVal net.HardwareAddr
+		wantErr bool
+	}{
+		// Valid MAC.
+		{`"00:11:22:33:44:55"`, mac("00:11:22:33:44:55"), false},
+		{`"A1-B2-C3-D4-E5-F6"`, mac("A1-B2-C3-D4-E5-F6"), false},
+
+		// Invalid MAC.
+		{"01:23:45:67:89:GH", nil, true}, // GH is not a valid hex digit.
+		{`"00-1B-2C-3D-4E"`, nil, true},  // Too few octets.
+		{`"A1B2C3D4E5F6"`, nil, true},    // Missing separators.
+	}
+	for i, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("Test%d", i+1), testDecodeEncode(
+			DecodeMAC,
+			EncodeMAC,
+			tt.input,
+			tt.wantVal,
+			tt.wantErr,
+		))
+	}
+}


### PR DESCRIPTION
Very simple PR that adds a new string primitive `mac` to be interpreted as a `net.HardwareAddr`, just like `ip` -> `netip.Addr`.

Marking as draft as I haven't added any integration test for the generator. I wonder where that should go. Should I create a new spec in the `_testdata` folder or add to an existing one? Also not suer about the `Array` functions. Those exist for the `UUID` primitive but not for e.g. the `IP` one? Why is that?

Anything I need to keep in mind?

If I can get this landed, I'll send a PR to the docs repo, as well.

Cheers!