### PR TITLE
feat: Support allOf additionalProperties merging if both are the equal

### DIFF
--- a/gen/schema_gen_sum.go
+++ b/gen/schema_gen_sum.go
@@ -836,9 +836,12 @@ func mergeSchemes(s1, s2 *jsonschema.Schema) (_ *jsonschema.Schema, err error) {
 		case s1.AdditionalProperties == nil && s2.AdditionalProperties != nil:
 			r.AdditionalProperties = s2.AdditionalProperties
 			r.Item = s2.Item
-		case reflect.DeepEqual(s1.AdditionalProperties, s2.AdditionalProperties) && reflect.DeepEqual(s1.Item, s2.Item):
+		case reflect.DeepEqual(s1.AdditionalProperties, s2.AdditionalProperties):
 			r.AdditionalProperties = s1.AdditionalProperties
-			r.Item = s1.Item
+			r.Item, err = mergeSchemes(s1.Item, s2.Item)
+			if err != nil {
+				return nil, errors.Wrap(err, "merge additionalProperties schema")
+			}
 		case s1.AdditionalProperties != nil && s2.AdditionalProperties != nil:
 			return nil, &ErrNotImplemented{Name: "allOf additionalProperties merging"}
 		}

--- a/gen/schema_gen_sum.go
+++ b/gen/schema_gen_sum.go
@@ -836,6 +836,9 @@ func mergeSchemes(s1, s2 *jsonschema.Schema) (_ *jsonschema.Schema, err error) {
 		case s1.AdditionalProperties == nil && s2.AdditionalProperties != nil:
 			r.AdditionalProperties = s2.AdditionalProperties
 			r.Item = s2.Item
+		case reflect.DeepEqual(s1.AdditionalProperties, s2.AdditionalProperties) && reflect.DeepEqual(s1.Item, s2.Item):
+			r.AdditionalProperties = s1.AdditionalProperties
+			r.Item = s1.Item
 		case s1.AdditionalProperties != nil && s2.AdditionalProperties != nil:
 			return nil, &ErrNotImplemented{Name: "allOf additionalProperties merging"}
 		}


### PR DESCRIPTION
We have a bunch of objects we merge using `allOf` where both have the exact same value for `additionalProperties`, however we get the following error:

```
Feature "allOf additionalProperties merging" is not implemented yet.
```

This PR adds support for merging if both items are equal.