### PR TITLE
feat: include Pattern when encountering NoRegexMatchError

### DIFF
--- a/internal/integration/all_of_test.go
+++ b/internal/integration/all_of_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -50,15 +51,27 @@ func TestAllof(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	regexPattern := "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+
 	ctx := context.Background()
 	t.Run("nullableStrings", func(t *testing.T) {
 		err := client.NullableStrings(ctx, api.NilString{})
-		_, ok := errors.Into[*validate.NoRegexMatchError](err)
+		regexMatchErr, ok := errors.Into[*validate.NoRegexMatchError](err)
 		require.True(t, ok, "validate: string: no regex match")
+		require.ErrorContains(
+			t,
+			regexMatchErr,
+			fmt.Sprintf("no regex match: %s", regexPattern),
+		)
 
 		err = client.NullableStrings(ctx, api.NewNilString("foo"))
-		_, ok = errors.Into[*validate.NoRegexMatchError](err)
+		regexMatchErr, ok = errors.Into[*validate.NoRegexMatchError](err)
 		require.True(t, ok, "validate: string: no regex match")
+		require.ErrorContains(
+			t,
+			regexMatchErr,
+			fmt.Sprintf("no regex match: %s", regexPattern),
+		)
 
 		err = client.NullableStrings(ctx, api.NewNilString("127.0.0.1"))
 		require.NoError(t, err)

--- a/jsonschema/parser.go
+++ b/jsonschema/parser.go
@@ -224,17 +224,17 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 		return p.wrapField(field, p.file(ctx), schema.Common.Locator, err)
 	}
 
-	validateMinMax := func(prop string, min, max *uint64) (rerr error) {
-		if min == nil || max == nil {
+	validateMinMax := func(prop string, minVal *uint64, maxVal *uint64) (rerr error) {
+		if minVal == nil || maxVal == nil {
 			return nil
 		}
-		if *min > *max {
-			msg := fmt.Sprintf("min%s (%d) is greater than max%s (%d)", prop, *min, prop, *max)
+		if *minVal > *maxVal {
+			msg := fmt.Sprintf("minVal%s (%d) is greater than maxVal%s (%d)", prop, *minVal, prop, *maxVal)
 			ptr := schema.Common.Locator.Pointer(p.file(ctx))
 
 			me := new(location.MultiError)
-			me.ReportPtr(ptr.Field("min"+prop), msg)
-			me.ReportPtr(ptr.Field("max"+prop), "")
+			me.ReportPtr(ptr.Field("minVal"+prop), msg)
+			me.ReportPtr(ptr.Field("maxVal"+prop), "")
 			return me
 		}
 		return nil

--- a/validate/errors.go
+++ b/validate/errors.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"github.com/ogen-go/ogen/ogenregex"
 	"strings"
 
 	"github.com/go-faster/errors"
@@ -102,9 +103,11 @@ func (e *MaxLengthError) Error() string {
 }
 
 // NoRegexMatchError reports that value have no regexp match.
-type NoRegexMatchError struct{}
+type NoRegexMatchError struct {
+	Pattern ogenregex.Regexp
+}
 
 // MaxLengthError implements error.
-func (*NoRegexMatchError) Error() string {
-	return "no regex match"
+func (e *NoRegexMatchError) Error() string {
+	return fmt.Sprintf("no regex match: %s", e.Pattern.String())
 }

--- a/validate/string.go
+++ b/validate/string.go
@@ -124,7 +124,9 @@ func (t String) Validate(v string) error {
 			return errors.Wrap(err, "execute regex")
 		}
 		if !match {
-			return &NoRegexMatchError{}
+			return &NoRegexMatchError{
+				Pattern: r,
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This change includes the `Regex` when returning a `NoRegexMatchError` so clients have an easier time understanding any errors they encounter.