### PR TITLE
fix(gen): use named key in QueryParameterObjectField

### DIFF
--- a/gen/templates.go
+++ b/gen/templates.go
@@ -265,7 +265,7 @@ func paramObjectFields(typ *ir.Type) string {
 			req = "true"
 		}
 
-		fields = append(fields, "{\""+f.Spec.Name+"\","+req+"}")
+		fields = append(fields, "{Name:\""+f.Spec.Name+"\",Required:"+req+"}")
 	}
 
 	return "[]uri.QueryParameterObjectField{" + strings.Join(fields, ",") + "}"

--- a/internal/integration/test_form/oas_request_decoders_gen.go
+++ b/internal/integration/test_form/oas_request_decoders_gen.go
@@ -452,7 +452,7 @@ func (s *Server) decodeTestFormURLEncodedRequest(r *http.Request) (
 				Name:    "object",
 				Style:   uri.QueryStyleForm,
 				Explode: true,
-				Fields:  []uri.QueryParameterObjectField{{"min", false}, {"max", true}},
+				Fields:  []uri.QueryParameterObjectField{{Name: "min", Required: false}, {Name: "max", Required: true}},
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
@@ -474,7 +474,7 @@ func (s *Server) decodeTestFormURLEncodedRequest(r *http.Request) (
 				Name:    "deepObject",
 				Style:   uri.QueryStyleDeepObject,
 				Explode: true,
-				Fields:  []uri.QueryParameterObjectField{{"min", false}, {"max", true}},
+				Fields:  []uri.QueryParameterObjectField{{Name: "min", Required: false}, {Name: "max", Required: true}},
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
@@ -697,7 +697,7 @@ func (s *Server) decodeTestMultipartRequest(r *http.Request) (
 				Name:    "deepObject",
 				Style:   uri.QueryStyleDeepObject,
 				Explode: true,
-				Fields:  []uri.QueryParameterObjectField{{"min", false}, {"max", true}},
+				Fields:  []uri.QueryParameterObjectField{{Name: "min", Required: false}, {Name: "max", Required: true}},
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -671,7 +671,7 @@ func decodeObjectQueryParameterParams(args [0]string, argsEscaped bool, r *http.
 			Name:    "formObject",
 			Style:   uri.QueryStyleForm,
 			Explode: true,
-			Fields:  []uri.QueryParameterObjectField{{"min", true}, {"max", true}, {"filter", true}},
+			Fields:  []uri.QueryParameterObjectField{{Name: "min", Required: true}, {Name: "max", Required: true}, {Name: "filter", Required: true}},
 		}
 
 		if err := q.HasParam(cfg); err == nil {
@@ -702,7 +702,7 @@ func decodeObjectQueryParameterParams(args [0]string, argsEscaped bool, r *http.
 			Name:    "deepObject",
 			Style:   uri.QueryStyleDeepObject,
 			Explode: true,
-			Fields:  []uri.QueryParameterObjectField{{"min", true}, {"max", true}, {"filter", true}},
+			Fields:  []uri.QueryParameterObjectField{{Name: "min", Required: true}, {Name: "max", Required: true}, {Name: "filter", Required: true}},
 		}
 
 		if err := q.HasParam(cfg); err == nil {


### PR DESCRIPTION
The code generated for `uri.QueryParameterObjectField` currently lacks field keys, leading to `go vet` flagging errors as shown below:

```bash
$ go vet ./...
# github.com/ogen-go/ogen/internal/integration/test_form
internal/integration/test_form/oas_request_decoders_gen.go:455:46: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_form/oas_request_decoders_gen.go:455:62: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_form/oas_request_decoders_gen.go:477:46: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_form/oas_request_decoders_gen.go:477:62: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_form/oas_request_decoders_gen.go:700:46: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_form/oas_request_decoders_gen.go:700:62: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
# github.com/ogen-go/ogen/internal/integration/test_parameters
internal/integration/test_parameters/oas_parameters_gen.go:674:45: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_parameters/oas_parameters_gen.go:674:60: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_parameters/oas_parameters_gen.go:674:75: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_parameters/oas_parameters_gen.go:705:45: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_parameters/oas_parameters_gen.go:705:60: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
internal/integration/test_parameters/oas_parameters_gen.go:705:75: github.com/ogen-go/ogen/uri.QueryParameterObjectField struct literal uses unkeyed fields
```

While the linter settings for this repository do not trigger any errors, the linter in each ogen user's project does inspect the generated code. Therefore, we want to ensure at a minimum that the code passes `go vet`.