### PR TITLE
feat(logging): exposing breadcrumbs gathered with errors.Wrap()/Wrapf()/etc when trySkip() fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _bin/*
 
 *.out
 *.dump
+cmd/ogen/ogen
+cmd/jschemagen/jschemagen

--- a/gen/errors.go
+++ b/gen/errors.go
@@ -91,14 +91,24 @@ func (g *Generator) trySkip(err error, msg string, l position) error {
 		return err
 	}
 
-	reason := err.Error()
 	if uErr, ok := errors.Into[unimplementedError](err); ok {
-		reason = uErr.Error()
+		// Debug the original error "deep", to include the various messages added with Wrap*().
+		g.log.WithOptions(zap.AddCallerSkip(1)).Debug(msg,
+			zapPosition(l),
+			zap.String("reason_error", fmt.Errorf("%w", err).Error()),
+		)
+		// Then log the brief error briefly with Info.
+		g.log.WithOptions(zap.AddCallerSkip(1)).Info(msg,
+			zapPosition(l),
+			zap.String("reason_error", uErr.Error()),
+		)
+	} else {
+		// Log the original error "deep", to include the various messages added with Wrap*().
+		g.log.WithOptions(zap.AddCallerSkip(1)).Info(msg,
+			zapPosition(l),
+			zap.String("reason_error", fmt.Errorf("%w", err).Error()),
+		)
 	}
-	g.log.WithOptions(zap.AddCallerSkip(1)).Info(msg,
-		zapPosition(l),
-		zap.String("reason_error", reason),
-	)
 	return nil
 }
 

--- a/gen/gen_server.go
+++ b/gen/gen_server.go
@@ -24,7 +24,9 @@ func (g *Generator) generateServer(s openapi.Server) (ir.Server, error) {
 			continue
 		}
 		if part.Param.Default == "" {
-			return ir.Server{}, &ErrNotImplemented{"empty server variable default"}
+			return ir.Server{}, errors.Wrap(
+				&ErrNotImplemented{"empty server variable default"},
+				part.Param.Name)
 		}
 
 		v := part.Param

--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -253,7 +253,7 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 		}
 		t, err := g.anyOf(sumName, schema, side)
 		if err != nil {
-			return nil, errors.Wrap(err, "anyOf")
+			return nil, errors.Wrap(errors.Wrap(err, "anyOf"), sumName)
 		}
 
 		if !side {
@@ -266,7 +266,7 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 	case len(schema.AllOf) > 0:
 		t, err := g.allOf(name, schema)
 		if err != nil {
-			return nil, errors.Wrap(err, "allOf")
+			return nil, errors.Wrap(errors.Wrap(err, "allOf"), name)
 		}
 		return t, nil
 	case len(schema.OneOf) > 0:
@@ -277,7 +277,7 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 		}
 		t, err := g.oneOf(sumName, schema, side)
 		if err != nil {
-			return nil, errors.Wrap(err, "oneOf")
+			return nil, errors.Wrap(errors.Wrap(err, "oneOf"), sumName)
 		}
 
 		if !side {
@@ -295,9 +295,10 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 			jsonschema.Boolean,
 			jsonschema.Null:
 		default:
-			return nil, &ErrNotImplemented{
-				Name: "non-primitive enum",
-			}
+			return nil, errors.Wrap(
+				&ErrNotImplemented{Name: "non-primitive enum"},
+				name,
+			)
 		}
 	}
 

--- a/gen/schema_gen_sum.go
+++ b/gen/schema_gen_sum.go
@@ -373,9 +373,9 @@ func (g *schemaGen) oneOf(name string, schema *jsonschema.Schema, side bool) (*i
 				// As always, OpenAPI is not clear enough.
 				key, ok := schemaName(ref)
 				if !ok {
-					return "", errors.Wrap(
+					return "", errors.Wrapf(
 						&ErrNotImplemented{"complicated reference"},
-						"unable to extract schema name",
+						"unable to extract schema name from %s", ref,
 					)
 				}
 


### PR DESCRIPTION
The code, very nicely, gathers breadcrumbs as it goes deep in the structures while generating. Unfortunately, since these were not exposed during logging, it was very hard to determine where the issues originated in a complex OAD.

Added also a couple of names to some errors, for more "bread-crumbing".