### PR TITLE
fix: docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download
 
 RUN CGO_ENABLED=0 go build -o /go/bin/ogen ./cmd/ogen/main.go
 
-FROM scratch
+FROM golang:1.23.3
 
 WORKDIR /
 


### PR DESCRIPTION
Changed docker image from scratch to golang because with golang/x/tools lift from v0.26.0 to v0.27.0 there was a breaking change of retrieving golang env variables using go executable. 

Which breaks ogen in scratch image as go isn't available.

Error:

```bash
docker run --rm \
  --volume ".:/workspace" \
  ogen5 --target workspace/petstore --clean workspace/petstore.yml
INFO    convenient      Convenient errors are not available     {"reason": "operation has no \"default\" response", "at": "petstore.yml:56:9"}
WARN    Header name is not canonical, canonical name will be used       {"at": "petstore.yml:196:11", "original_name": "api_key", "canonical_name": "Api_key"}
generate:
    main.run
        /go/src/app/cmd/ogen/main.go:379
  - write:
    main.generate
        /go/src/app/cmd/ogen/main.go:100
  - template "schemas":
    github.com/ogen-go/ogen/gen.(*Generator).WriteSource.(*Generator).WriteSource.func1.func2
        /go/src/app/gen/write.go:299
  - goimports:
  - err: go command required, not found: exec: "go": executable file not found in $PATH: stderr:
```