### PR TITLE
fix(ir): Add support for byte format in string validation

### DIFF
--- a/examples/ex_github/oas_validators_gen.go
+++ b/examples/ex_github/oas_validators_gen.go
@@ -23,6 +23,7 @@ func (s *ActionsCreateOrUpdateEnvironmentSecretReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"],
 		}).Validate(string(s.EncryptedValue)); err != nil {
@@ -56,6 +57,7 @@ func (s *ActionsCreateOrUpdateOrgSecretReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"],
 				}).Validate(string(value)); err != nil {
@@ -118,6 +120,7 @@ func (s *ActionsCreateOrUpdateRepoSecretReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"],
 				}).Validate(string(value)); err != nil {
@@ -2465,6 +2468,7 @@ func (s *AppsCreateContentAttachmentReq) Validate() error {
 			MaxLength:    1024,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -2484,6 +2488,7 @@ func (s *AppsCreateContentAttachmentReq) Validate() error {
 			MaxLength:    262144,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Body)); err != nil {
@@ -4256,6 +4261,7 @@ func (s CodeScanningAnalysisCommitSha) Validate() error {
 		MaxLength:    40,
 		MaxLengthSet: true,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        regexMap["^[0-9a-fA-F]+$"],
 	}).Validate(string(alias)); err != nil {
@@ -4750,6 +4756,7 @@ func (s *ContentReferenceAttachment) Validate() error {
 			MaxLength:    1024,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -4769,6 +4776,7 @@ func (s *ContentReferenceAttachment) Validate() error {
 			MaxLength:    262144,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Body)); err != nil {
@@ -4894,6 +4902,7 @@ func (s *DeploymentStatus) Validate() error {
 			MaxLength:    140,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -5042,6 +5051,7 @@ func (s *Email) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -6121,6 +6131,7 @@ func (s *GistComment) Validate() error {
 			MaxLength:    65535,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Body)); err != nil {
@@ -6304,6 +6315,7 @@ func (s *GistsCreateCommentReq) Validate() error {
 			MaxLength:    65535,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Body)); err != nil {
@@ -6585,6 +6597,7 @@ func (s *GistsUpdateCommentReq) Validate() error {
 			MaxLength:    65535,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Body)); err != nil {
@@ -6902,6 +6915,7 @@ func (s *GitRefObject) Validate() error {
 			MaxLength:    40,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Sha)); err != nil {
@@ -8877,6 +8891,7 @@ func (s *MarketplaceAccount) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8903,6 +8918,7 @@ func (s *MarketplaceAccount) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9653,6 +9669,7 @@ func (s *OAuthAuthorizationsCreateAuthorizationReq) Validate() error {
 					MaxLength:    20,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9679,6 +9696,7 @@ func (s *OAuthAuthorizationsCreateAuthorizationReq) Validate() error {
 					MaxLength:    40,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9731,6 +9749,7 @@ func (s *OAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintReq) Val
 			MaxLength:    40,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ClientSecret)); err != nil {
@@ -9796,6 +9815,7 @@ func (s *OAuthAuthorizationsGetOrCreateAuthorizationForAppReq) Validate() error 
 			MaxLength:    40,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ClientSecret)); err != nil {
@@ -10108,6 +10128,7 @@ func (s *OrganizationFull) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -10134,6 +10155,7 @@ func (s *OrganizationFull) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -11462,6 +11484,7 @@ func (s *PrivateUser) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -11840,6 +11863,7 @@ func (s *ProjectsMoveCardReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^(?:top|bottom|after:\\d+)$"],
 		}).Validate(string(s.Position)); err != nil {
@@ -11871,6 +11895,7 @@ func (s *ProjectsMoveColumnReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^(?:first|last|after:\\d+)$"],
 		}).Validate(string(s.Position)); err != nil {
@@ -12118,6 +12143,7 @@ func (s *PublicUser) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -14804,6 +14830,7 @@ func (s *ReposCreateDispatchEventReq) Validate() error {
 			MaxLength:    100,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.EventType)); err != nil {
@@ -19184,6 +19211,7 @@ func (s *UserSearchResultItem) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -19252,6 +19280,7 @@ func (s UsersAddEmailForAuthenticatedReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -19295,6 +19324,7 @@ func (s *UsersAddEmailForAuthenticatedReq0) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -19337,6 +19367,7 @@ func (s *UsersCreatePublicSSHKeyForAuthenticatedReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^ssh-(rsa|dss|ed25519) |^ecdsa-sha2-nistp(256|384|521) "],
 		}).Validate(string(s.Key)); err != nil {
@@ -19375,6 +19406,7 @@ func (s UsersDeleteEmailForAuthenticatedReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -19418,6 +19450,7 @@ func (s *UsersDeleteEmailForAuthenticatedReq0) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {

--- a/examples/ex_gotd/oas_validators_gen.go
+++ b/examples/ex_gotd/oas_validators_gen.go
@@ -145,6 +145,7 @@ func (s *AnswerCallbackQuery) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -211,6 +212,7 @@ func (s *AnswerInlineQuery) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -357,6 +359,7 @@ func (s *BotCommand) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Command)); err != nil {
@@ -376,6 +379,7 @@ func (s *BotCommand) Validate() error {
 			MaxLength:    256,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -589,6 +593,7 @@ func (s *ChatLocation) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Address)); err != nil {
@@ -708,6 +713,7 @@ func (s *CopyMessage) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -789,6 +795,7 @@ func (s *CreateChatInviteLink) Validate() error {
 					MaxLength:    32,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -852,6 +859,7 @@ func (s *CreateNewStickerSet) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -871,6 +879,7 @@ func (s *CreateNewStickerSet) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -952,6 +961,7 @@ func (s *EditChatInviteLink) Validate() error {
 					MaxLength:    32,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1017,6 +1027,7 @@ func (s *EditMessageCaption) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1291,6 +1302,7 @@ func (s *EditMessageText) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -1423,6 +1435,7 @@ func (s *ForceReply) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1489,6 +1502,7 @@ func (s *Game) Validate() error {
 					MaxLength:    4096,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1648,6 +1662,7 @@ func (s *InlineKeyboardButton) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2008,6 +2023,7 @@ func (s *InlineQueryResultAudio) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2029,6 +2045,7 @@ func (s *InlineQueryResultAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2153,6 +2170,7 @@ func (s *InlineQueryResultCachedAudio) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2174,6 +2192,7 @@ func (s *InlineQueryResultCachedAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2271,6 +2290,7 @@ func (s *InlineQueryResultCachedDocument) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2292,6 +2312,7 @@ func (s *InlineQueryResultCachedDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2389,6 +2410,7 @@ func (s *InlineQueryResultCachedGif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2410,6 +2432,7 @@ func (s *InlineQueryResultCachedGif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2507,6 +2530,7 @@ func (s *InlineQueryResultCachedMpeg4Gif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2528,6 +2552,7 @@ func (s *InlineQueryResultCachedMpeg4Gif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2625,6 +2650,7 @@ func (s *InlineQueryResultCachedPhoto) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2646,6 +2672,7 @@ func (s *InlineQueryResultCachedPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2743,6 +2770,7 @@ func (s *InlineQueryResultCachedSticker) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2810,6 +2838,7 @@ func (s *InlineQueryResultCachedVideo) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2831,6 +2860,7 @@ func (s *InlineQueryResultCachedVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2928,6 +2958,7 @@ func (s *InlineQueryResultCachedVoice) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2949,6 +2980,7 @@ func (s *InlineQueryResultCachedVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3048,6 +3080,7 @@ func (s *InlineQueryResultContact) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3174,6 +3207,7 @@ func (s *InlineQueryResultDocument) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3195,6 +3229,7 @@ func (s *InlineQueryResultDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3346,6 +3381,7 @@ func (s *InlineQueryResultGame) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3395,6 +3431,7 @@ func (s *InlineQueryResultGif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3497,6 +3534,7 @@ func (s *InlineQueryResultGif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3817,6 +3855,7 @@ func (s *InlineQueryResultMpeg4Gif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3919,6 +3958,7 @@ func (s *InlineQueryResultMpeg4Gif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4016,6 +4056,7 @@ func (s *InlineQueryResultPhoto) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4091,6 +4132,7 @@ func (s *InlineQueryResultPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4312,6 +4354,7 @@ func (s *InlineQueryResultVideo) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4333,6 +4376,7 @@ func (s *InlineQueryResultVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4511,6 +4555,7 @@ func (s *InlineQueryResultVoice) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4532,6 +4577,7 @@ func (s *InlineQueryResultVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4658,6 +4704,7 @@ func (s *InputContactMessageContent) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4694,6 +4741,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -4713,6 +4761,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -4732,6 +4781,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    128,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Payload)); err != nil {
@@ -4995,6 +5045,7 @@ func (s *InputMediaAnimation) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5139,6 +5190,7 @@ func (s *InputMediaAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5229,6 +5281,7 @@ func (s *InputMediaDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5292,6 +5345,7 @@ func (s *InputMediaPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5355,6 +5409,7 @@ func (s *InputMediaVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5529,6 +5584,7 @@ func (s *InputTextMessageContent) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.MessageText)); err != nil {
@@ -5811,6 +5867,7 @@ func (s *Message) Validate() error {
 					MaxLength:    4096,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6013,6 +6070,7 @@ func (s *Message) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6815,6 +6873,7 @@ func (s *Poll) Validate() error {
 			MaxLength:    300,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Question)); err != nil {
@@ -6875,6 +6934,7 @@ func (s *Poll) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6959,6 +7019,7 @@ func (s *PollOption) Validate() error {
 			MaxLength:    100,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -7031,6 +7092,7 @@ func (s *ReplyKeyboardMarkup) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7485,6 +7547,7 @@ func (s *SendAnimation) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7566,6 +7629,7 @@ func (s *SendAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7674,6 +7738,7 @@ func (s *SendContact) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7760,6 +7825,7 @@ func (s *SendDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7869,6 +7935,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -7888,6 +7955,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -7907,6 +7975,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    128,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Payload)); err != nil {
@@ -8239,6 +8308,7 @@ func (s *SendMessage) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -8315,6 +8385,7 @@ func (s *SendPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8394,6 +8465,7 @@ func (s *SendPoll) Validate() error {
 			MaxLength:    300,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Question)); err != nil {
@@ -8426,6 +8498,7 @@ func (s *SendPoll) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8694,6 +8767,7 @@ func (s *SendVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8832,6 +8906,7 @@ func (s *SendVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8938,6 +9013,7 @@ func (s *SetChatAdministratorCustomTitle) Validate() error {
 			MaxLength:    16,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.CustomTitle)); err != nil {
@@ -8971,6 +9047,7 @@ func (s *SetChatDescription) Validate() error {
 					MaxLength:    255,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9007,6 +9084,7 @@ func (s *SetChatTitle) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {

--- a/examples/ex_k8s/oas_validators_gen.go
+++ b/examples/ex_k8s/oas_validators_gen.go
@@ -245,6 +245,7 @@ func (s *IoK8sAPIAdmissionregistrationV1WebhookClientConfig) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         true,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 		}).Validate(string(s.CaBundle)); err != nil {
@@ -1348,6 +1349,7 @@ func (s *IoK8sAPICertificatesV1CertificateSigningRequestSpec) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         true,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 		}).Validate(string(s.Request)); err != nil {
@@ -1401,6 +1403,7 @@ func (s *IoK8sAPICertificatesV1CertificateSigningRequestStatus) Validate() error
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         true,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 		}).Validate(string(s.Certificate)); err != nil {
@@ -1581,6 +1584,7 @@ func (s IoK8sAPICoreV1ConfigMapBinaryData) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         true,
 				Hostname:     false,
 				Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 			}).Validate(string(elem)); err != nil {
@@ -2483,6 +2487,7 @@ func (s IoK8sAPICoreV1SecretData) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         true,
 				Hostname:     false,
 				Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 			}).Validate(string(elem)); err != nil {
@@ -5087,6 +5092,7 @@ func (s *IoK8sApiextensionsApiserverPkgApisApiextensionsV1WebhookClientConfig) V
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         true,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 		}).Validate(string(s.CaBundle)); err != nil {
@@ -5389,6 +5395,7 @@ func (s *IoK8sKubeAggregatorPkgApisApiregistrationV1APIServiceSpec) Validate() e
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         true,
 			Hostname:     false,
 			Regex:        regexMap["^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"],
 		}).Validate(string(s.CaBundle)); err != nil {

--- a/examples/ex_openai/oas_validators_gen.go
+++ b/examples/ex_openai/oas_validators_gen.go
@@ -95,6 +95,7 @@ func (s *CreateAnswerRequest) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Question)); err != nil {
@@ -142,6 +143,7 @@ func (s *CreateAnswerRequest) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -644,6 +646,7 @@ func (s *CreateClassificationRequest) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Query)); err != nil {
@@ -693,6 +696,7 @@ func (s *CreateClassificationRequest) Validate() error {
 									MaxLength:    0,
 									MaxLengthSet: false,
 									Email:        false,
+									Byte:         false,
 									Hostname:     false,
 									Regex:        nil,
 								}).Validate(string(elem)); err != nil {
@@ -1648,6 +1652,7 @@ func (s *CreateFineTuneRequest) Validate() error {
 					MaxLength:    40,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2170,6 +2175,7 @@ func (s *CreateSearchRequest) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Query)); err != nil {

--- a/examples/ex_route_params/oas_parameters_gen.go
+++ b/examples/ex_route_params/oas_parameters_gen.go
@@ -143,6 +143,7 @@ func decodeDataGetParams(args [2]string, argsEscaped bool, r *http.Request) (par
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Key)); err != nil {

--- a/examples/ex_telegram/oas_validators_gen.go
+++ b/examples/ex_telegram/oas_validators_gen.go
@@ -145,6 +145,7 @@ func (s *AnswerCallbackQuery) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -211,6 +212,7 @@ func (s *AnswerInlineQuery) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -334,6 +336,7 @@ func (s *BotCommand) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Command)); err != nil {
@@ -353,6 +356,7 @@ func (s *BotCommand) Validate() error {
 			MaxLength:    256,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -566,6 +570,7 @@ func (s *ChatLocation) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Address)); err != nil {
@@ -685,6 +690,7 @@ func (s *CopyMessage) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -790,6 +796,7 @@ func (s *CreateChatInviteLink) Validate() error {
 					MaxLength:    32,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -853,6 +860,7 @@ func (s *CreateNewStickerSet) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -872,6 +880,7 @@ func (s *CreateNewStickerSet) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -953,6 +962,7 @@ func (s *EditChatInviteLink) Validate() error {
 					MaxLength:    32,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1018,6 +1028,7 @@ func (s *EditMessageCaption) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1292,6 +1303,7 @@ func (s *EditMessageText) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -1424,6 +1436,7 @@ func (s *ForceReply) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1490,6 +1503,7 @@ func (s *Game) Validate() error {
 					MaxLength:    4096,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -1649,6 +1663,7 @@ func (s *InlineKeyboardButton) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2009,6 +2024,7 @@ func (s *InlineQueryResultAudio) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2030,6 +2046,7 @@ func (s *InlineQueryResultAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2154,6 +2171,7 @@ func (s *InlineQueryResultCachedAudio) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2175,6 +2193,7 @@ func (s *InlineQueryResultCachedAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2272,6 +2291,7 @@ func (s *InlineQueryResultCachedDocument) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2293,6 +2313,7 @@ func (s *InlineQueryResultCachedDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2390,6 +2411,7 @@ func (s *InlineQueryResultCachedGif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2411,6 +2433,7 @@ func (s *InlineQueryResultCachedGif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2508,6 +2531,7 @@ func (s *InlineQueryResultCachedMpeg4Gif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2529,6 +2553,7 @@ func (s *InlineQueryResultCachedMpeg4Gif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2626,6 +2651,7 @@ func (s *InlineQueryResultCachedPhoto) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2647,6 +2673,7 @@ func (s *InlineQueryResultCachedPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2744,6 +2771,7 @@ func (s *InlineQueryResultCachedSticker) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2811,6 +2839,7 @@ func (s *InlineQueryResultCachedVideo) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2832,6 +2861,7 @@ func (s *InlineQueryResultCachedVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -2929,6 +2959,7 @@ func (s *InlineQueryResultCachedVoice) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -2950,6 +2981,7 @@ func (s *InlineQueryResultCachedVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3049,6 +3081,7 @@ func (s *InlineQueryResultContact) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3175,6 +3208,7 @@ func (s *InlineQueryResultDocument) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3196,6 +3230,7 @@ func (s *InlineQueryResultDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3347,6 +3382,7 @@ func (s *InlineQueryResultGame) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3396,6 +3432,7 @@ func (s *InlineQueryResultGif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3498,6 +3535,7 @@ func (s *InlineQueryResultGif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -3818,6 +3856,7 @@ func (s *InlineQueryResultMpeg4Gif) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -3920,6 +3959,7 @@ func (s *InlineQueryResultMpeg4Gif) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4017,6 +4057,7 @@ func (s *InlineQueryResultPhoto) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4092,6 +4133,7 @@ func (s *InlineQueryResultPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4313,6 +4355,7 @@ func (s *InlineQueryResultVideo) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4334,6 +4377,7 @@ func (s *InlineQueryResultVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4512,6 +4556,7 @@ func (s *InlineQueryResultVoice) Validate() error {
 			MaxLength:    64,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.ID)); err != nil {
@@ -4533,6 +4578,7 @@ func (s *InlineQueryResultVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4659,6 +4705,7 @@ func (s *InputContactMessageContent) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4695,6 +4742,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -4714,6 +4762,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -4733,6 +4782,7 @@ func (s *InputInvoiceMessageContent) Validate() error {
 			MaxLength:    128,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Payload)); err != nil {
@@ -4996,6 +5046,7 @@ func (s *InputMediaAnimation) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5140,6 +5191,7 @@ func (s *InputMediaAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5230,6 +5282,7 @@ func (s *InputMediaDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5293,6 +5346,7 @@ func (s *InputMediaPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5356,6 +5410,7 @@ func (s *InputMediaVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -5530,6 +5585,7 @@ func (s *InputTextMessageContent) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.MessageText)); err != nil {
@@ -5812,6 +5868,7 @@ func (s *Message) Validate() error {
 					MaxLength:    4096,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6014,6 +6071,7 @@ func (s *Message) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6796,6 +6854,7 @@ func (s *Poll) Validate() error {
 			MaxLength:    300,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Question)); err != nil {
@@ -6856,6 +6915,7 @@ func (s *Poll) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -6940,6 +7000,7 @@ func (s *PollOption) Validate() error {
 			MaxLength:    100,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -7012,6 +7073,7 @@ func (s *ReplyKeyboardMarkup) Validate() error {
 					MaxLength:    64,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7392,6 +7454,7 @@ func (s *SendAnimation) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7497,6 +7560,7 @@ func (s *SendAudio) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7629,6 +7693,7 @@ func (s *SendContact) Validate() error {
 					MaxLength:    2048,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7763,6 +7828,7 @@ func (s *SendDocument) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -7896,6 +7962,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    32,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {
@@ -7915,6 +7982,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Description)); err != nil {
@@ -7934,6 +8002,7 @@ func (s *SendInvoice) Validate() error {
 			MaxLength:    128,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Payload)); err != nil {
@@ -8290,6 +8359,7 @@ func (s *SendMessage) Validate() error {
 			MaxLength:    4096,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Text)); err != nil {
@@ -8390,6 +8460,7 @@ func (s *SendPhoto) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8493,6 +8564,7 @@ func (s *SendPoll) Validate() error {
 			MaxLength:    300,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Question)); err != nil {
@@ -8525,6 +8597,7 @@ func (s *SendPoll) Validate() error {
 					MaxLength:    200,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8841,6 +8914,7 @@ func (s *SendVideo) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9027,6 +9101,7 @@ func (s *SendVoice) Validate() error {
 					MaxLength:    1024,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9157,6 +9232,7 @@ func (s *SetChatAdministratorCustomTitle) Validate() error {
 			MaxLength:    16,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.CustomTitle)); err != nil {
@@ -9190,6 +9266,7 @@ func (s *SetChatDescription) Validate() error {
 					MaxLength:    255,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9226,6 +9303,7 @@ func (s *SetChatTitle) Validate() error {
 			MaxLength:    255,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Title)); err != nil {

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -3509,6 +3509,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.StringEmail)); err != nil {
@@ -3576,6 +3577,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -3867,6 +3869,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(params.StringHostname)); err != nil {
@@ -3934,6 +3937,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {

--- a/examples/ex_test_format/oas_request_decoders_gen.go
+++ b/examples/ex_test_format/oas_request_decoders_gen.go
@@ -26318,6 +26318,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailRequest(r *http.Request) (
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        true,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(request)); err != nil {
@@ -26413,6 +26414,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailArrayRequest(r *http.Reques
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        true,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(elem)); err != nil {
@@ -26533,6 +26535,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailArrayArrayRequest(r *http.R
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        true,
+								Byte:         false,
 								Hostname:     false,
 								Regex:        nil,
 							}).Validate(string(elem)); err != nil {
@@ -26636,6 +26639,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailNullableRequest(r *http.Req
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        true,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -26736,6 +26740,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailNullableArrayRequest(r *htt
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        true,
+								Byte:         false,
 								Hostname:     false,
 								Regex:        nil,
 							}).Validate(string(value)); err != nil {
@@ -26861,6 +26866,7 @@ func (s *Server) decodeTestRequestRequiredStringEmailNullableArrayArrayRequest(r
 										MaxLength:    0,
 										MaxLengthSet: false,
 										Email:        true,
+										Byte:         false,
 										Hostname:     false,
 										Regex:        nil,
 									}).Validate(string(value)); err != nil {
@@ -28175,6 +28181,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameRequest(r *http.Request)
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     true,
 				Regex:        nil,
 			}).Validate(string(request)); err != nil {
@@ -28270,6 +28277,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameArrayRequest(r *http.Req
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     true,
 						Regex:        nil,
 					}).Validate(string(elem)); err != nil {
@@ -28390,6 +28398,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameArrayArrayRequest(r *htt
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        false,
+								Byte:         false,
 								Hostname:     true,
 								Regex:        nil,
 							}).Validate(string(elem)); err != nil {
@@ -28493,6 +28502,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameNullableRequest(r *http.
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     true,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -28593,6 +28603,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameNullableArrayRequest(r *
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        false,
+								Byte:         false,
 								Hostname:     true,
 								Regex:        nil,
 							}).Validate(string(value)); err != nil {
@@ -28718,6 +28729,7 @@ func (s *Server) decodeTestRequestRequiredStringHostnameNullableArrayArrayReques
 										MaxLength:    0,
 										MaxLengthSet: false,
 										Email:        false,
+										Byte:         false,
 										Hostname:     true,
 										Regex:        nil,
 									}).Validate(string(value)); err != nil {
@@ -43753,6 +43765,7 @@ func (s *Server) decodeTestRequestStringEmailRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        true,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -43853,6 +43866,7 @@ func (s *Server) decodeTestRequestStringEmailArrayRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        true,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(elem)); err != nil {
@@ -43973,6 +43987,7 @@ func (s *Server) decodeTestRequestStringEmailArrayArrayRequest(r *http.Request) 
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        true,
+								Byte:         false,
 								Hostname:     false,
 								Regex:        nil,
 							}).Validate(string(elem)); err != nil {
@@ -44080,6 +44095,7 @@ func (s *Server) decodeTestRequestStringEmailNullableRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        true,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -44180,6 +44196,7 @@ func (s *Server) decodeTestRequestStringEmailNullableArrayRequest(r *http.Reques
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        true,
+								Byte:         false,
 								Hostname:     false,
 								Regex:        nil,
 							}).Validate(string(value)); err != nil {
@@ -44305,6 +44322,7 @@ func (s *Server) decodeTestRequestStringEmailNullableArrayArrayRequest(r *http.R
 										MaxLength:    0,
 										MaxLengthSet: false,
 										Email:        true,
+										Byte:         false,
 										Hostname:     false,
 										Regex:        nil,
 									}).Validate(string(value)); err != nil {
@@ -45649,6 +45667,7 @@ func (s *Server) decodeTestRequestStringHostnameRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     true,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -45749,6 +45768,7 @@ func (s *Server) decodeTestRequestStringHostnameArrayRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     true,
 						Regex:        nil,
 					}).Validate(string(elem)); err != nil {
@@ -45869,6 +45889,7 @@ func (s *Server) decodeTestRequestStringHostnameArrayArrayRequest(r *http.Reques
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        false,
+								Byte:         false,
 								Hostname:     true,
 								Regex:        nil,
 							}).Validate(string(elem)); err != nil {
@@ -45976,6 +45997,7 @@ func (s *Server) decodeTestRequestStringHostnameNullableRequest(r *http.Request)
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     true,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {
@@ -46076,6 +46098,7 @@ func (s *Server) decodeTestRequestStringHostnameNullableArrayRequest(r *http.Req
 								MaxLength:    0,
 								MaxLengthSet: false,
 								Email:        false,
+								Byte:         false,
 								Hostname:     true,
 								Regex:        nil,
 							}).Validate(string(value)); err != nil {
@@ -46201,6 +46224,7 @@ func (s *Server) decodeTestRequestStringHostnameNullableArrayArrayRequest(r *htt
 										MaxLength:    0,
 										MaxLengthSet: false,
 										Email:        false,
+										Byte:         false,
 										Hostname:     true,
 										Regex:        nil,
 									}).Validate(string(value)); err != nil {

--- a/examples/ex_test_format/oas_response_decoders_gen.go
+++ b/examples/ex_test_format/oas_response_decoders_gen.go
@@ -38912,6 +38912,7 @@ func decodeTestResponseStringEmailResponse(resp *http.Response) (res string, _ e
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(response)); err != nil {
@@ -38986,6 +38987,7 @@ func decodeTestResponseStringEmailArrayResponse(resp *http.Response) (res []stri
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -39085,6 +39087,7 @@ func decodeTestResponseStringEmailArrayArrayResponse(resp *http.Response) (res [
 									MaxLength:    0,
 									MaxLengthSet: false,
 									Email:        true,
+									Byte:         false,
 									Hostname:     false,
 									Regex:        nil,
 								}).Validate(string(elem)); err != nil {
@@ -39167,6 +39170,7 @@ func decodeTestResponseStringEmailNullableResponse(resp *http.Response) (res Nil
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(value)); err != nil {
@@ -39246,6 +39250,7 @@ func decodeTestResponseStringEmailNullableArrayResponse(resp *http.Response) (re
 									MaxLength:    0,
 									MaxLengthSet: false,
 									Email:        true,
+									Byte:         false,
 									Hostname:     false,
 									Regex:        nil,
 								}).Validate(string(value)); err != nil {
@@ -39350,6 +39355,7 @@ func decodeTestResponseStringEmailNullableArrayArrayResponse(resp *http.Response
 											MaxLength:    0,
 											MaxLengthSet: false,
 											Email:        true,
+											Byte:         false,
 											Hostname:     false,
 											Regex:        nil,
 										}).Validate(string(value)); err != nil {
@@ -40391,6 +40397,7 @@ func decodeTestResponseStringHostnameResponse(resp *http.Response) (res string, 
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(response)); err != nil {
@@ -40465,6 +40472,7 @@ func decodeTestResponseStringHostnameArrayResponse(resp *http.Response) (res []s
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -40564,6 +40572,7 @@ func decodeTestResponseStringHostnameArrayArrayResponse(resp *http.Response) (re
 									MaxLength:    0,
 									MaxLengthSet: false,
 									Email:        false,
+									Byte:         false,
 									Hostname:     true,
 									Regex:        nil,
 								}).Validate(string(elem)); err != nil {
@@ -40646,6 +40655,7 @@ func decodeTestResponseStringHostnameNullableResponse(resp *http.Response) (res 
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(value)); err != nil {
@@ -40725,6 +40735,7 @@ func decodeTestResponseStringHostnameNullableArrayResponse(resp *http.Response) 
 									MaxLength:    0,
 									MaxLengthSet: false,
 									Email:        false,
+									Byte:         false,
 									Hostname:     true,
 									Regex:        nil,
 								}).Validate(string(value)); err != nil {
@@ -40829,6 +40840,7 @@ func decodeTestResponseStringHostnameNullableArrayArrayResponse(resp *http.Respo
 											MaxLength:    0,
 											MaxLengthSet: false,
 											Email:        false,
+											Byte:         false,
 											Hostname:     true,
 											Regex:        nil,
 										}).Validate(string(value)); err != nil {

--- a/examples/ex_test_format/oas_validators_gen.go
+++ b/examples/ex_test_format/oas_validators_gen.go
@@ -410,6 +410,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -502,6 +503,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -1688,6 +1690,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -1831,6 +1834,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -2549,6 +2553,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
@@ -2590,6 +2595,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
@@ -2687,6 +2693,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -2770,6 +2777,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -3610,6 +3618,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -3744,6 +3753,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -4416,6 +4426,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4478,6 +4489,7 @@ func (s *TestRequestFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -4901,6 +4913,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -4993,6 +5006,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -6179,6 +6193,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -6322,6 +6337,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -7040,6 +7056,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
@@ -7081,6 +7098,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
@@ -7178,6 +7196,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -7261,6 +7280,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -8101,6 +8121,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -8235,6 +8256,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -8907,6 +8929,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -8969,6 +8992,7 @@ func (s *TestRequestRequiredFormatTestReq) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -9392,6 +9416,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -9484,6 +9509,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -10670,6 +10696,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -10813,6 +10840,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -11531,6 +11559,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringEmail)); err != nil {
@@ -11572,6 +11601,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.RequiredStringHostname)); err != nil {
@@ -11669,6 +11699,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -11752,6 +11783,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(elem)); err != nil {
@@ -12592,6 +12624,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        true,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -12726,6 +12759,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 							MaxLength:    0,
 							MaxLengthSet: false,
 							Email:        false,
+							Byte:         false,
 							Hostname:     true,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -13398,6 +13432,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -13460,6 +13495,7 @@ func (s *TestResponseFormatTestOK) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {

--- a/gen/_template/validators.tmpl
+++ b/gen/_template/validators.tmpl
@@ -87,6 +87,7 @@
 			MaxLength:      {{ $v.MaxLength }},
 			MaxLengthSet:   {{ $v.MaxLengthSet }},
 			Email:          {{ $v.Email }},
+			Byte:           {{ $v.Byte }},
 			Hostname:       {{ $v.Hostname }},
 			{{- if $v.Regex }}
 			Regex:          regexMap[{{ quote $v.Regex }}],

--- a/gen/ir/validation.go
+++ b/gen/ir/validation.go
@@ -40,6 +40,9 @@ func (v *Validators) SetString(schema *jsonschema.Schema) (err error) {
 	if schema.Format == "hostname" {
 		v.String.Hostname = true
 	}
+	if schema.Format == "byte" {
+		v.String.Byte = true
+	}
 	return nil
 }
 

--- a/internal/integration/sample_api/oas_client_gen.go
+++ b/internal/integration/sample_api/oas_client_gen.go
@@ -1913,6 +1913,7 @@ func (c *Client) sendPetUpdateNamePost(ctx context.Context, request OptString) (
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {

--- a/internal/integration/sample_api/oas_parameters_gen.go
+++ b/internal/integration/sample_api/oas_parameters_gen.go
@@ -168,6 +168,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Foo)); err != nil {
@@ -229,6 +230,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Bar)); err != nil {
@@ -290,6 +292,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Baz)); err != nil {
@@ -351,6 +354,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Kek)); err != nil {

--- a/internal/integration/sample_api/oas_request_decoders_gen.go
+++ b/internal/integration/sample_api/oas_request_decoders_gen.go
@@ -473,6 +473,7 @@ func (s *Server) decodePetUpdateNamePostRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {

--- a/internal/integration/sample_api/oas_validators_gen.go
+++ b/internal/integration/sample_api/oas_validators_gen.go
@@ -64,6 +64,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -83,6 +84,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.Hostname)); err != nil {
@@ -102,6 +104,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^\\d-\\d$"],
 		}).Validate(string(s.Format)); err != nil {
@@ -171,6 +174,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -197,6 +201,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -223,6 +228,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^\\d-\\d$"],
 				}).Validate(string(value)); err != nil {
@@ -561,6 +567,7 @@ func (s *Pet) Validate() error {
 			MaxLength:    24,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -731,6 +738,7 @@ func (s *Pet) Validate() error {
 							MaxLength:    255,
 							MaxLengthSet: true,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -844,6 +852,7 @@ func (s PetName) Validate() error {
 		MaxLength:    0,
 		MaxLengthSet: false,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        nil,
 	}).Validate(string(alias)); err != nil {
@@ -898,6 +907,7 @@ func (s StringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {
@@ -1161,6 +1171,7 @@ func (s ValidationStringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {

--- a/internal/integration/sample_api_nc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nc/oas_parameters_gen.go
@@ -168,6 +168,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Foo)); err != nil {
@@ -229,6 +230,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Bar)); err != nil {
@@ -290,6 +292,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Baz)); err != nil {
@@ -351,6 +354,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Kek)); err != nil {

--- a/internal/integration/sample_api_nc/oas_request_decoders_gen.go
+++ b/internal/integration/sample_api_nc/oas_request_decoders_gen.go
@@ -473,6 +473,7 @@ func (s *Server) decodePetUpdateNamePostRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {

--- a/internal/integration/sample_api_nc/oas_validators_gen.go
+++ b/internal/integration/sample_api_nc/oas_validators_gen.go
@@ -64,6 +64,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -83,6 +84,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.Hostname)); err != nil {
@@ -102,6 +104,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^\\d-\\d$"],
 		}).Validate(string(s.Format)); err != nil {
@@ -171,6 +174,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -197,6 +201,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -223,6 +228,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^\\d-\\d$"],
 				}).Validate(string(value)); err != nil {
@@ -561,6 +567,7 @@ func (s *Pet) Validate() error {
 			MaxLength:    24,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -731,6 +738,7 @@ func (s *Pet) Validate() error {
 							MaxLength:    255,
 							MaxLengthSet: true,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -844,6 +852,7 @@ func (s PetName) Validate() error {
 		MaxLength:    0,
 		MaxLengthSet: false,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        nil,
 	}).Validate(string(alias)); err != nil {
@@ -898,6 +907,7 @@ func (s StringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {
@@ -1161,6 +1171,7 @@ func (s ValidationStringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {

--- a/internal/integration/sample_api_no_otel/oas_parameters_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_parameters_gen.go
@@ -168,6 +168,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Foo)); err != nil {
@@ -229,6 +230,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Bar)); err != nil {
@@ -290,6 +292,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Baz)); err != nil {
@@ -351,6 +354,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(params.Kek)); err != nil {

--- a/internal/integration/sample_api_no_otel/oas_request_decoders_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_request_decoders_gen.go
@@ -473,6 +473,7 @@ func (s *Server) decodePetUpdateNamePostRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {

--- a/internal/integration/sample_api_no_otel/oas_validators_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_validators_gen.go
@@ -64,6 +64,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -83,6 +84,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.Hostname)); err != nil {
@@ -102,6 +104,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^\\d-\\d$"],
 		}).Validate(string(s.Format)); err != nil {
@@ -171,6 +174,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -197,6 +201,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -223,6 +228,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^\\d-\\d$"],
 				}).Validate(string(value)); err != nil {
@@ -561,6 +567,7 @@ func (s *Pet) Validate() error {
 			MaxLength:    24,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -731,6 +738,7 @@ func (s *Pet) Validate() error {
 							MaxLength:    255,
 							MaxLengthSet: true,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -844,6 +852,7 @@ func (s PetName) Validate() error {
 		MaxLength:    0,
 		MaxLengthSet: false,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        nil,
 	}).Validate(string(alias)); err != nil {
@@ -898,6 +907,7 @@ func (s StringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {
@@ -1161,6 +1171,7 @@ func (s ValidationStringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {

--- a/internal/integration/sample_api_ns/oas_validators_gen.go
+++ b/internal/integration/sample_api_ns/oas_validators_gen.go
@@ -64,6 +64,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -83,6 +84,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.Hostname)); err != nil {
@@ -102,6 +104,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^\\d-\\d$"],
 		}).Validate(string(s.Format)); err != nil {
@@ -171,6 +174,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -197,6 +201,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -223,6 +228,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^\\d-\\d$"],
 				}).Validate(string(value)); err != nil {
@@ -561,6 +567,7 @@ func (s *Pet) Validate() error {
 			MaxLength:    24,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -731,6 +738,7 @@ func (s *Pet) Validate() error {
 							MaxLength:    255,
 							MaxLengthSet: true,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -844,6 +852,7 @@ func (s PetName) Validate() error {
 		MaxLength:    0,
 		MaxLengthSet: false,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        nil,
 	}).Validate(string(alias)); err != nil {
@@ -898,6 +907,7 @@ func (s StringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {
@@ -1161,6 +1171,7 @@ func (s ValidationStringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {

--- a/internal/integration/sample_api_nsnc/oas_validators_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_validators_gen.go
@@ -64,6 +64,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        true,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Email)); err != nil {
@@ -83,6 +84,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     true,
 			Regex:        nil,
 		}).Validate(string(s.Hostname)); err != nil {
@@ -102,6 +104,7 @@ func (s *Data) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^\\d-\\d$"],
 		}).Validate(string(s.Format)); err != nil {
@@ -171,6 +174,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        true,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -197,6 +201,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     true,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {
@@ -223,6 +228,7 @@ func (s *DefaultTest) Validate() error {
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^\\d-\\d$"],
 				}).Validate(string(value)); err != nil {
@@ -561,6 +567,7 @@ func (s *Pet) Validate() error {
 			MaxLength:    24,
 			MaxLengthSet: true,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Name)); err != nil {
@@ -731,6 +738,7 @@ func (s *Pet) Validate() error {
 							MaxLength:    255,
 							MaxLengthSet: true,
 							Email:        false,
+							Byte:         false,
 							Hostname:     false,
 							Regex:        nil,
 						}).Validate(string(elem)); err != nil {
@@ -844,6 +852,7 @@ func (s PetName) Validate() error {
 		MaxLength:    0,
 		MaxLengthSet: false,
 		Email:        false,
+		Byte:         false,
 		Hostname:     false,
 		Regex:        nil,
 	}).Validate(string(alias)); err != nil {
@@ -898,6 +907,7 @@ func (s StringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {
@@ -1161,6 +1171,7 @@ func (s ValidationStringMap) Validate() error {
 				MaxLength:    0,
 				MaxLengthSet: false,
 				Email:        false,
+				Byte:         false,
 				Hostname:     false,
 				Regex:        nil,
 			}).Validate(string(elem)); err != nil {

--- a/internal/integration/test_allof/oas_client_gen.go
+++ b/internal/integration/test_allof/oas_client_gen.go
@@ -140,6 +140,7 @@ func (c *Client) sendNullableStrings(ctx context.Context, request NilString) (re
 					MaxLength:    0,
 					MaxLengthSet: false,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        regexMap["^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"],
 				}).Validate(string(value)); err != nil {
@@ -771,6 +772,7 @@ func (c *Client) sendStringsNotype(ctx context.Context, request NilString) (res 
 					MaxLength:    15,
 					MaxLengthSet: true,
 					Email:        false,
+					Byte:         false,
 					Hostname:     false,
 					Regex:        nil,
 				}).Validate(string(value)); err != nil {

--- a/internal/integration/test_allof/oas_request_decoders_gen.go
+++ b/internal/integration/test_allof/oas_request_decoders_gen.go
@@ -84,6 +84,7 @@ func (s *Server) decodeNullableStringsRequest(r *http.Request) (
 						MaxLength:    0,
 						MaxLengthSet: false,
 						Email:        false,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        regexMap["^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"],
 					}).Validate(string(value)); err != nil {
@@ -837,6 +838,7 @@ func (s *Server) decodeStringsNotypeRequest(r *http.Request) (
 						MaxLength:    15,
 						MaxLengthSet: true,
 						Email:        false,
+						Byte:         false,
 						Hostname:     false,
 						Regex:        nil,
 					}).Validate(string(value)); err != nil {

--- a/internal/integration/test_allof/oas_validators_gen.go
+++ b/internal/integration/test_allof/oas_validators_gen.go
@@ -106,6 +106,7 @@ func (s *ObjectsWithConflictingPropertiesReq) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        nil,
 		}).Validate(string(s.Foo)); err != nil {

--- a/internal/integration/test_anyof/oas_validators_gen.go
+++ b/internal/integration/test_anyof/oas_validators_gen.go
@@ -81,6 +81,7 @@ func (s JaegerAnyOfSizeLimit) Validate() error {
 			MaxLength:    0,
 			MaxLengthSet: false,
 			Email:        false,
+			Byte:         false,
 			Hostname:     false,
 			Regex:        regexMap["^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"],
 		}).Validate(string(s.String)); err != nil {

--- a/validate/string.go
+++ b/validate/string.go
@@ -15,6 +15,7 @@ type String struct {
 	MaxLength    int
 	MaxLengthSet bool
 	Email        bool
+	Byte         bool
 	Regex        ogenregex.Regexp
 	Hostname     bool
 }
@@ -100,12 +101,16 @@ func (t String) checkEmail(v string) error {
 
 // Validate returns error if v does not match validation rules.
 func (t String) Validate(v string) error {
+	length := len([]rune(v))
+	if t.Byte {
+		length = len([]byte(v))
+	}
 	if err := (Array{
 		MinLength:    t.MinLength,
 		MinLengthSet: t.MinLengthSet,
 		MaxLength:    t.MaxLength,
 		MaxLengthSet: t.MaxLengthSet,
-	}).ValidateLength(len([]rune(v))); err != nil {
+	}).ValidateLength(length); err != nil {
 		return err
 	}
 	if t.Email {

--- a/validate/string_test.go
+++ b/validate/string_test.go
@@ -61,6 +61,29 @@ func TestHostname(t *testing.T) {
 	}
 }
 
+func TestByte(t *testing.T) {
+	v := String{Byte: true}
+	v.SetMinLength(2)
+	v.SetMaxLength(5)
+	require.True(t, v.Set())
+
+	for _, b := range [][]byte{
+		[]byte("12"),
+		[]byte("abcde"),
+		[]byte("α"), // equals []byte{0xCE, 0xB1}
+	} {
+		require.NoError(t, v.Validate(string(b)))
+	}
+	for _, b := range [][]byte{
+		[]byte("1"),
+		[]byte("abcdef"),
+		[]byte(""),
+		[]byte("αβγ"), // equals []byte{0xCE, 0xB1, 0xCE, 0xB2, 0xCE, 0xB3}
+	} {
+		require.Error(t, v.Validate(string(b)), "%q should be invalid", b)
+	}
+}
+
 func TestRegex(t *testing.T) {
 	v := String{Regex: ogenregex.MustCompile(`^\d$`)}
 	require.True(t, v.Set())


### PR DESCRIPTION
Fixes #1261 
## Overview
I've added a new `Byte` field to the `String` structure in the `validate` package.
This field is set to true when `format: byte` is specified in the string formats of OpenAPI.
When executing character length validation, if the `Byte` field is true, the length is verified using []byte instead of []rune.

> [!NOTE]
> This change may not be necessary.
> According to the [OpenAPI specification](https://swagger.io/docs/specification/data-models/data-types/#string), `format: byte` is specified for base64-encoded characters.
> If the characters used are those in base64 encoding, the length evaluation doesn't change during the `[]byte -> string -> []rune` conversion process.
> However, as mentioned in the issue, I suppose this change is necessary if we want to ensure validation behavior for more general bytes fields.
