### PR TITLE
feat: Add ParamsStruct in middleware.Request

### DIFF
--- a/gen/_template/handlers.tmpl
+++ b/gen/_template/handlers.tmpl
@@ -205,6 +205,7 @@ func (s *{{ if $op.WebhookInfo }}Webhook{{ end }}Server) handle{{ $op.Name }}Req
 				}: params.{{ $param.Name }},
 				{{- end }}
 			},
+			ParamsStruct: {{- if $op.Params }}params{{- else }}nil{{- end }},
 			Raw: r,
 		}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -58,6 +58,8 @@ type Request struct {
 	Body any
 	// Params is the operation parameters.
 	Params Parameters
+	// ParamsStruct is the operation parameters. May be nil, if the operation has not parameters.
+	ParamsStruct any
 	// Raw is the raw http request.
 	Raw *http.Request
 }


### PR DESCRIPTION
I wish to support custom validate（like https://github.com/go-ozzo/ozzo-validation）, but it only support validate on body currently

example middleware:

```golang
package middleware

import "github.com/ogen-go/ogen/middleware"

type validatable interface {
	Validate() error
}

// Validator 一个适用于 ogen 的校验中间件
func Validator() middleware.Middleware {
	return func(req middleware.Request, next middleware.Next) (middleware.Response, error) {
		if params, ok := req.ParamsStruct.(validatable); ok {
			err := params.Validate()
			if err != nil {
				return middleware.Response{}, err
			}
		}
		if body, ok := req.Body.(validatable); ok {
			err := body.Validate()
			if err != nil {
				return middleware.Response{}, err
			}
		}
		return next(req)
	}
}
```