### PR TITLE
fix(gen): set Explode:false for multipart arrays

### DIFF
--- a/gen/_template/request_decode.tmpl
+++ b/gen/_template/request_decode.tmpl
@@ -235,7 +235,8 @@ func (s *{{ if $op.WebhookInfo }}Webhook{{ end }}Server) decode{{ $op.Name }}Req
 			cfg := uri.QueryParameterDecodingConfig{
 				Name:    {{ quote $p.Spec.Name }},
 				Style:   uri.QueryStyle{{ capitalize $p.Spec.Style.String }},
-				Explode: {{ if $p.Spec.Explode }}true{{ else }}false{{ end }},
+				{{- /* NOTE: set Explode to false for multipart form arrays, see: https://github.com/ogen-go/ogen/pull/1323 */}}
+				Explode: {{ if and ($p.Spec.Explode) (ne $p.Type.Kind "array") }}true{{ else }}false{{ end }},
 				{{- if isObjectParam $p }}
 				Fields: {{ paramObjectFields $p.Type }},
 				{{- end }}

--- a/internal/integration/test_form/oas_request_decoders_gen.go
+++ b/internal/integration/test_form/oas_request_decoders_gen.go
@@ -418,7 +418,7 @@ func (s *Server) decodeTestFormURLEncodedRequest(r *http.Request) (
 			cfg := uri.QueryParameterDecodingConfig{
 				Name:    "array",
 				Style:   uri.QueryStyleForm,
-				Explode: true,
+				Explode: false,
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
@@ -636,7 +636,7 @@ func (s *Server) decodeTestMultipartRequest(r *http.Request) (
 			cfg := uri.QueryParameterDecodingConfig{
 				Name:    "array",
 				Style:   uri.QueryStyleForm,
-				Explode: true,
+				Explode: false,
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {


### PR DESCRIPTION
# problem

- currently the gen code from the schema below raises invalid length uuid error, when receiving multiple array items
  ```yml
  requestBody:
    content:
      multipart/form-data:
        schema:
        	type: object
             properties:
               ids:
                 type: array
                 items:
                   type: string
                   format: uuid
  ```

- here, there seems to be multiple possible ways to describe array in multipart/form-data as I looked shallowly on the internet (no canonical information like RFC kind), for example:
  - 1\. single key comma separated
    ```
    ------WebKitFormBoundaryBrahBrah
    Content-Disposition: form-data; name="ids"
    <uuid1>,<uuid2>
    ```
  
  - 2\. multiple keys
    ```
    ------WebKitFormBoundaryBrahBrah
    Content-Disposition: form-data; name="ids"
    <uuid1>
    
    ------WebKitFormBoundaryBrahBrah
    Content-Disposition: form-data; name="ids"
    <uuid2>
    ```
  
  - 3\. multiple bracketed keys
    ```
    ------WebKitFormBoundaryBrahBrah
    Content-Disposition: form-data; name="ids[]"
    <uuid1>
    
    ------WebKitFormBoundaryBrahBrah
    Content-Disposition: form-data; name="ids[]"
    <uuid2>
    ```
    
- the error above occurs when format 1. is specified, because ogen uses hardcoded `Explode:true` for the array decoding, and then parse comma separated values as a single uuid

# solution

set Explode to false for multipart array

# others

- seems like there's [`encoding` field](https://spec.openapis.org/oas/v3.1.0.html#encoding-object) that can be used to specify the `style` and `explode` of multipart data, which was introduced from OpenAPI3.1 , ideally we might wanna see this field someday
    - though ogen generated code uses `ParseMultipartForm()` from standard http package before its own parsing logic, and seems like this one accepts the format 1. only (for ~~format 2. and 3. only first item is picked and the rest is ignored~~ this might not be true), and might need more investigation to thoroughly support things
