### PR TITLE
Fix duplicate variable name with multiple oauth2 security schemes

### DIFF
--- a/examples/ex_oauth2/oas_security_gen.go
+++ b/examples/ex_oauth2/oas_security_gen.go
@@ -33,7 +33,7 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 	return "", false
 }
 
-var oauth2Scopes = map[string][]string{
+var oauth2ScopesOAuth2 = map[string][]string{
 	"AddPet": []string{
 		"admin",
 	},
@@ -55,7 +55,7 @@ func (s *Server) securityOAuth2(ctx context.Context, operationName string, req *
 		return ctx, false, nil
 	}
 	t.Token = token
-	t.Scopes = oauth2Scopes[operationName]
+	t.Scopes = oauth2ScopesOAuth2[operationName]
 	rctx, err := s.sec.HandleOAuth2(ctx, operationName, t)
 	if errors.Is(err, ogenerrors.ErrSkipServerSecurity) {
 		return nil, false, nil

--- a/gen/_template/security.tmpl
+++ b/gen/_template/security.tmpl
@@ -34,7 +34,7 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 
 {{ range $s := $.Securities }}
 {{- if $s.Format.IsOAuth2Security }}
-var oauth2Scopes = map[string][]string {
+var oauth2Scopes{{ $s.Type.Name }} = map[string][]string {
 {{- range $operationName, $scopes := $s.Scopes }}
 	{{ quote $operationName }}: []string{
 		{{- range $scope := $scopes }}
@@ -99,7 +99,7 @@ func (s *Server) security{{ $s.Type.Name }}(ctx context.Context, operationName s
 			return ctx, false, nil
 		}
 		t.Token = token
-		t.Scopes = oauth2Scopes[operationName]
+		t.Scopes = oauth2Scopes{{ $s.Type.Name }}[operationName]
 	{{- else if $s.Format.IsCustomSecurity }}
 		t := req
 	{{- else }}


### PR DESCRIPTION
If you have an OpenAPI spec that defines more than one oauth2 security scheme, the will each generate an `oauth2Scopes` variable in oas_security_gen.go, and the duplicate variable names will not compile. 

This fixes the issue by appending the unique name of the security scheme to the variable name so there will not be a conflict.