### PR TITLE
fix: `HasParam` returns `Err(Query|Header|Cookie)ParamRequred` including `qparam` / `cfg.Name`

### DIFF
--- a/examples/ex_2ch/oas_parameters_gen.go
+++ b/examples/ex_2ch/oas_parameters_gen.go
@@ -201,7 +201,7 @@ func decodeAPICaptcha2chcaptchaShowGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -747,7 +747,7 @@ func decodeAPIDislikeGetParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -800,7 +800,7 @@ func decodeAPIDislikeGetParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -867,7 +867,7 @@ func decodeAPILikeGetParams(args [0]string, argsEscaped bool, r *http.Request) (
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -920,7 +920,7 @@ func decodeAPILikeGetParams(args [0]string, argsEscaped bool, r *http.Request) (
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1466,7 +1466,7 @@ func decodeUserPassloginPostParams(args [0]string, argsEscaped bool, r *http.Req
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/examples/ex_github/oas_parameters_gen.go
+++ b/examples/ex_github/oas_parameters_gen.go
@@ -58055,7 +58055,7 @@ func decodePackagesListPackagesForAuthenticatedUserParams(args [0]string, argsEs
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -58203,7 +58203,7 @@ func decodePackagesListPackagesForOrganizationParams(args [1]string, argsEscaped
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -58396,7 +58396,7 @@ func decodePackagesListPackagesForUserParams(args [1]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -102403,7 +102403,7 @@ func decodeReposUploadReleaseAssetParams(args [3]string, argsEscaped bool, r *ht
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -102672,7 +102672,7 @@ func decodeSearchCodeParams(args [0]string, argsEscaped bool, r *http.Request) (
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -102989,7 +102989,7 @@ func decodeSearchCommitsParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -103309,7 +103309,7 @@ func decodeSearchIssuesAndPullRequestsParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -103633,7 +103633,7 @@ func decodeSearchLabelsParams(args [0]string, argsEscaped bool, r *http.Request)
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -103669,7 +103669,7 @@ func decodeSearchLabelsParams(args [0]string, argsEscaped bool, r *http.Request)
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -103988,7 +103988,7 @@ func decodeSearchReposParams(args [0]string, argsEscaped bool, r *http.Request) 
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -104280,7 +104280,7 @@ func decodeSearchTopicsParams(args [0]string, argsEscaped bool, r *http.Request)
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -104481,7 +104481,7 @@ func decodeSearchUsersParams(args [0]string, argsEscaped bool, r *http.Request) 
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/examples/ex_k8s/oas_response_decoders_gen.go
+++ b/examples/ex_k8s/oas_response_decoders_gen.go
@@ -63,7 +63,7 @@ func decodeConnectCoreV1DeleteNamespacedPodProxyResponse(resp *http.Response) (r
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -126,7 +126,7 @@ func decodeConnectCoreV1DeleteNamespacedPodProxyWithPathResponse(resp *http.Resp
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -189,7 +189,7 @@ func decodeConnectCoreV1DeleteNamespacedServiceProxyResponse(resp *http.Response
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -252,7 +252,7 @@ func decodeConnectCoreV1DeleteNamespacedServiceProxyWithPathResponse(resp *http.
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -315,7 +315,7 @@ func decodeConnectCoreV1DeleteNodeProxyResponse(resp *http.Response) (res Connec
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -378,7 +378,7 @@ func decodeConnectCoreV1DeleteNodeProxyWithPathResponse(resp *http.Response) (re
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -441,7 +441,7 @@ func decodeConnectCoreV1GetNamespacedPodAttachResponse(resp *http.Response) (res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -504,7 +504,7 @@ func decodeConnectCoreV1GetNamespacedPodExecResponse(resp *http.Response) (res C
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -567,7 +567,7 @@ func decodeConnectCoreV1GetNamespacedPodPortforwardResponse(resp *http.Response)
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -630,7 +630,7 @@ func decodeConnectCoreV1GetNamespacedPodProxyResponse(resp *http.Response) (res 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -693,7 +693,7 @@ func decodeConnectCoreV1GetNamespacedPodProxyWithPathResponse(resp *http.Respons
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -756,7 +756,7 @@ func decodeConnectCoreV1GetNamespacedServiceProxyResponse(resp *http.Response) (
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -819,7 +819,7 @@ func decodeConnectCoreV1GetNamespacedServiceProxyWithPathResponse(resp *http.Res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -882,7 +882,7 @@ func decodeConnectCoreV1GetNodeProxyResponse(resp *http.Response) (res ConnectCo
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -945,7 +945,7 @@ func decodeConnectCoreV1GetNodeProxyWithPathResponse(resp *http.Response) (res C
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1008,7 +1008,7 @@ func decodeConnectCoreV1HeadNamespacedPodProxyResponse(resp *http.Response) (res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1071,7 +1071,7 @@ func decodeConnectCoreV1HeadNamespacedPodProxyWithPathResponse(resp *http.Respon
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1134,7 +1134,7 @@ func decodeConnectCoreV1HeadNamespacedServiceProxyResponse(resp *http.Response) 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1197,7 +1197,7 @@ func decodeConnectCoreV1HeadNamespacedServiceProxyWithPathResponse(resp *http.Re
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1260,7 +1260,7 @@ func decodeConnectCoreV1HeadNodeProxyResponse(resp *http.Response) (res ConnectC
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1323,7 +1323,7 @@ func decodeConnectCoreV1HeadNodeProxyWithPathResponse(resp *http.Response) (res 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1386,7 +1386,7 @@ func decodeConnectCoreV1OptionsNamespacedPodProxyResponse(resp *http.Response) (
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1449,7 +1449,7 @@ func decodeConnectCoreV1OptionsNamespacedPodProxyWithPathResponse(resp *http.Res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1512,7 +1512,7 @@ func decodeConnectCoreV1OptionsNamespacedServiceProxyResponse(resp *http.Respons
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1575,7 +1575,7 @@ func decodeConnectCoreV1OptionsNamespacedServiceProxyWithPathResponse(resp *http
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1638,7 +1638,7 @@ func decodeConnectCoreV1OptionsNodeProxyResponse(resp *http.Response) (res Conne
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1701,7 +1701,7 @@ func decodeConnectCoreV1OptionsNodeProxyWithPathResponse(resp *http.Response) (r
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1764,7 +1764,7 @@ func decodeConnectCoreV1PatchNamespacedPodProxyResponse(resp *http.Response) (re
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1827,7 +1827,7 @@ func decodeConnectCoreV1PatchNamespacedPodProxyWithPathResponse(resp *http.Respo
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1890,7 +1890,7 @@ func decodeConnectCoreV1PatchNamespacedServiceProxyResponse(resp *http.Response)
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -1953,7 +1953,7 @@ func decodeConnectCoreV1PatchNamespacedServiceProxyWithPathResponse(resp *http.R
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2016,7 +2016,7 @@ func decodeConnectCoreV1PatchNodeProxyResponse(resp *http.Response) (res Connect
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2079,7 +2079,7 @@ func decodeConnectCoreV1PatchNodeProxyWithPathResponse(resp *http.Response) (res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2142,7 +2142,7 @@ func decodeConnectCoreV1PostNamespacedPodAttachResponse(resp *http.Response) (re
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2205,7 +2205,7 @@ func decodeConnectCoreV1PostNamespacedPodExecResponse(resp *http.Response) (res 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2268,7 +2268,7 @@ func decodeConnectCoreV1PostNamespacedPodPortforwardResponse(resp *http.Response
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2331,7 +2331,7 @@ func decodeConnectCoreV1PostNamespacedPodProxyResponse(resp *http.Response) (res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2394,7 +2394,7 @@ func decodeConnectCoreV1PostNamespacedPodProxyWithPathResponse(resp *http.Respon
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2457,7 +2457,7 @@ func decodeConnectCoreV1PostNamespacedServiceProxyResponse(resp *http.Response) 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2520,7 +2520,7 @@ func decodeConnectCoreV1PostNamespacedServiceProxyWithPathResponse(resp *http.Re
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2583,7 +2583,7 @@ func decodeConnectCoreV1PostNodeProxyResponse(resp *http.Response) (res ConnectC
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2646,7 +2646,7 @@ func decodeConnectCoreV1PostNodeProxyWithPathResponse(resp *http.Response) (res 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2709,7 +2709,7 @@ func decodeConnectCoreV1PutNamespacedPodProxyResponse(resp *http.Response) (res 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2772,7 +2772,7 @@ func decodeConnectCoreV1PutNamespacedPodProxyWithPathResponse(resp *http.Respons
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2835,7 +2835,7 @@ func decodeConnectCoreV1PutNamespacedServiceProxyResponse(resp *http.Response) (
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2898,7 +2898,7 @@ func decodeConnectCoreV1PutNamespacedServiceProxyWithPathResponse(resp *http.Res
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -2961,7 +2961,7 @@ func decodeConnectCoreV1PutNodeProxyResponse(resp *http.Response) (res ConnectCo
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -3024,7 +3024,7 @@ func decodeConnectCoreV1PutNodeProxyWithPathResponse(resp *http.Response) (res C
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {

--- a/examples/ex_manga/oas_parameters_gen.go
+++ b/examples/ex_manga/oas_parameters_gen.go
@@ -730,7 +730,7 @@ func decodeSearchParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -840,7 +840,7 @@ func decodeSearchByTagIDParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/examples/ex_manga/oas_response_decoders_gen.go
+++ b/examples/ex_manga/oas_response_decoders_gen.go
@@ -116,7 +116,7 @@ func decodeGetPageCoverImageResponse(resp *http.Response) (res GetPageCoverImage
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -179,7 +179,7 @@ func decodeGetPageImageResponse(resp *http.Response) (res GetPageImageRes, _ err
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -242,7 +242,7 @@ func decodeGetPageThumbnailImageResponse(resp *http.Response) (res GetPageThumbn
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -936,7 +936,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -989,7 +989,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1025,7 +1025,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1078,7 +1078,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1114,7 +1114,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1167,7 +1167,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1203,7 +1203,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1256,7 +1256,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1292,7 +1292,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1345,7 +1345,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1381,7 +1381,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1434,7 +1434,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1470,7 +1470,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1506,7 +1506,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1559,7 +1559,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1595,7 +1595,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1648,7 +1648,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1684,7 +1684,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1737,7 +1737,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1773,7 +1773,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1826,7 +1826,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1879,7 +1879,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1915,7 +1915,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1951,7 +1951,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2004,7 +2004,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2040,7 +2040,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2093,7 +2093,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2129,7 +2129,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2182,7 +2182,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2218,7 +2218,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2271,7 +2271,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2324,7 +2324,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2368,7 +2368,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2438,7 +2438,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2482,7 +2482,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2552,7 +2552,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2596,7 +2596,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2666,7 +2666,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2702,7 +2702,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2755,7 +2755,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2791,7 +2791,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2844,7 +2844,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2880,7 +2880,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2933,7 +2933,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -2969,7 +2969,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3022,7 +3022,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3058,7 +3058,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3111,7 +3111,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3147,7 +3147,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3200,7 +3200,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3236,7 +3236,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3272,7 +3272,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3325,7 +3325,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3378,7 +3378,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3414,7 +3414,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3467,7 +3467,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3519,7 +3519,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3597,7 +3597,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3641,7 +3641,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3711,7 +3711,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3755,7 +3755,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3825,7 +3825,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3877,7 +3877,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3955,7 +3955,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -3991,7 +3991,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4027,7 +4027,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4080,7 +4080,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4116,7 +4116,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4169,7 +4169,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4205,7 +4205,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4258,7 +4258,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4294,7 +4294,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4347,7 +4347,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4400,7 +4400,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4436,7 +4436,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4489,7 +4489,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4525,7 +4525,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4578,7 +4578,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4614,7 +4614,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4667,7 +4667,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4703,7 +4703,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4756,7 +4756,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4792,7 +4792,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4845,7 +4845,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4881,7 +4881,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4934,7 +4934,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -4970,7 +4970,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5006,7 +5006,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5059,7 +5059,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5095,7 +5095,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5148,7 +5148,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5184,7 +5184,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5237,7 +5237,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5273,7 +5273,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5326,7 +5326,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5379,7 +5379,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5415,7 +5415,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5451,7 +5451,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5504,7 +5504,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5540,7 +5540,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5593,7 +5593,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5629,7 +5629,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5682,7 +5682,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5718,7 +5718,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5771,7 +5771,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5824,7 +5824,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5860,7 +5860,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5913,7 +5913,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -5949,7 +5949,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -6002,7 +6002,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/examples/ex_tinkoff/oas_parameters_gen.go
+++ b/examples/ex_tinkoff/oas_parameters_gen.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // MarketCandlesGetParams is parameters of GET /market/candles operation.
@@ -85,7 +84,7 @@ func decodeMarketCandlesGetParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -121,7 +120,7 @@ func decodeMarketCandlesGetParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -157,7 +156,7 @@ func decodeMarketCandlesGetParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -201,7 +200,7 @@ func decodeMarketCandlesGetParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -268,7 +267,7 @@ func decodeMarketOrderbookGetParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -304,7 +303,7 @@ func decodeMarketOrderbookGetParams(args [0]string, argsEscaped bool, r *http.Re
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -362,7 +361,7 @@ func decodeMarketSearchByFigiGetParams(args [0]string, argsEscaped bool, r *http
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -420,7 +419,7 @@ func decodeMarketSearchByTickerGetParams(args [0]string, argsEscaped bool, r *ht
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -509,7 +508,7 @@ func decodeOperationsGetParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -545,7 +544,7 @@ func decodeOperationsGetParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -696,7 +695,7 @@ func decodeOrdersCancelPostParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -871,7 +870,7 @@ func decodeOrdersLimitOrderPostParams(args [0]string, argsEscaped bool, r *http.
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -982,7 +981,7 @@ func decodeOrdersMarketOrderPostParams(args [0]string, argsEscaped bool, r *http
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/gen/_template/parameter_decode.tmpl
+++ b/gen/_template/parameter_decode.tmpl
@@ -68,7 +68,7 @@ func decode{{ $.Name }}Params(args [{{ $.PathParamsCount }}]string, argsEscaped 
 			}
 			{{- end }}
 		} {{- if $p.Spec.Required }} else {
-			return validate.ErrFieldRequired
+			return err
 		} {{- end }}
 	{{- else if $p.Spec.In.Path }}
 	{{- /* If we cannot find such path parameter, defined path parameter is not used */ -}}
@@ -129,7 +129,7 @@ func decode{{ $.Name }}Params(args [{{ $.PathParamsCount }}]string, argsEscaped 
 			}
 			{{- end }}
 		} {{ if $p.Spec.Required }} else {
-			return validate.ErrFieldRequired
+			return err
 		} {{ end }}
 	{{- else if $p.Spec.In.Cookie }}
 		cfg := uri.CookieParameterDecodingConfig{
@@ -151,7 +151,7 @@ func decode{{ $.Name }}Params(args [{{ $.PathParamsCount }}]string, argsEscaped 
 			}
 			{{- end }}
 		} {{ if $p.Spec.Required }} else {
-			return validate.ErrFieldRequired
+			return err
 		} {{ end }}
 	{{- else }}
 		{{ errorf "unsupported location %s" $p.Spec.In }}

--- a/gen/_template/response_decode.tmpl
+++ b/gen/_template/response_decode.tmpl
@@ -223,7 +223,7 @@ h := uri.NewHeaderDecoder(resp.Header)
 			}
 			{{- end }}
 		} {{ if $header.Spec.Required }} else {
-			return validate.ErrFieldRequired
+			return err
 		} {{ end }}
 		return nil
 	}(); err != nil {

--- a/internal/integration/responses_test.go
+++ b/internal/integration/responses_test.go
@@ -332,14 +332,14 @@ func TestResponsesOptionalHeaders(t *testing.T) {
 		{
 			Name:    "NoHeaders",
 			Headers: nil,
-			Error:   `X-Required header: field required`,
+			Error:   `X-Required (field required)`,
 		},
 		{
 			Name: "OnlyOptionalHeaders",
 			Headers: []header{
 				{"X-Optional", "optional"},
 			},
-			Error: `X-Required header: field required`,
+			Error: `X-Required (field required)`,
 		},
 		{
 			Name: "OnlyRequiredHeaders",

--- a/internal/integration/sample_api/oas_parameters_gen.go
+++ b/internal/integration/sample_api/oas_parameters_gen.go
@@ -497,7 +497,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -533,7 +533,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -702,7 +702,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -753,7 +753,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -804,7 +804,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -840,7 +840,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -898,7 +898,7 @@ func decodePetGetAvatarByIDParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1154,7 +1154,7 @@ func decodePetUploadAvatarByIDParams(args [0]string, argsEscaped bool, r *http.R
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/sample_api_nc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nc/oas_parameters_gen.go
@@ -497,7 +497,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -533,7 +533,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -702,7 +702,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -753,7 +753,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -804,7 +804,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -840,7 +840,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -898,7 +898,7 @@ func decodePetGetAvatarByIDParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1154,7 +1154,7 @@ func decodePetUploadAvatarByIDParams(args [0]string, argsEscaped bool, r *http.R
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/sample_api_no_otel/oas_parameters_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_parameters_gen.go
@@ -497,7 +497,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -533,7 +533,7 @@ func decodeFoobarGetParams(args [0]string, argsEscaped bool, r *http.Request) (p
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -702,7 +702,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -753,7 +753,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -804,7 +804,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -840,7 +840,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -898,7 +898,7 @@ func decodePetGetAvatarByIDParams(args [0]string, argsEscaped bool, r *http.Requ
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1154,7 +1154,7 @@ func decodePetUploadAvatarByIDParams(args [0]string, argsEscaped bool, r *http.R
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/techempower/oas_parameters_gen.go
+++ b/internal/integration/techempower/oas_parameters_gen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // CachingParams is parameters of Caching operation.
@@ -56,7 +55,7 @@ func decodeCachingParams(args [0]string, argsEscaped bool, r *http.Request) (par
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -113,7 +112,7 @@ func decodeQueriesParams(args [0]string, argsEscaped bool, r *http.Request) (par
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -170,7 +169,7 @@ func decodeUpdatesParams(args [0]string, argsEscaped bool, r *http.Request) (par
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/test_client_options/oas_parameters_gen.go
+++ b/internal/integration/test_client_options/oas_parameters_gen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // FooParams is parameters of Foo operation.
@@ -56,7 +55,7 @@ func decodeFooParams(args [0]string, argsEscaped bool, r *http.Request) (params 
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/test_http_responses/oas_parameters_gen.go
+++ b/internal/integration/test_http_responses/oas_parameters_gen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // CombinedParams is parameters of combined operation.
@@ -64,7 +63,7 @@ func decodeCombinedParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -129,7 +128,7 @@ func decodeHeadersCombinedParams(args [0]string, argsEscaped bool, r *http.Reque
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -186,7 +185,7 @@ func decodeIntersectPatternCodeParams(args [0]string, argsEscaped bool, r *http.
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -243,7 +242,7 @@ func decodeStreamJSONParams(args [0]string, argsEscaped bool, r *http.Request) (
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/test_http_responses/oas_response_decoders_gen.go
+++ b/internal/integration/test_http_responses/oas_response_decoders_gen.go
@@ -63,7 +63,7 @@ func decodeAnyContentTypeBinaryStringSchemaResponse(resp *http.Response) (res *A
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -123,7 +123,7 @@ func decodeAnyContentTypeBinaryStringSchemaDefaultResponse(resp *http.Response) 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -368,7 +368,7 @@ func decodeHeaders200Response(resp *http.Response) (res *Headers200OK, _ error) 
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -411,7 +411,7 @@ func decodeHeadersCombinedResponse(resp *http.Response) (res HeadersCombinedRes,
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -452,7 +452,7 @@ func decodeHeadersCombinedResponse(resp *http.Response) (res HeadersCombinedRes,
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -496,7 +496,7 @@ func decodeHeadersCombinedResponse(resp *http.Response) (res HeadersCombinedRes,
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -542,7 +542,7 @@ func decodeHeadersDefaultResponse(resp *http.Response) (res *HeadersDefaultDef, 
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -591,7 +591,7 @@ func decodeHeadersJSONResponse(resp *http.Response) (res *HeadersJSONOK, _ error
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -632,7 +632,7 @@ func decodeHeadersJSONResponse(resp *http.Response) (res *HeadersJSONOK, _ error
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {
@@ -677,7 +677,7 @@ func decodeHeadersPatternResponse(resp *http.Response) (res *HeadersPattern4XX, 
 							return err
 						}
 					} else {
-						return validate.ErrFieldRequired
+						return err
 					}
 					return nil
 				}(); err != nil {
@@ -977,7 +977,7 @@ func decodeOptionalHeadersResponse(resp *http.Response) (res *OptionalHeadersOK,
 						return err
 					}
 				} else {
-					return validate.ErrFieldRequired
+					return err
 				}
 				return nil
 			}(); err != nil {

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -92,7 +92,7 @@ func decodeComplicatedParameterNameGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -128,7 +128,7 @@ func decodeComplicatedParameterNameGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -164,7 +164,7 @@ func decodeComplicatedParameterNameGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -200,7 +200,7 @@ func decodeComplicatedParameterNameGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -236,7 +236,7 @@ func decodeComplicatedParameterNameGetParams(args [0]string, argsEscaped bool, r
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -328,7 +328,7 @@ func decodeContentParametersParams(args [1]string, argsEscaped bool, r *http.Req
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -425,7 +425,7 @@ func decodeContentParametersParams(args [1]string, argsEscaped bool, r *http.Req
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -468,7 +468,7 @@ func decodeContentParametersParams(args [1]string, argsEscaped bool, r *http.Req
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -523,7 +523,7 @@ func decodeCookieParameterParams(args [0]string, argsEscaped bool, r *http.Reque
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -578,7 +578,7 @@ func decodeHeaderParameterParams(args [0]string, argsEscaped bool, r *http.Reque
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -622,7 +622,7 @@ func decodeObjectCookieParameterParams(args [0]string, argsEscaped bool, r *http
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1010,7 +1010,7 @@ func decodeSameNameParams(args [1]string, argsEscaped bool, r *http.Request) (pa
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1076,7 +1076,7 @@ func decodeSimilarNamesParams(args [0]string, argsEscaped bool, r *http.Request)
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -1110,7 +1110,7 @@ func decodeSimilarNamesParams(args [0]string, argsEscaped bool, r *http.Request)
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/test_time_extension/oas_parameters_gen.go
+++ b/internal/integration/test_time_extension/oas_parameters_gen.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // DefaultParams is parameters of default operation.
@@ -256,7 +255,7 @@ func decodeRequiredParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -292,7 +291,7 @@ func decodeRequiredParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -328,7 +327,7 @@ func decodeRequiredParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/internal/integration/test_webhooks/oas_parameters_gen.go
+++ b/internal/integration/test_webhooks/oas_parameters_gen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/uri"
-	"github.com/ogen-go/ogen/validate"
 )
 
 // UpdateWebhookParams is parameters of updateWebhook operation.
@@ -67,7 +66,7 @@ func decodeUpdateWebhookParams(args [0]string, argsEscaped bool, r *http.Request
 				return err
 			}
 		} else {
-			return validate.ErrFieldRequired
+			return err
 		}
 		return nil
 	}(); err != nil {

--- a/uri/cookie_decoder.go
+++ b/uri/cookie_decoder.go
@@ -1,6 +1,7 @@
 package uri
 
 import (
+	"github.com/ogen-go/ogen/validate"
 	"net/http"
 
 	"github.com/go-faster/errors"
@@ -24,7 +25,14 @@ type CookieParameterDecodingConfig struct {
 func (d *CookieDecoder) HasParam(cfg CookieParameterDecodingConfig) error {
 	_, err := d.req.Cookie(cfg.Name)
 	if errors.Is(err, http.ErrNoCookie) {
-		return errors.Errorf("cookie parameter %q not set", cfg.Name)
+		return &validate.Error{
+			Fields: []validate.FieldError{
+				{
+					Name:  cfg.Name,
+					Error: validate.ErrFieldRequired,
+				},
+			},
+		}
 	}
 	return err
 }

--- a/uri/cookie_decoder_test.go
+++ b/uri/cookie_decoder_test.go
@@ -17,7 +17,7 @@ func TestCookieDecoder_HasParam(t *testing.T) {
 		{
 			Input:      http.Header{},
 			CookieName: "foo",
-			WantErr:    "cookie parameter \"foo\" not set",
+			WantErr:    "invalid: foo (field required)",
 		},
 		{
 			Input: http.Header{

--- a/uri/header_decoder.go
+++ b/uri/header_decoder.go
@@ -1,9 +1,8 @@
 package uri
 
 import (
+	"github.com/ogen-go/ogen/validate"
 	"net/http"
-
-	"github.com/go-faster/errors"
 )
 
 type HeaderDecoder struct {
@@ -23,7 +22,14 @@ type HeaderParameterDecodingConfig struct {
 
 func (d *HeaderDecoder) HasParam(cfg HeaderParameterDecodingConfig) error {
 	if len(d.header.Values(cfg.Name)) == 0 {
-		return errors.Errorf("header parameter %q not set", cfg.Name)
+		return &validate.Error{
+			Fields: []validate.FieldError{
+				{
+					Name:  cfg.Name,
+					Error: validate.ErrFieldRequired,
+				},
+			},
+		}
 	}
 	return nil
 }

--- a/uri/header_decoder_test.go
+++ b/uri/header_decoder_test.go
@@ -17,7 +17,7 @@ func TestHeaderDecoder_HasParam(t *testing.T) {
 		{
 			Input:      http.Header{},
 			HeaderName: "X-Foo",
-			WantErr:    "header parameter \"X-Foo\" not set",
+			WantErr:    "invalid: X-Foo (field required)",
 		},
 		{
 			Input: http.Header{

--- a/uri/query_decoder.go
+++ b/uri/query_decoder.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	"github.com/go-faster/errors"
+	"github.com/ogen-go/ogen/validate"
 )
 
 type QueryDecoder struct {
@@ -50,7 +51,14 @@ func (d *QueryDecoder) HasParam(cfg QueryParameterDecodingConfig) error {
 				}
 
 				if field.Required {
-					return errors.Errorf("query parameter %q not set", qparam)
+					return &validate.Error{
+						Fields: []validate.FieldError{
+							{
+								Name:  qparam,
+								Error: validate.ErrFieldRequired,
+							},
+						},
+					}
 				}
 			}
 

--- a/uri/query_decoder_test.go
+++ b/uri/query_decoder_test.go
@@ -25,7 +25,7 @@ func TestQueryDecoder_HasParam(t *testing.T) {
 					{"foo", true},
 				},
 			},
-			WantErr: "query parameter \"object[foo]\" not set",
+			WantErr: "invalid: object[foo] (field required)",
 		},
 		{
 			Input: url.Values{},
@@ -64,7 +64,7 @@ func TestQueryDecoder_HasParam(t *testing.T) {
 					{"foo", true},
 				},
 			},
-			WantErr: "query parameter \"foo\" not set",
+			WantErr: "invalid: foo (field required)",
 		},
 		{
 			Input: url.Values{},

--- a/validate/errors.go
+++ b/validate/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-faster/errors"
 )
 
-// ErrFieldRequired reports that field is required, but not found.
+// ErrFieldRequired reports that a field is required, but not found.
 var ErrFieldRequired = errors.New("field required")
 
 // Error represents validation error.


### PR DESCRIPTION
This PR is comprised of three changes.

Firstly, we introduce 3 new Errors in `errors.go`:
```go
// ErrQueryParamRequired reports that a query parameter is required, but not found.
var ErrQueryParamRequired = errors.New("query parameter required")

// ErrHeaderParamRequired reports that a header parameter is required, but not found.
var ErrHeaderParamRequired = errors.New("header parameter required")

// ErrCookieParamRequired reports that a cookie parameter is required, but not found.
var ErrCookieParamRequired = errors.New("cookie parameter required")
```

Secondly in all the below methods:
* `(d *QueryDecoder) HasParam(...)`
* `(d *HeaderDecoder) HasParam(...)`
* `(d *CookieDecoder) HasParam(...)`

...we return a `validate.Error` rather than an `errors.Errorf`. 
This provides a better formatted error message, but also includes the full context that the specific error encountered was `validate.Err(Query|Header|Cookie)ParamRequired` and that `qparam` / `cfg.Name` is the formatted parameter that was not found.
For example, instead of returning `"query parameter \"object[foo]\" not set"`, we now return `"invalid: object[foo] (query parameter required)"`.

Lastly, in all generated code usages where `HasParam` is referenced, rather than returning a generic `validate.ErrFieldRequired`, we provide a more descriptive error (thanks to using `validate.Error` from `HasParam`) which also includes the specific `qparam` / `cfg.Name` that is not present.