### PR TITLE
Fix generated comments to match method names

### DIFF
--- a/examples/ex_github/oas_schemas_gen.go
+++ b/examples/ex_github/oas_schemas_gen.go
@@ -33675,10 +33675,10 @@ func (o *NilAutoMerge) SetTo(v AutoMerge) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilAutoMerge) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilAutoMerge) SetToNull() {
 	o.Null = true
 	var v AutoMerge
@@ -33720,10 +33720,10 @@ func (o *NilBool) SetTo(v bool) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilBool) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilBool) SetToNull() {
 	o.Null = true
 	var v bool
@@ -33765,10 +33765,10 @@ func (o *NilCheckRunCheckSuite) SetTo(v CheckRunCheckSuite) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCheckRunCheckSuite) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCheckRunCheckSuite) SetToNull() {
 	o.Null = true
 	var v CheckRunCheckSuite
@@ -33810,10 +33810,10 @@ func (o *NilCheckRunConclusion) SetTo(v CheckRunConclusion) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCheckRunConclusion) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCheckRunConclusion) SetToNull() {
 	o.Null = true
 	var v CheckRunConclusion
@@ -33855,10 +33855,10 @@ func (o *NilCheckSuiteConclusion) SetTo(v CheckSuiteConclusion) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCheckSuiteConclusion) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCheckSuiteConclusion) SetToNull() {
 	o.Null = true
 	var v CheckSuiteConclusion
@@ -33900,10 +33900,10 @@ func (o *NilCheckSuiteStatus) SetTo(v CheckSuiteStatus) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCheckSuiteStatus) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCheckSuiteStatus) SetToNull() {
 	o.Null = true
 	var v CheckSuiteStatus
@@ -33945,10 +33945,10 @@ func (o *NilCodeScanningAlertClassification) SetTo(v CodeScanningAlertClassifica
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCodeScanningAlertClassification) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCodeScanningAlertClassification) SetToNull() {
 	o.Null = true
 	var v CodeScanningAlertClassification
@@ -33990,10 +33990,10 @@ func (o *NilCodeScanningAlertDismissedAt) SetTo(v CodeScanningAlertDismissedAt) 
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCodeScanningAlertDismissedAt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCodeScanningAlertDismissedAt) SetToNull() {
 	o.Null = true
 	var v CodeScanningAlertDismissedAt
@@ -34035,10 +34035,10 @@ func (o *NilCodeScanningAlertDismissedReason) SetTo(v CodeScanningAlertDismissed
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilCodeScanningAlertDismissedReason) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilCodeScanningAlertDismissedReason) SetToNull() {
 	o.Null = true
 	var v CodeScanningAlertDismissedReason
@@ -34080,10 +34080,10 @@ func (o *NilDateTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilDateTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilDateTime) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -34125,10 +34125,10 @@ func (o *NilFileCommitContent) SetTo(v FileCommitContent) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilFileCommitContent) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilFileCommitContent) SetToNull() {
 	o.Null = true
 	var v FileCommitContent
@@ -34170,10 +34170,10 @@ func (o *NilGistSimpleFilesItem) SetTo(v GistSimpleFilesItem) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilGistSimpleFilesItem) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilGistSimpleFilesItem) SetToNull() {
 	o.Null = true
 	var v GistSimpleFilesItem
@@ -34215,10 +34215,10 @@ func (o *NilHookDeliveryRequestHeaders) SetTo(v HookDeliveryRequestHeaders) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilHookDeliveryRequestHeaders) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilHookDeliveryRequestHeaders) SetToNull() {
 	o.Null = true
 	var v HookDeliveryRequestHeaders
@@ -34260,10 +34260,10 @@ func (o *NilHookDeliveryRequestPayload) SetTo(v HookDeliveryRequestPayload) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilHookDeliveryRequestPayload) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilHookDeliveryRequestPayload) SetToNull() {
 	o.Null = true
 	var v HookDeliveryRequestPayload
@@ -34305,10 +34305,10 @@ func (o *NilHookDeliveryResponseHeaders) SetTo(v HookDeliveryResponseHeaders) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilHookDeliveryResponseHeaders) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilHookDeliveryResponseHeaders) SetToNull() {
 	o.Null = true
 	var v HookDeliveryResponseHeaders
@@ -34350,10 +34350,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -34395,10 +34395,10 @@ func (o *NilNullableCodeOfConductSimple) SetTo(v NullableCodeOfConductSimple) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableCodeOfConductSimple) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableCodeOfConductSimple) SetToNull() {
 	o.Null = true
 	var v NullableCodeOfConductSimple
@@ -34440,10 +34440,10 @@ func (o *NilNullableCommunityHealthFile) SetTo(v NullableCommunityHealthFile) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableCommunityHealthFile) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableCommunityHealthFile) SetToNull() {
 	o.Null = true
 	var v NullableCommunityHealthFile
@@ -34485,10 +34485,10 @@ func (o *NilNullableGitUser) SetTo(v NullableGitUser) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableGitUser) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableGitUser) SetToNull() {
 	o.Null = true
 	var v NullableGitUser
@@ -34530,10 +34530,10 @@ func (o *NilNullableIntegration) SetTo(v NullableIntegration) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableIntegration) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableIntegration) SetToNull() {
 	o.Null = true
 	var v NullableIntegration
@@ -34575,10 +34575,10 @@ func (o *NilNullableLicenseSimple) SetTo(v NullableLicenseSimple) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableLicenseSimple) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableLicenseSimple) SetToNull() {
 	o.Null = true
 	var v NullableLicenseSimple
@@ -34620,10 +34620,10 @@ func (o *NilNullableMilestone) SetTo(v NullableMilestone) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableMilestone) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableMilestone) SetToNull() {
 	o.Null = true
 	var v NullableMilestone
@@ -34665,10 +34665,10 @@ func (o *NilNullableSimpleCommit) SetTo(v NullableSimpleCommit) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableSimpleCommit) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableSimpleCommit) SetToNull() {
 	o.Null = true
 	var v NullableSimpleCommit
@@ -34710,10 +34710,10 @@ func (o *NilNullableSimpleCommitAuthor) SetTo(v NullableSimpleCommitAuthor) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableSimpleCommitAuthor) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableSimpleCommitAuthor) SetToNull() {
 	o.Null = true
 	var v NullableSimpleCommitAuthor
@@ -34755,10 +34755,10 @@ func (o *NilNullableSimpleCommitCommitter) SetTo(v NullableSimpleCommitCommitter
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableSimpleCommitCommitter) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableSimpleCommitCommitter) SetToNull() {
 	o.Null = true
 	var v NullableSimpleCommitCommitter
@@ -34800,10 +34800,10 @@ func (o *NilNullableSimpleUser) SetTo(v NullableSimpleUser) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableSimpleUser) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableSimpleUser) SetToNull() {
 	o.Null = true
 	var v NullableSimpleUser
@@ -34845,10 +34845,10 @@ func (o *NilNullableTeamSimple) SetTo(v NullableTeamSimple) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableTeamSimple) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableTeamSimple) SetToNull() {
 	o.Null = true
 	var v NullableTeamSimple
@@ -34890,10 +34890,10 @@ func (o *NilPageStatus) SetTo(v PageStatus) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilPageStatus) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilPageStatus) SetToNull() {
 	o.Null = true
 	var v PageStatus
@@ -34935,10 +34935,10 @@ func (o *NilPullRequestHeadRepo) SetTo(v PullRequestHeadRepo) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilPullRequestHeadRepo) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilPullRequestHeadRepo) SetToNull() {
 	o.Null = true
 	var v PullRequestHeadRepo
@@ -34980,10 +34980,10 @@ func (o *NilPullRequestHeadRepoLicense) SetTo(v PullRequestHeadRepoLicense) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilPullRequestHeadRepoLicense) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilPullRequestHeadRepoLicense) SetToNull() {
 	o.Null = true
 	var v PullRequestHeadRepoLicense
@@ -35025,10 +35025,10 @@ func (o *NilReposCreatePagesSiteReq) SetTo(v ReposCreatePagesSiteReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilReposCreatePagesSiteReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilReposCreatePagesSiteReq) SetToNull() {
 	o.Null = true
 	var v ReposCreatePagesSiteReq
@@ -35070,10 +35070,10 @@ func (o *NilReposUpdateBranchProtectionReqRequiredPullRequestReviews) SetTo(v Re
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilReposUpdateBranchProtectionReqRequiredPullRequestReviews) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilReposUpdateBranchProtectionReqRequiredPullRequestReviews) SetToNull() {
 	o.Null = true
 	var v ReposUpdateBranchProtectionReqRequiredPullRequestReviews
@@ -35115,10 +35115,10 @@ func (o *NilReposUpdateBranchProtectionReqRequiredStatusChecks) SetTo(v ReposUpd
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilReposUpdateBranchProtectionReqRequiredStatusChecks) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilReposUpdateBranchProtectionReqRequiredStatusChecks) SetToNull() {
 	o.Null = true
 	var v ReposUpdateBranchProtectionReqRequiredStatusChecks
@@ -35160,10 +35160,10 @@ func (o *NilReposUpdateBranchProtectionReqRestrictions) SetTo(v ReposUpdateBranc
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilReposUpdateBranchProtectionReqRestrictions) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilReposUpdateBranchProtectionReqRestrictions) SetToNull() {
 	o.Null = true
 	var v ReposUpdateBranchProtectionReqRestrictions
@@ -35205,10 +35205,10 @@ func (o *NilSimpleCommitAuthor) SetTo(v SimpleCommitAuthor) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilSimpleCommitAuthor) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilSimpleCommitAuthor) SetToNull() {
 	o.Null = true
 	var v SimpleCommitAuthor
@@ -35250,10 +35250,10 @@ func (o *NilSimpleCommitCommitter) SetTo(v SimpleCommitCommitter) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilSimpleCommitCommitter) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilSimpleCommitCommitter) SetToNull() {
 	o.Null = true
 	var v SimpleCommitCommitter
@@ -35295,10 +35295,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -35340,10 +35340,10 @@ func (o *NilURI) SetTo(v url.URL) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilURI) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilURI) SetToNull() {
 	o.Null = true
 	var v url.URL
@@ -47788,10 +47788,10 @@ func (o *OptNilBool) SetTo(v bool) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilBool) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilBool) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -47851,10 +47851,10 @@ func (o *OptNilCodeScanningAlertDismissedReason) SetTo(v CodeScanningAlertDismis
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAlertDismissedReason) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAlertDismissedReason) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -47914,10 +47914,10 @@ func (o *OptNilCodeScanningAlertRuleSecuritySeverityLevel) SetTo(v CodeScanningA
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAlertRuleSecuritySeverityLevel) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAlertRuleSecuritySeverityLevel) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -47977,10 +47977,10 @@ func (o *OptNilCodeScanningAlertRuleSeverity) SetTo(v CodeScanningAlertRuleSever
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAlertRuleSeverity) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAlertRuleSeverity) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48040,10 +48040,10 @@ func (o *OptNilCodeScanningAlertRuleSummarySeverity) SetTo(v CodeScanningAlertRu
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAlertRuleSummarySeverity) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAlertRuleSummarySeverity) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48103,10 +48103,10 @@ func (o *OptNilCodeScanningAnalysisToolGUID) SetTo(v CodeScanningAnalysisToolGUI
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAnalysisToolGUID) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAnalysisToolGUID) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48166,10 +48166,10 @@ func (o *OptNilCodeScanningAnalysisToolVersion) SetTo(v CodeScanningAnalysisTool
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCodeScanningAnalysisToolVersion) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCodeScanningAnalysisToolVersion) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48229,10 +48229,10 @@ func (o *OptNilDateTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilDateTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilDateTime) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48292,10 +48292,10 @@ func (o *OptNilFullRepositorySecurityAndAnalysis) SetTo(v FullRepositorySecurity
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilFullRepositorySecurityAndAnalysis) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilFullRepositorySecurityAndAnalysis) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48355,10 +48355,10 @@ func (o *OptNilGistHistoryArray) SetTo(v []GistHistory) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilGistHistoryArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilGistHistoryArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48418,10 +48418,10 @@ func (o *OptNilGistSimpleForkOf) SetTo(v GistSimpleForkOf) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilGistSimpleForkOf) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilGistSimpleForkOf) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48481,10 +48481,10 @@ func (o *OptNilGistSimpleForksItemArray) SetTo(v []GistSimpleForksItem) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilGistSimpleForksItemArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilGistSimpleForksItemArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48544,10 +48544,10 @@ func (o *OptNilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48607,10 +48607,10 @@ func (o *OptNilIssuesCreateReqMilestone) SetTo(v IssuesCreateReqMilestone) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIssuesCreateReqMilestone) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIssuesCreateReqMilestone) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48670,10 +48670,10 @@ func (o *OptNilIssuesLockReq) SetTo(v IssuesLockReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIssuesLockReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIssuesLockReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48733,10 +48733,10 @@ func (o *OptNilIssuesUpdateReqMilestone) SetTo(v IssuesUpdateReqMilestone) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIssuesUpdateReqMilestone) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIssuesUpdateReqMilestone) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48796,10 +48796,10 @@ func (o *OptNilIssuesUpdateReqTitle) SetTo(v IssuesUpdateReqTitle) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIssuesUpdateReqTitle) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIssuesUpdateReqTitle) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48859,10 +48859,10 @@ func (o *OptNilMarketplacePurchaseMarketplacePendingChange) SetTo(v MarketplaceP
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilMarketplacePurchaseMarketplacePendingChange) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilMarketplacePurchaseMarketplacePendingChange) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48922,10 +48922,10 @@ func (o *OptNilMigrationsUpdateImportReq) SetTo(v MigrationsUpdateImportReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilMigrationsUpdateImportReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilMigrationsUpdateImportReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -48985,10 +48985,10 @@ func (o *OptNilMinimalRepositoryLicense) SetTo(v MinimalRepositoryLicense) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilMinimalRepositoryLicense) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilMinimalRepositoryLicense) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49048,10 +49048,10 @@ func (o *OptNilNullableIntegration) SetTo(v NullableIntegration) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableIntegration) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableIntegration) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49111,10 +49111,10 @@ func (o *OptNilNullableMinimalRepository) SetTo(v NullableMinimalRepository) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableMinimalRepository) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableMinimalRepository) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49174,10 +49174,10 @@ func (o *OptNilNullableMinimalRepositoryLicense) SetTo(v NullableMinimalReposito
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableMinimalRepositoryLicense) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableMinimalRepositoryLicense) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49237,10 +49237,10 @@ func (o *OptNilNullableRepository) SetTo(v NullableRepository) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableRepository) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableRepository) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49300,10 +49300,10 @@ func (o *OptNilNullableRepositoryTemplateRepository) SetTo(v NullableRepositoryT
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableRepositoryTemplateRepository) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableRepositoryTemplateRepository) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49363,10 +49363,10 @@ func (o *OptNilNullableScopedInstallation) SetTo(v NullableScopedInstallation) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableScopedInstallation) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableScopedInstallation) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49426,10 +49426,10 @@ func (o *OptNilNullableSimpleUser) SetTo(v NullableSimpleUser) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableSimpleUser) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableSimpleUser) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49489,10 +49489,10 @@ func (o *OptNilNullableTeamSimple) SetTo(v NullableTeamSimple) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilNullableTeamSimple) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilNullableTeamSimple) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49552,10 +49552,10 @@ func (o *OptNilPageProtectedDomainState) SetTo(v PageProtectedDomainState) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilPageProtectedDomainState) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilPageProtectedDomainState) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49615,10 +49615,10 @@ func (o *OptNilPagesHealthCheckAltDomain) SetTo(v PagesHealthCheckAltDomain) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilPagesHealthCheckAltDomain) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilPagesHealthCheckAltDomain) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49678,10 +49678,10 @@ func (o *OptNilProjectsAddCollaboratorReq) SetTo(v ProjectsAddCollaboratorReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilProjectsAddCollaboratorReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilProjectsAddCollaboratorReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49741,10 +49741,10 @@ func (o *OptNilPullRequestReviewCommentStartSide) SetTo(v PullRequestReviewComme
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilPullRequestReviewCommentStartSide) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilPullRequestReviewCommentStartSide) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49804,10 +49804,10 @@ func (o *OptNilPullsMergeReq) SetTo(v PullsMergeReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilPullsMergeReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilPullsMergeReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49867,10 +49867,10 @@ func (o *OptNilPullsUpdateBranchReq) SetTo(v PullsUpdateBranchReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilPullsUpdateBranchReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilPullsUpdateBranchReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49930,10 +49930,10 @@ func (o *OptNilReposCreateForkReq) SetTo(v ReposCreateForkReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilReposCreateForkReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilReposCreateForkReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -49993,10 +49993,10 @@ func (o *OptNilReposCreateWebhookReq) SetTo(v ReposCreateWebhookReq) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilReposCreateWebhookReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilReposCreateWebhookReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50056,10 +50056,10 @@ func (o *OptNilReposUpdateReqSecurityAndAnalysis) SetTo(v ReposUpdateReqSecurity
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilReposUpdateReqSecurityAndAnalysis) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilReposUpdateReqSecurityAndAnalysis) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50119,10 +50119,10 @@ func (o *OptNilRepositoryTemplateRepository) SetTo(v RepositoryTemplateRepositor
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilRepositoryTemplateRepository) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilRepositoryTemplateRepository) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50182,10 +50182,10 @@ func (o *OptNilReviewCommentStartSide) SetTo(v ReviewCommentStartSide) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilReviewCommentStartSide) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilReviewCommentStartSide) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50245,10 +50245,10 @@ func (o *OptNilSecretScanningAlertResolution) SetTo(v SecretScanningAlertResolut
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilSecretScanningAlertResolution) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilSecretScanningAlertResolution) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50308,10 +50308,10 @@ func (o *OptNilSimpleUserArray) SetTo(v []SimpleUser) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilSimpleUserArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilSimpleUserArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50371,10 +50371,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50434,10 +50434,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50497,10 +50497,10 @@ func (o *OptNilTeamArray) SetTo(v []Team) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTeamArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTeamArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50560,10 +50560,10 @@ func (o *OptNilTeamSimpleArray) SetTo(v []TeamSimple) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTeamSimpleArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTeamSimpleArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50623,10 +50623,10 @@ func (o *OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq) SetTo(v TeamsAddOrUpd
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50686,10 +50686,10 @@ func (o *OptNilTopicSearchResultItemAliasesItemArray) SetTo(v []TopicSearchResul
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTopicSearchResultItemAliasesItemArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTopicSearchResultItemAliasesItemArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50749,10 +50749,10 @@ func (o *OptNilTopicSearchResultItemRelatedItemArray) SetTo(v []TopicSearchResul
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTopicSearchResultItemRelatedItemArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTopicSearchResultItemRelatedItemArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -50812,10 +50812,10 @@ func (o *OptNilURI) SetTo(v url.URL) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilURI) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilURI) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/examples/ex_openai/oas_schemas_gen.go
+++ b/examples/ex_openai/oas_schemas_gen.go
@@ -4579,10 +4579,10 @@ func (o *OptNilAnyArray) SetTo(v []jx.Raw) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilAnyArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilAnyArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4642,10 +4642,10 @@ func (o *OptNilBool) SetTo(v bool) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilBool) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilBool) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4705,10 +4705,10 @@ func (o *OptNilCreateAnswerRequestStop) SetTo(v CreateAnswerRequestStop) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateAnswerRequestStop) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateAnswerRequestStop) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4768,10 +4768,10 @@ func (o *OptNilCreateChatCompletionRequestStop) SetTo(v CreateChatCompletionRequ
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateChatCompletionRequestStop) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateChatCompletionRequestStop) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4831,10 +4831,10 @@ func (o *OptNilCreateCompletionRequestPrompt) SetTo(v CreateCompletionRequestPro
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateCompletionRequestPrompt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateCompletionRequestPrompt) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4894,10 +4894,10 @@ func (o *OptNilCreateCompletionRequestStop) SetTo(v CreateCompletionRequestStop)
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateCompletionRequestStop) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateCompletionRequestStop) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4957,10 +4957,10 @@ func (o *OptNilCreateCompletionResponseChoicesItemLogprobs) SetTo(v CreateComple
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateCompletionResponseChoicesItemLogprobs) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateCompletionResponseChoicesItemLogprobs) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5020,10 +5020,10 @@ func (o *OptNilCreateEditResponseChoicesItemLogprobs) SetTo(v CreateEditResponse
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateEditResponseChoicesItemLogprobs) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateEditResponseChoicesItemLogprobs) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5083,10 +5083,10 @@ func (o *OptNilCreateImageEditRequestMultipartResponseFormat) SetTo(v CreateImag
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageEditRequestMultipartResponseFormat) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageEditRequestMultipartResponseFormat) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5146,10 +5146,10 @@ func (o *OptNilCreateImageEditRequestMultipartSize) SetTo(v CreateImageEditReque
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageEditRequestMultipartSize) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageEditRequestMultipartSize) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5209,10 +5209,10 @@ func (o *OptNilCreateImageRequestResponseFormat) SetTo(v CreateImageRequestRespo
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageRequestResponseFormat) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageRequestResponseFormat) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5272,10 +5272,10 @@ func (o *OptNilCreateImageRequestSize) SetTo(v CreateImageRequestSize) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageRequestSize) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageRequestSize) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5335,10 +5335,10 @@ func (o *OptNilCreateImageVariationRequestMultipartResponseFormat) SetTo(v Creat
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageVariationRequestMultipartResponseFormat) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageVariationRequestMultipartResponseFormat) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5398,10 +5398,10 @@ func (o *OptNilCreateImageVariationRequestMultipartSize) SetTo(v CreateImageVari
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilCreateImageVariationRequestMultipartSize) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilCreateImageVariationRequestMultipartSize) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5461,10 +5461,10 @@ func (o *OptNilFloat64) SetTo(v float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilFloat64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilFloat64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5524,10 +5524,10 @@ func (o *OptNilFloat64Array) SetTo(v []float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilFloat64Array) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilFloat64Array) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5587,10 +5587,10 @@ func (o *OptNilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5650,10 +5650,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5713,10 +5713,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5776,10 +5776,10 @@ func (o *OptNilStringArrayArray) SetTo(v [][]string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArrayArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArrayArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/examples/ex_test_format/oas_schemas_gen.go
+++ b/examples/ex_test_format/oas_schemas_gen.go
@@ -57,10 +57,10 @@ func (o *NilBool) SetTo(v bool) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilBool) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilBool) SetToNull() {
 	o.Null = true
 	var v bool
@@ -102,10 +102,10 @@ func (o *NilDate) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilDate) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilDate) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -147,10 +147,10 @@ func (o *NilDateTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilDateTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilDateTime) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -192,10 +192,10 @@ func (o *NilDuration) SetTo(v time.Duration) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilDuration) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilDuration) SetToNull() {
 	o.Null = true
 	var v time.Duration
@@ -237,10 +237,10 @@ func (o *NilFloat32) SetTo(v float32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilFloat32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilFloat32) SetToNull() {
 	o.Null = true
 	var v float32
@@ -282,10 +282,10 @@ func (o *NilFloat64) SetTo(v float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilFloat64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilFloat64) SetToNull() {
 	o.Null = true
 	var v float64
@@ -327,10 +327,10 @@ func (o *NilHardwareAddr) SetTo(v net.HardwareAddr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilHardwareAddr) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilHardwareAddr) SetToNull() {
 	o.Null = true
 	var v net.HardwareAddr
@@ -372,10 +372,10 @@ func (o *NilIP) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilIP) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilIP) SetToNull() {
 	o.Null = true
 	var v netip.Addr
@@ -417,10 +417,10 @@ func (o *NilIPv4) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilIPv4) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilIPv4) SetToNull() {
 	o.Null = true
 	var v netip.Addr
@@ -462,10 +462,10 @@ func (o *NilIPv6) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilIPv6) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilIPv6) SetToNull() {
 	o.Null = true
 	var v netip.Addr
@@ -507,10 +507,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -552,10 +552,10 @@ func (o *NilInt16) SetTo(v int16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt16) SetToNull() {
 	o.Null = true
 	var v int16
@@ -597,10 +597,10 @@ func (o *NilInt32) SetTo(v int32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt32) SetToNull() {
 	o.Null = true
 	var v int32
@@ -642,10 +642,10 @@ func (o *NilInt64) SetTo(v int64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt64) SetToNull() {
 	o.Null = true
 	var v int64
@@ -687,10 +687,10 @@ func (o *NilInt8) SetTo(v int8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt8) SetToNull() {
 	o.Null = true
 	var v int8
@@ -732,10 +732,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -777,10 +777,10 @@ func (o *NilStringFloat32) SetTo(v float32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringFloat32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringFloat32) SetToNull() {
 	o.Null = true
 	var v float32
@@ -822,10 +822,10 @@ func (o *NilStringFloat64) SetTo(v float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringFloat64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringFloat64) SetToNull() {
 	o.Null = true
 	var v float64
@@ -867,10 +867,10 @@ func (o *NilStringInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -912,10 +912,10 @@ func (o *NilStringInt16) SetTo(v int16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringInt16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringInt16) SetToNull() {
 	o.Null = true
 	var v int16
@@ -957,10 +957,10 @@ func (o *NilStringInt32) SetTo(v int32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringInt32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringInt32) SetToNull() {
 	o.Null = true
 	var v int32
@@ -1002,10 +1002,10 @@ func (o *NilStringInt64) SetTo(v int64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringInt64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringInt64) SetToNull() {
 	o.Null = true
 	var v int64
@@ -1047,10 +1047,10 @@ func (o *NilStringInt8) SetTo(v int8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringInt8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringInt8) SetToNull() {
 	o.Null = true
 	var v int8
@@ -1092,10 +1092,10 @@ func (o *NilStringUint) SetTo(v uint) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUint) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUint) SetToNull() {
 	o.Null = true
 	var v uint
@@ -1137,10 +1137,10 @@ func (o *NilStringUint16) SetTo(v uint16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUint16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUint16) SetToNull() {
 	o.Null = true
 	var v uint16
@@ -1182,10 +1182,10 @@ func (o *NilStringUint32) SetTo(v uint32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUint32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUint32) SetToNull() {
 	o.Null = true
 	var v uint32
@@ -1227,10 +1227,10 @@ func (o *NilStringUint64) SetTo(v uint64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUint64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUint64) SetToNull() {
 	o.Null = true
 	var v uint64
@@ -1272,10 +1272,10 @@ func (o *NilStringUint8) SetTo(v uint8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUint8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUint8) SetToNull() {
 	o.Null = true
 	var v uint8
@@ -1317,10 +1317,10 @@ func (o *NilStringUnixMicro) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUnixMicro) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUnixMicro) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1362,10 +1362,10 @@ func (o *NilStringUnixMilli) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUnixMilli) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUnixMilli) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1407,10 +1407,10 @@ func (o *NilStringUnixNano) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUnixNano) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUnixNano) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1452,10 +1452,10 @@ func (o *NilStringUnixSeconds) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilStringUnixSeconds) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilStringUnixSeconds) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1497,10 +1497,10 @@ func (o *NilTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilTime) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1542,10 +1542,10 @@ func (o *NilURI) SetTo(v url.URL) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilURI) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilURI) SetToNull() {
 	o.Null = true
 	var v url.URL
@@ -1587,10 +1587,10 @@ func (o *NilUUID) SetTo(v uuid.UUID) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUUID) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUUID) SetToNull() {
 	o.Null = true
 	var v uuid.UUID
@@ -1632,10 +1632,10 @@ func (o *NilUint) SetTo(v uint) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUint) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUint) SetToNull() {
 	o.Null = true
 	var v uint
@@ -1677,10 +1677,10 @@ func (o *NilUint16) SetTo(v uint16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUint16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUint16) SetToNull() {
 	o.Null = true
 	var v uint16
@@ -1722,10 +1722,10 @@ func (o *NilUint32) SetTo(v uint32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUint32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUint32) SetToNull() {
 	o.Null = true
 	var v uint32
@@ -1767,10 +1767,10 @@ func (o *NilUint64) SetTo(v uint64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUint64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUint64) SetToNull() {
 	o.Null = true
 	var v uint64
@@ -1812,10 +1812,10 @@ func (o *NilUint8) SetTo(v uint8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUint8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUint8) SetToNull() {
 	o.Null = true
 	var v uint8
@@ -1857,10 +1857,10 @@ func (o *NilUnixMicro) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUnixMicro) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUnixMicro) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1902,10 +1902,10 @@ func (o *NilUnixMilli) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUnixMilli) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUnixMilli) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1947,10 +1947,10 @@ func (o *NilUnixNano) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUnixNano) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUnixNano) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -1992,10 +1992,10 @@ func (o *NilUnixSeconds) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilUnixSeconds) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilUnixSeconds) SetToNull() {
 	o.Null = true
 	var v time.Time
@@ -2741,10 +2741,10 @@ func (o *OptNilBool) SetTo(v bool) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilBool) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilBool) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -2804,10 +2804,10 @@ func (o *OptNilByte) SetTo(v []byte) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilByte) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilByte) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -2867,10 +2867,10 @@ func (o *OptNilDate) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilDate) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilDate) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -2930,10 +2930,10 @@ func (o *OptNilDateTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilDateTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilDateTime) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -2993,10 +2993,10 @@ func (o *OptNilDuration) SetTo(v time.Duration) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilDuration) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilDuration) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3056,10 +3056,10 @@ func (o *OptNilFloat32) SetTo(v float32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilFloat32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilFloat32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3119,10 +3119,10 @@ func (o *OptNilFloat64) SetTo(v float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilFloat64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilFloat64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3182,10 +3182,10 @@ func (o *OptNilHardwareAddr) SetTo(v net.HardwareAddr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilHardwareAddr) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilHardwareAddr) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3245,10 +3245,10 @@ func (o *OptNilIP) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIP) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIP) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3308,10 +3308,10 @@ func (o *OptNilIPv4) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIPv4) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIPv4) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3371,10 +3371,10 @@ func (o *OptNilIPv6) SetTo(v netip.Addr) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilIPv6) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilIPv6) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3434,10 +3434,10 @@ func (o *OptNilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3497,10 +3497,10 @@ func (o *OptNilInt16) SetTo(v int16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt16) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3560,10 +3560,10 @@ func (o *OptNilInt32) SetTo(v int32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3623,10 +3623,10 @@ func (o *OptNilInt64) SetTo(v int64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3686,10 +3686,10 @@ func (o *OptNilInt8) SetTo(v int8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilInt8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilInt8) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3749,10 +3749,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3812,10 +3812,10 @@ func (o *OptNilStringFloat32) SetTo(v float32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringFloat32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringFloat32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3875,10 +3875,10 @@ func (o *OptNilStringFloat64) SetTo(v float64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringFloat64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringFloat64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -3938,10 +3938,10 @@ func (o *OptNilStringInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringInt) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4001,10 +4001,10 @@ func (o *OptNilStringInt16) SetTo(v int16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringInt16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringInt16) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4064,10 +4064,10 @@ func (o *OptNilStringInt32) SetTo(v int32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringInt32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringInt32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4127,10 +4127,10 @@ func (o *OptNilStringInt64) SetTo(v int64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringInt64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringInt64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4190,10 +4190,10 @@ func (o *OptNilStringInt8) SetTo(v int8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringInt8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringInt8) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4253,10 +4253,10 @@ func (o *OptNilStringUint) SetTo(v uint) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUint) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUint) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4316,10 +4316,10 @@ func (o *OptNilStringUint16) SetTo(v uint16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUint16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUint16) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4379,10 +4379,10 @@ func (o *OptNilStringUint32) SetTo(v uint32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUint32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUint32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4442,10 +4442,10 @@ func (o *OptNilStringUint64) SetTo(v uint64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUint64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUint64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4505,10 +4505,10 @@ func (o *OptNilStringUint8) SetTo(v uint8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUint8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUint8) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4568,10 +4568,10 @@ func (o *OptNilStringUnixMicro) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUnixMicro) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUnixMicro) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4631,10 +4631,10 @@ func (o *OptNilStringUnixMilli) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUnixMilli) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUnixMilli) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4694,10 +4694,10 @@ func (o *OptNilStringUnixNano) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUnixNano) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUnixNano) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4757,10 +4757,10 @@ func (o *OptNilStringUnixSeconds) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringUnixSeconds) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringUnixSeconds) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4820,10 +4820,10 @@ func (o *OptNilTime) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilTime) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilTime) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4883,10 +4883,10 @@ func (o *OptNilURI) SetTo(v url.URL) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilURI) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilURI) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4946,10 +4946,10 @@ func (o *OptNilUUID) SetTo(v uuid.UUID) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUUID) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUUID) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5009,10 +5009,10 @@ func (o *OptNilUint) SetTo(v uint) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUint) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUint) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5072,10 +5072,10 @@ func (o *OptNilUint16) SetTo(v uint16) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUint16) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUint16) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5135,10 +5135,10 @@ func (o *OptNilUint32) SetTo(v uint32) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUint32) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUint32) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5198,10 +5198,10 @@ func (o *OptNilUint64) SetTo(v uint64) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUint64) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUint64) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5261,10 +5261,10 @@ func (o *OptNilUint8) SetTo(v uint8) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUint8) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUint8) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5324,10 +5324,10 @@ func (o *OptNilUnixMicro) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUnixMicro) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUnixMicro) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5387,10 +5387,10 @@ func (o *OptNilUnixMilli) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUnixMilli) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUnixMilli) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5450,10 +5450,10 @@ func (o *OptNilUnixNano) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUnixNano) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUnixNano) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -5513,10 +5513,10 @@ func (o *OptNilUnixSeconds) SetTo(v time.Time) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilUnixSeconds) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilUnixSeconds) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/gen/_template/schema/generic.tmpl
+++ b/gen/_template/schema/generic.tmpl
@@ -52,10 +52,10 @@ func (o *{{ $.Name }}) SetTo(v {{ $g.Go }}) {
 }
 
 {{- if $v.Nullable  }}
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o {{ $.ReadOnlyReceiver }}) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *{{ $.Name }}) SetToNull() {
 	{{- if $v.Optional }}
 	o.Set = true

--- a/internal/integration/sample_api/oas_schemas_gen.go
+++ b/internal/integration/sample_api/oas_schemas_gen.go
@@ -1747,10 +1747,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -1818,10 +1818,10 @@ func (o *NilNullableEnumsBoth) SetTo(v NullableEnumsBoth) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsBoth) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsBoth) SetToNull() {
 	o.Null = true
 	var v NullableEnumsBoth
@@ -1863,10 +1863,10 @@ func (o *NilNullableEnumsOnlyNullValue) SetTo(v NullableEnumsOnlyNullValue) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullValue) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullValue) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullValue
@@ -1908,10 +1908,10 @@ func (o *NilNullableEnumsOnlyNullable) SetTo(v NullableEnumsOnlyNullable) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullable) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullable) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullable
@@ -1953,10 +1953,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -4104,10 +4104,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4167,10 +4167,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/internal/integration/sample_api_nc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nc/oas_schemas_gen.go
@@ -1747,10 +1747,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -1818,10 +1818,10 @@ func (o *NilNullableEnumsBoth) SetTo(v NullableEnumsBoth) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsBoth) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsBoth) SetToNull() {
 	o.Null = true
 	var v NullableEnumsBoth
@@ -1863,10 +1863,10 @@ func (o *NilNullableEnumsOnlyNullValue) SetTo(v NullableEnumsOnlyNullValue) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullValue) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullValue) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullValue
@@ -1908,10 +1908,10 @@ func (o *NilNullableEnumsOnlyNullable) SetTo(v NullableEnumsOnlyNullable) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullable) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullable) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullable
@@ -1953,10 +1953,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -4104,10 +4104,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4167,10 +4167,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/internal/integration/sample_api_no_otel/oas_schemas_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_schemas_gen.go
@@ -1747,10 +1747,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -1818,10 +1818,10 @@ func (o *NilNullableEnumsBoth) SetTo(v NullableEnumsBoth) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsBoth) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsBoth) SetToNull() {
 	o.Null = true
 	var v NullableEnumsBoth
@@ -1863,10 +1863,10 @@ func (o *NilNullableEnumsOnlyNullValue) SetTo(v NullableEnumsOnlyNullValue) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullValue) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullValue) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullValue
@@ -1908,10 +1908,10 @@ func (o *NilNullableEnumsOnlyNullable) SetTo(v NullableEnumsOnlyNullable) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullable) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullable) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullable
@@ -1953,10 +1953,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -4104,10 +4104,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4167,10 +4167,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/internal/integration/sample_api_ns/oas_schemas_gen.go
+++ b/internal/integration/sample_api_ns/oas_schemas_gen.go
@@ -1747,10 +1747,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -1818,10 +1818,10 @@ func (o *NilNullableEnumsBoth) SetTo(v NullableEnumsBoth) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsBoth) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsBoth) SetToNull() {
 	o.Null = true
 	var v NullableEnumsBoth
@@ -1863,10 +1863,10 @@ func (o *NilNullableEnumsOnlyNullValue) SetTo(v NullableEnumsOnlyNullValue) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullValue) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullValue) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullValue
@@ -1908,10 +1908,10 @@ func (o *NilNullableEnumsOnlyNullable) SetTo(v NullableEnumsOnlyNullable) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullable) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullable) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullable
@@ -1953,10 +1953,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -4104,10 +4104,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4167,10 +4167,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/internal/integration/sample_api_nsnc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_schemas_gen.go
@@ -1747,10 +1747,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -1818,10 +1818,10 @@ func (o *NilNullableEnumsBoth) SetTo(v NullableEnumsBoth) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsBoth) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsBoth) SetToNull() {
 	o.Null = true
 	var v NullableEnumsBoth
@@ -1863,10 +1863,10 @@ func (o *NilNullableEnumsOnlyNullValue) SetTo(v NullableEnumsOnlyNullValue) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullValue) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullValue) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullValue
@@ -1908,10 +1908,10 @@ func (o *NilNullableEnumsOnlyNullable) SetTo(v NullableEnumsOnlyNullable) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilNullableEnumsOnlyNullable) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilNullableEnumsOnlyNullable) SetToNull() {
 	o.Null = true
 	var v NullableEnumsOnlyNullable
@@ -1953,10 +1953,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string
@@ -4104,10 +4104,10 @@ func (o *OptNilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilString) SetToNull() {
 	o.Set = true
 	o.Null = true
@@ -4167,10 +4167,10 @@ func (o *OptNilStringArray) SetTo(v []string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o OptNilStringArray) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *OptNilStringArray) SetToNull() {
 	o.Set = true
 	o.Null = true

--- a/internal/integration/test_allof/oas_schemas_gen.go
+++ b/internal/integration/test_allof/oas_schemas_gen.go
@@ -52,10 +52,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string

--- a/internal/integration/test_http_responses/oas_schemas_gen.go
+++ b/internal/integration/test_http_responses/oas_schemas_gen.go
@@ -537,10 +537,10 @@ func (o *NilInt) SetTo(v int) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilInt) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilInt) SetToNull() {
 	o.Null = true
 	var v int
@@ -584,10 +584,10 @@ func (o *NilString) SetTo(v string) {
 	o.Value = v
 }
 
-// IsSet returns true if value is Null.
+// IsNull returns true if value is Null.
 func (o NilString) IsNull() bool { return o.Null }
 
-// SetNull sets value to null.
+// SetToNull sets value to null.
 func (o *NilString) SetToNull() {
 	o.Null = true
 	var v string


### PR DESCRIPTION
Hello team, 👋
Thank you for developing and maintaining this OSS!

Generated comments for methods had mismatched names, which could cause confusion.
This PR updates the comments to correctly reflect the actual method names (IsNull and SetToNull).

## Changes
- Fixed IsSet → IsNull in the comment.
- Fixed SetNull → SetToNull in the comment.

This change improves code clarity and maintainability by ensuring that comments accurately describe the corresponding methods.