### PR TITLE
refactor: use slices from standard library

### DIFF
--- a/conv/decode.go
+++ b/conv/decode.go
@@ -4,11 +4,11 @@ import (
 	"net"
 	"net/netip"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 )
 
 func ToInt(s string) (int, error) {

--- a/dsl.go
+++ b/dsl.go
@@ -2,10 +2,10 @@ package ogen
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/jsonschema"
 	"github.com/ogen-go/ogen/openapi"

--- a/examples/hack.go
+++ b/examples/hack.go
@@ -7,6 +7,5 @@ import (
 	_ "go.uber.org/zap"
 	_ "golang.org/x/exp/constraints"
 	_ "golang.org/x/exp/maps"
-	_ "golang.org/x/exp/slices"
 	_ "golang.org/x/tools/imports"
 )

--- a/gen/errors.go
+++ b/gen/errors.go
@@ -2,12 +2,12 @@ package gen
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/ogen-go/ogen/gen/ir"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 type unimplementedError interface {

--- a/gen/features.go
+++ b/gen/features.go
@@ -2,10 +2,10 @@ package gen
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/yaml"
-	"golang.org/x/exp/slices"
 )
 
 // Feature is an ogen feature.

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -3,13 +3,13 @@ package gen
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/yaml"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen"
 	"github.com/ogen-go/ogen/gen/ir"

--- a/gen/ir/examples.go
+++ b/gen/ir/examples.go
@@ -1,10 +1,10 @@
 package ir
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 )
 
 func (t *Type) Examples() (r []string) {

--- a/gen/ir/field.go
+++ b/gen/ir/field.go
@@ -2,10 +2,9 @@ package ir
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/xmaps"
 	"github.com/ogen-go/ogen/jsonschema"

--- a/gen/ir/json.go
+++ b/gen/ir/json.go
@@ -1,9 +1,8 @@
 package ir
 
 import (
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/bitset"
 	"github.com/ogen-go/ogen/internal/naming"

--- a/gen/ir/params.go
+++ b/gen/ir/params.go
@@ -1,7 +1,7 @@
 package ir
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/ogen-go/ogen/openapi"
 )

--- a/gen/ir/recursion.go
+++ b/gen/ir/recursion.go
@@ -3,8 +3,7 @@ package ir
 import (
 	"fmt"
 	"reflect"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func (t *Type) RecursiveTo(target *Type) bool {

--- a/gen/ir/responses.go
+++ b/gen/ir/responses.go
@@ -2,9 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 type ResponseInfo struct {

--- a/gen/ir/template_helpers.go
+++ b/gen/ir/template_helpers.go
@@ -2,9 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/naming"
 	"github.com/ogen-go/ogen/jsonschema"

--- a/gen/ir/type_features.go
+++ b/gen/ir/type_features.go
@@ -1,6 +1,6 @@
 package ir
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 func (t *Type) HasFeature(feature string) bool {
 	return slices.Contains(t.Features, feature)

--- a/gen/ir/type_iface.go
+++ b/gen/ir/type_iface.go
@@ -2,9 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/xmaps"
 )

--- a/gen/ir/validation.go
+++ b/gen/ir/validation.go
@@ -3,10 +3,10 @@ package ir
 import (
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/jsonschema"
 	"github.com/ogen-go/ogen/ogenregex"

--- a/gen/options.go
+++ b/gen/options.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/yaml"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/gen/ir"
 	"github.com/ogen-go/ogen/internal/urlpath"

--- a/gen/router.go
+++ b/gen/router.go
@@ -1,11 +1,11 @@
 package gen
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/go-faster/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/gen/ir"
 	"github.com/ogen-go/ogen/openapi"

--- a/gen/schema_gen_sum.go
+++ b/gen/schema_gen_sum.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/gen/ir"
 	"github.com/ogen-go/ogen/internal/xmaps"

--- a/gen/write.go
+++ b/gen/write.go
@@ -8,11 +8,11 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"sync"
 	"text/template"
 
 	"github.com/go-faster/errors"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/imports"
 

--- a/http/multipart_file.go
+++ b/http/multipart_file.go
@@ -5,9 +5,8 @@ import (
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 // MultipartFile is multipart form file.

--- a/internal/xmaps/xmaps.go
+++ b/internal/xmaps/xmaps.go
@@ -2,9 +2,10 @@
 package xmaps
 
 import (
+	"slices"
+
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // SortedKeys returns a sorted slice of keys in the map.

--- a/internal/xslices/xslices.go
+++ b/internal/xslices/xslices.go
@@ -1,7 +1,7 @@
 // Package xslices provides some generic utilities missed from x/exp/slices.
 package xslices
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Filter performs in-place filtering of a slice.
 func Filter[S ~[]E, E any](s S, keep func(E) bool) S {

--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -1,11 +1,11 @@
 package jsonschema
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 )
 
 // Infer returns a JSON Schema that is inferred from the given JSON.

--- a/jsonschema/parser.go
+++ b/jsonschema/parser.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"go/token"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
-	"golang.org/x/exp/slices"
 
 	ogenjson "github.com/ogen-go/ogen/json"
 	"github.com/ogen-go/ogen/jsonpointer"

--- a/jsonschema/parser_enum.go
+++ b/jsonschema/parser_enum.go
@@ -2,10 +2,10 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/xslices"
 )

--- a/location/error.go
+++ b/location/error.go
@@ -3,12 +3,12 @@ package location
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/yaml"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen/internal/xmaps"
 )

--- a/openapi/parser/parse_server.go
+++ b/openapi/parser/parse_server.go
@@ -3,9 +3,9 @@ package parser
 import (
 	"fmt"
 	"go/token"
+	"slices"
 
 	"github.com/go-faster/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen"
 	"github.com/ogen-go/ogen/jsonpointer"

--- a/openapi/parser/resolve_test.go
+++ b/openapi/parser/resolve_test.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/go-faster/yaml"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen"
 	"github.com/ogen-go/ogen/jsonschema"

--- a/tools/mkformattest/main.go
+++ b/tools/mkformattest/main.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-faster/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen"
 	"github.com/ogen-go/ogen/gen"

--- a/tools/sgcollector/worker.go
+++ b/tools/sgcollector/worker.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
 	"github.com/go-faster/yaml"
-	"golang.org/x/exp/slices"
 
 	"github.com/ogen-go/ogen"
 	"github.com/ogen-go/ogen/gen"


### PR DESCRIPTION
I noticed `golang.org/x/exp/slices` was updated by Renovate in one of our pipelines. This PR removes the dependency in favor of the `slices` package from the standard library.

The same can be done with`golang.org/x/exp/maps` by adding `Keys()` and `Values()` to `xmaps`. Please let me know if I should do that as well.