### PR TITLE
fix(validation): prettier error in case of swagger file

### DIFF
--- a/openapi/parser/_testdata/negative/version/swagger.json
+++ b/openapi/parser/_testdata/negative/version/swagger.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Sample API",
+    "description": "API description in Markdown.",
+    "version": "1.0.0"
+  },
+  "host": "api.example.com",
+  "basePath": "/v1",
+  "schemes": ["https"],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in Markdown.",
+        "produces": ["application/json"],
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/openapi/parser/version.go
+++ b/openapi/parser/version.go
@@ -12,11 +12,17 @@ func (p *parser) parseVersion() (rerr error) {
 	defer func() {
 		rerr = p.wrapLocation(p.rootFile, p.rootLoc.Field("openapi"), rerr)
 	}()
-	if err := p.version.UnmarshalText([]byte(p.spec.OpenAPI)); err != nil {
+
+	version := p.spec.OpenAPI
+	if version == "" {
+		version = p.spec.Swagger
+	}
+
+	if err := p.version.UnmarshalText([]byte(version)); err != nil {
 		return errors.Wrap(err, "invalid version")
 	}
 	if p.version.Major != 3 || p.version.Minor > 1 {
-		return errors.Errorf("unsupported version: %s", p.spec.OpenAPI)
+		return errors.Errorf("unsupported version: %s", version)
 	}
 	return nil
 }

--- a/spec.go
+++ b/spec.go
@@ -39,6 +39,8 @@ type Spec struct {
 	// REQUIRED. This string MUST be the version number of the OpenAPI Specification
 	// that the OpenAPI document uses.
 	OpenAPI string `json:"openapi" yaml:"openapi"`
+	// Added just to detect v2 openAPI specifications and to pretty print version error.
+	Swagger string `json:"swagger,omitempty" yaml:"swagger,omitempty"`
 	// REQUIRED. Provides metadata about the API.
 	//
 	// The metadata MAY be used by tooling as required.

--- a/spec_test.go
+++ b/spec_test.go
@@ -51,3 +51,16 @@ func TestComponents_Init(t *testing.T) {
 		a.NotNil(f.Interface())
 	}
 }
+
+func TestSwaggerExtraction(t *testing.T) {
+	a := require.New(t)
+
+	{
+		var (
+			input = `{"swagger": "2.0.0"}`
+			s     ogen.Spec
+		)
+		a.NoError(yaml.Unmarshal([]byte(input), &s))
+		a.Equal("2.0.0", s.Swagger)
+	}
+}


### PR DESCRIPTION
Prettier error outup in case of swagger file/version. 
Before it returned Atoi parsing error because it was fed an empty string.