### PR TITLE
Fix staticcheck in generated code

### DIFF
--- a/examples/ex_2ch/oas_router_gen.go
+++ b/examples/ex_2ch/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "api/"
-				origElem := elem
+
 				if l := len("api/"); len(elem) >= l && elem[0:l] == "api/" {
 					elem = elem[l:]
 				} else {
@@ -74,7 +74,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "captcha/"
-					origElem := elem
+
 					if l := len("captcha/"); len(elem) >= l && elem[0:l] == "captcha/" {
 						elem = elem[l:]
 					} else {
@@ -86,7 +86,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '2': // Prefix: "2chcaptcha/"
-						origElem := elem
+
 						if l := len("2chcaptcha/"); len(elem) >= l && elem[0:l] == "2chcaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -98,7 +98,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -117,9 +117,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 's': // Prefix: "show"
-							origElem := elem
+
 							if l := len("show"); len(elem) >= l && elem[0:l] == "show" {
 								elem = elem[l:]
 							} else {
@@ -138,12 +137,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'a': // Prefix: "app/id/"
-						origElem := elem
+
 						if l := len("app/id/"); len(elem) >= l && elem[0:l] == "app/id/" {
 							elem = elem[l:]
 						} else {
@@ -173,9 +170,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "invisible_recaptcha/"
-						origElem := elem
+
 						if l := len("invisible_recaptcha/"); len(elem) >= l && elem[0:l] == "invisible_recaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -187,7 +183,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -206,9 +202,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mobile"
-							origElem := elem
+
 							if l := len("mobile"); len(elem) >= l && elem[0:l] == "mobile" {
 								elem = elem[l:]
 							} else {
@@ -227,12 +222,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "recaptcha/"
-						origElem := elem
+
 						if l := len("recaptcha/"); len(elem) >= l && elem[0:l] == "recaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -244,7 +237,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -263,9 +256,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mobile"
-							origElem := elem
+
 							if l := len("mobile"); len(elem) >= l && elem[0:l] == "mobile" {
 								elem = elem[l:]
 							} else {
@@ -284,15 +276,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'd': // Prefix: "dislike"
-					origElem := elem
+
 					if l := len("dislike"); len(elem) >= l && elem[0:l] == "dislike" {
 						elem = elem[l:]
 					} else {
@@ -311,9 +300,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "like"
-					origElem := elem
+
 					if l := len("like"); len(elem) >= l && elem[0:l] == "like" {
 						elem = elem[l:]
 					} else {
@@ -332,9 +320,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mobile/v2/"
-					origElem := elem
+
 					if l := len("mobile/v2/"); len(elem) >= l && elem[0:l] == "mobile/v2/" {
 						elem = elem[l:]
 					} else {
@@ -346,7 +333,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "after/"
-						origElem := elem
+
 						if l := len("after/"); len(elem) >= l && elem[0:l] == "after/" {
 							elem = elem[l:]
 						} else {
@@ -367,7 +354,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -388,7 +375,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -420,15 +407,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boards"
-						origElem := elem
+
 						if l := len("boards"); len(elem) >= l && elem[0:l] == "boards" {
 							elem = elem[l:]
 						} else {
@@ -447,9 +431,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "info/"
-						origElem := elem
+
 						if l := len("info/"); len(elem) >= l && elem[0:l] == "info/" {
 							elem = elem[l:]
 						} else {
@@ -470,7 +453,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -501,12 +484,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "post/"
-						origElem := elem
+
 						if l := len("post/"); len(elem) >= l && elem[0:l] == "post/" {
 							elem = elem[l:]
 						} else {
@@ -527,7 +508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -558,18 +539,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user/"
-				origElem := elem
+
 				if l := len("user/"); len(elem) >= l && elem[0:l] == "user/" {
 					elem = elem[l:]
 				} else {
@@ -581,7 +558,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "p"
-					origElem := elem
+
 					if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 						elem = elem[l:]
 					} else {
@@ -593,7 +570,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "asslogin"
-						origElem := elem
+
 						if l := len("asslogin"); len(elem) >= l && elem[0:l] == "asslogin" {
 							elem = elem[l:]
 						} else {
@@ -612,9 +589,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "osting"
-						origElem := elem
+
 						if l := len("osting"); len(elem) >= l && elem[0:l] == "osting" {
 							elem = elem[l:]
 						} else {
@@ -633,12 +609,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "report"
-					origElem := elem
+
 					if l := len("report"); len(elem) >= l && elem[0:l] == "report" {
 						elem = elem[l:]
 					} else {
@@ -657,13 +631,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -745,7 +716,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -757,7 +728,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "api/"
-				origElem := elem
+
 				if l := len("api/"); len(elem) >= l && elem[0:l] == "api/" {
 					elem = elem[l:]
 				} else {
@@ -769,7 +740,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "captcha/"
-					origElem := elem
+
 					if l := len("captcha/"); len(elem) >= l && elem[0:l] == "captcha/" {
 						elem = elem[l:]
 					} else {
@@ -781,7 +752,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '2': // Prefix: "2chcaptcha/"
-						origElem := elem
+
 						if l := len("2chcaptcha/"); len(elem) >= l && elem[0:l] == "2chcaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -793,7 +764,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -816,9 +787,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 's': // Prefix: "show"
-							origElem := elem
+
 							if l := len("show"); len(elem) >= l && elem[0:l] == "show" {
 								elem = elem[l:]
 							} else {
@@ -841,12 +811,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'a': // Prefix: "app/id/"
-						origElem := elem
+
 						if l := len("app/id/"); len(elem) >= l && elem[0:l] == "app/id/" {
 							elem = elem[l:]
 						} else {
@@ -878,9 +846,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "invisible_recaptcha/"
-						origElem := elem
+
 						if l := len("invisible_recaptcha/"); len(elem) >= l && elem[0:l] == "invisible_recaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -892,7 +859,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -915,9 +882,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mobile"
-							origElem := elem
+
 							if l := len("mobile"); len(elem) >= l && elem[0:l] == "mobile" {
 								elem = elem[l:]
 							} else {
@@ -940,12 +906,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "recaptcha/"
-						origElem := elem
+
 						if l := len("recaptcha/"); len(elem) >= l && elem[0:l] == "recaptcha/" {
 							elem = elem[l:]
 						} else {
@@ -957,7 +921,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "id"
-							origElem := elem
+
 							if l := len("id"); len(elem) >= l && elem[0:l] == "id" {
 								elem = elem[l:]
 							} else {
@@ -980,9 +944,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mobile"
-							origElem := elem
+
 							if l := len("mobile"); len(elem) >= l && elem[0:l] == "mobile" {
 								elem = elem[l:]
 							} else {
@@ -1005,15 +968,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'd': // Prefix: "dislike"
-					origElem := elem
+
 					if l := len("dislike"); len(elem) >= l && elem[0:l] == "dislike" {
 						elem = elem[l:]
 					} else {
@@ -1036,9 +996,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "like"
-					origElem := elem
+
 					if l := len("like"); len(elem) >= l && elem[0:l] == "like" {
 						elem = elem[l:]
 					} else {
@@ -1061,9 +1020,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mobile/v2/"
-					origElem := elem
+
 					if l := len("mobile/v2/"); len(elem) >= l && elem[0:l] == "mobile/v2/" {
 						elem = elem[l:]
 					} else {
@@ -1075,7 +1033,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "after/"
-						origElem := elem
+
 						if l := len("after/"); len(elem) >= l && elem[0:l] == "after/" {
 							elem = elem[l:]
 						} else {
@@ -1096,7 +1054,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -1117,7 +1075,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -1149,15 +1107,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boards"
-						origElem := elem
+
 						if l := len("boards"); len(elem) >= l && elem[0:l] == "boards" {
 							elem = elem[l:]
 						} else {
@@ -1180,9 +1135,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "info/"
-						origElem := elem
+
 						if l := len("info/"); len(elem) >= l && elem[0:l] == "info/" {
 							elem = elem[l:]
 						} else {
@@ -1203,7 +1157,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -1235,12 +1189,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "post/"
-						origElem := elem
+
 						if l := len("post/"); len(elem) >= l && elem[0:l] == "post/" {
 							elem = elem[l:]
 						} else {
@@ -1261,7 +1213,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -1293,18 +1245,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user/"
-				origElem := elem
+
 				if l := len("user/"); len(elem) >= l && elem[0:l] == "user/" {
 					elem = elem[l:]
 				} else {
@@ -1316,7 +1264,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "p"
-					origElem := elem
+
 					if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 						elem = elem[l:]
 					} else {
@@ -1328,7 +1276,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "asslogin"
-						origElem := elem
+
 						if l := len("asslogin"); len(elem) >= l && elem[0:l] == "asslogin" {
 							elem = elem[l:]
 						} else {
@@ -1351,9 +1299,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "osting"
-						origElem := elem
+
 						if l := len("osting"); len(elem) >= l && elem[0:l] == "osting" {
 							elem = elem[l:]
 						} else {
@@ -1376,12 +1323,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "report"
-					origElem := elem
+
 					if l := len("report"); len(elem) >= l && elem[0:l] == "report" {
 						elem = elem[l:]
 					} else {
@@ -1404,13 +1349,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_ent/oas_router_gen.go
+++ b/examples/ex_ent/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -71,7 +71,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -109,7 +109,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -121,7 +121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "categories"
-						origElem := elem
+
 						if l := len("categories"); len(elem) >= l && elem[0:l] == "categories" {
 							elem = elem[l:]
 						} else {
@@ -146,9 +146,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "friends"
-						origElem := elem
+
 						if l := len("friends"); len(elem) >= l && elem[0:l] == "friends" {
 							elem = elem[l:]
 						} else {
@@ -173,9 +172,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "owner"
-						origElem := elem
+
 						if l := len("owner"); len(elem) >= l && elem[0:l] == "owner" {
 							elem = elem[l:]
 						} else {
@@ -204,16 +202,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -295,7 +289,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -326,7 +320,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -374,7 +368,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -386,7 +380,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "categories"
-						origElem := elem
+
 						if l := len("categories"); len(elem) >= l && elem[0:l] == "categories" {
 							elem = elem[l:]
 						} else {
@@ -417,9 +411,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "friends"
-						origElem := elem
+
 						if l := len("friends"); len(elem) >= l && elem[0:l] == "friends" {
 							elem = elem[l:]
 						} else {
@@ -450,9 +443,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "owner"
-						origElem := elem
+
 						if l := len("owner"); len(elem) >= l && elem[0:l] == "owner" {
 							elem = elem[l:]
 						} else {
@@ -491,16 +483,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_firecracker/oas_router_gen.go
+++ b/examples/ex_firecracker/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -69,7 +69,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "actions"
-				origElem := elem
+
 				if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 					elem = elem[l:]
 				} else {
@@ -88,9 +88,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "b"
-				origElem := elem
+
 				if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 					elem = elem[l:]
 				} else {
@@ -102,7 +101,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "alloon"
-					origElem := elem
+
 					if l := len("alloon"); len(elem) >= l && elem[0:l] == "alloon" {
 						elem = elem[l:]
 					} else {
@@ -125,7 +124,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/statistics"
-						origElem := elem
+
 						if l := len("/statistics"); len(elem) >= l && elem[0:l] == "/statistics" {
 							elem = elem[l:]
 						} else {
@@ -146,12 +145,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oot-source"
-					origElem := elem
+
 					if l := len("oot-source"); len(elem) >= l && elem[0:l] == "oot-source" {
 						elem = elem[l:]
 					} else {
@@ -170,12 +167,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "drives/"
-				origElem := elem
+
 				if l := len("drives/"); len(elem) >= l && elem[0:l] == "drives/" {
 					elem = elem[l:]
 				} else {
@@ -209,9 +204,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "logger"
-				origElem := elem
+
 				if l := len("logger"); len(elem) >= l && elem[0:l] == "logger" {
 					elem = elem[l:]
 				} else {
@@ -230,9 +224,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "m"
-				origElem := elem
+
 				if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 					elem = elem[l:]
 				} else {
@@ -244,7 +237,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "achine-config"
-					origElem := elem
+
 					if l := len("achine-config"); len(elem) >= l && elem[0:l] == "achine-config" {
 						elem = elem[l:]
 					} else {
@@ -267,9 +260,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "etrics"
-					origElem := elem
+
 					if l := len("etrics"); len(elem) >= l && elem[0:l] == "etrics" {
 						elem = elem[l:]
 					} else {
@@ -288,9 +280,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mds"
-					origElem := elem
+
 					if l := len("mds"); len(elem) >= l && elem[0:l] == "mds" {
 						elem = elem[l:]
 					} else {
@@ -313,7 +304,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/config"
-						origElem := elem
+
 						if l := len("/config"); len(elem) >= l && elem[0:l] == "/config" {
 							elem = elem[l:]
 						} else {
@@ -332,15 +323,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "network-interfaces/"
-				origElem := elem
+
 				if l := len("network-interfaces/"); len(elem) >= l && elem[0:l] == "network-interfaces/" {
 					elem = elem[l:]
 				} else {
@@ -374,9 +362,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 's': // Prefix: "snapshot/"
-				origElem := elem
+
 				if l := len("snapshot/"); len(elem) >= l && elem[0:l] == "snapshot/" {
 					elem = elem[l:]
 				} else {
@@ -388,7 +375,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "create"
-					origElem := elem
+
 					if l := len("create"); len(elem) >= l && elem[0:l] == "create" {
 						elem = elem[l:]
 					} else {
@@ -407,9 +394,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "load"
-					origElem := elem
+
 					if l := len("load"); len(elem) >= l && elem[0:l] == "load" {
 						elem = elem[l:]
 					} else {
@@ -428,12 +414,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'v': // Prefix: "v"
-				origElem := elem
+
 				if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 					elem = elem[l:]
 				} else {
@@ -445,7 +429,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "m"
-					origElem := elem
+
 					if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 						elem = elem[l:]
 					} else {
@@ -464,7 +448,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/config"
-						origElem := elem
+
 						if l := len("/config"); len(elem) >= l && elem[0:l] == "/config" {
 							elem = elem[l:]
 						} else {
@@ -483,12 +467,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "sock"
-					origElem := elem
+
 					if l := len("sock"); len(elem) >= l && elem[0:l] == "sock" {
 						elem = elem[l:]
 					} else {
@@ -507,13 +489,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -595,7 +574,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -618,7 +597,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "actions"
-				origElem := elem
+
 				if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 					elem = elem[l:]
 				} else {
@@ -641,9 +620,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "b"
-				origElem := elem
+
 				if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 					elem = elem[l:]
 				} else {
@@ -655,7 +633,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "alloon"
-					origElem := elem
+
 					if l := len("alloon"); len(elem) >= l && elem[0:l] == "alloon" {
 						elem = elem[l:]
 					} else {
@@ -694,7 +672,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/statistics"
-						origElem := elem
+
 						if l := len("/statistics"); len(elem) >= l && elem[0:l] == "/statistics" {
 							elem = elem[l:]
 						} else {
@@ -725,12 +703,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oot-source"
-					origElem := elem
+
 					if l := len("oot-source"); len(elem) >= l && elem[0:l] == "oot-source" {
 						elem = elem[l:]
 					} else {
@@ -753,12 +729,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "drives/"
-				origElem := elem
+
 				if l := len("drives/"); len(elem) >= l && elem[0:l] == "drives/" {
 					elem = elem[l:]
 				} else {
@@ -798,9 +772,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "logger"
-				origElem := elem
+
 				if l := len("logger"); len(elem) >= l && elem[0:l] == "logger" {
 					elem = elem[l:]
 				} else {
@@ -823,9 +796,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "m"
-				origElem := elem
+
 				if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 					elem = elem[l:]
 				} else {
@@ -837,7 +809,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "achine-config"
-					origElem := elem
+
 					if l := len("achine-config"); len(elem) >= l && elem[0:l] == "achine-config" {
 						elem = elem[l:]
 					} else {
@@ -876,9 +848,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "etrics"
-					origElem := elem
+
 					if l := len("etrics"); len(elem) >= l && elem[0:l] == "etrics" {
 						elem = elem[l:]
 					} else {
@@ -901,9 +872,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mds"
-					origElem := elem
+
 					if l := len("mds"); len(elem) >= l && elem[0:l] == "mds" {
 						elem = elem[l:]
 					} else {
@@ -942,7 +912,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/config"
-						origElem := elem
+
 						if l := len("/config"); len(elem) >= l && elem[0:l] == "/config" {
 							elem = elem[l:]
 						} else {
@@ -965,15 +935,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "network-interfaces/"
-				origElem := elem
+
 				if l := len("network-interfaces/"); len(elem) >= l && elem[0:l] == "network-interfaces/" {
 					elem = elem[l:]
 				} else {
@@ -1013,9 +980,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 's': // Prefix: "snapshot/"
-				origElem := elem
+
 				if l := len("snapshot/"); len(elem) >= l && elem[0:l] == "snapshot/" {
 					elem = elem[l:]
 				} else {
@@ -1027,7 +993,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "create"
-					origElem := elem
+
 					if l := len("create"); len(elem) >= l && elem[0:l] == "create" {
 						elem = elem[l:]
 					} else {
@@ -1050,9 +1016,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "load"
-					origElem := elem
+
 					if l := len("load"); len(elem) >= l && elem[0:l] == "load" {
 						elem = elem[l:]
 					} else {
@@ -1075,12 +1040,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'v': // Prefix: "v"
-				origElem := elem
+
 				if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 					elem = elem[l:]
 				} else {
@@ -1092,7 +1055,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "m"
-					origElem := elem
+
 					if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 						elem = elem[l:]
 					} else {
@@ -1115,7 +1078,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/config"
-						origElem := elem
+
 						if l := len("/config"); len(elem) >= l && elem[0:l] == "/config" {
 							elem = elem[l:]
 						} else {
@@ -1138,12 +1101,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "sock"
-					origElem := elem
+
 					if l := len("sock"); len(elem) >= l && elem[0:l] == "sock" {
 						elem = elem[l:]
 					} else {
@@ -1166,13 +1127,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_github/oas_router_gen.go
+++ b/examples/ex_github/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -69,7 +69,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -81,7 +81,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "pp"
-					origElem := elem
+
 					if l := len("pp"); len(elem) >= l && elem[0:l] == "pp" {
 						elem = elem[l:]
 					} else {
@@ -100,7 +100,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '-': // Prefix: "-manifests/"
-						origElem := elem
+
 						if l := len("-manifests/"); len(elem) >= l && elem[0:l] == "-manifests/" {
 							elem = elem[l:]
 						} else {
@@ -121,7 +121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/conversions"
-							origElem := elem
+
 							if l := len("/conversions"); len(elem) >= l && elem[0:l] == "/conversions" {
 								elem = elem[l:]
 							} else {
@@ -142,12 +142,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -159,7 +157,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'h': // Prefix: "hook/"
-							origElem := elem
+
 							if l := len("hook/"); len(elem) >= l && elem[0:l] == "hook/" {
 								elem = elem[l:]
 							} else {
@@ -171,7 +169,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "config"
-								origElem := elem
+
 								if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 									elem = elem[l:]
 								} else {
@@ -192,9 +190,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "deliveries"
-								origElem := elem
+
 								if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 									elem = elem[l:]
 								} else {
@@ -213,7 +210,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -243,7 +240,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/attempts"
-										origElem := elem
+
 										if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 											elem = elem[l:]
 										} else {
@@ -264,18 +261,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "installations/"
-							origElem := elem
+
 							if l := len("installations/"); len(elem) >= l && elem[0:l] == "installations/" {
 								elem = elem[l:]
 							} else {
@@ -305,7 +298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -317,7 +310,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "access_tokens"
-									origElem := elem
+
 									if l := len("access_tokens"); len(elem) >= l && elem[0:l] == "access_tokens" {
 										elem = elem[l:]
 									} else {
@@ -338,9 +331,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "suspended"
-									origElem := elem
+
 									if l := len("suspended"); len(elem) >= l && elem[0:l] == "suspended" {
 										elem = elem[l:]
 									} else {
@@ -365,18 +357,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "lications/"
-						origElem := elem
+
 						if l := len("lications/"); len(elem) >= l && elem[0:l] == "lications/" {
 							elem = elem[l:]
 						} else {
@@ -407,7 +395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -441,7 +429,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -460,7 +447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -472,7 +459,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'g': // Prefix: "grant"
-								origElem := elem
+
 								if l := len("grant"); len(elem) >= l && elem[0:l] == "grant" {
 									elem = elem[l:]
 								} else {
@@ -493,9 +480,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 't': // Prefix: "token"
-								origElem := elem
+
 								if l := len("token"); len(elem) >= l && elem[0:l] == "token" {
 									elem = elem[l:]
 								} else {
@@ -524,7 +510,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/scoped"
-									origElem := elem
+
 									if l := len("/scoped"); len(elem) >= l && elem[0:l] == "/scoped" {
 										elem = elem[l:]
 									} else {
@@ -545,18 +531,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s/"
-						origElem := elem
+
 						if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 							elem = elem[l:]
 						} else {
@@ -586,12 +568,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "uthorizations"
-					origElem := elem
+
 					if l := len("uthorizations"); len(elem) >= l && elem[0:l] == "uthorizations" {
 						elem = elem[l:]
 					} else {
@@ -612,7 +592,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -654,7 +634,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -685,7 +665,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -721,15 +700,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "codes_of_conduct"
-				origElem := elem
+
 				if l := len("codes_of_conduct"); len(elem) >= l && elem[0:l] == "codes_of_conduct" {
 					elem = elem[l:]
 				} else {
@@ -748,7 +724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -778,12 +754,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -795,7 +769,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "mojis"
-					origElem := elem
+
 					if l := len("mojis"); len(elem) >= l && elem[0:l] == "mojis" {
 						elem = elem[l:]
 					} else {
@@ -814,9 +788,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nterprises/"
-					origElem := elem
+
 					if l := len("nterprises/"); len(elem) >= l && elem[0:l] == "nterprises/" {
 						elem = elem[l:]
 					} else {
@@ -837,7 +810,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -849,7 +822,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "a"
-							origElem := elem
+
 							if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 								elem = elem[l:]
 							} else {
@@ -861,7 +834,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "ctions/"
-								origElem := elem
+
 								if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 									elem = elem[l:]
 								} else {
@@ -873,7 +846,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "permissions"
-									origElem := elem
+
 									if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 										elem = elem[l:]
 									} else {
@@ -898,7 +871,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -910,7 +883,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'o': // Prefix: "organizations"
-											origElem := elem
+
 											if l := len("organizations"); len(elem) >= l && elem[0:l] == "organizations" {
 												elem = elem[l:]
 											} else {
@@ -935,7 +908,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -971,12 +944,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "selected-actions"
-											origElem := elem
+
 											if l := len("selected-actions"); len(elem) >= l && elem[0:l] == "selected-actions" {
 												elem = elem[l:]
 											} else {
@@ -1001,15 +972,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "runner"
-									origElem := elem
+
 									if l := len("runner"); len(elem) >= l && elem[0:l] == "runner" {
 										elem = elem[l:]
 									} else {
@@ -1021,7 +989,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-groups"
-										origElem := elem
+
 										if l := len("-groups"); len(elem) >= l && elem[0:l] == "-groups" {
 											elem = elem[l:]
 										} else {
@@ -1046,7 +1014,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -1087,7 +1055,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -1099,7 +1067,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'o': // Prefix: "organizations"
-													origElem := elem
+
 													if l := len("organizations"); len(elem) >= l && elem[0:l] == "organizations" {
 														elem = elem[l:]
 													} else {
@@ -1126,7 +1094,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -1164,12 +1132,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "runners"
-													origElem := elem
+
 													if l := len("runners"); len(elem) >= l && elem[0:l] == "runners" {
 														elem = elem[l:]
 													} else {
@@ -1196,7 +1162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -1234,21 +1200,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -1269,7 +1230,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -1316,7 +1277,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'g': // Prefix: "gistration-token"
-													origElem := elem
+
 													if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 														elem = elem[l:]
 													} else {
@@ -1337,9 +1298,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'm': // Prefix: "move-token"
-													origElem := elem
+
 													if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 														elem = elem[l:]
 													} else {
@@ -1360,7 +1320,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
 												elem = origElem
@@ -1394,18 +1353,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udit-log"
-								origElem := elem
+
 								if l := len("udit-log"); len(elem) >= l && elem[0:l] == "udit-log" {
 									elem = elem[l:]
 								} else {
@@ -1426,12 +1381,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "settings/billing/"
-							origElem := elem
+
 							if l := len("settings/billing/"); len(elem) >= l && elem[0:l] == "settings/billing/" {
 								elem = elem[l:]
 							} else {
@@ -1443,7 +1396,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "actions"
-								origElem := elem
+
 								if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 									elem = elem[l:]
 								} else {
@@ -1464,9 +1417,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "packages"
-								origElem := elem
+
 								if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 									elem = elem[l:]
 								} else {
@@ -1487,9 +1439,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 's': // Prefix: "shared-storage"
-								origElem := elem
+
 								if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 									elem = elem[l:]
 								} else {
@@ -1510,18 +1461,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vents"
-					origElem := elem
+
 					if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 						elem = elem[l:]
 					} else {
@@ -1540,12 +1487,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "feeds"
-				origElem := elem
+
 				if l := len("feeds"); len(elem) >= l && elem[0:l] == "feeds" {
 					elem = elem[l:]
 				} else {
@@ -1564,9 +1509,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "gi"
-				origElem := elem
+
 				if l := len("gi"); len(elem) >= l && elem[0:l] == "gi" {
 					elem = elem[l:]
 				} else {
@@ -1578,7 +1522,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "sts"
-					origElem := elem
+
 					if l := len("sts"); len(elem) >= l && elem[0:l] == "sts" {
 						elem = elem[l:]
 					} else {
@@ -1599,7 +1543,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1680,7 +1624,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -1704,7 +1648,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ents"
-									origElem := elem
+
 									if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 										elem = elem[l:]
 									} else {
@@ -1729,7 +1673,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -1770,12 +1714,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "its"
-									origElem := elem
+
 									if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 										elem = elem[l:]
 									} else {
@@ -1796,7 +1738,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
 								elem = origElem
@@ -1883,15 +1824,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tignore/templates"
-					origElem := elem
+
 					if l := len("tignore/templates"); len(elem) >= l && elem[0:l] == "tignore/templates" {
 						elem = elem[l:]
 					} else {
@@ -1910,7 +1848,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1940,15 +1878,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "i"
-				origElem := elem
+
 				if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 					elem = elem[l:]
 				} else {
@@ -1960,7 +1895,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "nstallation/"
-					origElem := elem
+
 					if l := len("nstallation/"); len(elem) >= l && elem[0:l] == "nstallation/" {
 						elem = elem[l:]
 					} else {
@@ -1972,7 +1907,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'r': // Prefix: "repositories"
-						origElem := elem
+
 						if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 							elem = elem[l:]
 						} else {
@@ -1991,9 +1926,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 't': // Prefix: "token"
-						origElem := elem
+
 						if l := len("token"); len(elem) >= l && elem[0:l] == "token" {
 							elem = elem[l:]
 						} else {
@@ -2012,12 +1946,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "ssues"
-					origElem := elem
+
 					if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 						elem = elem[l:]
 					} else {
@@ -2036,12 +1968,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "licenses"
-				origElem := elem
+
 				if l := len("licenses"); len(elem) >= l && elem[0:l] == "licenses" {
 					elem = elem[l:]
 				} else {
@@ -2060,7 +1990,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -2090,12 +2020,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "m"
-				origElem := elem
+
 				if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 					elem = elem[l:]
 				} else {
@@ -2107,7 +2035,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ark"
-					origElem := elem
+
 					if l := len("ark"); len(elem) >= l && elem[0:l] == "ark" {
 						elem = elem[l:]
 					} else {
@@ -2119,7 +2047,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'd': // Prefix: "down"
-						origElem := elem
+
 						if l := len("down"); len(elem) >= l && elem[0:l] == "down" {
 							elem = elem[l:]
 						} else {
@@ -2138,7 +2066,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/raw"
-							origElem := elem
+
 							if l := len("/raw"); len(elem) >= l && elem[0:l] == "/raw" {
 								elem = elem[l:]
 							} else {
@@ -2157,12 +2085,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "etplace_listing/"
-						origElem := elem
+
 						if l := len("etplace_listing/"); len(elem) >= l && elem[0:l] == "etplace_listing/" {
 							elem = elem[l:]
 						} else {
@@ -2174,7 +2100,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "accounts/"
-							origElem := elem
+
 							if l := len("accounts/"); len(elem) >= l && elem[0:l] == "accounts/" {
 								elem = elem[l:]
 							} else {
@@ -2204,9 +2130,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "plans"
-							origElem := elem
+
 							if l := len("plans"); len(elem) >= l && elem[0:l] == "plans" {
 								elem = elem[l:]
 							} else {
@@ -2225,7 +2150,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -2246,7 +2171,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/accounts"
-									origElem := elem
+
 									if l := len("/accounts"); len(elem) >= l && elem[0:l] == "/accounts" {
 										elem = elem[l:]
 									} else {
@@ -2267,15 +2192,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "stubbed/"
-							origElem := elem
+
 							if l := len("stubbed/"); len(elem) >= l && elem[0:l] == "stubbed/" {
 								elem = elem[l:]
 							} else {
@@ -2287,7 +2209,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "accounts/"
-								origElem := elem
+
 								if l := len("accounts/"); len(elem) >= l && elem[0:l] == "accounts/" {
 									elem = elem[l:]
 								} else {
@@ -2317,9 +2239,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "plans"
-								origElem := elem
+
 								if l := len("plans"); len(elem) >= l && elem[0:l] == "plans" {
 									elem = elem[l:]
 								} else {
@@ -2338,7 +2259,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -2359,7 +2280,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/accounts"
-										origElem := elem
+
 										if l := len("/accounts"); len(elem) >= l && elem[0:l] == "/accounts" {
 											elem = elem[l:]
 										} else {
@@ -2380,24 +2301,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "eta"
-					origElem := elem
+
 					if l := len("eta"); len(elem) >= l && elem[0:l] == "eta" {
 						elem = elem[l:]
 					} else {
@@ -2416,12 +2331,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -2433,7 +2346,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "etworks/"
-					origElem := elem
+
 					if l := len("etworks/"); len(elem) >= l && elem[0:l] == "etworks/" {
 						elem = elem[l:]
 					} else {
@@ -2454,7 +2367,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -2475,7 +2388,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/events"
-							origElem := elem
+
 							if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 								elem = elem[l:]
 							} else {
@@ -2497,15 +2410,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "otifications"
-					origElem := elem
+
 					if l := len("otifications"); len(elem) >= l && elem[0:l] == "otifications" {
 						elem = elem[l:]
 					} else {
@@ -2526,7 +2436,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/threads/"
-						origElem := elem
+
 						if l := len("/threads/"); len(elem) >= l && elem[0:l] == "/threads/" {
 							elem = elem[l:]
 						} else {
@@ -2560,7 +2470,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/subscription"
-							origElem := elem
+
 							if l := len("/subscription"); len(elem) >= l && elem[0:l] == "/subscription" {
 								elem = elem[l:]
 							} else {
@@ -2589,18 +2499,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -2612,7 +2518,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "ctocat"
-					origElem := elem
+
 					if l := len("ctocat"); len(elem) >= l && elem[0:l] == "ctocat" {
 						elem = elem[l:]
 					} else {
@@ -2631,9 +2537,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rg"
-					origElem := elem
+
 					if l := len("rg"); len(elem) >= l && elem[0:l] == "rg" {
 						elem = elem[l:]
 					} else {
@@ -2645,7 +2550,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "anizations"
-						origElem := elem
+
 						if l := len("anizations"); len(elem) >= l && elem[0:l] == "anizations" {
 							elem = elem[l:]
 						} else {
@@ -2664,9 +2569,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s/"
-						origElem := elem
+
 						if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 							elem = elem[l:]
 						} else {
@@ -2696,7 +2600,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -2708,7 +2612,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "a"
-								origElem := elem
+
 								if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 									elem = elem[l:]
 								} else {
@@ -2720,7 +2624,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "ctions/"
-									origElem := elem
+
 									if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 										elem = elem[l:]
 									} else {
@@ -2732,7 +2636,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'p': // Prefix: "permissions"
-										origElem := elem
+
 										if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 											elem = elem[l:]
 										} else {
@@ -2757,7 +2661,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -2769,7 +2673,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'r': // Prefix: "repositories"
-												origElem := elem
+
 												if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 													elem = elem[l:]
 												} else {
@@ -2794,7 +2698,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -2830,12 +2734,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "selected-actions"
-												origElem := elem
+
 												if l := len("selected-actions"); len(elem) >= l && elem[0:l] == "selected-actions" {
 													elem = elem[l:]
 												} else {
@@ -2860,15 +2762,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "runner"
-										origElem := elem
+
 										if l := len("runner"); len(elem) >= l && elem[0:l] == "runner" {
 											elem = elem[l:]
 										} else {
@@ -2880,7 +2779,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-groups"
-											origElem := elem
+
 											if l := len("-groups"); len(elem) >= l && elem[0:l] == "-groups" {
 												elem = elem[l:]
 											} else {
@@ -2905,7 +2804,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -2946,7 +2845,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/r"
-													origElem := elem
+
 													if l := len("/r"); len(elem) >= l && elem[0:l] == "/r" {
 														elem = elem[l:]
 													} else {
@@ -2958,7 +2857,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'e': // Prefix: "epositories"
-														origElem := elem
+
 														if l := len("epositories"); len(elem) >= l && elem[0:l] == "epositories" {
 															elem = elem[l:]
 														} else {
@@ -2985,7 +2884,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -3023,12 +2922,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unners"
-														origElem := elem
+
 														if l := len("unners"); len(elem) >= l && elem[0:l] == "unners" {
 															elem = elem[l:]
 														} else {
@@ -3055,7 +2952,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -3093,21 +2990,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -3128,7 +3020,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -3175,7 +3067,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'g': // Prefix: "gistration-token"
-														origElem := elem
+
 														if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 															elem = elem[l:]
 														} else {
@@ -3196,9 +3088,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "move-token"
-														origElem := elem
+
 														if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 															elem = elem[l:]
 														} else {
@@ -3219,7 +3110,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -3253,15 +3143,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "secrets"
-										origElem := elem
+
 										if l := len("secrets"); len(elem) >= l && elem[0:l] == "secrets" {
 											elem = elem[l:]
 										} else {
@@ -3282,7 +3169,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -3351,7 +3238,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/repositories"
-												origElem := elem
+
 												if l := len("/repositories"); len(elem) >= l && elem[0:l] == "/repositories" {
 													elem = elem[l:]
 												} else {
@@ -3378,7 +3265,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -3416,21 +3303,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "udit-log"
-									origElem := elem
+
 									if l := len("udit-log"); len(elem) >= l && elem[0:l] == "udit-log" {
 										elem = elem[l:]
 									} else {
@@ -3451,12 +3333,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "blocks"
-								origElem := elem
+
 								if l := len("blocks"); len(elem) >= l && elem[0:l] == "blocks" {
 									elem = elem[l:]
 								} else {
@@ -3477,7 +3357,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -3518,12 +3398,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'c': // Prefix: "credential-authorizations"
-								origElem := elem
+
 								if l := len("credential-authorizations"); len(elem) >= l && elem[0:l] == "credential-authorizations" {
 									elem = elem[l:]
 								} else {
@@ -3544,7 +3422,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -3575,12 +3453,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -3601,9 +3477,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "failed_invitations"
-								origElem := elem
+
 								if l := len("failed_invitations"); len(elem) >= l && elem[0:l] == "failed_invitations" {
 									elem = elem[l:]
 								} else {
@@ -3624,9 +3499,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hooks"
-								origElem := elem
+
 								if l := len("hooks"); len(elem) >= l && elem[0:l] == "hooks" {
 									elem = elem[l:]
 								} else {
@@ -3651,7 +3525,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -3692,7 +3566,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -3704,7 +3578,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "config"
-											origElem := elem
+
 											if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 												elem = elem[l:]
 											} else {
@@ -3731,9 +3605,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'd': // Prefix: "deliveries"
-											origElem := elem
+
 											if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 												elem = elem[l:]
 											} else {
@@ -3755,7 +3628,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -3787,7 +3660,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/attempts"
-													origElem := elem
+
 													if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 														elem = elem[l:]
 													} else {
@@ -3810,15 +3683,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'p': // Prefix: "pings"
-											origElem := elem
+
 											if l := len("pings"); len(elem) >= l && elem[0:l] == "pings" {
 												elem = elem[l:]
 											} else {
@@ -3840,18 +3710,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -3863,7 +3729,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "n"
-									origElem := elem
+
 									if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 										elem = elem[l:]
 									} else {
@@ -3875,7 +3741,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 't': // Prefix: "teraction-limits"
-										origElem := elem
+
 										if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 											elem = elem[l:]
 										} else {
@@ -3900,9 +3766,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "vitations"
-										origElem := elem
+
 										if l := len("vitations"); len(elem) >= l && elem[0:l] == "vitations" {
 											elem = elem[l:]
 										} else {
@@ -3927,7 +3792,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -3958,7 +3823,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/teams"
-												origElem := elem
+
 												if l := len("/teams"); len(elem) >= l && elem[0:l] == "/teams" {
 													elem = elem[l:]
 												} else {
@@ -3980,18 +3845,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 's': // Prefix: "ssues"
-									origElem := elem
+
 									if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 										elem = elem[l:]
 									} else {
@@ -4012,12 +3873,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "m"
-								origElem := elem
+
 								if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 									elem = elem[l:]
 								} else {
@@ -4029,7 +3888,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "embers"
-									origElem := elem
+
 									if l := len("embers"); len(elem) >= l && elem[0:l] == "embers" {
 										elem = elem[l:]
 									} else {
@@ -4050,7 +3909,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -4086,9 +3945,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'h': // Prefix: "hips/"
-										origElem := elem
+
 										if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 											elem = elem[l:]
 										} else {
@@ -4129,12 +3987,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "igrations"
-									origElem := elem
+
 									if l := len("igrations"); len(elem) >= l && elem[0:l] == "igrations" {
 										elem = elem[l:]
 									} else {
@@ -4159,7 +4015,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -4190,7 +4046,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -4202,7 +4058,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "archive"
-												origElem := elem
+
 												if l := len("archive"); len(elem) >= l && elem[0:l] == "archive" {
 													elem = elem[l:]
 												} else {
@@ -4229,9 +4085,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "repos"
-												origElem := elem
+
 												if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 													elem = elem[l:]
 												} else {
@@ -4243,7 +4098,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -4264,7 +4119,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/lock"
-														origElem := elem
+
 														if l := len("/lock"); len(elem) >= l && elem[0:l] == "/lock" {
 															elem = elem[l:]
 														} else {
@@ -4287,12 +4142,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'i': // Prefix: "itories"
-													origElem := elem
+
 													if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 														elem = elem[l:]
 													} else {
@@ -4314,24 +4167,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "outside_collaborators"
-								origElem := elem
+
 								if l := len("outside_collaborators"); len(elem) >= l && elem[0:l] == "outside_collaborators" {
 									elem = elem[l:]
 								} else {
@@ -4352,7 +4199,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -4388,12 +4235,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -4405,7 +4250,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ackages"
-									origElem := elem
+
 									if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 										elem = elem[l:]
 									} else {
@@ -4426,7 +4271,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -4447,7 +4292,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -4485,7 +4330,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -4497,7 +4342,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'r': // Prefix: "restore"
-													origElem := elem
+
 													if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 														elem = elem[l:]
 													} else {
@@ -4520,9 +4365,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "versions"
-													origElem := elem
+
 													if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 														elem = elem[l:]
 													} else {
@@ -4545,7 +4389,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -4585,7 +4429,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/restore"
-															origElem := elem
+
 															if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 																elem = elem[l:]
 															} else {
@@ -4609,27 +4453,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rojects"
-									origElem := elem
+
 									if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 										elem = elem[l:]
 									} else {
@@ -4654,9 +4491,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "ublic_members"
-									origElem := elem
+
 									if l := len("ublic_members"); len(elem) >= l && elem[0:l] == "ublic_members" {
 										elem = elem[l:]
 									} else {
@@ -4677,7 +4513,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -4718,15 +4554,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "repos"
-								origElem := elem
+
 								if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 									elem = elem[l:]
 								} else {
@@ -4751,9 +4584,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 's': // Prefix: "se"
-								origElem := elem
+
 								if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 									elem = elem[l:]
 								} else {
@@ -4765,7 +4597,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cret-scanning/alerts"
-									origElem := elem
+
 									if l := len("cret-scanning/alerts"); len(elem) >= l && elem[0:l] == "cret-scanning/alerts" {
 										elem = elem[l:]
 									} else {
@@ -4786,9 +4618,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 't': // Prefix: "ttings/billing/"
-									origElem := elem
+
 									if l := len("ttings/billing/"); len(elem) >= l && elem[0:l] == "ttings/billing/" {
 										elem = elem[l:]
 									} else {
@@ -4800,7 +4631,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "actions"
-										origElem := elem
+
 										if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 											elem = elem[l:]
 										} else {
@@ -4821,9 +4652,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "packages"
-										origElem := elem
+
 										if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 											elem = elem[l:]
 										} else {
@@ -4844,9 +4674,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "shared-storage"
-										origElem := elem
+
 										if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 											elem = elem[l:]
 										} else {
@@ -4867,15 +4696,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "team"
-								origElem := elem
+
 								if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 									elem = elem[l:]
 								} else {
@@ -4887,7 +4713,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '-': // Prefix: "-sync/groups"
-									origElem := elem
+
 									if l := len("-sync/groups"); len(elem) >= l && elem[0:l] == "-sync/groups" {
 										elem = elem[l:]
 									} else {
@@ -4908,9 +4734,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -4935,7 +4760,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -4976,7 +4801,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -4988,7 +4813,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "discussions"
-												origElem := elem
+
 												if l := len("discussions"); len(elem) >= l && elem[0:l] == "discussions" {
 													elem = elem[l:]
 												} else {
@@ -5015,7 +4840,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -5059,7 +4884,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5071,7 +4896,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "comments"
-															origElem := elem
+
 															if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 																elem = elem[l:]
 															} else {
@@ -5100,7 +4925,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -5147,7 +4972,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/reactions"
-																	origElem := elem
+
 																	if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																		elem = elem[l:]
 																	} else {
@@ -5178,7 +5003,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -5212,18 +5037,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "reactions"
-															origElem := elem
+
 															if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 																elem = elem[l:]
 															} else {
@@ -5252,7 +5073,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -5285,21 +5106,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'i': // Prefix: "invitations"
-												origElem := elem
+
 												if l := len("invitations"); len(elem) >= l && elem[0:l] == "invitations" {
 													elem = elem[l:]
 												} else {
@@ -5321,9 +5137,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "members"
-												origElem := elem
+
 												if l := len("members"); len(elem) >= l && elem[0:l] == "members" {
 													elem = elem[l:]
 												} else {
@@ -5345,7 +5160,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "hips/"
-													origElem := elem
+
 													if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 														elem = elem[l:]
 													} else {
@@ -5389,12 +5204,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "projects"
-												origElem := elem
+
 												if l := len("projects"); len(elem) >= l && elem[0:l] == "projects" {
 													elem = elem[l:]
 												} else {
@@ -5416,7 +5229,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -5460,12 +5273,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "repos"
-												origElem := elem
+
 												if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 													elem = elem[l:]
 												} else {
@@ -5487,7 +5298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -5508,7 +5319,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5555,15 +5366,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "team"
-												origElem := elem
+
 												if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 													elem = elem[l:]
 												} else {
@@ -5575,7 +5383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '-': // Prefix: "-sync/group-mappings"
-													origElem := elem
+
 													if l := len("-sync/group-mappings"); len(elem) >= l && elem[0:l] == "-sync/group-mappings" {
 														elem = elem[l:]
 													} else {
@@ -5602,9 +5410,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -5626,36 +5433,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "projects/"
-				origElem := elem
+
 				if l := len("projects/"); len(elem) >= l && elem[0:l] == "projects/" {
 					elem = elem[l:]
 				} else {
@@ -5717,7 +5514,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/moves"
-							origElem := elem
+
 							if l := len("/moves"); len(elem) >= l && elem[0:l] == "/moves" {
 								elem = elem[l:]
 							} else {
@@ -5738,7 +5535,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
 						elem = origElem
@@ -5774,7 +5570,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -5786,7 +5582,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cards"
-							origElem := elem
+
 							if l := len("cards"); len(elem) >= l && elem[0:l] == "cards" {
 								elem = elem[l:]
 							} else {
@@ -5807,9 +5603,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "moves"
-							origElem := elem
+
 							if l := len("moves"); len(elem) >= l && elem[0:l] == "moves" {
 								elem = elem[l:]
 							} else {
@@ -5830,10 +5625,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
 					elem = origElem
@@ -5869,7 +5662,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/col"
-					origElem := elem
+
 					if l := len("/col"); len(elem) >= l && elem[0:l] == "/col" {
 						elem = elem[l:]
 					} else {
@@ -5881,7 +5674,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'l': // Prefix: "laborators"
-						origElem := elem
+
 						if l := len("laborators"); len(elem) >= l && elem[0:l] == "laborators" {
 							elem = elem[l:]
 						} else {
@@ -5902,7 +5695,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -5938,7 +5731,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/permission"
-								origElem := elem
+
 								if l := len("/permission"); len(elem) >= l && elem[0:l] == "/permission" {
 									elem = elem[l:]
 								} else {
@@ -5960,15 +5753,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "umns"
-						origElem := elem
+
 						if l := len("umns"); len(elem) >= l && elem[0:l] == "umns" {
 							elem = elem[l:]
 						} else {
@@ -5993,15 +5783,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "r"
-				origElem := elem
+
 				if l := len("r"); len(elem) >= l && elem[0:l] == "r" {
 					elem = elem[l:]
 				} else {
@@ -6013,7 +5800,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ate_limit"
-					origElem := elem
+
 					if l := len("ate_limit"); len(elem) >= l && elem[0:l] == "ate_limit" {
 						elem = elem[l:]
 					} else {
@@ -6032,9 +5819,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -6046,7 +5832,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "actions/"
-						origElem := elem
+
 						if l := len("actions/"); len(elem) >= l && elem[0:l] == "actions/" {
 							elem = elem[l:]
 						} else {
@@ -6076,9 +5862,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pos"
-						origElem := elem
+
 						if l := len("pos"); len(elem) >= l && elem[0:l] == "pos" {
 							elem = elem[l:]
 						} else {
@@ -6090,7 +5875,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -6111,7 +5896,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -6152,7 +5937,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -6164,7 +5949,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "a"
-										origElem := elem
+
 										if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 											elem = elem[l:]
 										} else {
@@ -6176,7 +5961,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "ctions/"
-											origElem := elem
+
 											if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 												elem = elem[l:]
 											} else {
@@ -6188,7 +5973,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "artifacts"
-												origElem := elem
+
 												if l := len("artifacts"); len(elem) >= l && elem[0:l] == "artifacts" {
 													elem = elem[l:]
 												} else {
@@ -6210,7 +5995,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -6248,7 +6033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -6281,15 +6066,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'j': // Prefix: "jobs/"
-												origElem := elem
+
 												if l := len("jobs/"); len(elem) >= l && elem[0:l] == "jobs/" {
 													elem = elem[l:]
 												} else {
@@ -6321,7 +6103,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/logs"
-													origElem := elem
+
 													if l := len("/logs"); len(elem) >= l && elem[0:l] == "/logs" {
 														elem = elem[l:]
 													} else {
@@ -6344,12 +6126,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "permissions"
-												origElem := elem
+
 												if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 													elem = elem[l:]
 												} else {
@@ -6376,7 +6156,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/selected-actions"
-													origElem := elem
+
 													if l := len("/selected-actions"); len(elem) >= l && elem[0:l] == "/selected-actions" {
 														elem = elem[l:]
 													} else {
@@ -6403,12 +6183,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "run"
-												origElem := elem
+
 												if l := len("run"); len(elem) >= l && elem[0:l] == "run" {
 													elem = elem[l:]
 												} else {
@@ -6420,7 +6198,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'n': // Prefix: "ners"
-													origElem := elem
+
 													if l := len("ners"); len(elem) >= l && elem[0:l] == "ners" {
 														elem = elem[l:]
 													} else {
@@ -6442,7 +6220,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -6490,7 +6268,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case 'g': // Prefix: "gistration-token"
-																origElem := elem
+
 																if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 																	elem = elem[l:]
 																} else {
@@ -6512,9 +6290,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'm': // Prefix: "move-token"
-																origElem := elem
+
 																if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 																	elem = elem[l:]
 																} else {
@@ -6536,7 +6313,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
 															elem = origElem
@@ -6572,12 +6348,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -6599,7 +6373,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -6637,7 +6411,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -6649,7 +6423,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case 'a': // Prefix: "a"
-																origElem := elem
+
 																if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 																	elem = elem[l:]
 																} else {
@@ -6661,7 +6435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "pprov"
-																	origElem := elem
+
 																	if l := len("pprov"); len(elem) >= l && elem[0:l] == "pprov" {
 																		elem = elem[l:]
 																	} else {
@@ -6673,7 +6447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'a': // Prefix: "als"
-																		origElem := elem
+
 																		if l := len("als"); len(elem) >= l && elem[0:l] == "als" {
 																			elem = elem[l:]
 																		} else {
@@ -6696,9 +6470,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 'e': // Prefix: "e"
-																		origElem := elem
+
 																		if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 																			elem = elem[l:]
 																		} else {
@@ -6721,12 +6494,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 'r': // Prefix: "rtifacts"
-																	origElem := elem
+
 																	if l := len("rtifacts"); len(elem) >= l && elem[0:l] == "rtifacts" {
 																		elem = elem[l:]
 																	} else {
@@ -6749,12 +6520,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 'c': // Prefix: "cancel"
-																origElem := elem
+
 																if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 																	elem = elem[l:]
 																} else {
@@ -6777,9 +6546,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'j': // Prefix: "jobs"
-																origElem := elem
+
 																if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 																	elem = elem[l:]
 																} else {
@@ -6802,9 +6570,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'l': // Prefix: "logs"
-																origElem := elem
+
 																if l := len("logs"); len(elem) >= l && elem[0:l] == "logs" {
 																	elem = elem[l:]
 																} else {
@@ -6833,9 +6600,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'p': // Prefix: "pending_deployments"
-																origElem := elem
+
 																if l := len("pending_deployments"); len(elem) >= l && elem[0:l] == "pending_deployments" {
 																	elem = elem[l:]
 																} else {
@@ -6858,9 +6624,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'r': // Prefix: "re"
-																origElem := elem
+
 																if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 																	elem = elem[l:]
 																} else {
@@ -6872,7 +6637,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'r': // Prefix: "run"
-																	origElem := elem
+
 																	if l := len("run"); len(elem) >= l && elem[0:l] == "run" {
 																		elem = elem[l:]
 																	} else {
@@ -6895,9 +6660,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 't': // Prefix: "try"
-																	origElem := elem
+
 																	if l := len("try"); len(elem) >= l && elem[0:l] == "try" {
 																		elem = elem[l:]
 																	} else {
@@ -6920,12 +6684,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 't': // Prefix: "timing"
-																origElem := elem
+
 																if l := len("timing"); len(elem) >= l && elem[0:l] == "timing" {
 																	elem = elem[l:]
 																} else {
@@ -6948,21 +6710,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "secrets"
-												origElem := elem
+
 												if l := len("secrets"); len(elem) >= l && elem[0:l] == "secrets" {
 													elem = elem[l:]
 												} else {
@@ -6984,7 +6741,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -7057,12 +6814,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "workflows"
-												origElem := elem
+
 												if l := len("workflows"); len(elem) >= l && elem[0:l] == "workflows" {
 													elem = elem[l:]
 												} else {
@@ -7084,12 +6839,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "ssignees"
-											origElem := elem
+
 											if l := len("ssignees"); len(elem) >= l && elem[0:l] == "ssignees" {
 												elem = elem[l:]
 											} else {
@@ -7111,7 +6864,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -7143,12 +6896,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "uto"
-											origElem := elem
+
 											if l := len("uto"); len(elem) >= l && elem[0:l] == "uto" {
 												elem = elem[l:]
 											} else {
@@ -7160,7 +6911,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'l': // Prefix: "links"
-												origElem := elem
+
 												if l := len("links"); len(elem) >= l && elem[0:l] == "links" {
 													elem = elem[l:]
 												} else {
@@ -7187,7 +6938,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -7225,12 +6976,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "mated-security-fixes"
-												origElem := elem
+
 												if l := len("mated-security-fixes"); len(elem) >= l && elem[0:l] == "mated-security-fixes" {
 													elem = elem[l:]
 												} else {
@@ -7257,15 +7006,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'b': // Prefix: "branches"
-										origElem := elem
+
 										if l := len("branches"); len(elem) >= l && elem[0:l] == "branches" {
 											elem = elem[l:]
 										} else {
@@ -7287,7 +7033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -7319,7 +7065,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -7331,7 +7077,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'p': // Prefix: "protection"
-													origElem := elem
+
 													if l := len("protection"); len(elem) >= l && elem[0:l] == "protection" {
 														elem = elem[l:]
 													} else {
@@ -7366,7 +7112,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -7378,7 +7124,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'e': // Prefix: "enforce_admins"
-															origElem := elem
+
 															if l := len("enforce_admins"); len(elem) >= l && elem[0:l] == "enforce_admins" {
 																elem = elem[l:]
 															} else {
@@ -7413,9 +7159,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "re"
-															origElem := elem
+
 															if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 																elem = elem[l:]
 															} else {
@@ -7427,7 +7172,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case 'q': // Prefix: "quired_"
-																origElem := elem
+
 																if l := len("quired_"); len(elem) >= l && elem[0:l] == "quired_" {
 																	elem = elem[l:]
 																} else {
@@ -7439,7 +7184,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "pull_request_reviews"
-																	origElem := elem
+
 																	if l := len("pull_request_reviews"); len(elem) >= l && elem[0:l] == "pull_request_reviews" {
 																		elem = elem[l:]
 																	} else {
@@ -7474,9 +7219,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "s"
-																	origElem := elem
+
 																	if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 																		elem = elem[l:]
 																	} else {
@@ -7488,7 +7232,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'i': // Prefix: "ignatures"
-																		origElem := elem
+
 																		if l := len("ignatures"); len(elem) >= l && elem[0:l] == "ignatures" {
 																			elem = elem[l:]
 																		} else {
@@ -7523,9 +7267,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 't': // Prefix: "tatus_checks"
-																		origElem := elem
+
 																		if l := len("tatus_checks"); len(elem) >= l && elem[0:l] == "tatus_checks" {
 																			elem = elem[l:]
 																		} else {
@@ -7560,7 +7303,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		}
 																		switch elem[0] {
 																		case '/': // Prefix: "/contexts"
-																			origElem := elem
+
 																			if l := len("/contexts"); len(elem) >= l && elem[0:l] == "/contexts" {
 																				elem = elem[l:]
 																			} else {
@@ -7601,18 +7344,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																				return
 																			}
 
-																			elem = origElem
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 's': // Prefix: "strictions"
-																origElem := elem
+
 																if l := len("strictions"); len(elem) >= l && elem[0:l] == "strictions" {
 																	elem = elem[l:]
 																} else {
@@ -7641,7 +7380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -7653,7 +7392,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'a': // Prefix: "apps"
-																		origElem := elem
+
 																		if l := len("apps"); len(elem) >= l && elem[0:l] == "apps" {
 																			elem = elem[l:]
 																		} else {
@@ -7694,9 +7433,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 't': // Prefix: "teams"
-																		origElem := elem
+
 																		if l := len("teams"); len(elem) >= l && elem[0:l] == "teams" {
 																			elem = elem[l:]
 																		} else {
@@ -7737,9 +7475,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 'u': // Prefix: "users"
-																		origElem := elem
+
 																		if l := len("users"); len(elem) >= l && elem[0:l] == "users" {
 																			elem = elem[l:]
 																		} else {
@@ -7780,24 +7517,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rename"
-													origElem := elem
+
 													if l := len("rename"); len(elem) >= l && elem[0:l] == "rename" {
 														elem = elem[l:]
 													} else {
@@ -7820,18 +7551,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'c': // Prefix: "c"
-										origElem := elem
+
 										if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 											elem = elem[l:]
 										} else {
@@ -7843,7 +7570,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'h': // Prefix: "heck-"
-											origElem := elem
+
 											if l := len("heck-"); len(elem) >= l && elem[0:l] == "heck-" {
 												elem = elem[l:]
 											} else {
@@ -7855,7 +7582,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'r': // Prefix: "runs/"
-												origElem := elem
+
 												if l := len("runs/"); len(elem) >= l && elem[0:l] == "runs/" {
 													elem = elem[l:]
 												} else {
@@ -7887,7 +7614,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/annotations"
-													origElem := elem
+
 													if l := len("/annotations"); len(elem) >= l && elem[0:l] == "/annotations" {
 														elem = elem[l:]
 													} else {
@@ -7910,12 +7637,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "suites"
-												origElem := elem
+
 												if l := len("suites"); len(elem) >= l && elem[0:l] == "suites" {
 													elem = elem[l:]
 												} else {
@@ -7937,7 +7662,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -7998,7 +7723,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -8010,7 +7735,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "check-runs"
-															origElem := elem
+
 															if l := len("check-runs"); len(elem) >= l && elem[0:l] == "check-runs" {
 																elem = elem[l:]
 															} else {
@@ -8033,9 +7758,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "rerequest"
-															origElem := elem
+
 															if l := len("rerequest"); len(elem) >= l && elem[0:l] == "rerequest" {
 																elem = elem[l:]
 															} else {
@@ -8058,21 +7782,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'o': // Prefix: "o"
-											origElem := elem
+
 											if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 												elem = elem[l:]
 											} else {
@@ -8084,7 +7803,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "de-scanning/"
-												origElem := elem
+
 												if l := len("de-scanning/"); len(elem) >= l && elem[0:l] == "de-scanning/" {
 													elem = elem[l:]
 												} else {
@@ -8096,7 +7815,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "a"
-													origElem := elem
+
 													if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 														elem = elem[l:]
 													} else {
@@ -8108,7 +7827,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'l': // Prefix: "lerts"
-														origElem := elem
+
 														if l := len("lerts"); len(elem) >= l && elem[0:l] == "lerts" {
 															elem = elem[l:]
 														} else {
@@ -8130,7 +7849,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -8168,7 +7887,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/instances"
-																origElem := elem
+
 																if l := len("/instances"); len(elem) >= l && elem[0:l] == "/instances" {
 																	elem = elem[l:]
 																} else {
@@ -8191,15 +7910,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nalyses"
-														origElem := elem
+
 														if l := len("nalyses"); len(elem) >= l && elem[0:l] == "nalyses" {
 															elem = elem[l:]
 														} else {
@@ -8221,7 +7937,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -8259,15 +7975,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "sarifs"
-													origElem := elem
+
 													if l := len("sarifs"); len(elem) >= l && elem[0:l] == "sarifs" {
 														elem = elem[l:]
 													} else {
@@ -8289,7 +8002,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -8321,15 +8034,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "llaborators"
-												origElem := elem
+
 												if l := len("llaborators"); len(elem) >= l && elem[0:l] == "llaborators" {
 													elem = elem[l:]
 												} else {
@@ -8351,7 +8061,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -8395,7 +8105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/permission"
-														origElem := elem
+
 														if l := len("/permission"); len(elem) >= l && elem[0:l] == "/permission" {
 															elem = elem[l:]
 														} else {
@@ -8418,15 +8128,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "m"
-												origElem := elem
+
 												if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 													elem = elem[l:]
 												} else {
@@ -8438,7 +8145,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'm': // Prefix: "m"
-													origElem := elem
+
 													if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 														elem = elem[l:]
 													} else {
@@ -8450,7 +8157,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'e': // Prefix: "ents"
-														origElem := elem
+
 														if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 															elem = elem[l:]
 														} else {
@@ -8472,7 +8179,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -8516,7 +8223,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/reactions"
-																origElem := elem
+
 																if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																	elem = elem[l:]
 																} else {
@@ -8545,7 +8252,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -8578,18 +8285,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'i': // Prefix: "its"
-														origElem := elem
+
 														if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 															elem = elem[l:]
 														} else {
@@ -8611,7 +8314,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -8643,7 +8346,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -8655,7 +8358,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'b': // Prefix: "branches-where-head"
-																	origElem := elem
+
 																	if l := len("branches-where-head"); len(elem) >= l && elem[0:l] == "branches-where-head" {
 																		elem = elem[l:]
 																	} else {
@@ -8678,9 +8381,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 'c': // Prefix: "c"
-																	origElem := elem
+
 																	if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 																		elem = elem[l:]
 																	} else {
@@ -8692,7 +8394,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'h': // Prefix: "heck-"
-																		origElem := elem
+
 																		if l := len("heck-"); len(elem) >= l && elem[0:l] == "heck-" {
 																			elem = elem[l:]
 																		} else {
@@ -8704,7 +8406,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		}
 																		switch elem[0] {
 																		case 'r': // Prefix: "runs"
-																			origElem := elem
+
 																			if l := len("runs"); len(elem) >= l && elem[0:l] == "runs" {
 																				elem = elem[l:]
 																			} else {
@@ -8727,9 +8429,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																				return
 																			}
 
-																			elem = origElem
 																		case 's': // Prefix: "suites"
-																			origElem := elem
+
 																			if l := len("suites"); len(elem) >= l && elem[0:l] == "suites" {
 																				elem = elem[l:]
 																			} else {
@@ -8752,12 +8453,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																				return
 																			}
 
-																			elem = origElem
 																		}
 
-																		elem = origElem
 																	case 'o': // Prefix: "omments"
-																		origElem := elem
+
 																		if l := len("omments"); len(elem) >= l && elem[0:l] == "omments" {
 																			elem = elem[l:]
 																		} else {
@@ -8786,12 +8485,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 'p': // Prefix: "pulls"
-																	origElem := elem
+
 																	if l := len("pulls"); len(elem) >= l && elem[0:l] == "pulls" {
 																		elem = elem[l:]
 																	} else {
@@ -8814,9 +8511,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "status"
-																	origElem := elem
+
 																	if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																		elem = elem[l:]
 																	} else {
@@ -8839,7 +8535,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'e': // Prefix: "es"
-																		origElem := elem
+
 																		if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 																			elem = elem[l:]
 																		} else {
@@ -8862,21 +8558,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unity/profile"
-														origElem := elem
+
 														if l := len("unity/profile"); len(elem) >= l && elem[0:l] == "unity/profile" {
 															elem = elem[l:]
 														} else {
@@ -8898,12 +8589,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "pare/"
-													origElem := elem
+
 													if l := len("pare/"); len(elem) >= l && elem[0:l] == "pare/" {
 														elem = elem[l:]
 													} else {
@@ -8935,12 +8624,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nt"
-												origElem := elem
+
 												if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 													elem = elem[l:]
 												} else {
@@ -8952,7 +8639,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'e': // Prefix: "ent"
-													origElem := elem
+
 													if l := len("ent"); len(elem) >= l && elem[0:l] == "ent" {
 														elem = elem[l:]
 													} else {
@@ -8964,7 +8651,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_references/"
-														origElem := elem
+
 														if l := len("_references/"); len(elem) >= l && elem[0:l] == "_references/" {
 															elem = elem[l:]
 														} else {
@@ -8985,7 +8672,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/attachments"
-															origElem := elem
+
 															if l := len("/attachments"); len(elem) >= l && elem[0:l] == "/attachments" {
 																elem = elem[l:]
 															} else {
@@ -9008,12 +8695,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s/"
-														origElem := elem
+
 														if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 															elem = elem[l:]
 														} else {
@@ -9051,12 +8736,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "ributors"
-													origElem := elem
+
 													if l := len("ributors"); len(elem) >= l && elem[0:l] == "ributors" {
 														elem = elem[l:]
 													} else {
@@ -9078,18 +8761,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "d"
-										origElem := elem
+
 										if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 											elem = elem[l:]
 										} else {
@@ -9101,7 +8780,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "eployments"
-											origElem := elem
+
 											if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 												elem = elem[l:]
 											} else {
@@ -9128,7 +8807,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -9166,7 +8845,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/statuses"
-													origElem := elem
+
 													if l := len("/statuses"); len(elem) >= l && elem[0:l] == "/statuses" {
 														elem = elem[l:]
 													} else {
@@ -9195,7 +8874,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -9228,18 +8907,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "ispatches"
-											origElem := elem
+
 											if l := len("ispatches"); len(elem) >= l && elem[0:l] == "ispatches" {
 												elem = elem[l:]
 											} else {
@@ -9261,12 +8936,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "e"
-										origElem := elem
+
 										if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 											elem = elem[l:]
 										} else {
@@ -9278,7 +8951,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'n': // Prefix: "nvironments/"
-											origElem := elem
+
 											if l := len("nvironments/"); len(elem) >= l && elem[0:l] == "nvironments/" {
 												elem = elem[l:]
 											} else {
@@ -9310,9 +8983,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "vents"
-											origElem := elem
+
 											if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 												elem = elem[l:]
 											} else {
@@ -9334,12 +9006,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'f': // Prefix: "forks"
-										origElem := elem
+
 										if l := len("forks"); len(elem) >= l && elem[0:l] == "forks" {
 											elem = elem[l:]
 										} else {
@@ -9366,9 +9036,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'g': // Prefix: "g"
-										origElem := elem
+
 										if l := len("g"); len(elem) >= l && elem[0:l] == "g" {
 											elem = elem[l:]
 										} else {
@@ -9380,7 +9049,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "enerate"
-											origElem := elem
+
 											if l := len("enerate"); len(elem) >= l && elem[0:l] == "enerate" {
 												elem = elem[l:]
 											} else {
@@ -9402,9 +9071,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "it/"
-											origElem := elem
+
 											if l := len("it/"); len(elem) >= l && elem[0:l] == "it/" {
 												elem = elem[l:]
 											} else {
@@ -9416,7 +9084,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "blobs"
-												origElem := elem
+
 												if l := len("blobs"); len(elem) >= l && elem[0:l] == "blobs" {
 													elem = elem[l:]
 												} else {
@@ -9438,7 +9106,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -9470,12 +9138,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'c': // Prefix: "commits"
-												origElem := elem
+
 												if l := len("commits"); len(elem) >= l && elem[0:l] == "commits" {
 													elem = elem[l:]
 												} else {
@@ -9497,7 +9163,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -9529,12 +9195,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "matching-refs/"
-												origElem := elem
+
 												if l := len("matching-refs/"); len(elem) >= l && elem[0:l] == "matching-refs/" {
 													elem = elem[l:]
 												} else {
@@ -9566,9 +9230,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "ref"
-												origElem := elem
+
 												if l := len("ref"); len(elem) >= l && elem[0:l] == "ref" {
 													elem = elem[l:]
 												} else {
@@ -9580,7 +9243,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -9612,9 +9275,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -9636,7 +9298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -9674,15 +9336,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "t"
-												origElem := elem
+
 												if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 													elem = elem[l:]
 												} else {
@@ -9694,7 +9353,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "ags"
-													origElem := elem
+
 													if l := len("ags"); len(elem) >= l && elem[0:l] == "ags" {
 														elem = elem[l:]
 													} else {
@@ -9716,7 +9375,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -9748,12 +9407,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rees"
-													origElem := elem
+
 													if l := len("rees"); len(elem) >= l && elem[0:l] == "rees" {
 														elem = elem[l:]
 													} else {
@@ -9775,7 +9432,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -9807,21 +9464,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'h': // Prefix: "hooks"
-										origElem := elem
+
 										if l := len("hooks"); len(elem) >= l && elem[0:l] == "hooks" {
 											elem = elem[l:]
 										} else {
@@ -9848,7 +9500,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9892,7 +9544,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -9904,7 +9556,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "config"
-													origElem := elem
+
 													if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 														elem = elem[l:]
 													} else {
@@ -9933,9 +9585,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'd': // Prefix: "deliveries"
-													origElem := elem
+
 													if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 														elem = elem[l:]
 													} else {
@@ -9958,7 +9609,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -9991,7 +9642,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/attempts"
-															origElem := elem
+
 															if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 																elem = elem[l:]
 															} else {
@@ -10015,15 +9666,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "pings"
-													origElem := elem
+
 													if l := len("pings"); len(elem) >= l && elem[0:l] == "pings" {
 														elem = elem[l:]
 													} else {
@@ -10046,9 +9694,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 't': // Prefix: "tests"
-													origElem := elem
+
 													if l := len("tests"); len(elem) >= l && elem[0:l] == "tests" {
 														elem = elem[l:]
 													} else {
@@ -10071,18 +9718,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "i"
-										origElem := elem
+
 										if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 											elem = elem[l:]
 										} else {
@@ -10094,7 +9737,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mport"
-											origElem := elem
+
 											if l := len("mport"); len(elem) >= l && elem[0:l] == "mport" {
 												elem = elem[l:]
 											} else {
@@ -10131,7 +9774,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -10143,7 +9786,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "authors"
-													origElem := elem
+
 													if l := len("authors"); len(elem) >= l && elem[0:l] == "authors" {
 														elem = elem[l:]
 													} else {
@@ -10165,7 +9808,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -10197,12 +9840,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "l"
-													origElem := elem
+
 													if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 														elem = elem[l:]
 													} else {
@@ -10214,7 +9855,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "arge_files"
-														origElem := elem
+
 														if l := len("arge_files"); len(elem) >= l && elem[0:l] == "arge_files" {
 															elem = elem[l:]
 														} else {
@@ -10236,9 +9877,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'f': // Prefix: "fs"
-														origElem := elem
+
 														if l := len("fs"); len(elem) >= l && elem[0:l] == "fs" {
 															elem = elem[l:]
 														} else {
@@ -10260,18 +9900,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "n"
-											origElem := elem
+
 											if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 												elem = elem[l:]
 											} else {
@@ -10283,7 +9919,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 't': // Prefix: "teraction-limits"
-												origElem := elem
+
 												if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 													elem = elem[l:]
 												} else {
@@ -10310,9 +9946,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'v': // Prefix: "vitations"
-												origElem := elem
+
 												if l := len("vitations"); len(elem) >= l && elem[0:l] == "vitations" {
 													elem = elem[l:]
 												} else {
@@ -10334,7 +9969,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -10372,15 +10007,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "ssues"
-											origElem := elem
+
 											if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 												elem = elem[l:]
 											} else {
@@ -10407,7 +10039,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -10441,7 +10073,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -10485,7 +10117,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/reactions"
-															origElem := elem
+
 															if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																elem = elem[l:]
 															} else {
@@ -10514,7 +10146,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -10547,13 +10179,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -10580,7 +10209,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -10612,7 +10241,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -10648,7 +10276,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -10660,7 +10288,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "assignees"
-														origElem := elem
+
 														if l := len("assignees"); len(elem) >= l && elem[0:l] == "assignees" {
 															elem = elem[l:]
 														} else {
@@ -10689,9 +10317,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'c': // Prefix: "comments"
-														origElem := elem
+
 														if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 															elem = elem[l:]
 														} else {
@@ -10720,9 +10347,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'l': // Prefix: "l"
-														origElem := elem
+
 														if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 															elem = elem[l:]
 														} else {
@@ -10734,7 +10360,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "abels"
-															origElem := elem
+
 															if l := len("abels"); len(elem) >= l && elem[0:l] == "abels" {
 																elem = elem[l:]
 															} else {
@@ -10763,7 +10389,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -10796,12 +10422,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'o': // Prefix: "ock"
-															origElem := elem
+
 															if l := len("ock"); len(elem) >= l && elem[0:l] == "ock" {
 																elem = elem[l:]
 															} else {
@@ -10830,12 +10454,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "reactions"
-														origElem := elem
+
 														if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 															elem = elem[l:]
 														} else {
@@ -10864,7 +10486,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -10897,24 +10519,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'k': // Prefix: "keys"
-										origElem := elem
+
 										if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 											elem = elem[l:]
 										} else {
@@ -10941,7 +10557,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10979,12 +10595,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'l': // Prefix: "l"
-										origElem := elem
+
 										if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 											elem = elem[l:]
 										} else {
@@ -10996,7 +10610,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "a"
-											origElem := elem
+
 											if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 												elem = elem[l:]
 											} else {
@@ -11008,7 +10622,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "bels"
-												origElem := elem
+
 												if l := len("bels"); len(elem) >= l && elem[0:l] == "bels" {
 													elem = elem[l:]
 												} else {
@@ -11035,7 +10649,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -11079,12 +10693,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nguages"
-												origElem := elem
+
 												if l := len("nguages"); len(elem) >= l && elem[0:l] == "nguages" {
 													elem = elem[l:]
 												} else {
@@ -11106,12 +10718,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'f': // Prefix: "fs"
-											origElem := elem
+
 											if l := len("fs"); len(elem) >= l && elem[0:l] == "fs" {
 												elem = elem[l:]
 											} else {
@@ -11138,9 +10748,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "icense"
-											origElem := elem
+
 											if l := len("icense"); len(elem) >= l && elem[0:l] == "icense" {
 												elem = elem[l:]
 											} else {
@@ -11162,12 +10771,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'm': // Prefix: "m"
-										origElem := elem
+
 										if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 											elem = elem[l:]
 										} else {
@@ -11179,7 +10786,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "erge"
-											origElem := elem
+
 											if l := len("erge"); len(elem) >= l && elem[0:l] == "erge" {
 												elem = elem[l:]
 											} else {
@@ -11191,7 +10798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '-': // Prefix: "-upstream"
-												origElem := elem
+
 												if l := len("-upstream"); len(elem) >= l && elem[0:l] == "-upstream" {
 													elem = elem[l:]
 												} else {
@@ -11213,9 +10820,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 's': // Prefix: "s"
-												origElem := elem
+
 												if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 													elem = elem[l:]
 												} else {
@@ -11237,12 +10843,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "ilestones"
-											origElem := elem
+
 											if l := len("ilestones"); len(elem) >= l && elem[0:l] == "ilestones" {
 												elem = elem[l:]
 											} else {
@@ -11269,7 +10873,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11313,7 +10917,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/labels"
-													origElem := elem
+
 													if l := len("/labels"); len(elem) >= l && elem[0:l] == "/labels" {
 														elem = elem[l:]
 													} else {
@@ -11336,18 +10940,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "notifications"
-										origElem := elem
+
 										if l := len("notifications"); len(elem) >= l && elem[0:l] == "notifications" {
 											elem = elem[l:]
 										} else {
@@ -11374,9 +10974,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "p"
-										origElem := elem
+
 										if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 											elem = elem[l:]
 										} else {
@@ -11388,7 +10987,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "ages"
-											origElem := elem
+
 											if l := len("ages"); len(elem) >= l && elem[0:l] == "ages" {
 												elem = elem[l:]
 											} else {
@@ -11420,7 +11019,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11432,7 +11031,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'b': // Prefix: "builds"
-													origElem := elem
+
 													if l := len("builds"); len(elem) >= l && elem[0:l] == "builds" {
 														elem = elem[l:]
 													} else {
@@ -11459,7 +11058,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -11520,12 +11119,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'h': // Prefix: "health"
-													origElem := elem
+
 													if l := len("health"); len(elem) >= l && elem[0:l] == "health" {
 														elem = elem[l:]
 													} else {
@@ -11547,15 +11144,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "rojects"
-											origElem := elem
+
 											if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 												elem = elem[l:]
 											} else {
@@ -11582,9 +11176,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "ulls"
-											origElem := elem
+
 											if l := len("ulls"); len(elem) >= l && elem[0:l] == "ulls" {
 												elem = elem[l:]
 											} else {
@@ -11611,7 +11204,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11645,7 +11238,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -11689,7 +11282,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/reactions"
-															origElem := elem
+
 															if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																elem = elem[l:]
 															} else {
@@ -11718,7 +11311,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -11751,13 +11344,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -11793,7 +11383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -11805,7 +11395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'c': // Prefix: "comm"
-														origElem := elem
+
 														if l := len("comm"); len(elem) >= l && elem[0:l] == "comm" {
 															elem = elem[l:]
 														} else {
@@ -11817,7 +11407,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'e': // Prefix: "ents"
-															origElem := elem
+
 															if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 																elem = elem[l:]
 															} else {
@@ -11846,7 +11436,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -11867,7 +11457,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/replies"
-																	origElem := elem
+
 																	if l := len("/replies"); len(elem) >= l && elem[0:l] == "/replies" {
 																		elem = elem[l:]
 																	} else {
@@ -11891,15 +11481,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'i': // Prefix: "its"
-															origElem := elem
+
 															if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 																elem = elem[l:]
 															} else {
@@ -11922,12 +11509,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'f': // Prefix: "files"
-														origElem := elem
+
 														if l := len("files"); len(elem) >= l && elem[0:l] == "files" {
 															elem = elem[l:]
 														} else {
@@ -11950,9 +11535,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "merge"
-														origElem := elem
+
 														if l := len("merge"); len(elem) >= l && elem[0:l] == "merge" {
 															elem = elem[l:]
 														} else {
@@ -11981,9 +11565,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "re"
-														origElem := elem
+
 														if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 															elem = elem[l:]
 														} else {
@@ -11995,7 +11578,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'q': // Prefix: "quested_reviewers"
-															origElem := elem
+
 															if l := len("quested_reviewers"); len(elem) >= l && elem[0:l] == "quested_reviewers" {
 																elem = elem[l:]
 															} else {
@@ -12024,9 +11607,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 'v': // Prefix: "views"
-															origElem := elem
+
 															if l := len("views"); len(elem) >= l && elem[0:l] == "views" {
 																elem = elem[l:]
 															} else {
@@ -12055,7 +11637,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -12102,7 +11684,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -12114,7 +11696,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case 'c': // Prefix: "comments"
-																		origElem := elem
+
 																		if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 																			elem = elem[l:]
 																		} else {
@@ -12138,9 +11720,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 'd': // Prefix: "dismissals"
-																		origElem := elem
+
 																		if l := len("dismissals"); len(elem) >= l && elem[0:l] == "dismissals" {
 																			elem = elem[l:]
 																		} else {
@@ -12164,9 +11745,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	case 'e': // Prefix: "events"
-																		origElem := elem
+
 																		if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 																			elem = elem[l:]
 																		} else {
@@ -12190,21 +11770,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "update-branch"
-														origElem := elem
+
 														if l := len("update-branch"); len(elem) >= l && elem[0:l] == "update-branch" {
 															elem = elem[l:]
 														} else {
@@ -12227,21 +11802,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "re"
-										origElem := elem
+
 										if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 											elem = elem[l:]
 										} else {
@@ -12253,7 +11823,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "adme"
-											origElem := elem
+
 											if l := len("adme"); len(elem) >= l && elem[0:l] == "adme" {
 												elem = elem[l:]
 											} else {
@@ -12275,7 +11845,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12307,12 +11877,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'l': // Prefix: "leases"
-											origElem := elem
+
 											if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 												elem = elem[l:]
 											} else {
@@ -12339,7 +11907,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12492,7 +12060,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -12504,7 +12072,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "assets"
-														origElem := elem
+
 														if l := len("assets"); len(elem) >= l && elem[0:l] == "assets" {
 															elem = elem[l:]
 														} else {
@@ -12533,9 +12101,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "reactions"
-														origElem := elem
+
 														if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 															elem = elem[l:]
 														} else {
@@ -12558,21 +12125,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -12584,7 +12146,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "ecret-scanning/alerts"
-											origElem := elem
+
 											if l := len("ecret-scanning/alerts"); len(elem) >= l && elem[0:l] == "ecret-scanning/alerts" {
 												elem = elem[l:]
 											} else {
@@ -12606,7 +12168,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12644,12 +12206,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 't': // Prefix: "tat"
-											origElem := elem
+
 											if l := len("tat"); len(elem) >= l && elem[0:l] == "tat" {
 												elem = elem[l:]
 											} else {
@@ -12661,7 +12221,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 's': // Prefix: "s/"
-												origElem := elem
+
 												if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 													elem = elem[l:]
 												} else {
@@ -12673,7 +12233,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "co"
-													origElem := elem
+
 													if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 														elem = elem[l:]
 													} else {
@@ -12685,7 +12245,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'd': // Prefix: "de_frequency"
-														origElem := elem
+
 														if l := len("de_frequency"); len(elem) >= l && elem[0:l] == "de_frequency" {
 															elem = elem[l:]
 														} else {
@@ -12707,9 +12267,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "mmit_activity"
-														origElem := elem
+
 														if l := len("mmit_activity"); len(elem) >= l && elem[0:l] == "mmit_activity" {
 															elem = elem[l:]
 														} else {
@@ -12731,9 +12290,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "ntributors"
-														origElem := elem
+
 														if l := len("ntributors"); len(elem) >= l && elem[0:l] == "ntributors" {
 															elem = elem[l:]
 														} else {
@@ -12755,12 +12313,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "p"
-													origElem := elem
+
 													if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 														elem = elem[l:]
 													} else {
@@ -12772,7 +12328,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "articipation"
-														origElem := elem
+
 														if l := len("articipation"); len(elem) >= l && elem[0:l] == "articipation" {
 															elem = elem[l:]
 														} else {
@@ -12794,9 +12350,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unch_card"
-														origElem := elem
+
 														if l := len("unch_card"); len(elem) >= l && elem[0:l] == "unch_card" {
 															elem = elem[l:]
 														} else {
@@ -12818,15 +12373,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'u': // Prefix: "uses/"
-												origElem := elem
+
 												if l := len("uses/"); len(elem) >= l && elem[0:l] == "uses/" {
 													elem = elem[l:]
 												} else {
@@ -12858,12 +12410,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "ubscri"
-											origElem := elem
+
 											if l := len("ubscri"); len(elem) >= l && elem[0:l] == "ubscri" {
 												elem = elem[l:]
 											} else {
@@ -12875,7 +12425,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "bers"
-												origElem := elem
+
 												if l := len("bers"); len(elem) >= l && elem[0:l] == "bers" {
 													elem = elem[l:]
 												} else {
@@ -12897,9 +12447,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "ption"
-												origElem := elem
+
 												if l := len("ption"); len(elem) >= l && elem[0:l] == "ption" {
 													elem = elem[l:]
 												} else {
@@ -12931,15 +12480,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 't': // Prefix: "t"
-										origElem := elem
+
 										if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 											elem = elem[l:]
 										} else {
@@ -12951,7 +12497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "a"
-											origElem := elem
+
 											if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 												elem = elem[l:]
 											} else {
@@ -12963,7 +12509,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'g': // Prefix: "gs"
-												origElem := elem
+
 												if l := len("gs"); len(elem) >= l && elem[0:l] == "gs" {
 													elem = elem[l:]
 												} else {
@@ -12985,9 +12531,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "rball/"
-												origElem := elem
+
 												if l := len("rball/"); len(elem) >= l && elem[0:l] == "rball/" {
 													elem = elem[l:]
 												} else {
@@ -13019,12 +12564,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "eams"
-											origElem := elem
+
 											if l := len("eams"); len(elem) >= l && elem[0:l] == "eams" {
 												elem = elem[l:]
 											} else {
@@ -13046,9 +12589,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'o': // Prefix: "opics"
-											origElem := elem
+
 											if l := len("opics"); len(elem) >= l && elem[0:l] == "opics" {
 												elem = elem[l:]
 											} else {
@@ -13075,9 +12617,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "ra"
-											origElem := elem
+
 											if l := len("ra"); len(elem) >= l && elem[0:l] == "ra" {
 												elem = elem[l:]
 											} else {
@@ -13089,7 +12630,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'f': // Prefix: "ffic/"
-												origElem := elem
+
 												if l := len("ffic/"); len(elem) >= l && elem[0:l] == "ffic/" {
 													elem = elem[l:]
 												} else {
@@ -13101,7 +12642,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "clones"
-													origElem := elem
+
 													if l := len("clones"); len(elem) >= l && elem[0:l] == "clones" {
 														elem = elem[l:]
 													} else {
@@ -13123,9 +12664,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "popular/"
-													origElem := elem
+
 													if l := len("popular/"); len(elem) >= l && elem[0:l] == "popular/" {
 														elem = elem[l:]
 													} else {
@@ -13137,7 +12677,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'p': // Prefix: "paths"
-														origElem := elem
+
 														if l := len("paths"); len(elem) >= l && elem[0:l] == "paths" {
 															elem = elem[l:]
 														} else {
@@ -13159,9 +12699,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "referrers"
-														origElem := elem
+
 														if l := len("referrers"); len(elem) >= l && elem[0:l] == "referrers" {
 															elem = elem[l:]
 														} else {
@@ -13183,12 +12722,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "views"
-													origElem := elem
+
 													if l := len("views"); len(elem) >= l && elem[0:l] == "views" {
 														elem = elem[l:]
 													} else {
@@ -13210,12 +12747,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nsfer"
-												origElem := elem
+
 												if l := len("nsfer"); len(elem) >= l && elem[0:l] == "nsfer" {
 													elem = elem[l:]
 												} else {
@@ -13237,15 +12772,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "vulnerability-alerts"
-										origElem := elem
+
 										if l := len("vulnerability-alerts"); len(elem) >= l && elem[0:l] == "vulnerability-alerts" {
 											elem = elem[l:]
 										} else {
@@ -13277,9 +12809,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'z': // Prefix: "zipball/"
-										origElem := elem
+
 										if l := len("zipball/"); len(elem) >= l && elem[0:l] == "zipball/" {
 											elem = elem[l:]
 										} else {
@@ -13311,18 +12842,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "itories"
-							origElem := elem
+
 							if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 								elem = elem[l:]
 							} else {
@@ -13341,7 +12868,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -13362,7 +12889,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/environments/"
-									origElem := elem
+
 									if l := len("/environments/"); len(elem) >= l && elem[0:l] == "/environments/" {
 										elem = elem[l:]
 									} else {
@@ -13383,7 +12910,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/secrets"
-										origElem := elem
+
 										if l := len("/secrets"); len(elem) >= l && elem[0:l] == "/secrets" {
 											elem = elem[l:]
 										} else {
@@ -13405,7 +12932,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -13478,30 +13005,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -13513,7 +13032,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "cim/v2/"
-					origElem := elem
+
 					if l := len("cim/v2/"); len(elem) >= l && elem[0:l] == "cim/v2/" {
 						elem = elem[l:]
 					} else {
@@ -13525,7 +13044,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "enterprises/"
-						origElem := elem
+
 						if l := len("enterprises/"); len(elem) >= l && elem[0:l] == "enterprises/" {
 							elem = elem[l:]
 						} else {
@@ -13546,7 +13065,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -13558,7 +13077,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'G': // Prefix: "Groups"
-								origElem := elem
+
 								if l := len("Groups"); len(elem) >= l && elem[0:l] == "Groups" {
 									elem = elem[l:]
 								} else {
@@ -13583,7 +13102,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -13629,12 +13148,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'U': // Prefix: "Users"
-								origElem := elem
+
 								if l := len("Users"); len(elem) >= l && elem[0:l] == "Users" {
 									elem = elem[l:]
 								} else {
@@ -13659,7 +13176,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -13705,18 +13222,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "organizations/"
-						origElem := elem
+
 						if l := len("organizations/"); len(elem) >= l && elem[0:l] == "organizations/" {
 							elem = elem[l:]
 						} else {
@@ -13737,7 +13250,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/Users/"
-							origElem := elem
+
 							if l := len("/Users/"); len(elem) >= l && elem[0:l] == "/Users/" {
 								elem = elem[l:]
 							} else {
@@ -13768,15 +13281,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "earch/"
-					origElem := elem
+
 					if l := len("earch/"); len(elem) >= l && elem[0:l] == "earch/" {
 						elem = elem[l:]
 					} else {
@@ -13788,7 +13298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "co"
-						origElem := elem
+
 						if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 							elem = elem[l:]
 						} else {
@@ -13800,7 +13310,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'd': // Prefix: "de"
-							origElem := elem
+
 							if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 								elem = elem[l:]
 							} else {
@@ -13819,9 +13329,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mmits"
-							origElem := elem
+
 							if l := len("mmits"); len(elem) >= l && elem[0:l] == "mmits" {
 								elem = elem[l:]
 							} else {
@@ -13840,12 +13349,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "issues"
-						origElem := elem
+
 						if l := len("issues"); len(elem) >= l && elem[0:l] == "issues" {
 							elem = elem[l:]
 						} else {
@@ -13864,9 +13371,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "labels"
-						origElem := elem
+
 						if l := len("labels"); len(elem) >= l && elem[0:l] == "labels" {
 							elem = elem[l:]
 						} else {
@@ -13885,9 +13391,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repositories"
-						origElem := elem
+
 						if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 							elem = elem[l:]
 						} else {
@@ -13906,9 +13411,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 't': // Prefix: "topics"
-						origElem := elem
+
 						if l := len("topics"); len(elem) >= l && elem[0:l] == "topics" {
 							elem = elem[l:]
 						} else {
@@ -13927,9 +13431,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "users"
-						origElem := elem
+
 						if l := len("users"); len(elem) >= l && elem[0:l] == "users" {
 							elem = elem[l:]
 						} else {
@@ -13948,15 +13451,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "teams/"
-				origElem := elem
+
 				if l := len("teams/"); len(elem) >= l && elem[0:l] == "teams/" {
 					elem = elem[l:]
 				} else {
@@ -13994,7 +13494,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -14006,7 +13506,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'd': // Prefix: "discussions"
-						origElem := elem
+
 						if l := len("discussions"); len(elem) >= l && elem[0:l] == "discussions" {
 							elem = elem[l:]
 						} else {
@@ -14031,7 +13531,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14072,7 +13572,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -14084,7 +13584,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "comments"
-									origElem := elem
+
 									if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 										elem = elem[l:]
 									} else {
@@ -14111,7 +13611,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -14155,7 +13655,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/reactions"
-											origElem := elem
+
 											if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 												elem = elem[l:]
 											} else {
@@ -14184,15 +13684,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "reactions"
-									origElem := elem
+
 									if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 										elem = elem[l:]
 									} else {
@@ -14219,18 +13716,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "invitations"
-						origElem := elem
+
 						if l := len("invitations"); len(elem) >= l && elem[0:l] == "invitations" {
 							elem = elem[l:]
 						} else {
@@ -14251,9 +13744,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "members"
-						origElem := elem
+
 						if l := len("members"); len(elem) >= l && elem[0:l] == "members" {
 							elem = elem[l:]
 						} else {
@@ -14274,7 +13766,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14315,9 +13807,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'h': // Prefix: "hips/"
-							origElem := elem
+
 							if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 								elem = elem[l:]
 							} else {
@@ -14358,12 +13849,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "projects"
-						origElem := elem
+
 						if l := len("projects"); len(elem) >= l && elem[0:l] == "projects" {
 							elem = elem[l:]
 						} else {
@@ -14384,7 +13873,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14425,12 +13914,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repos"
-						origElem := elem
+
 						if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 							elem = elem[l:]
 						} else {
@@ -14451,7 +13938,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14472,7 +13959,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -14516,15 +14003,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "team"
-						origElem := elem
+
 						if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 							elem = elem[l:]
 						} else {
@@ -14536,7 +14020,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '-': // Prefix: "-sync/group-mappings"
-							origElem := elem
+
 							if l := len("-sync/group-mappings"); len(elem) >= l && elem[0:l] == "-sync/group-mappings" {
 								elem = elem[l:]
 							} else {
@@ -14561,9 +14045,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 's': // Prefix: "s"
-							origElem := elem
+
 							if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 								elem = elem[l:]
 							} else {
@@ -14584,18 +14067,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user"
-				origElem := elem
+
 				if l := len("user"); len(elem) >= l && elem[0:l] == "user" {
 					elem = elem[l:]
 				} else {
@@ -14616,7 +14095,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -14628,7 +14107,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "blocks"
-						origElem := elem
+
 						if l := len("blocks"); len(elem) >= l && elem[0:l] == "blocks" {
 							elem = elem[l:]
 						} else {
@@ -14647,7 +14126,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14685,12 +14164,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "email"
-						origElem := elem
+
 						if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 							elem = elem[l:]
 						} else {
@@ -14702,7 +14179,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/visibility"
-							origElem := elem
+
 							if l := len("/visibility"); len(elem) >= l && elem[0:l] == "/visibility" {
 								elem = elem[l:]
 							} else {
@@ -14721,9 +14198,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 's': // Prefix: "s"
-							origElem := elem
+
 							if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 								elem = elem[l:]
 							} else {
@@ -14746,12 +14222,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "follow"
-						origElem := elem
+
 						if l := len("follow"); len(elem) >= l && elem[0:l] == "follow" {
 							elem = elem[l:]
 						} else {
@@ -14763,7 +14237,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "ers"
-							origElem := elem
+
 							if l := len("ers"); len(elem) >= l && elem[0:l] == "ers" {
 								elem = elem[l:]
 							} else {
@@ -14782,9 +14256,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "ing"
-							origElem := elem
+
 							if l := len("ing"); len(elem) >= l && elem[0:l] == "ing" {
 								elem = elem[l:]
 							} else {
@@ -14803,7 +14276,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -14841,15 +14314,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'g': // Prefix: "gpg_keys"
-						origElem := elem
+
 						if l := len("gpg_keys"); len(elem) >= l && elem[0:l] == "gpg_keys" {
 							elem = elem[l:]
 						} else {
@@ -14870,7 +14340,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -14904,12 +14374,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "i"
-						origElem := elem
+
 						if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 							elem = elem[l:]
 						} else {
@@ -14921,7 +14389,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'n': // Prefix: "n"
-							origElem := elem
+
 							if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 								elem = elem[l:]
 							} else {
@@ -14933,7 +14401,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 's': // Prefix: "stallations/"
-								origElem := elem
+
 								if l := len("stallations/"); len(elem) >= l && elem[0:l] == "stallations/" {
 									elem = elem[l:]
 								} else {
@@ -14954,7 +14422,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/repositories"
-									origElem := elem
+
 									if l := len("/repositories"); len(elem) >= l && elem[0:l] == "/repositories" {
 										elem = elem[l:]
 									} else {
@@ -14975,7 +14443,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -15011,15 +14479,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "teraction-limits"
-								origElem := elem
+
 								if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 									elem = elem[l:]
 								} else {
@@ -15040,12 +14505,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "ssues"
-							origElem := elem
+
 							if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 								elem = elem[l:]
 							} else {
@@ -15064,12 +14527,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'k': // Prefix: "keys"
-						origElem := elem
+
 						if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 							elem = elem[l:]
 						} else {
@@ -15090,7 +14551,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -15124,12 +14585,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "m"
-						origElem := elem
+
 						if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 							elem = elem[l:]
 						} else {
@@ -15141,7 +14600,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "arketplace_purchases"
-							origElem := elem
+
 							if l := len("arketplace_purchases"); len(elem) >= l && elem[0:l] == "arketplace_purchases" {
 								elem = elem[l:]
 							} else {
@@ -15160,7 +14619,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/stubbed"
-								origElem := elem
+
 								if l := len("/stubbed"); len(elem) >= l && elem[0:l] == "/stubbed" {
 									elem = elem[l:]
 								} else {
@@ -15179,12 +14638,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'e': // Prefix: "emberships/orgs"
-							origElem := elem
+
 							if l := len("emberships/orgs"); len(elem) >= l && elem[0:l] == "emberships/orgs" {
 								elem = elem[l:]
 							} else {
@@ -15203,7 +14660,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -15237,12 +14694,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "igrations"
-							origElem := elem
+
 							if l := len("igrations"); len(elem) >= l && elem[0:l] == "igrations" {
 								elem = elem[l:]
 							} else {
@@ -15263,7 +14718,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -15293,7 +14748,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -15305,7 +14760,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "archive"
-										origElem := elem
+
 										if l := len("archive"); len(elem) >= l && elem[0:l] == "archive" {
 											elem = elem[l:]
 										} else {
@@ -15330,9 +14785,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "repos"
-										origElem := elem
+
 										if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 											elem = elem[l:]
 										} else {
@@ -15344,7 +14798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -15365,7 +14819,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/lock"
-												origElem := elem
+
 												if l := len("/lock"); len(elem) >= l && elem[0:l] == "/lock" {
 													elem = elem[l:]
 												} else {
@@ -15387,12 +14841,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "itories"
-											origElem := elem
+
 											if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 												elem = elem[l:]
 											} else {
@@ -15413,24 +14865,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "orgs"
-						origElem := elem
+
 						if l := len("orgs"); len(elem) >= l && elem[0:l] == "orgs" {
 							elem = elem[l:]
 						} else {
@@ -15449,9 +14895,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "p"
-						origElem := elem
+
 						if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 							elem = elem[l:]
 						} else {
@@ -15463,7 +14908,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "ackages"
-							origElem := elem
+
 							if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 								elem = elem[l:]
 							} else {
@@ -15482,7 +14927,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -15503,7 +14948,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -15539,7 +14984,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -15551,7 +14996,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'r': // Prefix: "restore"
-											origElem := elem
+
 											if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 												elem = elem[l:]
 											} else {
@@ -15573,9 +15018,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "versions"
-											origElem := elem
+
 											if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 												elem = elem[l:]
 											} else {
@@ -15597,7 +15041,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -15635,7 +15079,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/restore"
-													origElem := elem
+
 													if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 														elem = elem[l:]
 													} else {
@@ -15658,27 +15102,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'r': // Prefix: "rojects"
-							origElem := elem
+
 							if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 								elem = elem[l:]
 							} else {
@@ -15697,9 +15134,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ublic_emails"
-							origElem := elem
+
 							if l := len("ublic_emails"); len(elem) >= l && elem[0:l] == "ublic_emails" {
 								elem = elem[l:]
 							} else {
@@ -15718,12 +15154,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repos"
-						origElem := elem
+
 						if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 							elem = elem[l:]
 						} else {
@@ -15744,7 +15178,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "itory_invitations"
-							origElem := elem
+
 							if l := len("itory_invitations"); len(elem) >= l && elem[0:l] == "itory_invitations" {
 								elem = elem[l:]
 							} else {
@@ -15763,7 +15197,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -15797,15 +15231,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s"
-						origElem := elem
+
 						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 							elem = elem[l:]
 						} else {
@@ -15817,7 +15248,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 't': // Prefix: "tarred"
-							origElem := elem
+
 							if l := len("tarred"); len(elem) >= l && elem[0:l] == "tarred" {
 								elem = elem[l:]
 							} else {
@@ -15836,7 +15267,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -15857,7 +15288,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -15898,15 +15329,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ubscriptions"
-							origElem := elem
+
 							if l := len("ubscriptions"); len(elem) >= l && elem[0:l] == "ubscriptions" {
 								elem = elem[l:]
 							} else {
@@ -15925,12 +15353,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "teams"
-						origElem := elem
+
 						if l := len("teams"); len(elem) >= l && elem[0:l] == "teams" {
 							elem = elem[l:]
 						} else {
@@ -15949,12 +15375,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s"
-					origElem := elem
+
 					if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 						elem = elem[l:]
 					} else {
@@ -15973,7 +15397,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -16003,7 +15427,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -16015,7 +15439,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -16036,7 +15460,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -16048,7 +15472,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'o': // Prefix: "orgs/"
-										origElem := elem
+
 										if l := len("orgs/"); len(elem) >= l && elem[0:l] == "orgs/" {
 											elem = elem[l:]
 										} else {
@@ -16079,9 +15503,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "public"
-										origElem := elem
+
 										if l := len("public"); len(elem) >= l && elem[0:l] == "public" {
 											elem = elem[l:]
 										} else {
@@ -16102,15 +15525,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "follow"
-								origElem := elem
+
 								if l := len("follow"); len(elem) >= l && elem[0:l] == "follow" {
 									elem = elem[l:]
 								} else {
@@ -16122,7 +15542,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ers"
-									origElem := elem
+
 									if l := len("ers"); len(elem) >= l && elem[0:l] == "ers" {
 										elem = elem[l:]
 									} else {
@@ -16143,9 +15563,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "ing"
-									origElem := elem
+
 									if l := len("ing"); len(elem) >= l && elem[0:l] == "ing" {
 										elem = elem[l:]
 									} else {
@@ -16166,7 +15585,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -16197,15 +15616,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'g': // Prefix: "g"
-								origElem := elem
+
 								if l := len("g"); len(elem) >= l && elem[0:l] == "g" {
 									elem = elem[l:]
 								} else {
@@ -16217,7 +15633,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "ists"
-									origElem := elem
+
 									if l := len("ists"); len(elem) >= l && elem[0:l] == "ists" {
 										elem = elem[l:]
 									} else {
@@ -16238,9 +15654,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pg_keys"
-									origElem := elem
+
 									if l := len("pg_keys"); len(elem) >= l && elem[0:l] == "pg_keys" {
 										elem = elem[l:]
 									} else {
@@ -16261,12 +15676,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hovercard"
-								origElem := elem
+
 								if l := len("hovercard"); len(elem) >= l && elem[0:l] == "hovercard" {
 									elem = elem[l:]
 								} else {
@@ -16287,9 +15700,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'k': // Prefix: "keys"
-								origElem := elem
+
 								if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 									elem = elem[l:]
 								} else {
@@ -16310,9 +15722,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "orgs"
-								origElem := elem
+
 								if l := len("orgs"); len(elem) >= l && elem[0:l] == "orgs" {
 									elem = elem[l:]
 								} else {
@@ -16333,9 +15744,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -16347,7 +15757,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ackages"
-									origElem := elem
+
 									if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 										elem = elem[l:]
 									} else {
@@ -16368,7 +15778,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -16389,7 +15799,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -16427,7 +15837,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -16439,7 +15849,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'r': // Prefix: "restore"
-													origElem := elem
+
 													if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 														elem = elem[l:]
 													} else {
@@ -16462,9 +15872,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "versions"
-													origElem := elem
+
 													if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 														elem = elem[l:]
 													} else {
@@ -16487,7 +15896,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16527,7 +15936,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/restore"
-															origElem := elem
+
 															if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 																elem = elem[l:]
 															} else {
@@ -16551,27 +15960,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rojects"
-									origElem := elem
+
 									if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 										elem = elem[l:]
 									} else {
@@ -16592,12 +15994,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "re"
-								origElem := elem
+
 								if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 									elem = elem[l:]
 								} else {
@@ -16609,7 +16009,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "ceived_events"
-									origElem := elem
+
 									if l := len("ceived_events"); len(elem) >= l && elem[0:l] == "ceived_events" {
 										elem = elem[l:]
 									} else {
@@ -16630,7 +16030,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/public"
-										origElem := elem
+
 										if l := len("/public"); len(elem) >= l && elem[0:l] == "/public" {
 											elem = elem[l:]
 										} else {
@@ -16651,12 +16051,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pos"
-									origElem := elem
+
 									if l := len("pos"); len(elem) >= l && elem[0:l] == "pos" {
 										elem = elem[l:]
 									} else {
@@ -16677,12 +16075,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 's': // Prefix: "s"
-								origElem := elem
+
 								if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 									elem = elem[l:]
 								} else {
@@ -16694,7 +16090,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ettings/billing/"
-									origElem := elem
+
 									if l := len("ettings/billing/"); len(elem) >= l && elem[0:l] == "ettings/billing/" {
 										elem = elem[l:]
 									} else {
@@ -16706,7 +16102,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "actions"
-										origElem := elem
+
 										if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 											elem = elem[l:]
 										} else {
@@ -16727,9 +16123,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "packages"
-										origElem := elem
+
 										if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 											elem = elem[l:]
 										} else {
@@ -16750,9 +16145,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "shared-storage"
-										origElem := elem
+
 										if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 											elem = elem[l:]
 										} else {
@@ -16773,12 +16167,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "ubscriptions"
-									origElem := elem
+
 									if l := len("ubscriptions"); len(elem) >= l && elem[0:l] == "ubscriptions" {
 										elem = elem[l:]
 									} else {
@@ -16799,24 +16191,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'z': // Prefix: "zen"
-				origElem := elem
+
 				if l := len("zen"); len(elem) >= l && elem[0:l] == "zen" {
 					elem = elem[l:]
 				} else {
@@ -16835,10 +16221,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -16920,7 +16304,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -16943,7 +16327,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -16955,7 +16339,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "pp"
-					origElem := elem
+
 					if l := len("pp"); len(elem) >= l && elem[0:l] == "pp" {
 						elem = elem[l:]
 					} else {
@@ -16978,7 +16362,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '-': // Prefix: "-manifests/"
-						origElem := elem
+
 						if l := len("-manifests/"); len(elem) >= l && elem[0:l] == "-manifests/" {
 							elem = elem[l:]
 						} else {
@@ -16999,7 +16383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/conversions"
-							origElem := elem
+
 							if l := len("/conversions"); len(elem) >= l && elem[0:l] == "/conversions" {
 								elem = elem[l:]
 							} else {
@@ -17022,12 +16406,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -17039,7 +16421,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'h': // Prefix: "hook/"
-							origElem := elem
+
 							if l := len("hook/"); len(elem) >= l && elem[0:l] == "hook/" {
 								elem = elem[l:]
 							} else {
@@ -17051,7 +16433,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "config"
-								origElem := elem
+
 								if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 									elem = elem[l:]
 								} else {
@@ -17082,9 +16464,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "deliveries"
-								origElem := elem
+
 								if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 									elem = elem[l:]
 								} else {
@@ -17107,7 +16488,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -17139,7 +16520,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/attempts"
-										origElem := elem
+
 										if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 											elem = elem[l:]
 										} else {
@@ -17162,18 +16543,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "installations/"
-							origElem := elem
+
 							if l := len("installations/"); len(elem) >= l && elem[0:l] == "installations/" {
 								elem = elem[l:]
 							} else {
@@ -17205,7 +16582,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -17217,7 +16594,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "access_tokens"
-									origElem := elem
+
 									if l := len("access_tokens"); len(elem) >= l && elem[0:l] == "access_tokens" {
 										elem = elem[l:]
 									} else {
@@ -17240,9 +16617,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "suspended"
-									origElem := elem
+
 									if l := len("suspended"); len(elem) >= l && elem[0:l] == "suspended" {
 										elem = elem[l:]
 									} else {
@@ -17273,18 +16649,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "lications/"
-						origElem := elem
+
 						if l := len("lications/"); len(elem) >= l && elem[0:l] == "lications/" {
 							elem = elem[l:]
 						} else {
@@ -17319,7 +16691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -17359,7 +16731,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -17378,7 +16749,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -17390,7 +16761,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'g': // Prefix: "grant"
-								origElem := elem
+
 								if l := len("grant"); len(elem) >= l && elem[0:l] == "grant" {
 									elem = elem[l:]
 								} else {
@@ -17413,9 +16784,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 't': // Prefix: "token"
-								origElem := elem
+
 								if l := len("token"); len(elem) >= l && elem[0:l] == "token" {
 									elem = elem[l:]
 								} else {
@@ -17454,7 +16824,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/scoped"
-									origElem := elem
+
 									if l := len("/scoped"); len(elem) >= l && elem[0:l] == "/scoped" {
 										elem = elem[l:]
 									} else {
@@ -17477,18 +16847,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s/"
-						origElem := elem
+
 						if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 							elem = elem[l:]
 						} else {
@@ -17520,12 +16886,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "uthorizations"
-					origElem := elem
+
 					if l := len("uthorizations"); len(elem) >= l && elem[0:l] == "uthorizations" {
 						elem = elem[l:]
 					} else {
@@ -17556,7 +16920,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -17600,7 +16964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -17632,7 +16996,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -17678,15 +17041,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "codes_of_conduct"
-				origElem := elem
+
 				if l := len("codes_of_conduct"); len(elem) >= l && elem[0:l] == "codes_of_conduct" {
 					elem = elem[l:]
 				} else {
@@ -17709,7 +17069,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -17741,12 +17101,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -17758,7 +17116,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "mojis"
-					origElem := elem
+
 					if l := len("mojis"); len(elem) >= l && elem[0:l] == "mojis" {
 						elem = elem[l:]
 					} else {
@@ -17781,9 +17139,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nterprises/"
-					origElem := elem
+
 					if l := len("nterprises/"); len(elem) >= l && elem[0:l] == "nterprises/" {
 						elem = elem[l:]
 					} else {
@@ -17804,7 +17161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -17816,7 +17173,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "a"
-							origElem := elem
+
 							if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 								elem = elem[l:]
 							} else {
@@ -17828,7 +17185,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "ctions/"
-								origElem := elem
+
 								if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 									elem = elem[l:]
 								} else {
@@ -17840,7 +17197,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "permissions"
-									origElem := elem
+
 									if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 										elem = elem[l:]
 									} else {
@@ -17871,7 +17228,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -17883,7 +17240,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'o': // Prefix: "organizations"
-											origElem := elem
+
 											if l := len("organizations"); len(elem) >= l && elem[0:l] == "organizations" {
 												elem = elem[l:]
 											} else {
@@ -17914,7 +17271,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -17954,12 +17311,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "selected-actions"
-											origElem := elem
+
 											if l := len("selected-actions"); len(elem) >= l && elem[0:l] == "selected-actions" {
 												elem = elem[l:]
 											} else {
@@ -17990,15 +17345,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "runner"
-									origElem := elem
+
 									if l := len("runner"); len(elem) >= l && elem[0:l] == "runner" {
 										elem = elem[l:]
 									} else {
@@ -18010,7 +17362,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-groups"
-										origElem := elem
+
 										if l := len("-groups"); len(elem) >= l && elem[0:l] == "-groups" {
 											elem = elem[l:]
 										} else {
@@ -18041,7 +17393,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -18089,7 +17441,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -18101,7 +17453,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'o': // Prefix: "organizations"
-													origElem := elem
+
 													if l := len("organizations"); len(elem) >= l && elem[0:l] == "organizations" {
 														elem = elem[l:]
 													} else {
@@ -18132,7 +17484,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -18172,12 +17524,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "runners"
-													origElem := elem
+
 													if l := len("runners"); len(elem) >= l && elem[0:l] == "runners" {
 														elem = elem[l:]
 													} else {
@@ -18208,7 +17558,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -18248,21 +17598,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -18285,7 +17630,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -18334,7 +17679,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'g': // Prefix: "gistration-token"
-													origElem := elem
+
 													if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 														elem = elem[l:]
 													} else {
@@ -18357,9 +17702,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'm': // Prefix: "move-token"
-													origElem := elem
+
 													if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 														elem = elem[l:]
 													} else {
@@ -18382,7 +17726,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
 												elem = origElem
@@ -18420,18 +17763,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udit-log"
-								origElem := elem
+
 								if l := len("udit-log"); len(elem) >= l && elem[0:l] == "udit-log" {
 									elem = elem[l:]
 								} else {
@@ -18454,12 +17793,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "settings/billing/"
-							origElem := elem
+
 							if l := len("settings/billing/"); len(elem) >= l && elem[0:l] == "settings/billing/" {
 								elem = elem[l:]
 							} else {
@@ -18471,7 +17808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "actions"
-								origElem := elem
+
 								if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 									elem = elem[l:]
 								} else {
@@ -18494,9 +17831,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "packages"
-								origElem := elem
+
 								if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 									elem = elem[l:]
 								} else {
@@ -18519,9 +17855,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 's': // Prefix: "shared-storage"
-								origElem := elem
+
 								if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 									elem = elem[l:]
 								} else {
@@ -18544,18 +17879,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vents"
-					origElem := elem
+
 					if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 						elem = elem[l:]
 					} else {
@@ -18578,12 +17909,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "feeds"
-				origElem := elem
+
 				if l := len("feeds"); len(elem) >= l && elem[0:l] == "feeds" {
 					elem = elem[l:]
 				} else {
@@ -18606,9 +17935,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "gi"
-				origElem := elem
+
 				if l := len("gi"); len(elem) >= l && elem[0:l] == "gi" {
 					elem = elem[l:]
 				} else {
@@ -18620,7 +17948,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "sts"
-					origElem := elem
+
 					if l := len("sts"); len(elem) >= l && elem[0:l] == "sts" {
 						elem = elem[l:]
 					} else {
@@ -18651,7 +17979,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -18746,7 +18074,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -18770,7 +18098,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ents"
-									origElem := elem
+
 									if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 										elem = elem[l:]
 									} else {
@@ -18801,7 +18129,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -18849,12 +18177,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "its"
-									origElem := elem
+
 									if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 										elem = elem[l:]
 									} else {
@@ -18877,7 +18203,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
 								elem = origElem
@@ -18981,15 +18306,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tignore/templates"
-					origElem := elem
+
 					if l := len("tignore/templates"); len(elem) >= l && elem[0:l] == "tignore/templates" {
 						elem = elem[l:]
 					} else {
@@ -19012,7 +18334,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -19044,15 +18366,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "i"
-				origElem := elem
+
 				if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 					elem = elem[l:]
 				} else {
@@ -19064,7 +18383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "nstallation/"
-					origElem := elem
+
 					if l := len("nstallation/"); len(elem) >= l && elem[0:l] == "nstallation/" {
 						elem = elem[l:]
 					} else {
@@ -19076,7 +18395,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'r': // Prefix: "repositories"
-						origElem := elem
+
 						if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 							elem = elem[l:]
 						} else {
@@ -19099,9 +18418,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 't': // Prefix: "token"
-						origElem := elem
+
 						if l := len("token"); len(elem) >= l && elem[0:l] == "token" {
 							elem = elem[l:]
 						} else {
@@ -19124,12 +18442,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "ssues"
-					origElem := elem
+
 					if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 						elem = elem[l:]
 					} else {
@@ -19152,12 +18468,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "licenses"
-				origElem := elem
+
 				if l := len("licenses"); len(elem) >= l && elem[0:l] == "licenses" {
 					elem = elem[l:]
 				} else {
@@ -19180,7 +18494,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -19212,12 +18526,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "m"
-				origElem := elem
+
 				if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 					elem = elem[l:]
 				} else {
@@ -19229,7 +18541,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ark"
-					origElem := elem
+
 					if l := len("ark"); len(elem) >= l && elem[0:l] == "ark" {
 						elem = elem[l:]
 					} else {
@@ -19241,7 +18553,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'd': // Prefix: "down"
-						origElem := elem
+
 						if l := len("down"); len(elem) >= l && elem[0:l] == "down" {
 							elem = elem[l:]
 						} else {
@@ -19264,7 +18576,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/raw"
-							origElem := elem
+
 							if l := len("/raw"); len(elem) >= l && elem[0:l] == "/raw" {
 								elem = elem[l:]
 							} else {
@@ -19287,12 +18599,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "etplace_listing/"
-						origElem := elem
+
 						if l := len("etplace_listing/"); len(elem) >= l && elem[0:l] == "etplace_listing/" {
 							elem = elem[l:]
 						} else {
@@ -19304,7 +18614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "accounts/"
-							origElem := elem
+
 							if l := len("accounts/"); len(elem) >= l && elem[0:l] == "accounts/" {
 								elem = elem[l:]
 							} else {
@@ -19336,9 +18646,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "plans"
-							origElem := elem
+
 							if l := len("plans"); len(elem) >= l && elem[0:l] == "plans" {
 								elem = elem[l:]
 							} else {
@@ -19361,7 +18670,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -19382,7 +18691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/accounts"
-									origElem := elem
+
 									if l := len("/accounts"); len(elem) >= l && elem[0:l] == "/accounts" {
 										elem = elem[l:]
 									} else {
@@ -19405,15 +18714,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "stubbed/"
-							origElem := elem
+
 							if l := len("stubbed/"); len(elem) >= l && elem[0:l] == "stubbed/" {
 								elem = elem[l:]
 							} else {
@@ -19425,7 +18731,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "accounts/"
-								origElem := elem
+
 								if l := len("accounts/"); len(elem) >= l && elem[0:l] == "accounts/" {
 									elem = elem[l:]
 								} else {
@@ -19457,9 +18763,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "plans"
-								origElem := elem
+
 								if l := len("plans"); len(elem) >= l && elem[0:l] == "plans" {
 									elem = elem[l:]
 								} else {
@@ -19482,7 +18787,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -19503,7 +18808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/accounts"
-										origElem := elem
+
 										if l := len("/accounts"); len(elem) >= l && elem[0:l] == "/accounts" {
 											elem = elem[l:]
 										} else {
@@ -19526,24 +18831,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "eta"
-					origElem := elem
+
 					if l := len("eta"); len(elem) >= l && elem[0:l] == "eta" {
 						elem = elem[l:]
 					} else {
@@ -19566,12 +18865,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -19583,7 +18880,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "etworks/"
-					origElem := elem
+
 					if l := len("etworks/"); len(elem) >= l && elem[0:l] == "etworks/" {
 						elem = elem[l:]
 					} else {
@@ -19604,7 +18901,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -19625,7 +18922,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/events"
-							origElem := elem
+
 							if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 								elem = elem[l:]
 							} else {
@@ -19648,15 +18945,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "otifications"
-					origElem := elem
+
 					if l := len("otifications"); len(elem) >= l && elem[0:l] == "otifications" {
 						elem = elem[l:]
 					} else {
@@ -19687,7 +18981,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/threads/"
-						origElem := elem
+
 						if l := len("/threads/"); len(elem) >= l && elem[0:l] == "/threads/" {
 							elem = elem[l:]
 						} else {
@@ -19727,7 +19021,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/subscription"
-							origElem := elem
+
 							if l := len("/subscription"); len(elem) >= l && elem[0:l] == "/subscription" {
 								elem = elem[l:]
 							} else {
@@ -19766,18 +19060,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -19789,7 +19079,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "ctocat"
-					origElem := elem
+
 					if l := len("ctocat"); len(elem) >= l && elem[0:l] == "ctocat" {
 						elem = elem[l:]
 					} else {
@@ -19812,9 +19102,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rg"
-					origElem := elem
+
 					if l := len("rg"); len(elem) >= l && elem[0:l] == "rg" {
 						elem = elem[l:]
 					} else {
@@ -19826,7 +19115,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "anizations"
-						origElem := elem
+
 						if l := len("anizations"); len(elem) >= l && elem[0:l] == "anizations" {
 							elem = elem[l:]
 						} else {
@@ -19849,9 +19138,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s/"
-						origElem := elem
+
 						if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 							elem = elem[l:]
 						} else {
@@ -19883,7 +19171,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -19895,7 +19183,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "a"
-								origElem := elem
+
 								if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 									elem = elem[l:]
 								} else {
@@ -19907,7 +19195,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "ctions/"
-									origElem := elem
+
 									if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 										elem = elem[l:]
 									} else {
@@ -19919,7 +19207,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'p': // Prefix: "permissions"
-										origElem := elem
+
 										if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 											elem = elem[l:]
 										} else {
@@ -19950,7 +19238,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -19962,7 +19250,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'r': // Prefix: "repositories"
-												origElem := elem
+
 												if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 													elem = elem[l:]
 												} else {
@@ -19993,7 +19281,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -20033,12 +19321,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "selected-actions"
-												origElem := elem
+
 												if l := len("selected-actions"); len(elem) >= l && elem[0:l] == "selected-actions" {
 													elem = elem[l:]
 												} else {
@@ -20069,15 +19355,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "runner"
-										origElem := elem
+
 										if l := len("runner"); len(elem) >= l && elem[0:l] == "runner" {
 											elem = elem[l:]
 										} else {
@@ -20089,7 +19372,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-groups"
-											origElem := elem
+
 											if l := len("-groups"); len(elem) >= l && elem[0:l] == "-groups" {
 												elem = elem[l:]
 											} else {
@@ -20120,7 +19403,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -20168,7 +19451,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/r"
-													origElem := elem
+
 													if l := len("/r"); len(elem) >= l && elem[0:l] == "/r" {
 														elem = elem[l:]
 													} else {
@@ -20180,7 +19463,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'e': // Prefix: "epositories"
-														origElem := elem
+
 														if l := len("epositories"); len(elem) >= l && elem[0:l] == "epositories" {
 															elem = elem[l:]
 														} else {
@@ -20211,7 +19494,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -20251,12 +19534,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unners"
-														origElem := elem
+
 														if l := len("unners"); len(elem) >= l && elem[0:l] == "unners" {
 															elem = elem[l:]
 														} else {
@@ -20287,7 +19568,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -20327,21 +19608,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -20364,7 +19640,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -20413,7 +19689,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'g': // Prefix: "gistration-token"
-														origElem := elem
+
 														if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 															elem = elem[l:]
 														} else {
@@ -20436,9 +19712,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "move-token"
-														origElem := elem
+
 														if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 															elem = elem[l:]
 														} else {
@@ -20461,7 +19736,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -20499,15 +19773,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "secrets"
-										origElem := elem
+
 										if l := len("secrets"); len(elem) >= l && elem[0:l] == "secrets" {
 											elem = elem[l:]
 										} else {
@@ -20530,7 +19801,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -20608,7 +19879,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/repositories"
-												origElem := elem
+
 												if l := len("/repositories"); len(elem) >= l && elem[0:l] == "/repositories" {
 													elem = elem[l:]
 												} else {
@@ -20639,7 +19910,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -20679,21 +19950,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "udit-log"
-									origElem := elem
+
 									if l := len("udit-log"); len(elem) >= l && elem[0:l] == "udit-log" {
 										elem = elem[l:]
 									} else {
@@ -20716,12 +19982,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "blocks"
-								origElem := elem
+
 								if l := len("blocks"); len(elem) >= l && elem[0:l] == "blocks" {
 									elem = elem[l:]
 								} else {
@@ -20744,7 +20008,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -20792,12 +20056,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'c': // Prefix: "credential-authorizations"
-								origElem := elem
+
 								if l := len("credential-authorizations"); len(elem) >= l && elem[0:l] == "credential-authorizations" {
 									elem = elem[l:]
 								} else {
@@ -20820,7 +20082,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -20852,12 +20114,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -20880,9 +20140,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "failed_invitations"
-								origElem := elem
+
 								if l := len("failed_invitations"); len(elem) >= l && elem[0:l] == "failed_invitations" {
 									elem = elem[l:]
 								} else {
@@ -20905,9 +20164,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hooks"
-								origElem := elem
+
 								if l := len("hooks"); len(elem) >= l && elem[0:l] == "hooks" {
 									elem = elem[l:]
 								} else {
@@ -20938,7 +20196,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -20986,7 +20244,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -20998,7 +20256,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "config"
-											origElem := elem
+
 											if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 												elem = elem[l:]
 											} else {
@@ -21029,9 +20287,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'd': // Prefix: "deliveries"
-											origElem := elem
+
 											if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 												elem = elem[l:]
 											} else {
@@ -21054,7 +20311,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -21086,7 +20343,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/attempts"
-													origElem := elem
+
 													if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 														elem = elem[l:]
 													} else {
@@ -21109,15 +20366,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'p': // Prefix: "pings"
-											origElem := elem
+
 											if l := len("pings"); len(elem) >= l && elem[0:l] == "pings" {
 												elem = elem[l:]
 											} else {
@@ -21140,18 +20394,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -21163,7 +20413,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "n"
-									origElem := elem
+
 									if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 										elem = elem[l:]
 									} else {
@@ -21175,7 +20425,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 't': // Prefix: "teraction-limits"
-										origElem := elem
+
 										if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 											elem = elem[l:]
 										} else {
@@ -21206,9 +20456,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "vitations"
-										origElem := elem
+
 										if l := len("vitations"); len(elem) >= l && elem[0:l] == "vitations" {
 											elem = elem[l:]
 										} else {
@@ -21239,7 +20488,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21271,7 +20520,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/teams"
-												origElem := elem
+
 												if l := len("/teams"); len(elem) >= l && elem[0:l] == "/teams" {
 													elem = elem[l:]
 												} else {
@@ -21294,18 +20543,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 's': // Prefix: "ssues"
-									origElem := elem
+
 									if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 										elem = elem[l:]
 									} else {
@@ -21328,12 +20573,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "m"
-								origElem := elem
+
 								if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 									elem = elem[l:]
 								} else {
@@ -21345,7 +20588,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "embers"
-									origElem := elem
+
 									if l := len("embers"); len(elem) >= l && elem[0:l] == "embers" {
 										elem = elem[l:]
 									} else {
@@ -21368,7 +20611,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -21408,9 +20651,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'h': // Prefix: "hips/"
-										origElem := elem
+
 										if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 											elem = elem[l:]
 										} else {
@@ -21458,12 +20700,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "igrations"
-									origElem := elem
+
 									if l := len("igrations"); len(elem) >= l && elem[0:l] == "igrations" {
 										elem = elem[l:]
 									} else {
@@ -21494,7 +20734,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -21526,7 +20766,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21538,7 +20778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "archive"
-												origElem := elem
+
 												if l := len("archive"); len(elem) >= l && elem[0:l] == "archive" {
 													elem = elem[l:]
 												} else {
@@ -21569,9 +20809,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "repos"
-												origElem := elem
+
 												if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 													elem = elem[l:]
 												} else {
@@ -21583,7 +20822,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -21604,7 +20843,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/lock"
-														origElem := elem
+
 														if l := len("/lock"); len(elem) >= l && elem[0:l] == "/lock" {
 															elem = elem[l:]
 														} else {
@@ -21627,12 +20866,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'i': // Prefix: "itories"
-													origElem := elem
+
 													if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 														elem = elem[l:]
 													} else {
@@ -21655,24 +20892,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "outside_collaborators"
-								origElem := elem
+
 								if l := len("outside_collaborators"); len(elem) >= l && elem[0:l] == "outside_collaborators" {
 									elem = elem[l:]
 								} else {
@@ -21695,7 +20926,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -21735,12 +20966,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -21752,7 +20981,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ackages"
-									origElem := elem
+
 									if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 										elem = elem[l:]
 									} else {
@@ -21775,7 +21004,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -21796,7 +21025,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21836,7 +21065,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -21848,7 +21077,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'r': // Prefix: "restore"
-													origElem := elem
+
 													if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 														elem = elem[l:]
 													} else {
@@ -21871,9 +21100,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "versions"
-													origElem := elem
+
 													if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 														elem = elem[l:]
 													} else {
@@ -21896,7 +21124,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -21936,7 +21164,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/restore"
-															origElem := elem
+
 															if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 																elem = elem[l:]
 															} else {
@@ -21959,27 +21187,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rojects"
-									origElem := elem
+
 									if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 										elem = elem[l:]
 									} else {
@@ -22010,9 +21231,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "ublic_members"
-									origElem := elem
+
 									if l := len("ublic_members"); len(elem) >= l && elem[0:l] == "ublic_members" {
 										elem = elem[l:]
 									} else {
@@ -22035,7 +21255,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -22083,15 +21303,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "repos"
-								origElem := elem
+
 								if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 									elem = elem[l:]
 								} else {
@@ -22122,9 +21339,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 's': // Prefix: "se"
-								origElem := elem
+
 								if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 									elem = elem[l:]
 								} else {
@@ -22136,7 +21352,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cret-scanning/alerts"
-									origElem := elem
+
 									if l := len("cret-scanning/alerts"); len(elem) >= l && elem[0:l] == "cret-scanning/alerts" {
 										elem = elem[l:]
 									} else {
@@ -22159,9 +21375,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 't': // Prefix: "ttings/billing/"
-									origElem := elem
+
 									if l := len("ttings/billing/"); len(elem) >= l && elem[0:l] == "ttings/billing/" {
 										elem = elem[l:]
 									} else {
@@ -22173,7 +21388,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "actions"
-										origElem := elem
+
 										if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 											elem = elem[l:]
 										} else {
@@ -22196,9 +21411,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "packages"
-										origElem := elem
+
 										if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 											elem = elem[l:]
 										} else {
@@ -22221,9 +21435,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "shared-storage"
-										origElem := elem
+
 										if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 											elem = elem[l:]
 										} else {
@@ -22246,15 +21459,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "team"
-								origElem := elem
+
 								if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 									elem = elem[l:]
 								} else {
@@ -22266,7 +21476,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '-': // Prefix: "-sync/groups"
-									origElem := elem
+
 									if l := len("-sync/groups"); len(elem) >= l && elem[0:l] == "-sync/groups" {
 										elem = elem[l:]
 									} else {
@@ -22289,9 +21499,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -22322,7 +21531,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -22370,7 +21579,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -22382,7 +21591,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "discussions"
-												origElem := elem
+
 												if l := len("discussions"); len(elem) >= l && elem[0:l] == "discussions" {
 													elem = elem[l:]
 												} else {
@@ -22413,7 +21622,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -22461,7 +21670,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -22473,7 +21682,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "comments"
-															origElem := elem
+
 															if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 																elem = elem[l:]
 															} else {
@@ -22504,7 +21713,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -22552,7 +21761,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/reactions"
-																	origElem := elem
+
 																	if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																		elem = elem[l:]
 																	} else {
@@ -22583,7 +21792,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -22615,18 +21824,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "reactions"
-															origElem := elem
+
 															if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 																elem = elem[l:]
 															} else {
@@ -22657,7 +21862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -22689,21 +21894,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'i': // Prefix: "invitations"
-												origElem := elem
+
 												if l := len("invitations"); len(elem) >= l && elem[0:l] == "invitations" {
 													elem = elem[l:]
 												} else {
@@ -22726,9 +21926,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "members"
-												origElem := elem
+
 												if l := len("members"); len(elem) >= l && elem[0:l] == "members" {
 													elem = elem[l:]
 												} else {
@@ -22751,7 +21950,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "hips/"
-													origElem := elem
+
 													if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 														elem = elem[l:]
 													} else {
@@ -22799,12 +21998,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "projects"
-												origElem := elem
+
 												if l := len("projects"); len(elem) >= l && elem[0:l] == "projects" {
 													elem = elem[l:]
 												} else {
@@ -22827,7 +22024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -22875,12 +22072,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "repos"
-												origElem := elem
+
 												if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 													elem = elem[l:]
 												} else {
@@ -22903,7 +22098,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -22924,7 +22119,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -22972,15 +22167,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "team"
-												origElem := elem
+
 												if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 													elem = elem[l:]
 												} else {
@@ -22992,7 +22184,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '-': // Prefix: "-sync/group-mappings"
-													origElem := elem
+
 													if l := len("-sync/group-mappings"); len(elem) >= l && elem[0:l] == "-sync/group-mappings" {
 														elem = elem[l:]
 													} else {
@@ -23023,9 +22215,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -23048,36 +22239,26 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "projects/"
-				origElem := elem
+
 				if l := len("projects/"); len(elem) >= l && elem[0:l] == "projects/" {
 					elem = elem[l:]
 				} else {
@@ -23149,7 +22330,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/moves"
-							origElem := elem
+
 							if l := len("/moves"); len(elem) >= l && elem[0:l] == "/moves" {
 								elem = elem[l:]
 							} else {
@@ -23172,7 +22353,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
 						elem = origElem
@@ -23218,7 +22398,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -23230,7 +22410,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cards"
-							origElem := elem
+
 							if l := len("cards"); len(elem) >= l && elem[0:l] == "cards" {
 								elem = elem[l:]
 							} else {
@@ -23253,9 +22433,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "moves"
-							origElem := elem
+
 							if l := len("moves"); len(elem) >= l && elem[0:l] == "moves" {
 								elem = elem[l:]
 							} else {
@@ -23278,10 +22457,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
 					elem = origElem
@@ -23327,7 +22504,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/col"
-					origElem := elem
+
 					if l := len("/col"); len(elem) >= l && elem[0:l] == "/col" {
 						elem = elem[l:]
 					} else {
@@ -23339,7 +22516,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'l': // Prefix: "laborators"
-						origElem := elem
+
 						if l := len("laborators"); len(elem) >= l && elem[0:l] == "laborators" {
 							elem = elem[l:]
 						} else {
@@ -23362,7 +22539,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -23402,7 +22579,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/permission"
-								origElem := elem
+
 								if l := len("/permission"); len(elem) >= l && elem[0:l] == "/permission" {
 									elem = elem[l:]
 								} else {
@@ -23425,15 +22602,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "umns"
-						origElem := elem
+
 						if l := len("umns"); len(elem) >= l && elem[0:l] == "umns" {
 							elem = elem[l:]
 						} else {
@@ -23464,15 +22638,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "r"
-				origElem := elem
+
 				if l := len("r"); len(elem) >= l && elem[0:l] == "r" {
 					elem = elem[l:]
 				} else {
@@ -23484,7 +22655,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ate_limit"
-					origElem := elem
+
 					if l := len("ate_limit"); len(elem) >= l && elem[0:l] == "ate_limit" {
 						elem = elem[l:]
 					} else {
@@ -23507,9 +22678,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -23521,7 +22691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "actions/"
-						origElem := elem
+
 						if l := len("actions/"); len(elem) >= l && elem[0:l] == "actions/" {
 							elem = elem[l:]
 						} else {
@@ -23553,9 +22723,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pos"
-						origElem := elem
+
 						if l := len("pos"); len(elem) >= l && elem[0:l] == "pos" {
 							elem = elem[l:]
 						} else {
@@ -23567,7 +22736,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -23588,7 +22757,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -23636,7 +22805,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -23648,7 +22817,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "a"
-										origElem := elem
+
 										if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 											elem = elem[l:]
 										} else {
@@ -23660,7 +22829,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "ctions/"
-											origElem := elem
+
 											if l := len("ctions/"); len(elem) >= l && elem[0:l] == "ctions/" {
 												elem = elem[l:]
 											} else {
@@ -23672,7 +22841,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "artifacts"
-												origElem := elem
+
 												if l := len("artifacts"); len(elem) >= l && elem[0:l] == "artifacts" {
 													elem = elem[l:]
 												} else {
@@ -23695,7 +22864,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -23735,7 +22904,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -23767,15 +22936,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'j': // Prefix: "jobs/"
-												origElem := elem
+
 												if l := len("jobs/"); len(elem) >= l && elem[0:l] == "jobs/" {
 													elem = elem[l:]
 												} else {
@@ -23807,7 +22973,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/logs"
-													origElem := elem
+
 													if l := len("/logs"); len(elem) >= l && elem[0:l] == "/logs" {
 														elem = elem[l:]
 													} else {
@@ -23830,12 +22996,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "permissions"
-												origElem := elem
+
 												if l := len("permissions"); len(elem) >= l && elem[0:l] == "permissions" {
 													elem = elem[l:]
 												} else {
@@ -23866,7 +23030,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/selected-actions"
-													origElem := elem
+
 													if l := len("/selected-actions"); len(elem) >= l && elem[0:l] == "/selected-actions" {
 														elem = elem[l:]
 													} else {
@@ -23897,12 +23061,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "run"
-												origElem := elem
+
 												if l := len("run"); len(elem) >= l && elem[0:l] == "run" {
 													elem = elem[l:]
 												} else {
@@ -23914,7 +23076,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'n': // Prefix: "ners"
-													origElem := elem
+
 													if l := len("ners"); len(elem) >= l && elem[0:l] == "ners" {
 														elem = elem[l:]
 													} else {
@@ -23937,7 +23099,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -23986,7 +23148,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case 'g': // Prefix: "gistration-token"
-																origElem := elem
+
 																if l := len("gistration-token"); len(elem) >= l && elem[0:l] == "gistration-token" {
 																	elem = elem[l:]
 																} else {
@@ -24009,9 +23171,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'm': // Prefix: "move-token"
-																origElem := elem
+
 																if l := len("move-token"); len(elem) >= l && elem[0:l] == "move-token" {
 																	elem = elem[l:]
 																} else {
@@ -24034,7 +23195,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
 															elem = origElem
@@ -24072,12 +23232,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -24100,7 +23258,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -24140,7 +23298,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -24152,7 +23310,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case 'a': // Prefix: "a"
-																origElem := elem
+
 																if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 																	elem = elem[l:]
 																} else {
@@ -24164,7 +23322,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "pprov"
-																	origElem := elem
+
 																	if l := len("pprov"); len(elem) >= l && elem[0:l] == "pprov" {
 																		elem = elem[l:]
 																	} else {
@@ -24176,7 +23334,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'a': // Prefix: "als"
-																		origElem := elem
+
 																		if l := len("als"); len(elem) >= l && elem[0:l] == "als" {
 																			elem = elem[l:]
 																		} else {
@@ -24199,9 +23357,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 'e': // Prefix: "e"
-																		origElem := elem
+
 																		if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 																			elem = elem[l:]
 																		} else {
@@ -24224,12 +23381,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 'r': // Prefix: "rtifacts"
-																	origElem := elem
+
 																	if l := len("rtifacts"); len(elem) >= l && elem[0:l] == "rtifacts" {
 																		elem = elem[l:]
 																	} else {
@@ -24252,12 +23407,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 'c': // Prefix: "cancel"
-																origElem := elem
+
 																if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 																	elem = elem[l:]
 																} else {
@@ -24280,9 +23433,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'j': // Prefix: "jobs"
-																origElem := elem
+
 																if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 																	elem = elem[l:]
 																} else {
@@ -24305,9 +23457,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'l': // Prefix: "logs"
-																origElem := elem
+
 																if l := len("logs"); len(elem) >= l && elem[0:l] == "logs" {
 																	elem = elem[l:]
 																} else {
@@ -24338,9 +23489,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'p': // Prefix: "pending_deployments"
-																origElem := elem
+
 																if l := len("pending_deployments"); len(elem) >= l && elem[0:l] == "pending_deployments" {
 																	elem = elem[l:]
 																} else {
@@ -24363,9 +23513,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'r': // Prefix: "re"
-																origElem := elem
+
 																if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 																	elem = elem[l:]
 																} else {
@@ -24377,7 +23526,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'r': // Prefix: "run"
-																	origElem := elem
+
 																	if l := len("run"); len(elem) >= l && elem[0:l] == "run" {
 																		elem = elem[l:]
 																	} else {
@@ -24400,9 +23549,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 't': // Prefix: "try"
-																	origElem := elem
+
 																	if l := len("try"); len(elem) >= l && elem[0:l] == "try" {
 																		elem = elem[l:]
 																	} else {
@@ -24425,12 +23573,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 't': // Prefix: "timing"
-																origElem := elem
+
 																if l := len("timing"); len(elem) >= l && elem[0:l] == "timing" {
 																	elem = elem[l:]
 																} else {
@@ -24453,21 +23599,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "secrets"
-												origElem := elem
+
 												if l := len("secrets"); len(elem) >= l && elem[0:l] == "secrets" {
 													elem = elem[l:]
 												} else {
@@ -24490,7 +23631,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -24568,12 +23709,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "workflows"
-												origElem := elem
+
 												if l := len("workflows"); len(elem) >= l && elem[0:l] == "workflows" {
 													elem = elem[l:]
 												} else {
@@ -24596,12 +23735,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "ssignees"
-											origElem := elem
+
 											if l := len("ssignees"); len(elem) >= l && elem[0:l] == "ssignees" {
 												elem = elem[l:]
 											} else {
@@ -24624,7 +23761,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -24656,12 +23793,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "uto"
-											origElem := elem
+
 											if l := len("uto"); len(elem) >= l && elem[0:l] == "uto" {
 												elem = elem[l:]
 											} else {
@@ -24673,7 +23808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'l': // Prefix: "links"
-												origElem := elem
+
 												if l := len("links"); len(elem) >= l && elem[0:l] == "links" {
 													elem = elem[l:]
 												} else {
@@ -24704,7 +23839,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -24744,12 +23879,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "mated-security-fixes"
-												origElem := elem
+
 												if l := len("mated-security-fixes"); len(elem) >= l && elem[0:l] == "mated-security-fixes" {
 													elem = elem[l:]
 												} else {
@@ -24780,15 +23913,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'b': // Prefix: "branches"
-										origElem := elem
+
 										if l := len("branches"); len(elem) >= l && elem[0:l] == "branches" {
 											elem = elem[l:]
 										} else {
@@ -24811,7 +23941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -24843,7 +23973,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -24855,7 +23985,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'p': // Prefix: "protection"
-													origElem := elem
+
 													if l := len("protection"); len(elem) >= l && elem[0:l] == "protection" {
 														elem = elem[l:]
 													} else {
@@ -24894,7 +24024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -24906,7 +24036,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'e': // Prefix: "enforce_admins"
-															origElem := elem
+
 															if l := len("enforce_admins"); len(elem) >= l && elem[0:l] == "enforce_admins" {
 																elem = elem[l:]
 															} else {
@@ -24945,9 +24075,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "re"
-															origElem := elem
+
 															if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 																elem = elem[l:]
 															} else {
@@ -24959,7 +24088,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case 'q': // Prefix: "quired_"
-																origElem := elem
+
 																if l := len("quired_"); len(elem) >= l && elem[0:l] == "quired_" {
 																	elem = elem[l:]
 																} else {
@@ -24971,7 +24100,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "pull_request_reviews"
-																	origElem := elem
+
 																	if l := len("pull_request_reviews"); len(elem) >= l && elem[0:l] == "pull_request_reviews" {
 																		elem = elem[l:]
 																	} else {
@@ -25010,9 +24139,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "s"
-																	origElem := elem
+
 																	if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 																		elem = elem[l:]
 																	} else {
@@ -25024,7 +24152,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'i': // Prefix: "ignatures"
-																		origElem := elem
+
 																		if l := len("ignatures"); len(elem) >= l && elem[0:l] == "ignatures" {
 																			elem = elem[l:]
 																		} else {
@@ -25063,9 +24191,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 't': // Prefix: "tatus_checks"
-																		origElem := elem
+
 																		if l := len("tatus_checks"); len(elem) >= l && elem[0:l] == "tatus_checks" {
 																			elem = elem[l:]
 																		} else {
@@ -25104,7 +24231,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																		switch elem[0] {
 																		case '/': // Prefix: "/contexts"
-																			origElem := elem
+
 																			if l := len("/contexts"); len(elem) >= l && elem[0:l] == "/contexts" {
 																				elem = elem[l:]
 																			} else {
@@ -25151,18 +24278,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																				}
 																			}
 
-																			elem = origElem
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 's': // Prefix: "strictions"
-																origElem := elem
+
 																if l := len("strictions"); len(elem) >= l && elem[0:l] == "strictions" {
 																	elem = elem[l:]
 																} else {
@@ -25193,7 +24316,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -25205,7 +24328,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'a': // Prefix: "apps"
-																		origElem := elem
+
 																		if l := len("apps"); len(elem) >= l && elem[0:l] == "apps" {
 																			elem = elem[l:]
 																		} else {
@@ -25252,9 +24375,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 't': // Prefix: "teams"
-																		origElem := elem
+
 																		if l := len("teams"); len(elem) >= l && elem[0:l] == "teams" {
 																			elem = elem[l:]
 																		} else {
@@ -25301,9 +24423,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 'u': // Prefix: "users"
-																		origElem := elem
+
 																		if l := len("users"); len(elem) >= l && elem[0:l] == "users" {
 																			elem = elem[l:]
 																		} else {
@@ -25350,24 +24471,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rename"
-													origElem := elem
+
 													if l := len("rename"); len(elem) >= l && elem[0:l] == "rename" {
 														elem = elem[l:]
 													} else {
@@ -25390,18 +24505,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'c': // Prefix: "c"
-										origElem := elem
+
 										if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 											elem = elem[l:]
 										} else {
@@ -25413,7 +24524,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'h': // Prefix: "heck-"
-											origElem := elem
+
 											if l := len("heck-"); len(elem) >= l && elem[0:l] == "heck-" {
 												elem = elem[l:]
 											} else {
@@ -25425,7 +24536,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'r': // Prefix: "runs/"
-												origElem := elem
+
 												if l := len("runs/"); len(elem) >= l && elem[0:l] == "runs/" {
 													elem = elem[l:]
 												} else {
@@ -25457,7 +24568,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/annotations"
-													origElem := elem
+
 													if l := len("/annotations"); len(elem) >= l && elem[0:l] == "/annotations" {
 														elem = elem[l:]
 													} else {
@@ -25480,12 +24591,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "suites"
-												origElem := elem
+
 												if l := len("suites"); len(elem) >= l && elem[0:l] == "suites" {
 													elem = elem[l:]
 												} else {
@@ -25508,7 +24617,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -25570,7 +24679,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -25582,7 +24691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "check-runs"
-															origElem := elem
+
 															if l := len("check-runs"); len(elem) >= l && elem[0:l] == "check-runs" {
 																elem = elem[l:]
 															} else {
@@ -25605,9 +24714,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 'r': // Prefix: "rerequest"
-															origElem := elem
+
 															if l := len("rerequest"); len(elem) >= l && elem[0:l] == "rerequest" {
 																elem = elem[l:]
 															} else {
@@ -25630,21 +24738,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'o': // Prefix: "o"
-											origElem := elem
+
 											if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 												elem = elem[l:]
 											} else {
@@ -25656,7 +24759,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "de-scanning/"
-												origElem := elem
+
 												if l := len("de-scanning/"); len(elem) >= l && elem[0:l] == "de-scanning/" {
 													elem = elem[l:]
 												} else {
@@ -25668,7 +24771,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "a"
-													origElem := elem
+
 													if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 														elem = elem[l:]
 													} else {
@@ -25680,7 +24783,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'l': // Prefix: "lerts"
-														origElem := elem
+
 														if l := len("lerts"); len(elem) >= l && elem[0:l] == "lerts" {
 															elem = elem[l:]
 														} else {
@@ -25703,7 +24806,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -25743,7 +24846,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/instances"
-																origElem := elem
+
 																if l := len("/instances"); len(elem) >= l && elem[0:l] == "/instances" {
 																	elem = elem[l:]
 																} else {
@@ -25766,15 +24869,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nalyses"
-														origElem := elem
+
 														if l := len("nalyses"); len(elem) >= l && elem[0:l] == "nalyses" {
 															elem = elem[l:]
 														} else {
@@ -25797,7 +24897,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -25837,15 +24937,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "sarifs"
-													origElem := elem
+
 													if l := len("sarifs"); len(elem) >= l && elem[0:l] == "sarifs" {
 														elem = elem[l:]
 													} else {
@@ -25868,7 +24965,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -25900,15 +24997,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "llaborators"
-												origElem := elem
+
 												if l := len("llaborators"); len(elem) >= l && elem[0:l] == "llaborators" {
 													elem = elem[l:]
 												} else {
@@ -25931,7 +25025,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -25979,7 +25073,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/permission"
-														origElem := elem
+
 														if l := len("/permission"); len(elem) >= l && elem[0:l] == "/permission" {
 															elem = elem[l:]
 														} else {
@@ -26002,15 +25096,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "m"
-												origElem := elem
+
 												if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 													elem = elem[l:]
 												} else {
@@ -26022,7 +25113,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'm': // Prefix: "m"
-													origElem := elem
+
 													if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 														elem = elem[l:]
 													} else {
@@ -26034,7 +25125,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'e': // Prefix: "ents"
-														origElem := elem
+
 														if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 															elem = elem[l:]
 														} else {
@@ -26057,7 +25148,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -26105,7 +25196,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/reactions"
-																origElem := elem
+
 																if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																	elem = elem[l:]
 																} else {
@@ -26136,7 +25227,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -26168,18 +25259,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'i': // Prefix: "its"
-														origElem := elem
+
 														if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 															elem = elem[l:]
 														} else {
@@ -26202,7 +25289,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -26234,7 +25321,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -26246,7 +25333,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'b': // Prefix: "branches-where-head"
-																	origElem := elem
+
 																	if l := len("branches-where-head"); len(elem) >= l && elem[0:l] == "branches-where-head" {
 																		elem = elem[l:]
 																	} else {
@@ -26269,9 +25356,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 'c': // Prefix: "c"
-																	origElem := elem
+
 																	if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 																		elem = elem[l:]
 																	} else {
@@ -26283,7 +25369,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'h': // Prefix: "heck-"
-																		origElem := elem
+
 																		if l := len("heck-"); len(elem) >= l && elem[0:l] == "heck-" {
 																			elem = elem[l:]
 																		} else {
@@ -26295,7 +25381,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																		switch elem[0] {
 																		case 'r': // Prefix: "runs"
-																			origElem := elem
+
 																			if l := len("runs"); len(elem) >= l && elem[0:l] == "runs" {
 																				elem = elem[l:]
 																			} else {
@@ -26318,9 +25404,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																				}
 																			}
 
-																			elem = origElem
 																		case 's': // Prefix: "suites"
-																			origElem := elem
+
 																			if l := len("suites"); len(elem) >= l && elem[0:l] == "suites" {
 																				elem = elem[l:]
 																			} else {
@@ -26343,12 +25428,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																				}
 																			}
 
-																			elem = origElem
 																		}
 
-																		elem = origElem
 																	case 'o': // Prefix: "omments"
-																		origElem := elem
+
 																		if l := len("omments"); len(elem) >= l && elem[0:l] == "omments" {
 																			elem = elem[l:]
 																		} else {
@@ -26379,12 +25462,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 'p': // Prefix: "pulls"
-																	origElem := elem
+
 																	if l := len("pulls"); len(elem) >= l && elem[0:l] == "pulls" {
 																		elem = elem[l:]
 																	} else {
@@ -26407,9 +25488,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "status"
-																	origElem := elem
+
 																	if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																		elem = elem[l:]
 																	} else {
@@ -26432,7 +25512,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'e': // Prefix: "es"
-																		origElem := elem
+
 																		if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 																			elem = elem[l:]
 																		} else {
@@ -26455,21 +25535,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unity/profile"
-														origElem := elem
+
 														if l := len("unity/profile"); len(elem) >= l && elem[0:l] == "unity/profile" {
 															elem = elem[l:]
 														} else {
@@ -26492,12 +25567,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "pare/"
-													origElem := elem
+
 													if l := len("pare/"); len(elem) >= l && elem[0:l] == "pare/" {
 														elem = elem[l:]
 													} else {
@@ -26529,12 +25602,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nt"
-												origElem := elem
+
 												if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 													elem = elem[l:]
 												} else {
@@ -26546,7 +25617,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'e': // Prefix: "ent"
-													origElem := elem
+
 													if l := len("ent"); len(elem) >= l && elem[0:l] == "ent" {
 														elem = elem[l:]
 													} else {
@@ -26558,7 +25629,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_references/"
-														origElem := elem
+
 														if l := len("_references/"); len(elem) >= l && elem[0:l] == "_references/" {
 															elem = elem[l:]
 														} else {
@@ -26579,7 +25650,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/attachments"
-															origElem := elem
+
 															if l := len("/attachments"); len(elem) >= l && elem[0:l] == "/attachments" {
 																elem = elem[l:]
 															} else {
@@ -26602,12 +25673,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s/"
-														origElem := elem
+
 														if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 															elem = elem[l:]
 														} else {
@@ -26647,12 +25716,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "ributors"
-													origElem := elem
+
 													if l := len("ributors"); len(elem) >= l && elem[0:l] == "ributors" {
 														elem = elem[l:]
 													} else {
@@ -26675,18 +25742,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "d"
-										origElem := elem
+
 										if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 											elem = elem[l:]
 										} else {
@@ -26698,7 +25761,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "eployments"
-											origElem := elem
+
 											if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 												elem = elem[l:]
 											} else {
@@ -26729,7 +25792,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -26769,7 +25832,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/statuses"
-													origElem := elem
+
 													if l := len("/statuses"); len(elem) >= l && elem[0:l] == "/statuses" {
 														elem = elem[l:]
 													} else {
@@ -26800,7 +25863,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -26832,18 +25895,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "ispatches"
-											origElem := elem
+
 											if l := len("ispatches"); len(elem) >= l && elem[0:l] == "ispatches" {
 												elem = elem[l:]
 											} else {
@@ -26866,12 +25925,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "e"
-										origElem := elem
+
 										if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 											elem = elem[l:]
 										} else {
@@ -26883,7 +25940,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'n': // Prefix: "nvironments/"
-											origElem := elem
+
 											if l := len("nvironments/"); len(elem) >= l && elem[0:l] == "nvironments/" {
 												elem = elem[l:]
 											} else {
@@ -26915,9 +25972,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "vents"
-											origElem := elem
+
 											if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 												elem = elem[l:]
 											} else {
@@ -26940,12 +25996,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'f': // Prefix: "forks"
-										origElem := elem
+
 										if l := len("forks"); len(elem) >= l && elem[0:l] == "forks" {
 											elem = elem[l:]
 										} else {
@@ -26976,9 +26030,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'g': // Prefix: "g"
-										origElem := elem
+
 										if l := len("g"); len(elem) >= l && elem[0:l] == "g" {
 											elem = elem[l:]
 										} else {
@@ -26990,7 +26043,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "enerate"
-											origElem := elem
+
 											if l := len("enerate"); len(elem) >= l && elem[0:l] == "enerate" {
 												elem = elem[l:]
 											} else {
@@ -27013,9 +26066,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "it/"
-											origElem := elem
+
 											if l := len("it/"); len(elem) >= l && elem[0:l] == "it/" {
 												elem = elem[l:]
 											} else {
@@ -27027,7 +26079,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "blobs"
-												origElem := elem
+
 												if l := len("blobs"); len(elem) >= l && elem[0:l] == "blobs" {
 													elem = elem[l:]
 												} else {
@@ -27050,7 +26102,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27082,12 +26134,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'c': // Prefix: "commits"
-												origElem := elem
+
 												if l := len("commits"); len(elem) >= l && elem[0:l] == "commits" {
 													elem = elem[l:]
 												} else {
@@ -27110,7 +26160,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27142,12 +26192,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'm': // Prefix: "matching-refs/"
-												origElem := elem
+
 												if l := len("matching-refs/"); len(elem) >= l && elem[0:l] == "matching-refs/" {
 													elem = elem[l:]
 												} else {
@@ -27179,9 +26227,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "ref"
-												origElem := elem
+
 												if l := len("ref"); len(elem) >= l && elem[0:l] == "ref" {
 													elem = elem[l:]
 												} else {
@@ -27193,7 +26240,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27225,9 +26272,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -27250,7 +26296,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -27290,15 +26336,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "t"
-												origElem := elem
+
 												if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 													elem = elem[l:]
 												} else {
@@ -27310,7 +26353,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "ags"
-													origElem := elem
+
 													if l := len("ags"); len(elem) >= l && elem[0:l] == "ags" {
 														elem = elem[l:]
 													} else {
@@ -27333,7 +26376,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -27365,12 +26408,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rees"
-													origElem := elem
+
 													if l := len("rees"); len(elem) >= l && elem[0:l] == "rees" {
 														elem = elem[l:]
 													} else {
@@ -27393,7 +26434,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -27425,21 +26466,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'h': // Prefix: "hooks"
-										origElem := elem
+
 										if l := len("hooks"); len(elem) >= l && elem[0:l] == "hooks" {
 											elem = elem[l:]
 										} else {
@@ -27470,7 +26506,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -27518,7 +26554,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27530,7 +26566,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "config"
-													origElem := elem
+
 													if l := len("config"); len(elem) >= l && elem[0:l] == "config" {
 														elem = elem[l:]
 													} else {
@@ -27561,9 +26597,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'd': // Prefix: "deliveries"
-													origElem := elem
+
 													if l := len("deliveries"); len(elem) >= l && elem[0:l] == "deliveries" {
 														elem = elem[l:]
 													} else {
@@ -27586,7 +26621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -27618,7 +26653,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/attempts"
-															origElem := elem
+
 															if l := len("/attempts"); len(elem) >= l && elem[0:l] == "/attempts" {
 																elem = elem[l:]
 															} else {
@@ -27641,15 +26676,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "pings"
-													origElem := elem
+
 													if l := len("pings"); len(elem) >= l && elem[0:l] == "pings" {
 														elem = elem[l:]
 													} else {
@@ -27672,9 +26704,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 't': // Prefix: "tests"
-													origElem := elem
+
 													if l := len("tests"); len(elem) >= l && elem[0:l] == "tests" {
 														elem = elem[l:]
 													} else {
@@ -27697,18 +26728,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "i"
-										origElem := elem
+
 										if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 											elem = elem[l:]
 										} else {
@@ -27720,7 +26747,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mport"
-											origElem := elem
+
 											if l := len("mport"); len(elem) >= l && elem[0:l] == "mport" {
 												elem = elem[l:]
 											} else {
@@ -27767,7 +26794,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27779,7 +26806,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "authors"
-													origElem := elem
+
 													if l := len("authors"); len(elem) >= l && elem[0:l] == "authors" {
 														elem = elem[l:]
 													} else {
@@ -27802,7 +26829,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -27834,12 +26861,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "l"
-													origElem := elem
+
 													if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 														elem = elem[l:]
 													} else {
@@ -27851,7 +26876,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "arge_files"
-														origElem := elem
+
 														if l := len("arge_files"); len(elem) >= l && elem[0:l] == "arge_files" {
 															elem = elem[l:]
 														} else {
@@ -27874,9 +26899,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'f': // Prefix: "fs"
-														origElem := elem
+
 														if l := len("fs"); len(elem) >= l && elem[0:l] == "fs" {
 															elem = elem[l:]
 														} else {
@@ -27899,18 +26923,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "n"
-											origElem := elem
+
 											if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 												elem = elem[l:]
 											} else {
@@ -27922,7 +26942,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 't': // Prefix: "teraction-limits"
-												origElem := elem
+
 												if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 													elem = elem[l:]
 												} else {
@@ -27953,9 +26973,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'v': // Prefix: "vitations"
-												origElem := elem
+
 												if l := len("vitations"); len(elem) >= l && elem[0:l] == "vitations" {
 													elem = elem[l:]
 												} else {
@@ -27978,7 +26997,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -28018,15 +27037,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "ssues"
-											origElem := elem
+
 											if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 												elem = elem[l:]
 											} else {
@@ -28057,7 +27073,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -28092,7 +27108,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -28140,7 +27156,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/reactions"
-															origElem := elem
+
 															if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																elem = elem[l:]
 															} else {
@@ -28171,7 +27187,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -28203,13 +27219,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -28237,7 +27250,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -28269,7 +27282,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -28307,7 +27319,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -28319,7 +27331,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "assignees"
-														origElem := elem
+
 														if l := len("assignees"); len(elem) >= l && elem[0:l] == "assignees" {
 															elem = elem[l:]
 														} else {
@@ -28350,9 +27362,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'c': // Prefix: "comments"
-														origElem := elem
+
 														if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 															elem = elem[l:]
 														} else {
@@ -28383,9 +27394,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'l': // Prefix: "l"
-														origElem := elem
+
 														if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 															elem = elem[l:]
 														} else {
@@ -28397,7 +27407,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "abels"
-															origElem := elem
+
 															if l := len("abels"); len(elem) >= l && elem[0:l] == "abels" {
 																elem = elem[l:]
 															} else {
@@ -28428,7 +27438,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -28460,12 +27470,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'o': // Prefix: "ock"
-															origElem := elem
+
 															if l := len("ock"); len(elem) >= l && elem[0:l] == "ock" {
 																elem = elem[l:]
 															} else {
@@ -28496,12 +27504,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "reactions"
-														origElem := elem
+
 														if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 															elem = elem[l:]
 														} else {
@@ -28532,7 +27538,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -28564,24 +27570,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'k': // Prefix: "keys"
-										origElem := elem
+
 										if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 											elem = elem[l:]
 										} else {
@@ -28612,7 +27612,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -28652,12 +27652,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'l': // Prefix: "l"
-										origElem := elem
+
 										if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 											elem = elem[l:]
 										} else {
@@ -28669,7 +27667,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "a"
-											origElem := elem
+
 											if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 												elem = elem[l:]
 											} else {
@@ -28681,7 +27679,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "bels"
-												origElem := elem
+
 												if l := len("bels"); len(elem) >= l && elem[0:l] == "bels" {
 													elem = elem[l:]
 												} else {
@@ -28712,7 +27710,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -28760,12 +27758,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nguages"
-												origElem := elem
+
 												if l := len("nguages"); len(elem) >= l && elem[0:l] == "nguages" {
 													elem = elem[l:]
 												} else {
@@ -28788,12 +27784,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'f': // Prefix: "fs"
-											origElem := elem
+
 											if l := len("fs"); len(elem) >= l && elem[0:l] == "fs" {
 												elem = elem[l:]
 											} else {
@@ -28824,9 +27818,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "icense"
-											origElem := elem
+
 											if l := len("icense"); len(elem) >= l && elem[0:l] == "icense" {
 												elem = elem[l:]
 											} else {
@@ -28849,12 +27842,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'm': // Prefix: "m"
-										origElem := elem
+
 										if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 											elem = elem[l:]
 										} else {
@@ -28866,7 +27857,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "erge"
-											origElem := elem
+
 											if l := len("erge"); len(elem) >= l && elem[0:l] == "erge" {
 												elem = elem[l:]
 											} else {
@@ -28878,7 +27869,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '-': // Prefix: "-upstream"
-												origElem := elem
+
 												if l := len("-upstream"); len(elem) >= l && elem[0:l] == "-upstream" {
 													elem = elem[l:]
 												} else {
@@ -28901,9 +27892,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 's': // Prefix: "s"
-												origElem := elem
+
 												if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 													elem = elem[l:]
 												} else {
@@ -28926,12 +27916,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "ilestones"
-											origElem := elem
+
 											if l := len("ilestones"); len(elem) >= l && elem[0:l] == "ilestones" {
 												elem = elem[l:]
 											} else {
@@ -28962,7 +27950,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -29010,7 +27998,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/labels"
-													origElem := elem
+
 													if l := len("/labels"); len(elem) >= l && elem[0:l] == "/labels" {
 														elem = elem[l:]
 													} else {
@@ -29033,18 +28021,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "notifications"
-										origElem := elem
+
 										if l := len("notifications"); len(elem) >= l && elem[0:l] == "notifications" {
 											elem = elem[l:]
 										} else {
@@ -29075,9 +28059,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "p"
-										origElem := elem
+
 										if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 											elem = elem[l:]
 										} else {
@@ -29089,7 +28072,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "ages"
-											origElem := elem
+
 											if l := len("ages"); len(elem) >= l && elem[0:l] == "ages" {
 												elem = elem[l:]
 											} else {
@@ -29128,7 +28111,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -29140,7 +28123,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'b': // Prefix: "builds"
-													origElem := elem
+
 													if l := len("builds"); len(elem) >= l && elem[0:l] == "builds" {
 														elem = elem[l:]
 													} else {
@@ -29171,7 +28154,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -29233,12 +28216,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'h': // Prefix: "health"
-													origElem := elem
+
 													if l := len("health"); len(elem) >= l && elem[0:l] == "health" {
 														elem = elem[l:]
 													} else {
@@ -29261,15 +28242,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "rojects"
-											origElem := elem
+
 											if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 												elem = elem[l:]
 											} else {
@@ -29300,9 +28278,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "ulls"
-											origElem := elem
+
 											if l := len("ulls"); len(elem) >= l && elem[0:l] == "ulls" {
 												elem = elem[l:]
 											} else {
@@ -29333,7 +28310,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -29368,7 +28345,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -29416,7 +28393,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/reactions"
-															origElem := elem
+
 															if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 																elem = elem[l:]
 															} else {
@@ -29447,7 +28424,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -29479,13 +28456,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
 													elem = origElem
@@ -29523,7 +28497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -29535,7 +28509,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'c': // Prefix: "comm"
-														origElem := elem
+
 														if l := len("comm"); len(elem) >= l && elem[0:l] == "comm" {
 															elem = elem[l:]
 														} else {
@@ -29547,7 +28521,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'e': // Prefix: "ents"
-															origElem := elem
+
 															if l := len("ents"); len(elem) >= l && elem[0:l] == "ents" {
 																elem = elem[l:]
 															} else {
@@ -29578,7 +28552,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -29599,7 +28573,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/replies"
-																	origElem := elem
+
 																	if l := len("/replies"); len(elem) >= l && elem[0:l] == "/replies" {
 																		elem = elem[l:]
 																	} else {
@@ -29622,15 +28596,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'i': // Prefix: "its"
-															origElem := elem
+
 															if l := len("its"); len(elem) >= l && elem[0:l] == "its" {
 																elem = elem[l:]
 															} else {
@@ -29653,12 +28624,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'f': // Prefix: "files"
-														origElem := elem
+
 														if l := len("files"); len(elem) >= l && elem[0:l] == "files" {
 															elem = elem[l:]
 														} else {
@@ -29681,9 +28650,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "merge"
-														origElem := elem
+
 														if l := len("merge"); len(elem) >= l && elem[0:l] == "merge" {
 															elem = elem[l:]
 														} else {
@@ -29714,9 +28682,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "re"
-														origElem := elem
+
 														if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 															elem = elem[l:]
 														} else {
@@ -29728,7 +28695,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'q': // Prefix: "quested_reviewers"
-															origElem := elem
+
 															if l := len("quested_reviewers"); len(elem) >= l && elem[0:l] == "quested_reviewers" {
 																elem = elem[l:]
 															} else {
@@ -29759,9 +28726,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 'v': // Prefix: "views"
-															origElem := elem
+
 															if l := len("views"); len(elem) >= l && elem[0:l] == "views" {
 																elem = elem[l:]
 															} else {
@@ -29792,7 +28758,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -29840,7 +28806,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '/': // Prefix: "/"
-																	origElem := elem
+
 																	if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																		elem = elem[l:]
 																	} else {
@@ -29852,7 +28818,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case 'c': // Prefix: "comments"
-																		origElem := elem
+
 																		if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 																			elem = elem[l:]
 																		} else {
@@ -29875,9 +28841,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 'd': // Prefix: "dismissals"
-																		origElem := elem
+
 																		if l := len("dismissals"); len(elem) >= l && elem[0:l] == "dismissals" {
 																			elem = elem[l:]
 																		} else {
@@ -29900,9 +28865,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	case 'e': // Prefix: "events"
-																		origElem := elem
+
 																		if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 																			elem = elem[l:]
 																		} else {
@@ -29925,21 +28889,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "update-branch"
-														origElem := elem
+
 														if l := len("update-branch"); len(elem) >= l && elem[0:l] == "update-branch" {
 															elem = elem[l:]
 														} else {
@@ -29962,21 +28921,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "re"
-										origElem := elem
+
 										if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 											elem = elem[l:]
 										} else {
@@ -29988,7 +28942,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "adme"
-											origElem := elem
+
 											if l := len("adme"); len(elem) >= l && elem[0:l] == "adme" {
 												elem = elem[l:]
 											} else {
@@ -30011,7 +28965,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -30043,12 +28997,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'l': // Prefix: "leases"
-											origElem := elem
+
 											if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 												elem = elem[l:]
 											} else {
@@ -30079,7 +29031,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -30241,7 +29193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -30253,7 +29205,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "assets"
-														origElem := elem
+
 														if l := len("assets"); len(elem) >= l && elem[0:l] == "assets" {
 															elem = elem[l:]
 														} else {
@@ -30284,9 +29236,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "reactions"
-														origElem := elem
+
 														if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 															elem = elem[l:]
 														} else {
@@ -30309,21 +29260,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -30335,7 +29281,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'e': // Prefix: "ecret-scanning/alerts"
-											origElem := elem
+
 											if l := len("ecret-scanning/alerts"); len(elem) >= l && elem[0:l] == "ecret-scanning/alerts" {
 												elem = elem[l:]
 											} else {
@@ -30358,7 +29304,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -30398,12 +29344,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 't': // Prefix: "tat"
-											origElem := elem
+
 											if l := len("tat"); len(elem) >= l && elem[0:l] == "tat" {
 												elem = elem[l:]
 											} else {
@@ -30415,7 +29359,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 's': // Prefix: "s/"
-												origElem := elem
+
 												if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 													elem = elem[l:]
 												} else {
@@ -30427,7 +29371,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "co"
-													origElem := elem
+
 													if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 														elem = elem[l:]
 													} else {
@@ -30439,7 +29383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'd': // Prefix: "de_frequency"
-														origElem := elem
+
 														if l := len("de_frequency"); len(elem) >= l && elem[0:l] == "de_frequency" {
 															elem = elem[l:]
 														} else {
@@ -30462,9 +29406,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'm': // Prefix: "mmit_activity"
-														origElem := elem
+
 														if l := len("mmit_activity"); len(elem) >= l && elem[0:l] == "mmit_activity" {
 															elem = elem[l:]
 														} else {
@@ -30487,9 +29430,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "ntributors"
-														origElem := elem
+
 														if l := len("ntributors"); len(elem) >= l && elem[0:l] == "ntributors" {
 															elem = elem[l:]
 														} else {
@@ -30512,12 +29454,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "p"
-													origElem := elem
+
 													if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 														elem = elem[l:]
 													} else {
@@ -30529,7 +29469,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "articipation"
-														origElem := elem
+
 														if l := len("articipation"); len(elem) >= l && elem[0:l] == "articipation" {
 															elem = elem[l:]
 														} else {
@@ -30552,9 +29492,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'u': // Prefix: "unch_card"
-														origElem := elem
+
 														if l := len("unch_card"); len(elem) >= l && elem[0:l] == "unch_card" {
 															elem = elem[l:]
 														} else {
@@ -30577,15 +29516,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'u': // Prefix: "uses/"
-												origElem := elem
+
 												if l := len("uses/"); len(elem) >= l && elem[0:l] == "uses/" {
 													elem = elem[l:]
 												} else {
@@ -30617,12 +29553,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'u': // Prefix: "ubscri"
-											origElem := elem
+
 											if l := len("ubscri"); len(elem) >= l && elem[0:l] == "ubscri" {
 												elem = elem[l:]
 											} else {
@@ -30634,7 +29568,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'b': // Prefix: "bers"
-												origElem := elem
+
 												if l := len("bers"); len(elem) >= l && elem[0:l] == "bers" {
 													elem = elem[l:]
 												} else {
@@ -30657,9 +29591,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "ption"
-												origElem := elem
+
 												if l := len("ption"); len(elem) >= l && elem[0:l] == "ption" {
 													elem = elem[l:]
 												} else {
@@ -30698,15 +29631,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 't': // Prefix: "t"
-										origElem := elem
+
 										if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 											elem = elem[l:]
 										} else {
@@ -30718,7 +29648,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "a"
-											origElem := elem
+
 											if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 												elem = elem[l:]
 											} else {
@@ -30730,7 +29660,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'g': // Prefix: "gs"
-												origElem := elem
+
 												if l := len("gs"); len(elem) >= l && elem[0:l] == "gs" {
 													elem = elem[l:]
 												} else {
@@ -30753,9 +29683,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "rball/"
-												origElem := elem
+
 												if l := len("rball/"); len(elem) >= l && elem[0:l] == "rball/" {
 													elem = elem[l:]
 												} else {
@@ -30787,12 +29716,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "eams"
-											origElem := elem
+
 											if l := len("eams"); len(elem) >= l && elem[0:l] == "eams" {
 												elem = elem[l:]
 											} else {
@@ -30815,9 +29742,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'o': // Prefix: "opics"
-											origElem := elem
+
 											if l := len("opics"); len(elem) >= l && elem[0:l] == "opics" {
 												elem = elem[l:]
 											} else {
@@ -30848,9 +29774,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "ra"
-											origElem := elem
+
 											if l := len("ra"); len(elem) >= l && elem[0:l] == "ra" {
 												elem = elem[l:]
 											} else {
@@ -30862,7 +29787,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'f': // Prefix: "ffic/"
-												origElem := elem
+
 												if l := len("ffic/"); len(elem) >= l && elem[0:l] == "ffic/" {
 													elem = elem[l:]
 												} else {
@@ -30874,7 +29799,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "clones"
-													origElem := elem
+
 													if l := len("clones"); len(elem) >= l && elem[0:l] == "clones" {
 														elem = elem[l:]
 													} else {
@@ -30897,9 +29822,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'p': // Prefix: "popular/"
-													origElem := elem
+
 													if l := len("popular/"); len(elem) >= l && elem[0:l] == "popular/" {
 														elem = elem[l:]
 													} else {
@@ -30911,7 +29835,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'p': // Prefix: "paths"
-														origElem := elem
+
 														if l := len("paths"); len(elem) >= l && elem[0:l] == "paths" {
 															elem = elem[l:]
 														} else {
@@ -30934,9 +29858,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													case 'r': // Prefix: "referrers"
-														origElem := elem
+
 														if l := len("referrers"); len(elem) >= l && elem[0:l] == "referrers" {
 															elem = elem[l:]
 														} else {
@@ -30959,12 +29882,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "views"
-													origElem := elem
+
 													if l := len("views"); len(elem) >= l && elem[0:l] == "views" {
 														elem = elem[l:]
 													} else {
@@ -30987,12 +29908,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nsfer"
-												origElem := elem
+
 												if l := len("nsfer"); len(elem) >= l && elem[0:l] == "nsfer" {
 													elem = elem[l:]
 												} else {
@@ -31015,15 +29934,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "vulnerability-alerts"
-										origElem := elem
+
 										if l := len("vulnerability-alerts"); len(elem) >= l && elem[0:l] == "vulnerability-alerts" {
 											elem = elem[l:]
 										} else {
@@ -31062,9 +29978,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'z': // Prefix: "zipball/"
-										origElem := elem
+
 										if l := len("zipball/"); len(elem) >= l && elem[0:l] == "zipball/" {
 											elem = elem[l:]
 										} else {
@@ -31096,18 +30011,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "itories"
-							origElem := elem
+
 							if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 								elem = elem[l:]
 							} else {
@@ -31130,7 +30041,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -31151,7 +30062,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/environments/"
-									origElem := elem
+
 									if l := len("/environments/"); len(elem) >= l && elem[0:l] == "/environments/" {
 										elem = elem[l:]
 									} else {
@@ -31172,7 +30083,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/secrets"
-										origElem := elem
+
 										if l := len("/secrets"); len(elem) >= l && elem[0:l] == "/secrets" {
 											elem = elem[l:]
 										} else {
@@ -31195,7 +30106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -31273,30 +30184,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -31308,7 +30211,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "cim/v2/"
-					origElem := elem
+
 					if l := len("cim/v2/"); len(elem) >= l && elem[0:l] == "cim/v2/" {
 						elem = elem[l:]
 					} else {
@@ -31320,7 +30223,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "enterprises/"
-						origElem := elem
+
 						if l := len("enterprises/"); len(elem) >= l && elem[0:l] == "enterprises/" {
 							elem = elem[l:]
 						} else {
@@ -31341,7 +30244,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -31353,7 +30256,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'G': // Prefix: "Groups"
-								origElem := elem
+
 								if l := len("Groups"); len(elem) >= l && elem[0:l] == "Groups" {
 									elem = elem[l:]
 								} else {
@@ -31384,7 +30287,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -31440,12 +30343,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'U': // Prefix: "Users"
-								origElem := elem
+
 								if l := len("Users"); len(elem) >= l && elem[0:l] == "Users" {
 									elem = elem[l:]
 								} else {
@@ -31476,7 +30377,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -31532,18 +30433,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "organizations/"
-						origElem := elem
+
 						if l := len("organizations/"); len(elem) >= l && elem[0:l] == "organizations/" {
 							elem = elem[l:]
 						} else {
@@ -31564,7 +30461,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/Users/"
-							origElem := elem
+
 							if l := len("/Users/"); len(elem) >= l && elem[0:l] == "/Users/" {
 								elem = elem[l:]
 							} else {
@@ -31596,15 +30493,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "earch/"
-					origElem := elem
+
 					if l := len("earch/"); len(elem) >= l && elem[0:l] == "earch/" {
 						elem = elem[l:]
 					} else {
@@ -31616,7 +30510,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "co"
-						origElem := elem
+
 						if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 							elem = elem[l:]
 						} else {
@@ -31628,7 +30522,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'd': // Prefix: "de"
-							origElem := elem
+
 							if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 								elem = elem[l:]
 							} else {
@@ -31651,9 +30545,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mmits"
-							origElem := elem
+
 							if l := len("mmits"); len(elem) >= l && elem[0:l] == "mmits" {
 								elem = elem[l:]
 							} else {
@@ -31676,12 +30569,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "issues"
-						origElem := elem
+
 						if l := len("issues"); len(elem) >= l && elem[0:l] == "issues" {
 							elem = elem[l:]
 						} else {
@@ -31704,9 +30595,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "labels"
-						origElem := elem
+
 						if l := len("labels"); len(elem) >= l && elem[0:l] == "labels" {
 							elem = elem[l:]
 						} else {
@@ -31729,9 +30619,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repositories"
-						origElem := elem
+
 						if l := len("repositories"); len(elem) >= l && elem[0:l] == "repositories" {
 							elem = elem[l:]
 						} else {
@@ -31754,9 +30643,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 't': // Prefix: "topics"
-						origElem := elem
+
 						if l := len("topics"); len(elem) >= l && elem[0:l] == "topics" {
 							elem = elem[l:]
 						} else {
@@ -31779,9 +30667,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "users"
-						origElem := elem
+
 						if l := len("users"); len(elem) >= l && elem[0:l] == "users" {
 							elem = elem[l:]
 						} else {
@@ -31804,15 +30691,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "teams/"
-				origElem := elem
+
 				if l := len("teams/"); len(elem) >= l && elem[0:l] == "teams/" {
 					elem = elem[l:]
 				} else {
@@ -31860,7 +30744,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -31872,7 +30756,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'd': // Prefix: "discussions"
-						origElem := elem
+
 						if l := len("discussions"); len(elem) >= l && elem[0:l] == "discussions" {
 							elem = elem[l:]
 						} else {
@@ -31903,7 +30787,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -31951,7 +30835,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -31963,7 +30847,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "comments"
-									origElem := elem
+
 									if l := len("comments"); len(elem) >= l && elem[0:l] == "comments" {
 										elem = elem[l:]
 									} else {
@@ -31994,7 +30878,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -32042,7 +30926,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/reactions"
-											origElem := elem
+
 											if l := len("/reactions"); len(elem) >= l && elem[0:l] == "/reactions" {
 												elem = elem[l:]
 											} else {
@@ -32073,15 +30957,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "reactions"
-									origElem := elem
+
 									if l := len("reactions"); len(elem) >= l && elem[0:l] == "reactions" {
 										elem = elem[l:]
 									} else {
@@ -32112,18 +30993,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "invitations"
-						origElem := elem
+
 						if l := len("invitations"); len(elem) >= l && elem[0:l] == "invitations" {
 							elem = elem[l:]
 						} else {
@@ -32146,9 +31023,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "members"
-						origElem := elem
+
 						if l := len("members"); len(elem) >= l && elem[0:l] == "members" {
 							elem = elem[l:]
 						} else {
@@ -32171,7 +31047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -32219,9 +31095,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'h': // Prefix: "hips/"
-							origElem := elem
+
 							if l := len("hips/"); len(elem) >= l && elem[0:l] == "hips/" {
 								elem = elem[l:]
 							} else {
@@ -32269,12 +31144,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "projects"
-						origElem := elem
+
 						if l := len("projects"); len(elem) >= l && elem[0:l] == "projects" {
 							elem = elem[l:]
 						} else {
@@ -32297,7 +31170,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -32345,12 +31218,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repos"
-						origElem := elem
+
 						if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 							elem = elem[l:]
 						} else {
@@ -32373,7 +31244,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -32394,7 +31265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -32442,15 +31313,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "team"
-						origElem := elem
+
 						if l := len("team"); len(elem) >= l && elem[0:l] == "team" {
 							elem = elem[l:]
 						} else {
@@ -32462,7 +31330,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '-': // Prefix: "-sync/group-mappings"
-							origElem := elem
+
 							if l := len("-sync/group-mappings"); len(elem) >= l && elem[0:l] == "-sync/group-mappings" {
 								elem = elem[l:]
 							} else {
@@ -32493,9 +31361,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 's': // Prefix: "s"
-							origElem := elem
+
 							if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 								elem = elem[l:]
 							} else {
@@ -32518,18 +31385,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user"
-				origElem := elem
+
 				if l := len("user"); len(elem) >= l && elem[0:l] == "user" {
 					elem = elem[l:]
 				} else {
@@ -32560,7 +31423,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -32572,7 +31435,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "blocks"
-						origElem := elem
+
 						if l := len("blocks"); len(elem) >= l && elem[0:l] == "blocks" {
 							elem = elem[l:]
 						} else {
@@ -32595,7 +31458,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -32643,12 +31506,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "email"
-						origElem := elem
+
 						if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 							elem = elem[l:]
 						} else {
@@ -32660,7 +31521,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/visibility"
-							origElem := elem
+
 							if l := len("/visibility"); len(elem) >= l && elem[0:l] == "/visibility" {
 								elem = elem[l:]
 							} else {
@@ -32683,9 +31544,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 's': // Prefix: "s"
-							origElem := elem
+
 							if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 								elem = elem[l:]
 							} else {
@@ -32724,12 +31584,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "follow"
-						origElem := elem
+
 						if l := len("follow"); len(elem) >= l && elem[0:l] == "follow" {
 							elem = elem[l:]
 						} else {
@@ -32741,7 +31599,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "ers"
-							origElem := elem
+
 							if l := len("ers"); len(elem) >= l && elem[0:l] == "ers" {
 								elem = elem[l:]
 							} else {
@@ -32764,9 +31622,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "ing"
-							origElem := elem
+
 							if l := len("ing"); len(elem) >= l && elem[0:l] == "ing" {
 								elem = elem[l:]
 							} else {
@@ -32789,7 +31646,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -32837,15 +31694,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'g': // Prefix: "gpg_keys"
-						origElem := elem
+
 						if l := len("gpg_keys"); len(elem) >= l && elem[0:l] == "gpg_keys" {
 							elem = elem[l:]
 						} else {
@@ -32876,7 +31730,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -32916,12 +31770,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "i"
-						origElem := elem
+
 						if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 							elem = elem[l:]
 						} else {
@@ -32933,7 +31785,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'n': // Prefix: "n"
-							origElem := elem
+
 							if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 								elem = elem[l:]
 							} else {
@@ -32945,7 +31797,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 's': // Prefix: "stallations/"
-								origElem := elem
+
 								if l := len("stallations/"); len(elem) >= l && elem[0:l] == "stallations/" {
 									elem = elem[l:]
 								} else {
@@ -32966,7 +31818,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/repositories"
-									origElem := elem
+
 									if l := len("/repositories"); len(elem) >= l && elem[0:l] == "/repositories" {
 										elem = elem[l:]
 									} else {
@@ -32989,7 +31841,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -33029,15 +31881,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "teraction-limits"
-								origElem := elem
+
 								if l := len("teraction-limits"); len(elem) >= l && elem[0:l] == "teraction-limits" {
 									elem = elem[l:]
 								} else {
@@ -33068,12 +31917,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "ssues"
-							origElem := elem
+
 							if l := len("ssues"); len(elem) >= l && elem[0:l] == "ssues" {
 								elem = elem[l:]
 							} else {
@@ -33096,12 +31943,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'k': // Prefix: "keys"
-						origElem := elem
+
 						if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 							elem = elem[l:]
 						} else {
@@ -33132,7 +31977,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -33172,12 +32017,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "m"
-						origElem := elem
+
 						if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
 							elem = elem[l:]
 						} else {
@@ -33189,7 +32032,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "arketplace_purchases"
-							origElem := elem
+
 							if l := len("arketplace_purchases"); len(elem) >= l && elem[0:l] == "arketplace_purchases" {
 								elem = elem[l:]
 							} else {
@@ -33212,7 +32055,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/stubbed"
-								origElem := elem
+
 								if l := len("/stubbed"); len(elem) >= l && elem[0:l] == "/stubbed" {
 									elem = elem[l:]
 								} else {
@@ -33235,12 +32078,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'e': // Prefix: "emberships/orgs"
-							origElem := elem
+
 							if l := len("emberships/orgs"); len(elem) >= l && elem[0:l] == "emberships/orgs" {
 								elem = elem[l:]
 							} else {
@@ -33263,7 +32104,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -33303,12 +32144,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "igrations"
-							origElem := elem
+
 							if l := len("igrations"); len(elem) >= l && elem[0:l] == "igrations" {
 								elem = elem[l:]
 							} else {
@@ -33339,7 +32178,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -33371,7 +32210,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -33383,7 +32222,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "archive"
-										origElem := elem
+
 										if l := len("archive"); len(elem) >= l && elem[0:l] == "archive" {
 											elem = elem[l:]
 										} else {
@@ -33414,9 +32253,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "repos"
-										origElem := elem
+
 										if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 											elem = elem[l:]
 										} else {
@@ -33428,7 +32266,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -33449,7 +32287,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/lock"
-												origElem := elem
+
 												if l := len("/lock"); len(elem) >= l && elem[0:l] == "/lock" {
 													elem = elem[l:]
 												} else {
@@ -33472,12 +32310,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'i': // Prefix: "itories"
-											origElem := elem
+
 											if l := len("itories"); len(elem) >= l && elem[0:l] == "itories" {
 												elem = elem[l:]
 											} else {
@@ -33500,24 +32336,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "orgs"
-						origElem := elem
+
 						if l := len("orgs"); len(elem) >= l && elem[0:l] == "orgs" {
 							elem = elem[l:]
 						} else {
@@ -33540,9 +32370,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "p"
-						origElem := elem
+
 						if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 							elem = elem[l:]
 						} else {
@@ -33554,7 +32383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'a': // Prefix: "ackages"
-							origElem := elem
+
 							if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 								elem = elem[l:]
 							} else {
@@ -33577,7 +32406,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -33598,7 +32427,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -33638,7 +32467,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -33650,7 +32479,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'r': // Prefix: "restore"
-											origElem := elem
+
 											if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 												elem = elem[l:]
 											} else {
@@ -33673,9 +32502,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "versions"
-											origElem := elem
+
 											if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 												elem = elem[l:]
 											} else {
@@ -33698,7 +32526,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -33738,7 +32566,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/restore"
-													origElem := elem
+
 													if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 														elem = elem[l:]
 													} else {
@@ -33761,27 +32589,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'r': // Prefix: "rojects"
-							origElem := elem
+
 							if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 								elem = elem[l:]
 							} else {
@@ -33804,9 +32625,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ublic_emails"
-							origElem := elem
+
 							if l := len("ublic_emails"); len(elem) >= l && elem[0:l] == "ublic_emails" {
 								elem = elem[l:]
 							} else {
@@ -33829,12 +32649,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "repos"
-						origElem := elem
+
 						if l := len("repos"); len(elem) >= l && elem[0:l] == "repos" {
 							elem = elem[l:]
 						} else {
@@ -33865,7 +32683,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'i': // Prefix: "itory_invitations"
-							origElem := elem
+
 							if l := len("itory_invitations"); len(elem) >= l && elem[0:l] == "itory_invitations" {
 								elem = elem[l:]
 							} else {
@@ -33888,7 +32706,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -33928,15 +32746,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s"
-						origElem := elem
+
 						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 							elem = elem[l:]
 						} else {
@@ -33948,7 +32763,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 't': // Prefix: "tarred"
-							origElem := elem
+
 							if l := len("tarred"); len(elem) >= l && elem[0:l] == "tarred" {
 								elem = elem[l:]
 							} else {
@@ -33971,7 +32786,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -33992,7 +32807,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -34040,15 +32855,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ubscriptions"
-							origElem := elem
+
 							if l := len("ubscriptions"); len(elem) >= l && elem[0:l] == "ubscriptions" {
 								elem = elem[l:]
 							} else {
@@ -34071,12 +32883,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "teams"
-						origElem := elem
+
 						if l := len("teams"); len(elem) >= l && elem[0:l] == "teams" {
 							elem = elem[l:]
 						} else {
@@ -34099,12 +32909,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s"
-					origElem := elem
+
 					if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 						elem = elem[l:]
 					} else {
@@ -34127,7 +32935,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -34159,7 +32967,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -34171,7 +32979,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -34194,7 +33002,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -34206,7 +33014,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'o': // Prefix: "orgs/"
-										origElem := elem
+
 										if l := len("orgs/"); len(elem) >= l && elem[0:l] == "orgs/" {
 											elem = elem[l:]
 										} else {
@@ -34238,9 +33046,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "public"
-										origElem := elem
+
 										if l := len("public"); len(elem) >= l && elem[0:l] == "public" {
 											elem = elem[l:]
 										} else {
@@ -34263,15 +33070,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "follow"
-								origElem := elem
+
 								if l := len("follow"); len(elem) >= l && elem[0:l] == "follow" {
 									elem = elem[l:]
 								} else {
@@ -34283,7 +33087,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ers"
-									origElem := elem
+
 									if l := len("ers"); len(elem) >= l && elem[0:l] == "ers" {
 										elem = elem[l:]
 									} else {
@@ -34306,9 +33110,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "ing"
-									origElem := elem
+
 									if l := len("ing"); len(elem) >= l && elem[0:l] == "ing" {
 										elem = elem[l:]
 									} else {
@@ -34331,7 +33134,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -34363,15 +33166,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'g': // Prefix: "g"
-								origElem := elem
+
 								if l := len("g"); len(elem) >= l && elem[0:l] == "g" {
 									elem = elem[l:]
 								} else {
@@ -34383,7 +33183,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "ists"
-									origElem := elem
+
 									if l := len("ists"); len(elem) >= l && elem[0:l] == "ists" {
 										elem = elem[l:]
 									} else {
@@ -34406,9 +33206,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pg_keys"
-									origElem := elem
+
 									if l := len("pg_keys"); len(elem) >= l && elem[0:l] == "pg_keys" {
 										elem = elem[l:]
 									} else {
@@ -34431,12 +33230,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hovercard"
-								origElem := elem
+
 								if l := len("hovercard"); len(elem) >= l && elem[0:l] == "hovercard" {
 									elem = elem[l:]
 								} else {
@@ -34459,9 +33256,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'k': // Prefix: "keys"
-								origElem := elem
+
 								if l := len("keys"); len(elem) >= l && elem[0:l] == "keys" {
 									elem = elem[l:]
 								} else {
@@ -34484,9 +33280,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "orgs"
-								origElem := elem
+
 								if l := len("orgs"); len(elem) >= l && elem[0:l] == "orgs" {
 									elem = elem[l:]
 								} else {
@@ -34509,9 +33304,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -34523,7 +33317,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ackages"
-									origElem := elem
+
 									if l := len("ackages"); len(elem) >= l && elem[0:l] == "ackages" {
 										elem = elem[l:]
 									} else {
@@ -34546,7 +33340,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -34567,7 +33361,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -34607,7 +33401,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -34619,7 +33413,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'r': // Prefix: "restore"
-													origElem := elem
+
 													if l := len("restore"); len(elem) >= l && elem[0:l] == "restore" {
 														elem = elem[l:]
 													} else {
@@ -34642,9 +33436,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "versions"
-													origElem := elem
+
 													if l := len("versions"); len(elem) >= l && elem[0:l] == "versions" {
 														elem = elem[l:]
 													} else {
@@ -34667,7 +33460,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -34707,7 +33500,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/restore"
-															origElem := elem
+
 															if l := len("/restore"); len(elem) >= l && elem[0:l] == "/restore" {
 																elem = elem[l:]
 															} else {
@@ -34730,27 +33523,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rojects"
-									origElem := elem
+
 									if l := len("rojects"); len(elem) >= l && elem[0:l] == "rojects" {
 										elem = elem[l:]
 									} else {
@@ -34773,12 +33559,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "re"
-								origElem := elem
+
 								if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 									elem = elem[l:]
 								} else {
@@ -34790,7 +33574,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "ceived_events"
-									origElem := elem
+
 									if l := len("ceived_events"); len(elem) >= l && elem[0:l] == "ceived_events" {
 										elem = elem[l:]
 									} else {
@@ -34813,7 +33597,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/public"
-										origElem := elem
+
 										if l := len("/public"); len(elem) >= l && elem[0:l] == "/public" {
 											elem = elem[l:]
 										} else {
@@ -34836,12 +33620,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pos"
-									origElem := elem
+
 									if l := len("pos"); len(elem) >= l && elem[0:l] == "pos" {
 										elem = elem[l:]
 									} else {
@@ -34864,12 +33646,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 's': // Prefix: "s"
-								origElem := elem
+
 								if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 									elem = elem[l:]
 								} else {
@@ -34881,7 +33661,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ettings/billing/"
-									origElem := elem
+
 									if l := len("ettings/billing/"); len(elem) >= l && elem[0:l] == "ettings/billing/" {
 										elem = elem[l:]
 									} else {
@@ -34893,7 +33673,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "actions"
-										origElem := elem
+
 										if l := len("actions"); len(elem) >= l && elem[0:l] == "actions" {
 											elem = elem[l:]
 										} else {
@@ -34916,9 +33696,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "packages"
-										origElem := elem
+
 										if l := len("packages"); len(elem) >= l && elem[0:l] == "packages" {
 											elem = elem[l:]
 										} else {
@@ -34941,9 +33720,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "shared-storage"
-										origElem := elem
+
 										if l := len("shared-storage"); len(elem) >= l && elem[0:l] == "shared-storage" {
 											elem = elem[l:]
 										} else {
@@ -34966,12 +33744,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "ubscriptions"
-									origElem := elem
+
 									if l := len("ubscriptions"); len(elem) >= l && elem[0:l] == "ubscriptions" {
 										elem = elem[l:]
 									} else {
@@ -34994,24 +33770,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'z': // Prefix: "zen"
-				origElem := elem
+
 				if l := len("zen"); len(elem) >= l && elem[0:l] == "zen" {
 					elem = elem[l:]
 				} else {
@@ -35034,10 +33804,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_gotd/oas_router_gen.go
+++ b/examples/ex_gotd/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -73,7 +73,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "ddStickerToSet"
-					origElem := elem
+
 					if l := len("ddStickerToSet"); len(elem) >= l && elem[0:l] == "ddStickerToSet" {
 						elem = elem[l:]
 					} else {
@@ -92,9 +92,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nswer"
-					origElem := elem
+
 					if l := len("nswer"); len(elem) >= l && elem[0:l] == "nswer" {
 						elem = elem[l:]
 					} else {
@@ -106,7 +105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CallbackQuery"
-						origElem := elem
+
 						if l := len("CallbackQuery"); len(elem) >= l && elem[0:l] == "CallbackQuery" {
 							elem = elem[l:]
 						} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'I': // Prefix: "InlineQuery"
-						origElem := elem
+
 						if l := len("InlineQuery"); len(elem) >= l && elem[0:l] == "InlineQuery" {
 							elem = elem[l:]
 						} else {
@@ -146,9 +144,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "PreCheckoutQuery"
-						origElem := elem
+
 						if l := len("PreCheckoutQuery"); len(elem) >= l && elem[0:l] == "PreCheckoutQuery" {
 							elem = elem[l:]
 						} else {
@@ -167,9 +164,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "ShippingQuery"
-						origElem := elem
+
 						if l := len("ShippingQuery"); len(elem) >= l && elem[0:l] == "ShippingQuery" {
 							elem = elem[l:]
 						} else {
@@ -188,9 +184,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "WebAppQuery"
-						origElem := elem
+
 						if l := len("WebAppQuery"); len(elem) >= l && elem[0:l] == "WebAppQuery" {
 							elem = elem[l:]
 						} else {
@@ -209,12 +204,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "pproveChatJoinRequest"
-					origElem := elem
+
 					if l := len("pproveChatJoinRequest"); len(elem) >= l && elem[0:l] == "pproveChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -233,12 +226,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "banChat"
-				origElem := elem
+
 				if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 					elem = elem[l:]
 				} else {
@@ -250,7 +241,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'M': // Prefix: "Member"
-					origElem := elem
+
 					if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 						elem = elem[l:]
 					} else {
@@ -269,9 +260,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "SenderChat"
-					origElem := elem
+
 					if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 						elem = elem[l:]
 					} else {
@@ -290,12 +280,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -307,7 +295,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "lose"
-					origElem := elem
+
 					if l := len("lose"); len(elem) >= l && elem[0:l] == "lose" {
 						elem = elem[l:]
 					} else {
@@ -326,9 +314,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "opyMessage"
-					origElem := elem
+
 					if l := len("opyMessage"); len(elem) >= l && elem[0:l] == "opyMessage" {
 						elem = elem[l:]
 					} else {
@@ -347,9 +334,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "reate"
-					origElem := elem
+
 					if l := len("reate"); len(elem) >= l && elem[0:l] == "reate" {
 						elem = elem[l:]
 					} else {
@@ -361,7 +347,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -380,9 +366,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'N': // Prefix: "NewStickerSet"
-						origElem := elem
+
 						if l := len("NewStickerSet"); len(elem) >= l && elem[0:l] == "NewStickerSet" {
 							elem = elem[l:]
 						} else {
@@ -401,15 +386,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "de"
-				origElem := elem
+
 				if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 					elem = elem[l:]
 				} else {
@@ -421,7 +403,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "clineChatJoinRequest"
-					origElem := elem
+
 					if l := len("clineChatJoinRequest"); len(elem) >= l && elem[0:l] == "clineChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -440,9 +422,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lete"
-					origElem := elem
+
 					if l := len("lete"); len(elem) >= l && elem[0:l] == "lete" {
 						elem = elem[l:]
 					} else {
@@ -454,7 +435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "Chat"
-						origElem := elem
+
 						if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 							elem = elem[l:]
 						} else {
@@ -466,7 +447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'P': // Prefix: "Photo"
-							origElem := elem
+
 							if l := len("Photo"); len(elem) >= l && elem[0:l] == "Photo" {
 								elem = elem[l:]
 							} else {
@@ -485,9 +466,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "StickerSet"
-							origElem := elem
+
 							if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 								elem = elem[l:]
 							} else {
@@ -506,12 +486,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "M"
-						origElem := elem
+
 						if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 							elem = elem[l:]
 						} else {
@@ -523,7 +501,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "essage"
-							origElem := elem
+
 							if l := len("essage"); len(elem) >= l && elem[0:l] == "essage" {
 								elem = elem[l:]
 							} else {
@@ -542,9 +520,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'y': // Prefix: "yCommands"
-							origElem := elem
+
 							if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 								elem = elem[l:]
 							} else {
@@ -563,12 +540,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "StickerFromSet"
-						origElem := elem
+
 						if l := len("StickerFromSet"); len(elem) >= l && elem[0:l] == "StickerFromSet" {
 							elem = elem[l:]
 						} else {
@@ -587,9 +562,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "Webhook"
-						origElem := elem
+
 						if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 							elem = elem[l:]
 						} else {
@@ -608,15 +582,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -628,7 +599,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dit"
-					origElem := elem
+
 					if l := len("dit"); len(elem) >= l && elem[0:l] == "dit" {
 						elem = elem[l:]
 					} else {
@@ -640,7 +611,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -659,9 +630,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Message"
-						origElem := elem
+
 						if l := len("Message"); len(elem) >= l && elem[0:l] == "Message" {
 							elem = elem[l:]
 						} else {
@@ -673,7 +643,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Caption"
-							origElem := elem
+
 							if l := len("Caption"); len(elem) >= l && elem[0:l] == "Caption" {
 								elem = elem[l:]
 							} else {
@@ -692,9 +662,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "LiveLocation"
-							origElem := elem
+
 							if l := len("LiveLocation"); len(elem) >= l && elem[0:l] == "LiveLocation" {
 								elem = elem[l:]
 							} else {
@@ -713,9 +682,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Media"
-							origElem := elem
+
 							if l := len("Media"); len(elem) >= l && elem[0:l] == "Media" {
 								elem = elem[l:]
 							} else {
@@ -734,9 +702,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'R': // Prefix: "ReplyMarkup"
-							origElem := elem
+
 							if l := len("ReplyMarkup"); len(elem) >= l && elem[0:l] == "ReplyMarkup" {
 								elem = elem[l:]
 							} else {
@@ -755,9 +722,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'T': // Prefix: "Text"
-							origElem := elem
+
 							if l := len("Text"); len(elem) >= l && elem[0:l] == "Text" {
 								elem = elem[l:]
 							} else {
@@ -776,15 +742,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'x': // Prefix: "xportChatInviteLink"
-					origElem := elem
+
 					if l := len("xportChatInviteLink"); len(elem) >= l && elem[0:l] == "xportChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -803,12 +766,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "forwardMessage"
-				origElem := elem
+
 				if l := len("forwardMessage"); len(elem) >= l && elem[0:l] == "forwardMessage" {
 					elem = elem[l:]
 				} else {
@@ -827,9 +788,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "get"
-				origElem := elem
+
 				if l := len("get"); len(elem) >= l && elem[0:l] == "get" {
 					elem = elem[l:]
 				} else {
@@ -841,7 +801,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'C': // Prefix: "Chat"
-					origElem := elem
+
 					if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 						elem = elem[l:]
 					} else {
@@ -860,7 +820,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Administrators"
-						origElem := elem
+
 						if l := len("Administrators"); len(elem) >= l && elem[0:l] == "Administrators" {
 							elem = elem[l:]
 						} else {
@@ -879,9 +839,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Me"
-						origElem := elem
+
 						if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 							elem = elem[l:]
 						} else {
@@ -893,7 +852,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -912,7 +871,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'C': // Prefix: "Count"
-								origElem := elem
+
 								if l := len("Count"); len(elem) >= l && elem[0:l] == "Count" {
 									elem = elem[l:]
 								} else {
@@ -931,12 +890,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "nuButton"
-							origElem := elem
+
 							if l := len("nuButton"); len(elem) >= l && elem[0:l] == "nuButton" {
 								elem = elem[l:]
 							} else {
@@ -955,15 +912,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'F': // Prefix: "File"
-					origElem := elem
+
 					if l := len("File"); len(elem) >= l && elem[0:l] == "File" {
 						elem = elem[l:]
 					} else {
@@ -982,9 +936,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'G': // Prefix: "GameHighScores"
-					origElem := elem
+
 					if l := len("GameHighScores"); len(elem) >= l && elem[0:l] == "GameHighScores" {
 						elem = elem[l:]
 					} else {
@@ -1003,9 +956,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "M"
-					origElem := elem
+
 					if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 						elem = elem[l:]
 					} else {
@@ -1017,7 +969,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "e"
-						origElem := elem
+
 						if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 							elem = elem[l:]
 						} else {
@@ -1036,9 +988,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'y': // Prefix: "y"
-						origElem := elem
+
 						if l := len("y"); len(elem) >= l && elem[0:l] == "y" {
 							elem = elem[l:]
 						} else {
@@ -1050,7 +1001,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Commands"
-							origElem := elem
+
 							if l := len("Commands"); len(elem) >= l && elem[0:l] == "Commands" {
 								elem = elem[l:]
 							} else {
@@ -1069,9 +1020,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "DefaultAdministratorRights"
-							origElem := elem
+
 							if l := len("DefaultAdministratorRights"); len(elem) >= l && elem[0:l] == "DefaultAdministratorRights" {
 								elem = elem[l:]
 							} else {
@@ -1090,15 +1040,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "StickerSet"
-					origElem := elem
+
 					if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 						elem = elem[l:]
 					} else {
@@ -1117,9 +1064,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "U"
-					origElem := elem
+
 					if l := len("U"); len(elem) >= l && elem[0:l] == "U" {
 						elem = elem[l:]
 					} else {
@@ -1131,7 +1077,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'p': // Prefix: "pdates"
-						origElem := elem
+
 						if l := len("pdates"); len(elem) >= l && elem[0:l] == "pdates" {
 							elem = elem[l:]
 						} else {
@@ -1150,9 +1096,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "serProfilePhotos"
-						origElem := elem
+
 						if l := len("serProfilePhotos"); len(elem) >= l && elem[0:l] == "serProfilePhotos" {
 							elem = elem[l:]
 						} else {
@@ -1171,12 +1116,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'W': // Prefix: "WebhookInfo"
-					origElem := elem
+
 					if l := len("WebhookInfo"); len(elem) >= l && elem[0:l] == "WebhookInfo" {
 						elem = elem[l:]
 					} else {
@@ -1195,12 +1138,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "l"
-				origElem := elem
+
 				if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 					elem = elem[l:]
 				} else {
@@ -1212,7 +1153,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "eaveChat"
-					origElem := elem
+
 					if l := len("eaveChat"); len(elem) >= l && elem[0:l] == "eaveChat" {
 						elem = elem[l:]
 					} else {
@@ -1231,9 +1172,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ogOut"
-					origElem := elem
+
 					if l := len("ogOut"); len(elem) >= l && elem[0:l] == "ogOut" {
 						elem = elem[l:]
 					} else {
@@ -1252,12 +1192,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -1269,7 +1207,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "inChatMessage"
-					origElem := elem
+
 					if l := len("inChatMessage"); len(elem) >= l && elem[0:l] == "inChatMessage" {
 						elem = elem[l:]
 					} else {
@@ -1288,9 +1226,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "romoteChatMember"
-					origElem := elem
+
 					if l := len("romoteChatMember"); len(elem) >= l && elem[0:l] == "romoteChatMember" {
 						elem = elem[l:]
 					} else {
@@ -1309,12 +1246,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -1326,7 +1261,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "strictChatMember"
-					origElem := elem
+
 					if l := len("strictChatMember"); len(elem) >= l && elem[0:l] == "strictChatMember" {
 						elem = elem[l:]
 					} else {
@@ -1345,9 +1280,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vokeChatInviteLink"
-					origElem := elem
+
 					if l := len("vokeChatInviteLink"); len(elem) >= l && elem[0:l] == "vokeChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -1366,12 +1300,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -1383,7 +1315,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -1395,7 +1327,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nd"
-						origElem := elem
+
 						if l := len("nd"); len(elem) >= l && elem[0:l] == "nd" {
 							elem = elem[l:]
 						} else {
@@ -1407,7 +1339,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "A"
-							origElem := elem
+
 							if l := len("A"); len(elem) >= l && elem[0:l] == "A" {
 								elem = elem[l:]
 							} else {
@@ -1419,7 +1351,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "nimation"
-								origElem := elem
+
 								if l := len("nimation"); len(elem) >= l && elem[0:l] == "nimation" {
 									elem = elem[l:]
 								} else {
@@ -1438,9 +1370,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udio"
-								origElem := elem
+
 								if l := len("udio"); len(elem) >= l && elem[0:l] == "udio" {
 									elem = elem[l:]
 								} else {
@@ -1459,12 +1390,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "C"
-							origElem := elem
+
 							if l := len("C"); len(elem) >= l && elem[0:l] == "C" {
 								elem = elem[l:]
 							} else {
@@ -1476,7 +1405,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hatAction"
-								origElem := elem
+
 								if l := len("hatAction"); len(elem) >= l && elem[0:l] == "hatAction" {
 									elem = elem[l:]
 								} else {
@@ -1495,9 +1424,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ontact"
-								origElem := elem
+
 								if l := len("ontact"); len(elem) >= l && elem[0:l] == "ontact" {
 									elem = elem[l:]
 								} else {
@@ -1516,12 +1444,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "D"
-							origElem := elem
+
 							if l := len("D"); len(elem) >= l && elem[0:l] == "D" {
 								elem = elem[l:]
 							} else {
@@ -1533,7 +1459,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "ice"
-								origElem := elem
+
 								if l := len("ice"); len(elem) >= l && elem[0:l] == "ice" {
 									elem = elem[l:]
 								} else {
@@ -1552,9 +1478,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ocument"
-								origElem := elem
+
 								if l := len("ocument"); len(elem) >= l && elem[0:l] == "ocument" {
 									elem = elem[l:]
 								} else {
@@ -1573,12 +1498,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "Game"
-							origElem := elem
+
 							if l := len("Game"); len(elem) >= l && elem[0:l] == "Game" {
 								elem = elem[l:]
 							} else {
@@ -1597,9 +1520,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'I': // Prefix: "Invoice"
-							origElem := elem
+
 							if l := len("Invoice"); len(elem) >= l && elem[0:l] == "Invoice" {
 								elem = elem[l:]
 							} else {
@@ -1618,9 +1540,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "Location"
-							origElem := elem
+
 							if l := len("Location"); len(elem) >= l && elem[0:l] == "Location" {
 								elem = elem[l:]
 							} else {
@@ -1639,9 +1560,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Me"
-							origElem := elem
+
 							if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 								elem = elem[l:]
 							} else {
@@ -1653,7 +1573,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'd': // Prefix: "diaGroup"
-								origElem := elem
+
 								if l := len("diaGroup"); len(elem) >= l && elem[0:l] == "diaGroup" {
 									elem = elem[l:]
 								} else {
@@ -1672,9 +1592,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 's': // Prefix: "ssage"
-								origElem := elem
+
 								if l := len("ssage"); len(elem) >= l && elem[0:l] == "ssage" {
 									elem = elem[l:]
 								} else {
@@ -1693,12 +1612,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "P"
-							origElem := elem
+
 							if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 								elem = elem[l:]
 							} else {
@@ -1710,7 +1627,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hoto"
-								origElem := elem
+
 								if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 									elem = elem[l:]
 								} else {
@@ -1729,9 +1646,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oll"
-								origElem := elem
+
 								if l := len("oll"); len(elem) >= l && elem[0:l] == "oll" {
 									elem = elem[l:]
 								} else {
@@ -1750,12 +1666,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -1774,9 +1688,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'V': // Prefix: "V"
-							origElem := elem
+
 							if l := len("V"); len(elem) >= l && elem[0:l] == "V" {
 								elem = elem[l:]
 							} else {
@@ -1788,7 +1701,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "enue"
-								origElem := elem
+
 								if l := len("enue"); len(elem) >= l && elem[0:l] == "enue" {
 									elem = elem[l:]
 								} else {
@@ -1807,9 +1720,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "ideo"
-								origElem := elem
+
 								if l := len("ideo"); len(elem) >= l && elem[0:l] == "ideo" {
 									elem = elem[l:]
 								} else {
@@ -1828,7 +1740,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'N': // Prefix: "Note"
-									origElem := elem
+
 									if l := len("Note"); len(elem) >= l && elem[0:l] == "Note" {
 										elem = elem[l:]
 									} else {
@@ -1847,12 +1759,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oice"
-								origElem := elem
+
 								if l := len("oice"); len(elem) >= l && elem[0:l] == "oice" {
 									elem = elem[l:]
 								} else {
@@ -1871,15 +1781,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t"
-						origElem := elem
+
 						if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 							elem = elem[l:]
 						} else {
@@ -1891,7 +1798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Chat"
-							origElem := elem
+
 							if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 								elem = elem[l:]
 							} else {
@@ -1903,7 +1810,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "AdministratorCustomTitle"
-								origElem := elem
+
 								if l := len("AdministratorCustomTitle"); len(elem) >= l && elem[0:l] == "AdministratorCustomTitle" {
 									elem = elem[l:]
 								} else {
@@ -1922,9 +1829,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "Description"
-								origElem := elem
+
 								if l := len("Description"); len(elem) >= l && elem[0:l] == "Description" {
 									elem = elem[l:]
 								} else {
@@ -1943,9 +1849,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'M': // Prefix: "MenuButton"
-								origElem := elem
+
 								if l := len("MenuButton"); len(elem) >= l && elem[0:l] == "MenuButton" {
 									elem = elem[l:]
 								} else {
@@ -1964,9 +1869,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'P': // Prefix: "P"
-								origElem := elem
+
 								if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 									elem = elem[l:]
 								} else {
@@ -1978,7 +1882,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ermissions"
-									origElem := elem
+
 									if l := len("ermissions"); len(elem) >= l && elem[0:l] == "ermissions" {
 										elem = elem[l:]
 									} else {
@@ -1997,9 +1901,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hoto"
-									origElem := elem
+
 									if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 										elem = elem[l:]
 									} else {
@@ -2018,12 +1921,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "StickerSet"
-								origElem := elem
+
 								if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 									elem = elem[l:]
 								} else {
@@ -2042,9 +1943,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'T': // Prefix: "Title"
-								origElem := elem
+
 								if l := len("Title"); len(elem) >= l && elem[0:l] == "Title" {
 									elem = elem[l:]
 								} else {
@@ -2063,12 +1963,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "GameScore"
-							origElem := elem
+
 							if l := len("GameScore"); len(elem) >= l && elem[0:l] == "GameScore" {
 								elem = elem[l:]
 							} else {
@@ -2087,9 +1985,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "My"
-							origElem := elem
+
 							if l := len("My"); len(elem) >= l && elem[0:l] == "My" {
 								elem = elem[l:]
 							} else {
@@ -2101,7 +1998,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'C': // Prefix: "Commands"
-								origElem := elem
+
 								if l := len("Commands"); len(elem) >= l && elem[0:l] == "Commands" {
 									elem = elem[l:]
 								} else {
@@ -2120,9 +2017,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "DefaultAdministratorRights"
-								origElem := elem
+
 								if l := len("DefaultAdministratorRights"); len(elem) >= l && elem[0:l] == "DefaultAdministratorRights" {
 									elem = elem[l:]
 								} else {
@@ -2141,12 +2037,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "PassportDataErrors"
-							origElem := elem
+
 							if l := len("PassportDataErrors"); len(elem) >= l && elem[0:l] == "PassportDataErrors" {
 								elem = elem[l:]
 							} else {
@@ -2165,9 +2059,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -2179,7 +2072,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'P': // Prefix: "PositionInSet"
-								origElem := elem
+
 								if l := len("PositionInSet"); len(elem) >= l && elem[0:l] == "PositionInSet" {
 									elem = elem[l:]
 								} else {
@@ -2198,9 +2091,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "SetThumb"
-								origElem := elem
+
 								if l := len("SetThumb"); len(elem) >= l && elem[0:l] == "SetThumb" {
 									elem = elem[l:]
 								} else {
@@ -2219,12 +2111,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'W': // Prefix: "Webhook"
-							origElem := elem
+
 							if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 								elem = elem[l:]
 							} else {
@@ -2243,15 +2133,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "top"
-					origElem := elem
+
 					if l := len("top"); len(elem) >= l && elem[0:l] == "top" {
 						elem = elem[l:]
 					} else {
@@ -2263,7 +2150,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'M': // Prefix: "MessageLiveLocation"
-						origElem := elem
+
 						if l := len("MessageLiveLocation"); len(elem) >= l && elem[0:l] == "MessageLiveLocation" {
 							elem = elem[l:]
 						} else {
@@ -2282,9 +2169,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "Poll"
-						origElem := elem
+
 						if l := len("Poll"); len(elem) >= l && elem[0:l] == "Poll" {
 							elem = elem[l:]
 						} else {
@@ -2303,15 +2189,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "u"
-				origElem := elem
+
 				if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 					elem = elem[l:]
 				} else {
@@ -2323,7 +2206,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "n"
-					origElem := elem
+
 					if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 						elem = elem[l:]
 					} else {
@@ -2335,7 +2218,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "banChat"
-						origElem := elem
+
 						if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 							elem = elem[l:]
 						} else {
@@ -2347,7 +2230,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'M': // Prefix: "Member"
-							origElem := elem
+
 							if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 								elem = elem[l:]
 							} else {
@@ -2366,9 +2249,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "SenderChat"
-							origElem := elem
+
 							if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 								elem = elem[l:]
 							} else {
@@ -2387,12 +2269,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pin"
-						origElem := elem
+
 						if l := len("pin"); len(elem) >= l && elem[0:l] == "pin" {
 							elem = elem[l:]
 						} else {
@@ -2404,7 +2284,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "AllChatMessages"
-							origElem := elem
+
 							if l := len("AllChatMessages"); len(elem) >= l && elem[0:l] == "AllChatMessages" {
 								elem = elem[l:]
 							} else {
@@ -2423,9 +2303,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "ChatMessage"
-							origElem := elem
+
 							if l := len("ChatMessage"); len(elem) >= l && elem[0:l] == "ChatMessage" {
 								elem = elem[l:]
 							} else {
@@ -2444,15 +2323,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ploadStickerFile"
-					origElem := elem
+
 					if l := len("ploadStickerFile"); len(elem) >= l && elem[0:l] == "ploadStickerFile" {
 						elem = elem[l:]
 					} else {
@@ -2471,13 +2347,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -2559,7 +2432,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -2571,7 +2444,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -2583,7 +2456,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "ddStickerToSet"
-					origElem := elem
+
 					if l := len("ddStickerToSet"); len(elem) >= l && elem[0:l] == "ddStickerToSet" {
 						elem = elem[l:]
 					} else {
@@ -2606,9 +2479,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nswer"
-					origElem := elem
+
 					if l := len("nswer"); len(elem) >= l && elem[0:l] == "nswer" {
 						elem = elem[l:]
 					} else {
@@ -2620,7 +2492,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CallbackQuery"
-						origElem := elem
+
 						if l := len("CallbackQuery"); len(elem) >= l && elem[0:l] == "CallbackQuery" {
 							elem = elem[l:]
 						} else {
@@ -2643,9 +2515,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'I': // Prefix: "InlineQuery"
-						origElem := elem
+
 						if l := len("InlineQuery"); len(elem) >= l && elem[0:l] == "InlineQuery" {
 							elem = elem[l:]
 						} else {
@@ -2668,9 +2539,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "PreCheckoutQuery"
-						origElem := elem
+
 						if l := len("PreCheckoutQuery"); len(elem) >= l && elem[0:l] == "PreCheckoutQuery" {
 							elem = elem[l:]
 						} else {
@@ -2693,9 +2563,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "ShippingQuery"
-						origElem := elem
+
 						if l := len("ShippingQuery"); len(elem) >= l && elem[0:l] == "ShippingQuery" {
 							elem = elem[l:]
 						} else {
@@ -2718,9 +2587,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "WebAppQuery"
-						origElem := elem
+
 						if l := len("WebAppQuery"); len(elem) >= l && elem[0:l] == "WebAppQuery" {
 							elem = elem[l:]
 						} else {
@@ -2743,12 +2611,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "pproveChatJoinRequest"
-					origElem := elem
+
 					if l := len("pproveChatJoinRequest"); len(elem) >= l && elem[0:l] == "pproveChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -2771,12 +2637,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "banChat"
-				origElem := elem
+
 				if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 					elem = elem[l:]
 				} else {
@@ -2788,7 +2652,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'M': // Prefix: "Member"
-					origElem := elem
+
 					if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 						elem = elem[l:]
 					} else {
@@ -2811,9 +2675,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "SenderChat"
-					origElem := elem
+
 					if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 						elem = elem[l:]
 					} else {
@@ -2836,12 +2699,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -2853,7 +2714,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "lose"
-					origElem := elem
+
 					if l := len("lose"); len(elem) >= l && elem[0:l] == "lose" {
 						elem = elem[l:]
 					} else {
@@ -2876,9 +2737,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "opyMessage"
-					origElem := elem
+
 					if l := len("opyMessage"); len(elem) >= l && elem[0:l] == "opyMessage" {
 						elem = elem[l:]
 					} else {
@@ -2901,9 +2761,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "reate"
-					origElem := elem
+
 					if l := len("reate"); len(elem) >= l && elem[0:l] == "reate" {
 						elem = elem[l:]
 					} else {
@@ -2915,7 +2774,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -2938,9 +2797,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'N': // Prefix: "NewStickerSet"
-						origElem := elem
+
 						if l := len("NewStickerSet"); len(elem) >= l && elem[0:l] == "NewStickerSet" {
 							elem = elem[l:]
 						} else {
@@ -2963,15 +2821,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "de"
-				origElem := elem
+
 				if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 					elem = elem[l:]
 				} else {
@@ -2983,7 +2838,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "clineChatJoinRequest"
-					origElem := elem
+
 					if l := len("clineChatJoinRequest"); len(elem) >= l && elem[0:l] == "clineChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -3006,9 +2861,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lete"
-					origElem := elem
+
 					if l := len("lete"); len(elem) >= l && elem[0:l] == "lete" {
 						elem = elem[l:]
 					} else {
@@ -3020,7 +2874,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "Chat"
-						origElem := elem
+
 						if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 							elem = elem[l:]
 						} else {
@@ -3032,7 +2886,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'P': // Prefix: "Photo"
-							origElem := elem
+
 							if l := len("Photo"); len(elem) >= l && elem[0:l] == "Photo" {
 								elem = elem[l:]
 							} else {
@@ -3055,9 +2909,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "StickerSet"
-							origElem := elem
+
 							if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 								elem = elem[l:]
 							} else {
@@ -3080,12 +2933,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "M"
-						origElem := elem
+
 						if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 							elem = elem[l:]
 						} else {
@@ -3097,7 +2948,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "essage"
-							origElem := elem
+
 							if l := len("essage"); len(elem) >= l && elem[0:l] == "essage" {
 								elem = elem[l:]
 							} else {
@@ -3120,9 +2971,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'y': // Prefix: "yCommands"
-							origElem := elem
+
 							if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 								elem = elem[l:]
 							} else {
@@ -3145,12 +2995,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "StickerFromSet"
-						origElem := elem
+
 						if l := len("StickerFromSet"); len(elem) >= l && elem[0:l] == "StickerFromSet" {
 							elem = elem[l:]
 						} else {
@@ -3173,9 +3021,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "Webhook"
-						origElem := elem
+
 						if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 							elem = elem[l:]
 						} else {
@@ -3198,15 +3045,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -3218,7 +3062,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dit"
-					origElem := elem
+
 					if l := len("dit"); len(elem) >= l && elem[0:l] == "dit" {
 						elem = elem[l:]
 					} else {
@@ -3230,7 +3074,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -3253,9 +3097,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Message"
-						origElem := elem
+
 						if l := len("Message"); len(elem) >= l && elem[0:l] == "Message" {
 							elem = elem[l:]
 						} else {
@@ -3267,7 +3110,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Caption"
-							origElem := elem
+
 							if l := len("Caption"); len(elem) >= l && elem[0:l] == "Caption" {
 								elem = elem[l:]
 							} else {
@@ -3290,9 +3133,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "LiveLocation"
-							origElem := elem
+
 							if l := len("LiveLocation"); len(elem) >= l && elem[0:l] == "LiveLocation" {
 								elem = elem[l:]
 							} else {
@@ -3315,9 +3157,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Media"
-							origElem := elem
+
 							if l := len("Media"); len(elem) >= l && elem[0:l] == "Media" {
 								elem = elem[l:]
 							} else {
@@ -3340,9 +3181,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'R': // Prefix: "ReplyMarkup"
-							origElem := elem
+
 							if l := len("ReplyMarkup"); len(elem) >= l && elem[0:l] == "ReplyMarkup" {
 								elem = elem[l:]
 							} else {
@@ -3365,9 +3205,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'T': // Prefix: "Text"
-							origElem := elem
+
 							if l := len("Text"); len(elem) >= l && elem[0:l] == "Text" {
 								elem = elem[l:]
 							} else {
@@ -3390,15 +3229,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'x': // Prefix: "xportChatInviteLink"
-					origElem := elem
+
 					if l := len("xportChatInviteLink"); len(elem) >= l && elem[0:l] == "xportChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -3421,12 +3257,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "forwardMessage"
-				origElem := elem
+
 				if l := len("forwardMessage"); len(elem) >= l && elem[0:l] == "forwardMessage" {
 					elem = elem[l:]
 				} else {
@@ -3449,9 +3283,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "get"
-				origElem := elem
+
 				if l := len("get"); len(elem) >= l && elem[0:l] == "get" {
 					elem = elem[l:]
 				} else {
@@ -3463,7 +3296,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'C': // Prefix: "Chat"
-					origElem := elem
+
 					if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 						elem = elem[l:]
 					} else {
@@ -3486,7 +3319,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Administrators"
-						origElem := elem
+
 						if l := len("Administrators"); len(elem) >= l && elem[0:l] == "Administrators" {
 							elem = elem[l:]
 						} else {
@@ -3509,9 +3342,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Me"
-						origElem := elem
+
 						if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 							elem = elem[l:]
 						} else {
@@ -3523,7 +3355,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -3546,7 +3378,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'C': // Prefix: "Count"
-								origElem := elem
+
 								if l := len("Count"); len(elem) >= l && elem[0:l] == "Count" {
 									elem = elem[l:]
 								} else {
@@ -3569,12 +3401,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "nuButton"
-							origElem := elem
+
 							if l := len("nuButton"); len(elem) >= l && elem[0:l] == "nuButton" {
 								elem = elem[l:]
 							} else {
@@ -3597,15 +3427,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'F': // Prefix: "File"
-					origElem := elem
+
 					if l := len("File"); len(elem) >= l && elem[0:l] == "File" {
 						elem = elem[l:]
 					} else {
@@ -3628,9 +3455,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'G': // Prefix: "GameHighScores"
-					origElem := elem
+
 					if l := len("GameHighScores"); len(elem) >= l && elem[0:l] == "GameHighScores" {
 						elem = elem[l:]
 					} else {
@@ -3653,9 +3479,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "M"
-					origElem := elem
+
 					if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 						elem = elem[l:]
 					} else {
@@ -3667,7 +3492,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "e"
-						origElem := elem
+
 						if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 							elem = elem[l:]
 						} else {
@@ -3690,9 +3515,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'y': // Prefix: "y"
-						origElem := elem
+
 						if l := len("y"); len(elem) >= l && elem[0:l] == "y" {
 							elem = elem[l:]
 						} else {
@@ -3704,7 +3528,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Commands"
-							origElem := elem
+
 							if l := len("Commands"); len(elem) >= l && elem[0:l] == "Commands" {
 								elem = elem[l:]
 							} else {
@@ -3727,9 +3551,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "DefaultAdministratorRights"
-							origElem := elem
+
 							if l := len("DefaultAdministratorRights"); len(elem) >= l && elem[0:l] == "DefaultAdministratorRights" {
 								elem = elem[l:]
 							} else {
@@ -3752,15 +3575,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "StickerSet"
-					origElem := elem
+
 					if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 						elem = elem[l:]
 					} else {
@@ -3783,9 +3603,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "U"
-					origElem := elem
+
 					if l := len("U"); len(elem) >= l && elem[0:l] == "U" {
 						elem = elem[l:]
 					} else {
@@ -3797,7 +3616,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'p': // Prefix: "pdates"
-						origElem := elem
+
 						if l := len("pdates"); len(elem) >= l && elem[0:l] == "pdates" {
 							elem = elem[l:]
 						} else {
@@ -3820,9 +3639,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "serProfilePhotos"
-						origElem := elem
+
 						if l := len("serProfilePhotos"); len(elem) >= l && elem[0:l] == "serProfilePhotos" {
 							elem = elem[l:]
 						} else {
@@ -3845,12 +3663,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'W': // Prefix: "WebhookInfo"
-					origElem := elem
+
 					if l := len("WebhookInfo"); len(elem) >= l && elem[0:l] == "WebhookInfo" {
 						elem = elem[l:]
 					} else {
@@ -3873,12 +3689,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "l"
-				origElem := elem
+
 				if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 					elem = elem[l:]
 				} else {
@@ -3890,7 +3704,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "eaveChat"
-					origElem := elem
+
 					if l := len("eaveChat"); len(elem) >= l && elem[0:l] == "eaveChat" {
 						elem = elem[l:]
 					} else {
@@ -3913,9 +3727,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ogOut"
-					origElem := elem
+
 					if l := len("ogOut"); len(elem) >= l && elem[0:l] == "ogOut" {
 						elem = elem[l:]
 					} else {
@@ -3938,12 +3751,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -3955,7 +3766,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "inChatMessage"
-					origElem := elem
+
 					if l := len("inChatMessage"); len(elem) >= l && elem[0:l] == "inChatMessage" {
 						elem = elem[l:]
 					} else {
@@ -3978,9 +3789,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "romoteChatMember"
-					origElem := elem
+
 					if l := len("romoteChatMember"); len(elem) >= l && elem[0:l] == "romoteChatMember" {
 						elem = elem[l:]
 					} else {
@@ -4003,12 +3813,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -4020,7 +3828,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "strictChatMember"
-					origElem := elem
+
 					if l := len("strictChatMember"); len(elem) >= l && elem[0:l] == "strictChatMember" {
 						elem = elem[l:]
 					} else {
@@ -4043,9 +3851,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vokeChatInviteLink"
-					origElem := elem
+
 					if l := len("vokeChatInviteLink"); len(elem) >= l && elem[0:l] == "vokeChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -4068,12 +3875,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -4085,7 +3890,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -4097,7 +3902,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nd"
-						origElem := elem
+
 						if l := len("nd"); len(elem) >= l && elem[0:l] == "nd" {
 							elem = elem[l:]
 						} else {
@@ -4109,7 +3914,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "A"
-							origElem := elem
+
 							if l := len("A"); len(elem) >= l && elem[0:l] == "A" {
 								elem = elem[l:]
 							} else {
@@ -4121,7 +3926,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "nimation"
-								origElem := elem
+
 								if l := len("nimation"); len(elem) >= l && elem[0:l] == "nimation" {
 									elem = elem[l:]
 								} else {
@@ -4144,9 +3949,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udio"
-								origElem := elem
+
 								if l := len("udio"); len(elem) >= l && elem[0:l] == "udio" {
 									elem = elem[l:]
 								} else {
@@ -4169,12 +3973,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "C"
-							origElem := elem
+
 							if l := len("C"); len(elem) >= l && elem[0:l] == "C" {
 								elem = elem[l:]
 							} else {
@@ -4186,7 +3988,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hatAction"
-								origElem := elem
+
 								if l := len("hatAction"); len(elem) >= l && elem[0:l] == "hatAction" {
 									elem = elem[l:]
 								} else {
@@ -4209,9 +4011,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ontact"
-								origElem := elem
+
 								if l := len("ontact"); len(elem) >= l && elem[0:l] == "ontact" {
 									elem = elem[l:]
 								} else {
@@ -4234,12 +4035,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "D"
-							origElem := elem
+
 							if l := len("D"); len(elem) >= l && elem[0:l] == "D" {
 								elem = elem[l:]
 							} else {
@@ -4251,7 +4050,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "ice"
-								origElem := elem
+
 								if l := len("ice"); len(elem) >= l && elem[0:l] == "ice" {
 									elem = elem[l:]
 								} else {
@@ -4274,9 +4073,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ocument"
-								origElem := elem
+
 								if l := len("ocument"); len(elem) >= l && elem[0:l] == "ocument" {
 									elem = elem[l:]
 								} else {
@@ -4299,12 +4097,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "Game"
-							origElem := elem
+
 							if l := len("Game"); len(elem) >= l && elem[0:l] == "Game" {
 								elem = elem[l:]
 							} else {
@@ -4327,9 +4123,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'I': // Prefix: "Invoice"
-							origElem := elem
+
 							if l := len("Invoice"); len(elem) >= l && elem[0:l] == "Invoice" {
 								elem = elem[l:]
 							} else {
@@ -4352,9 +4147,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "Location"
-							origElem := elem
+
 							if l := len("Location"); len(elem) >= l && elem[0:l] == "Location" {
 								elem = elem[l:]
 							} else {
@@ -4377,9 +4171,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Me"
-							origElem := elem
+
 							if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 								elem = elem[l:]
 							} else {
@@ -4391,7 +4184,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'd': // Prefix: "diaGroup"
-								origElem := elem
+
 								if l := len("diaGroup"); len(elem) >= l && elem[0:l] == "diaGroup" {
 									elem = elem[l:]
 								} else {
@@ -4414,9 +4207,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 's': // Prefix: "ssage"
-								origElem := elem
+
 								if l := len("ssage"); len(elem) >= l && elem[0:l] == "ssage" {
 									elem = elem[l:]
 								} else {
@@ -4439,12 +4231,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "P"
-							origElem := elem
+
 							if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 								elem = elem[l:]
 							} else {
@@ -4456,7 +4246,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hoto"
-								origElem := elem
+
 								if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 									elem = elem[l:]
 								} else {
@@ -4479,9 +4269,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oll"
-								origElem := elem
+
 								if l := len("oll"); len(elem) >= l && elem[0:l] == "oll" {
 									elem = elem[l:]
 								} else {
@@ -4504,12 +4293,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -4532,9 +4319,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'V': // Prefix: "V"
-							origElem := elem
+
 							if l := len("V"); len(elem) >= l && elem[0:l] == "V" {
 								elem = elem[l:]
 							} else {
@@ -4546,7 +4332,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "enue"
-								origElem := elem
+
 								if l := len("enue"); len(elem) >= l && elem[0:l] == "enue" {
 									elem = elem[l:]
 								} else {
@@ -4569,9 +4355,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "ideo"
-								origElem := elem
+
 								if l := len("ideo"); len(elem) >= l && elem[0:l] == "ideo" {
 									elem = elem[l:]
 								} else {
@@ -4594,7 +4379,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'N': // Prefix: "Note"
-									origElem := elem
+
 									if l := len("Note"); len(elem) >= l && elem[0:l] == "Note" {
 										elem = elem[l:]
 									} else {
@@ -4617,12 +4402,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oice"
-								origElem := elem
+
 								if l := len("oice"); len(elem) >= l && elem[0:l] == "oice" {
 									elem = elem[l:]
 								} else {
@@ -4645,15 +4428,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t"
-						origElem := elem
+
 						if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 							elem = elem[l:]
 						} else {
@@ -4665,7 +4445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Chat"
-							origElem := elem
+
 							if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 								elem = elem[l:]
 							} else {
@@ -4677,7 +4457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "AdministratorCustomTitle"
-								origElem := elem
+
 								if l := len("AdministratorCustomTitle"); len(elem) >= l && elem[0:l] == "AdministratorCustomTitle" {
 									elem = elem[l:]
 								} else {
@@ -4700,9 +4480,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "Description"
-								origElem := elem
+
 								if l := len("Description"); len(elem) >= l && elem[0:l] == "Description" {
 									elem = elem[l:]
 								} else {
@@ -4725,9 +4504,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'M': // Prefix: "MenuButton"
-								origElem := elem
+
 								if l := len("MenuButton"); len(elem) >= l && elem[0:l] == "MenuButton" {
 									elem = elem[l:]
 								} else {
@@ -4750,9 +4528,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'P': // Prefix: "P"
-								origElem := elem
+
 								if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 									elem = elem[l:]
 								} else {
@@ -4764,7 +4541,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ermissions"
-									origElem := elem
+
 									if l := len("ermissions"); len(elem) >= l && elem[0:l] == "ermissions" {
 										elem = elem[l:]
 									} else {
@@ -4787,9 +4564,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hoto"
-									origElem := elem
+
 									if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 										elem = elem[l:]
 									} else {
@@ -4812,12 +4588,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "StickerSet"
-								origElem := elem
+
 								if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 									elem = elem[l:]
 								} else {
@@ -4840,9 +4614,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'T': // Prefix: "Title"
-								origElem := elem
+
 								if l := len("Title"); len(elem) >= l && elem[0:l] == "Title" {
 									elem = elem[l:]
 								} else {
@@ -4865,12 +4638,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "GameScore"
-							origElem := elem
+
 							if l := len("GameScore"); len(elem) >= l && elem[0:l] == "GameScore" {
 								elem = elem[l:]
 							} else {
@@ -4893,9 +4664,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "My"
-							origElem := elem
+
 							if l := len("My"); len(elem) >= l && elem[0:l] == "My" {
 								elem = elem[l:]
 							} else {
@@ -4907,7 +4677,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'C': // Prefix: "Commands"
-								origElem := elem
+
 								if l := len("Commands"); len(elem) >= l && elem[0:l] == "Commands" {
 									elem = elem[l:]
 								} else {
@@ -4930,9 +4700,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "DefaultAdministratorRights"
-								origElem := elem
+
 								if l := len("DefaultAdministratorRights"); len(elem) >= l && elem[0:l] == "DefaultAdministratorRights" {
 									elem = elem[l:]
 								} else {
@@ -4955,12 +4724,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "PassportDataErrors"
-							origElem := elem
+
 							if l := len("PassportDataErrors"); len(elem) >= l && elem[0:l] == "PassportDataErrors" {
 								elem = elem[l:]
 							} else {
@@ -4983,9 +4750,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -4997,7 +4763,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'P': // Prefix: "PositionInSet"
-								origElem := elem
+
 								if l := len("PositionInSet"); len(elem) >= l && elem[0:l] == "PositionInSet" {
 									elem = elem[l:]
 								} else {
@@ -5020,9 +4786,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "SetThumb"
-								origElem := elem
+
 								if l := len("SetThumb"); len(elem) >= l && elem[0:l] == "SetThumb" {
 									elem = elem[l:]
 								} else {
@@ -5045,12 +4810,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'W': // Prefix: "Webhook"
-							origElem := elem
+
 							if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 								elem = elem[l:]
 							} else {
@@ -5073,15 +4836,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "top"
-					origElem := elem
+
 					if l := len("top"); len(elem) >= l && elem[0:l] == "top" {
 						elem = elem[l:]
 					} else {
@@ -5093,7 +4853,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'M': // Prefix: "MessageLiveLocation"
-						origElem := elem
+
 						if l := len("MessageLiveLocation"); len(elem) >= l && elem[0:l] == "MessageLiveLocation" {
 							elem = elem[l:]
 						} else {
@@ -5116,9 +4876,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "Poll"
-						origElem := elem
+
 						if l := len("Poll"); len(elem) >= l && elem[0:l] == "Poll" {
 							elem = elem[l:]
 						} else {
@@ -5141,15 +4900,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "u"
-				origElem := elem
+
 				if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 					elem = elem[l:]
 				} else {
@@ -5161,7 +4917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "n"
-					origElem := elem
+
 					if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 						elem = elem[l:]
 					} else {
@@ -5173,7 +4929,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "banChat"
-						origElem := elem
+
 						if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 							elem = elem[l:]
 						} else {
@@ -5185,7 +4941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'M': // Prefix: "Member"
-							origElem := elem
+
 							if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 								elem = elem[l:]
 							} else {
@@ -5208,9 +4964,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "SenderChat"
-							origElem := elem
+
 							if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 								elem = elem[l:]
 							} else {
@@ -5233,12 +4988,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pin"
-						origElem := elem
+
 						if l := len("pin"); len(elem) >= l && elem[0:l] == "pin" {
 							elem = elem[l:]
 						} else {
@@ -5250,7 +5003,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "AllChatMessages"
-							origElem := elem
+
 							if l := len("AllChatMessages"); len(elem) >= l && elem[0:l] == "AllChatMessages" {
 								elem = elem[l:]
 							} else {
@@ -5273,9 +5026,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "ChatMessage"
-							origElem := elem
+
 							if l := len("ChatMessage"); len(elem) >= l && elem[0:l] == "ChatMessage" {
 								elem = elem[l:]
 							} else {
@@ -5298,15 +5050,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ploadStickerFile"
-					origElem := elem
+
 					if l := len("ploadStickerFile"); len(elem) >= l && elem[0:l] == "ploadStickerFile" {
 						elem = elem[l:]
 					} else {
@@ -5329,13 +5078,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_k8s/oas_router_gen.go
+++ b/examples/ex_k8s/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '.': // Prefix: ".well-known/openid-configuration/"
-				origElem := elem
+
 				if l := len(".well-known/openid-configuration/"); len(elem) >= l && elem[0:l] == ".well-known/openid-configuration/" {
 					elem = elem[l:]
 				} else {
@@ -81,9 +81,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'a': // Prefix: "api"
-				origElem := elem
+
 				if l := len("api"); len(elem) >= l && elem[0:l] == "api" {
 					elem = elem[l:]
 				} else {
@@ -95,7 +94,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -114,7 +113,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'v': // Prefix: "v1/"
-						origElem := elem
+
 						if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 							elem = elem[l:]
 						} else {
@@ -133,7 +132,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "co"
-							origElem := elem
+
 							if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 								elem = elem[l:]
 							} else {
@@ -145,7 +144,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'm': // Prefix: "mponentstatuses"
-								origElem := elem
+
 								if l := len("mponentstatuses"); len(elem) >= l && elem[0:l] == "mponentstatuses" {
 									elem = elem[l:]
 								} else {
@@ -164,7 +163,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -194,12 +193,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nfigmaps"
-								origElem := elem
+
 								if l := len("nfigmaps"); len(elem) >= l && elem[0:l] == "nfigmaps" {
 									elem = elem[l:]
 								} else {
@@ -218,12 +215,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'e': // Prefix: "e"
-							origElem := elem
+
 							if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 								elem = elem[l:]
 							} else {
@@ -235,7 +230,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "ndpoints"
-								origElem := elem
+
 								if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 									elem = elem[l:]
 								} else {
@@ -254,9 +249,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'v': // Prefix: "vents"
-								origElem := elem
+
 								if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 									elem = elem[l:]
 								} else {
@@ -275,12 +269,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'l': // Prefix: "limitranges"
-							origElem := elem
+
 							if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 								elem = elem[l:]
 							} else {
@@ -299,9 +291,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "n"
-							origElem := elem
+
 							if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 								elem = elem[l:]
 							} else {
@@ -313,7 +304,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "amespaces"
-								origElem := elem
+
 								if l := len("amespaces"); len(elem) >= l && elem[0:l] == "amespaces" {
 									elem = elem[l:]
 								} else {
@@ -332,7 +323,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -362,7 +353,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -374,7 +365,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "configmaps"
-											origElem := elem
+
 											if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 												elem = elem[l:]
 											} else {
@@ -395,7 +386,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -426,12 +417,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "e"
-											origElem := elem
+
 											if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 												elem = elem[l:]
 											} else {
@@ -443,7 +432,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'n': // Prefix: "ndpoints"
-												origElem := elem
+
 												if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 													elem = elem[l:]
 												} else {
@@ -464,7 +453,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -495,12 +484,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'v': // Prefix: "vents"
-												origElem := elem
+
 												if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 													elem = elem[l:]
 												} else {
@@ -521,7 +508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -552,15 +539,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'l': // Prefix: "limitranges"
-											origElem := elem
+
 											if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 												elem = elem[l:]
 											} else {
@@ -581,7 +565,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -612,12 +596,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'p': // Prefix: "p"
-											origElem := elem
+
 											if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 												elem = elem[l:]
 											} else {
@@ -629,7 +611,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'e': // Prefix: "ersistentvolumeclaims"
-												origElem := elem
+
 												if l := len("ersistentvolumeclaims"); len(elem) >= l && elem[0:l] == "ersistentvolumeclaims" {
 													elem = elem[l:]
 												} else {
@@ -650,7 +632,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -681,7 +663,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -703,15 +685,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'o': // Prefix: "od"
-												origElem := elem
+
 												if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 													elem = elem[l:]
 												} else {
@@ -723,7 +702,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -744,7 +723,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -775,7 +754,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -787,7 +766,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case 'a': // Prefix: "attach"
-																origElem := elem
+
 																if l := len("attach"); len(elem) >= l && elem[0:l] == "attach" {
 																	elem = elem[l:]
 																} else {
@@ -814,9 +793,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'e': // Prefix: "e"
-																origElem := elem
+
 																if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 																	elem = elem[l:]
 																} else {
@@ -828,7 +806,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "phemeralcontainers"
-																	origElem := elem
+
 																	if l := len("phemeralcontainers"); len(elem) >= l && elem[0:l] == "phemeralcontainers" {
 																		elem = elem[l:]
 																	} else {
@@ -850,9 +828,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 'x': // Prefix: "xec"
-																	origElem := elem
+
 																	if l := len("xec"); len(elem) >= l && elem[0:l] == "xec" {
 																		elem = elem[l:]
 																	} else {
@@ -879,12 +856,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 'l': // Prefix: "log"
-																origElem := elem
+
 																if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
 																	elem = elem[l:]
 																} else {
@@ -906,9 +881,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 'p': // Prefix: "p"
-																origElem := elem
+
 																if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 																	elem = elem[l:]
 																} else {
@@ -920,7 +894,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'o': // Prefix: "ortforward"
-																	origElem := elem
+
 																	if l := len("ortforward"); len(elem) >= l && elem[0:l] == "ortforward" {
 																		elem = elem[l:]
 																	} else {
@@ -947,9 +921,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																case 'r': // Prefix: "roxy"
-																	origElem := elem
+
 																	if l := len("roxy"); len(elem) >= l && elem[0:l] == "roxy" {
 																		elem = elem[l:]
 																	} else {
@@ -1001,7 +974,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -1069,15 +1042,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 's': // Prefix: "status"
-																origElem := elem
+
 																if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																	elem = elem[l:]
 																} else {
@@ -1099,18 +1069,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 't': // Prefix: "templates"
-													origElem := elem
+
 													if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 														elem = elem[l:]
 													} else {
@@ -1131,7 +1097,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -1162,18 +1128,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "re"
-											origElem := elem
+
 											if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 												elem = elem[l:]
 											} else {
@@ -1185,7 +1147,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'p': // Prefix: "plicationcontrollers"
-												origElem := elem
+
 												if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 													elem = elem[l:]
 												} else {
@@ -1206,7 +1168,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -1237,7 +1199,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -1249,7 +1211,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -1271,9 +1233,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -1295,18 +1256,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "sourcequotas"
-												origElem := elem
+
 												if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 													elem = elem[l:]
 												} else {
@@ -1327,7 +1284,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -1358,7 +1315,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -1380,18 +1337,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -1403,7 +1356,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'e': // Prefix: "e"
-												origElem := elem
+
 												if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 													elem = elem[l:]
 												} else {
@@ -1415,7 +1368,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "crets"
-													origElem := elem
+
 													if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 														elem = elem[l:]
 													} else {
@@ -1436,7 +1389,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -1467,12 +1420,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rvice"
-													origElem := elem
+
 													if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 														elem = elem[l:]
 													} else {
@@ -1484,7 +1435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "accounts"
-														origElem := elem
+
 														if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 															elem = elem[l:]
 														} else {
@@ -1505,7 +1456,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -1536,12 +1487,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -1562,7 +1511,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -1593,7 +1542,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -1605,7 +1554,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "proxy"
-																	origElem := elem
+
 																	if l := len("proxy"); len(elem) >= l && elem[0:l] == "proxy" {
 																		elem = elem[l:]
 																	} else {
@@ -1657,7 +1606,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -1725,12 +1674,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																			return
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "status"
-																	origElem := elem
+
 																	if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																		elem = elem[l:]
 																	} else {
@@ -1752,24 +1699,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "tatus"
-												origElem := elem
+
 												if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 													elem = elem[l:]
 												} else {
@@ -1790,21 +1731,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "odes"
-								origElem := elem
+
 								if l := len("odes"); len(elem) >= l && elem[0:l] == "odes" {
 									elem = elem[l:]
 								} else {
@@ -1823,7 +1759,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -1853,7 +1789,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -1865,7 +1801,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'p': // Prefix: "proxy"
-											origElem := elem
+
 											if l := len("proxy"); len(elem) >= l && elem[0:l] == "proxy" {
 												elem = elem[l:]
 											} else {
@@ -1910,7 +1846,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -1971,12 +1907,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "status"
-											origElem := elem
+
 											if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 												elem = elem[l:]
 											} else {
@@ -1997,21 +1931,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "p"
-							origElem := elem
+
 							if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 								elem = elem[l:]
 							} else {
@@ -2023,7 +1952,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "ersistentvolume"
-								origElem := elem
+
 								if l := len("ersistentvolume"); len(elem) >= l && elem[0:l] == "ersistentvolume" {
 									elem = elem[l:]
 								} else {
@@ -2035,7 +1964,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "claims"
-									origElem := elem
+
 									if l := len("claims"); len(elem) >= l && elem[0:l] == "claims" {
 										elem = elem[l:]
 									} else {
@@ -2054,9 +1983,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -2075,7 +2003,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -2105,7 +2033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -2126,18 +2054,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "od"
-								origElem := elem
+
 								if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 									elem = elem[l:]
 								} else {
@@ -2149,7 +2073,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -2168,9 +2092,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 't': // Prefix: "templates"
-									origElem := elem
+
 									if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 										elem = elem[l:]
 									} else {
@@ -2189,15 +2112,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'r': // Prefix: "re"
-							origElem := elem
+
 							if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 								elem = elem[l:]
 							} else {
@@ -2209,7 +2129,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'p': // Prefix: "plicationcontrollers"
-								origElem := elem
+
 								if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 									elem = elem[l:]
 								} else {
@@ -2228,9 +2148,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 's': // Prefix: "sourcequotas"
-								origElem := elem
+
 								if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 									elem = elem[l:]
 								} else {
@@ -2249,12 +2168,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "se"
-							origElem := elem
+
 							if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 								elem = elem[l:]
 							} else {
@@ -2266,7 +2183,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "crets"
-								origElem := elem
+
 								if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 									elem = elem[l:]
 								} else {
@@ -2285,9 +2202,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "rvice"
-								origElem := elem
+
 								if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 									elem = elem[l:]
 								} else {
@@ -2299,7 +2215,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "accounts"
-									origElem := elem
+
 									if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 										elem = elem[l:]
 									} else {
@@ -2318,9 +2234,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -2339,15 +2254,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'w': // Prefix: "watch/"
-							origElem := elem
+
 							if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 								elem = elem[l:]
 							} else {
@@ -2359,7 +2271,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "configmaps"
-								origElem := elem
+
 								if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 									elem = elem[l:]
 								} else {
@@ -2378,9 +2290,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "e"
-								origElem := elem
+
 								if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 									elem = elem[l:]
 								} else {
@@ -2392,7 +2303,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "ndpoints"
-									origElem := elem
+
 									if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 										elem = elem[l:]
 									} else {
@@ -2411,9 +2322,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'v': // Prefix: "vents"
-									origElem := elem
+
 									if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 										elem = elem[l:]
 									} else {
@@ -2432,12 +2342,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'l': // Prefix: "limitranges"
-								origElem := elem
+
 								if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 									elem = elem[l:]
 								} else {
@@ -2456,9 +2364,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "n"
-								origElem := elem
+
 								if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 									elem = elem[l:]
 								} else {
@@ -2470,7 +2377,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "amespaces"
-									origElem := elem
+
 									if l := len("amespaces"); len(elem) >= l && elem[0:l] == "amespaces" {
 										elem = elem[l:]
 									} else {
@@ -2489,7 +2396,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -2519,7 +2426,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -2531,7 +2438,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "configmaps"
-												origElem := elem
+
 												if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 													elem = elem[l:]
 												} else {
@@ -2552,7 +2459,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -2583,12 +2490,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'e': // Prefix: "e"
-												origElem := elem
+
 												if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 													elem = elem[l:]
 												} else {
@@ -2600,7 +2505,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'n': // Prefix: "ndpoints"
-													origElem := elem
+
 													if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 														elem = elem[l:]
 													} else {
@@ -2621,7 +2526,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -2652,12 +2557,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "vents"
-													origElem := elem
+
 													if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 														elem = elem[l:]
 													} else {
@@ -2678,7 +2581,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -2709,15 +2612,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "limitranges"
-												origElem := elem
+
 												if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 													elem = elem[l:]
 												} else {
@@ -2738,7 +2638,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -2769,12 +2669,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "p"
-												origElem := elem
+
 												if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 													elem = elem[l:]
 												} else {
@@ -2786,7 +2684,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'e': // Prefix: "ersistentvolumeclaims"
-													origElem := elem
+
 													if l := len("ersistentvolumeclaims"); len(elem) >= l && elem[0:l] == "ersistentvolumeclaims" {
 														elem = elem[l:]
 													} else {
@@ -2807,7 +2705,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -2838,12 +2736,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'o': // Prefix: "od"
-													origElem := elem
+
 													if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 														elem = elem[l:]
 													} else {
@@ -2855,7 +2751,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -2876,7 +2772,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -2907,12 +2803,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 't': // Prefix: "templates"
-														origElem := elem
+
 														if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 															elem = elem[l:]
 														} else {
@@ -2933,7 +2827,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -2964,18 +2858,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "re"
-												origElem := elem
+
 												if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 													elem = elem[l:]
 												} else {
@@ -2987,7 +2877,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'p': // Prefix: "plicationcontrollers"
-													origElem := elem
+
 													if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 														elem = elem[l:]
 													} else {
@@ -3008,7 +2898,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -3039,12 +2929,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "sourcequotas"
-													origElem := elem
+
 													if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 														elem = elem[l:]
 													} else {
@@ -3065,7 +2953,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -3096,15 +2984,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "se"
-												origElem := elem
+
 												if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 													elem = elem[l:]
 												} else {
@@ -3116,7 +3001,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "crets"
-													origElem := elem
+
 													if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 														elem = elem[l:]
 													} else {
@@ -3137,7 +3022,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -3168,12 +3053,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rvice"
-													origElem := elem
+
 													if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 														elem = elem[l:]
 													} else {
@@ -3185,7 +3068,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "accounts"
-														origElem := elem
+
 														if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 															elem = elem[l:]
 														} else {
@@ -3206,7 +3089,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -3237,12 +3120,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -3263,7 +3144,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -3294,27 +3175,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "odes"
-									origElem := elem
+
 									if l := len("odes"); len(elem) >= l && elem[0:l] == "odes" {
 										elem = elem[l:]
 									} else {
@@ -3333,7 +3207,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -3363,15 +3237,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -3383,7 +3254,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ersistentvolume"
-									origElem := elem
+
 									if l := len("ersistentvolume"); len(elem) >= l && elem[0:l] == "ersistentvolume" {
 										elem = elem[l:]
 									} else {
@@ -3395,7 +3266,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "claims"
-										origElem := elem
+
 										if l := len("claims"); len(elem) >= l && elem[0:l] == "claims" {
 											elem = elem[l:]
 										} else {
@@ -3414,9 +3285,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -3435,7 +3305,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -3465,15 +3335,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "od"
-									origElem := elem
+
 									if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 										elem = elem[l:]
 									} else {
@@ -3485,7 +3352,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -3504,9 +3371,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 't': // Prefix: "templates"
-										origElem := elem
+
 										if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 											elem = elem[l:]
 										} else {
@@ -3525,15 +3391,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "re"
-								origElem := elem
+
 								if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 									elem = elem[l:]
 								} else {
@@ -3545,7 +3408,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "plicationcontrollers"
-									origElem := elem
+
 									if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 										elem = elem[l:]
 									} else {
@@ -3564,9 +3427,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "sourcequotas"
-									origElem := elem
+
 									if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 										elem = elem[l:]
 									} else {
@@ -3585,12 +3447,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 's': // Prefix: "se"
-								origElem := elem
+
 								if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 									elem = elem[l:]
 								} else {
@@ -3602,7 +3462,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "crets"
-									origElem := elem
+
 									if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 										elem = elem[l:]
 									} else {
@@ -3621,9 +3481,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rvice"
-									origElem := elem
+
 									if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 										elem = elem[l:]
 									} else {
@@ -3635,7 +3494,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "accounts"
-										origElem := elem
+
 										if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 											elem = elem[l:]
 										} else {
@@ -3654,9 +3513,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -3675,24 +3533,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s/"
-					origElem := elem
+
 					if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 						elem = elem[l:]
 					} else {
@@ -3711,7 +3563,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "a"
-						origElem := elem
+
 						if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 							elem = elem[l:]
 						} else {
@@ -3723,7 +3575,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'd': // Prefix: "dmissionregistration.k8s.io/"
-							origElem := elem
+
 							if l := len("dmissionregistration.k8s.io/"); len(elem) >= l && elem[0:l] == "dmissionregistration.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -3742,7 +3594,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -3761,7 +3613,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'm': // Prefix: "mutatingwebhookconfigurations"
-									origElem := elem
+
 									if l := len("mutatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "mutatingwebhookconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -3780,7 +3632,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -3810,12 +3662,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'v': // Prefix: "validatingwebhookconfigurations"
-									origElem := elem
+
 									if l := len("validatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "validatingwebhookconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -3834,7 +3684,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -3864,12 +3714,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -3881,7 +3729,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'm': // Prefix: "mutatingwebhookconfigurations"
-										origElem := elem
+
 										if l := len("mutatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "mutatingwebhookconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -3900,7 +3748,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -3930,12 +3778,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "validatingwebhookconfigurations"
-										origElem := elem
+
 										if l := len("validatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "validatingwebhookconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -3954,7 +3800,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -3984,21 +3830,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "p"
-							origElem := elem
+
 							if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 								elem = elem[l:]
 							} else {
@@ -4010,7 +3851,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -4022,7 +3863,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "extensions.k8s.io/"
-									origElem := elem
+
 									if l := len("extensions.k8s.io/"); len(elem) >= l && elem[0:l] == "extensions.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -4041,7 +3882,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -4060,7 +3901,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "customresourcedefinitions"
-											origElem := elem
+
 											if l := len("customresourcedefinitions"); len(elem) >= l && elem[0:l] == "customresourcedefinitions" {
 												elem = elem[l:]
 											} else {
@@ -4079,7 +3920,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -4109,7 +3950,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -4130,15 +3971,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/customresourcedefinitions"
-											origElem := elem
+
 											if l := len("watch/customresourcedefinitions"); len(elem) >= l && elem[0:l] == "watch/customresourcedefinitions" {
 												elem = elem[l:]
 											} else {
@@ -4157,7 +3995,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -4187,18 +4025,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "registration.k8s.io/"
-									origElem := elem
+
 									if l := len("registration.k8s.io/"); len(elem) >= l && elem[0:l] == "registration.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -4217,7 +4051,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -4236,7 +4070,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "apiservices"
-											origElem := elem
+
 											if l := len("apiservices"); len(elem) >= l && elem[0:l] == "apiservices" {
 												elem = elem[l:]
 											} else {
@@ -4255,7 +4089,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -4285,7 +4119,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -4306,15 +4140,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/apiservices"
-											origElem := elem
+
 											if l := len("watch/apiservices"); len(elem) >= l && elem[0:l] == "watch/apiservices" {
 												elem = elem[l:]
 											} else {
@@ -4333,7 +4164,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -4363,21 +4194,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "ps/"
-								origElem := elem
+
 								if l := len("ps/"); len(elem) >= l && elem[0:l] == "ps/" {
 									elem = elem[l:]
 								} else {
@@ -4396,7 +4222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'v': // Prefix: "v1/"
-									origElem := elem
+
 									if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 										elem = elem[l:]
 									} else {
@@ -4415,7 +4241,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "controllerrevisions"
-										origElem := elem
+
 										if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 											elem = elem[l:]
 										} else {
@@ -4434,9 +4260,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "d"
-										origElem := elem
+
 										if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 											elem = elem[l:]
 										} else {
@@ -4448,7 +4273,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "aemonsets"
-											origElem := elem
+
 											if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 												elem = elem[l:]
 											} else {
@@ -4467,9 +4292,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "eployments"
-											origElem := elem
+
 											if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 												elem = elem[l:]
 											} else {
@@ -4488,12 +4312,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -4514,7 +4336,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -4526,7 +4348,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "controllerrevisions"
-												origElem := elem
+
 												if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 													elem = elem[l:]
 												} else {
@@ -4547,7 +4369,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -4578,12 +4400,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'd': // Prefix: "d"
-												origElem := elem
+
 												if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 													elem = elem[l:]
 												} else {
@@ -4595,7 +4415,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "aemonsets"
-													origElem := elem
+
 													if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 														elem = elem[l:]
 													} else {
@@ -4616,7 +4436,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -4647,7 +4467,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -4669,15 +4489,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'e': // Prefix: "eployments"
-													origElem := elem
+
 													if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 														elem = elem[l:]
 													} else {
@@ -4698,7 +4515,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -4729,7 +4546,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/s"
-															origElem := elem
+
 															if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 																elem = elem[l:]
 															} else {
@@ -4741,7 +4558,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case 'c': // Prefix: "cale"
-																origElem := elem
+
 																if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																	elem = elem[l:]
 																} else {
@@ -4763,9 +4580,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															case 't': // Prefix: "tatus"
-																origElem := elem
+
 																if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																	elem = elem[l:]
 																} else {
@@ -4787,21 +4603,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "replicasets"
-												origElem := elem
+
 												if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 													elem = elem[l:]
 												} else {
@@ -4822,7 +4633,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -4853,7 +4664,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -4865,7 +4676,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -4887,9 +4698,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -4911,18 +4721,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "statefulsets"
-												origElem := elem
+
 												if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 													elem = elem[l:]
 												} else {
@@ -4943,7 +4749,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -4974,7 +4780,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -4986,7 +4792,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -5008,9 +4814,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -5032,24 +4837,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "replicasets"
-										origElem := elem
+
 										if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 											elem = elem[l:]
 										} else {
@@ -5068,9 +4867,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "statefulsets"
-										origElem := elem
+
 										if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 											elem = elem[l:]
 										} else {
@@ -5089,9 +4887,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -5103,7 +4900,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "controllerrevisions"
-											origElem := elem
+
 											if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 												elem = elem[l:]
 											} else {
@@ -5122,9 +4919,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'd': // Prefix: "d"
-											origElem := elem
+
 											if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 												elem = elem[l:]
 											} else {
@@ -5136,7 +4932,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "aemonsets"
-												origElem := elem
+
 												if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 													elem = elem[l:]
 												} else {
@@ -5155,9 +4951,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'e': // Prefix: "eployments"
-												origElem := elem
+
 												if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 													elem = elem[l:]
 												} else {
@@ -5176,12 +4971,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -5202,7 +4995,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -5214,7 +5007,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "controllerrevisions"
-													origElem := elem
+
 													if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 														elem = elem[l:]
 													} else {
@@ -5235,7 +5028,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5266,12 +5059,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'd': // Prefix: "d"
-													origElem := elem
+
 													if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 														elem = elem[l:]
 													} else {
@@ -5283,7 +5074,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "aemonsets"
-														origElem := elem
+
 														if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 															elem = elem[l:]
 														} else {
@@ -5304,7 +5095,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -5335,12 +5126,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'e': // Prefix: "eployments"
-														origElem := elem
+
 														if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 															elem = elem[l:]
 														} else {
@@ -5361,7 +5150,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -5392,15 +5181,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "replicasets"
-													origElem := elem
+
 													if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 														elem = elem[l:]
 													} else {
@@ -5421,7 +5207,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5452,12 +5238,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "statefulsets"
-													origElem := elem
+
 													if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 														elem = elem[l:]
 													} else {
@@ -5478,7 +5262,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5509,18 +5293,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "replicasets"
-											origElem := elem
+
 											if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 												elem = elem[l:]
 											} else {
@@ -5539,9 +5319,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 's': // Prefix: "statefulsets"
-											origElem := elem
+
 											if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 												elem = elem[l:]
 											} else {
@@ -5560,21 +5339,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ut"
-							origElem := elem
+
 							if l := len("ut"); len(elem) >= l && elem[0:l] == "ut" {
 								elem = elem[l:]
 							} else {
@@ -5586,7 +5360,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "h"
-								origElem := elem
+
 								if l := len("h"); len(elem) >= l && elem[0:l] == "h" {
 									elem = elem[l:]
 								} else {
@@ -5598,7 +5372,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "entication.k8s.io/"
-									origElem := elem
+
 									if l := len("entication.k8s.io/"); len(elem) >= l && elem[0:l] == "entication.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -5617,7 +5391,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -5636,12 +5410,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "orization.k8s.io/"
-									origElem := elem
+
 									if l := len("orization.k8s.io/"); len(elem) >= l && elem[0:l] == "orization.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -5660,7 +5432,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -5679,15 +5451,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oscaling/"
-								origElem := elem
+
 								if l := len("oscaling/"); len(elem) >= l && elem[0:l] == "oscaling/" {
 									elem = elem[l:]
 								} else {
@@ -5706,7 +5475,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'v': // Prefix: "v"
-									origElem := elem
+
 									if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 										elem = elem[l:]
 									} else {
@@ -5718,7 +5487,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "1/"
-										origElem := elem
+
 										if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 											elem = elem[l:]
 										} else {
@@ -5737,7 +5506,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'h': // Prefix: "horizontalpodautoscalers"
-											origElem := elem
+
 											if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 												elem = elem[l:]
 											} else {
@@ -5756,9 +5525,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -5779,7 +5547,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -5800,7 +5568,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -5831,7 +5599,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -5853,18 +5621,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/"
-											origElem := elem
+
 											if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 												elem = elem[l:]
 											} else {
@@ -5876,7 +5640,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -5895,9 +5659,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -5918,7 +5681,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -5939,7 +5702,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -5970,21 +5733,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '2': // Prefix: "2beta"
-										origElem := elem
+
 										if l := len("2beta"); len(elem) >= l && elem[0:l] == "2beta" {
 											elem = elem[l:]
 										} else {
@@ -5996,7 +5754,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "1/"
-											origElem := elem
+
 											if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 												elem = elem[l:]
 											} else {
@@ -6015,7 +5773,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -6034,9 +5792,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -6057,7 +5814,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -6078,7 +5835,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -6109,7 +5866,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -6131,18 +5888,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "watch/"
-												origElem := elem
+
 												if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 													elem = elem[l:]
 												} else {
@@ -6154,7 +5907,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -6173,9 +5926,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "namespaces/"
-													origElem := elem
+
 													if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 														elem = elem[l:]
 													} else {
@@ -6196,7 +5948,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/horizontalpodautoscalers"
-														origElem := elem
+
 														if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 															elem = elem[l:]
 														} else {
@@ -6217,7 +5969,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -6248,21 +6000,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '2': // Prefix: "2/"
-											origElem := elem
+
 											if l := len("2/"); len(elem) >= l && elem[0:l] == "2/" {
 												elem = elem[l:]
 											} else {
@@ -6281,7 +6028,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -6300,9 +6047,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -6323,7 +6069,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -6344,7 +6090,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -6375,7 +6121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -6397,18 +6143,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "watch/"
-												origElem := elem
+
 												if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 													elem = elem[l:]
 												} else {
@@ -6420,7 +6162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -6439,9 +6181,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "namespaces/"
-													origElem := elem
+
 													if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 														elem = elem[l:]
 													} else {
@@ -6462,7 +6203,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/horizontalpodautoscalers"
-														origElem := elem
+
 														if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 															elem = elem[l:]
 														} else {
@@ -6483,7 +6224,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -6514,36 +6255,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "batch/"
-						origElem := elem
+
 						if l := len("batch/"); len(elem) >= l && elem[0:l] == "batch/" {
 							elem = elem[l:]
 						} else {
@@ -6562,7 +6293,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -6574,7 +6305,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -6593,7 +6324,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cronjobs"
-									origElem := elem
+
 									if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 										elem = elem[l:]
 									} else {
@@ -6612,9 +6343,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'j': // Prefix: "jobs"
-									origElem := elem
+
 									if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 										elem = elem[l:]
 									} else {
@@ -6633,9 +6363,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -6656,7 +6385,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -6668,7 +6397,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "cronjobs"
-											origElem := elem
+
 											if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 												elem = elem[l:]
 											} else {
@@ -6689,7 +6418,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -6720,7 +6449,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -6742,15 +6471,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'j': // Prefix: "jobs"
-											origElem := elem
+
 											if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 												elem = elem[l:]
 											} else {
@@ -6771,7 +6497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -6802,7 +6528,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -6824,21 +6550,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -6850,7 +6571,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "cronjobs"
-										origElem := elem
+
 										if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -6869,9 +6590,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'j': // Prefix: "jobs"
-										origElem := elem
+
 										if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 											elem = elem[l:]
 										} else {
@@ -6890,9 +6610,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -6913,7 +6632,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -6925,7 +6644,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cronjobs"
-												origElem := elem
+
 												if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 													elem = elem[l:]
 												} else {
@@ -6946,7 +6665,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -6977,12 +6696,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'j': // Prefix: "jobs"
-												origElem := elem
+
 												if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 													elem = elem[l:]
 												} else {
@@ -7003,7 +6720,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -7034,24 +6751,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -7070,7 +6781,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cronjobs"
-									origElem := elem
+
 									if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 										elem = elem[l:]
 									} else {
@@ -7089,9 +6800,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -7112,7 +6822,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/cronjobs"
-										origElem := elem
+
 										if l := len("/cronjobs"); len(elem) >= l && elem[0:l] == "/cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -7133,7 +6843,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -7164,7 +6874,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -7186,18 +6896,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -7209,7 +6915,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "cronjobs"
-										origElem := elem
+
 										if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -7228,9 +6934,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -7251,7 +6956,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/cronjobs"
-											origElem := elem
+
 											if l := len("/cronjobs"); len(elem) >= l && elem[0:l] == "/cronjobs" {
 												elem = elem[l:]
 											} else {
@@ -7272,7 +6977,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -7303,27 +7008,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'c': // Prefix: "c"
-						origElem := elem
+
 						if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 							elem = elem[l:]
 						} else {
@@ -7335,7 +7033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "ertificates.k8s.io/"
-							origElem := elem
+
 							if l := len("ertificates.k8s.io/"); len(elem) >= l && elem[0:l] == "ertificates.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -7354,7 +7052,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -7373,7 +7071,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "certificatesigningrequests"
-									origElem := elem
+
 									if l := len("certificatesigningrequests"); len(elem) >= l && elem[0:l] == "certificatesigningrequests" {
 										elem = elem[l:]
 									} else {
@@ -7392,7 +7090,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -7422,7 +7120,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -7434,7 +7132,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "approval"
-												origElem := elem
+
 												if l := len("approval"); len(elem) >= l && elem[0:l] == "approval" {
 													elem = elem[l:]
 												} else {
@@ -7455,9 +7153,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											case 's': // Prefix: "status"
-												origElem := elem
+
 												if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 													elem = elem[l:]
 												} else {
@@ -7478,18 +7175,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/certificatesigningrequests"
-									origElem := elem
+
 									if l := len("watch/certificatesigningrequests"); len(elem) >= l && elem[0:l] == "watch/certificatesigningrequests" {
 										elem = elem[l:]
 									} else {
@@ -7508,7 +7201,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -7538,18 +7231,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'o': // Prefix: "oordination.k8s.io/"
-							origElem := elem
+
 							if l := len("oordination.k8s.io/"); len(elem) >= l && elem[0:l] == "oordination.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -7568,7 +7257,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -7587,7 +7276,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'l': // Prefix: "leases"
-									origElem := elem
+
 									if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 										elem = elem[l:]
 									} else {
@@ -7606,9 +7295,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -7629,7 +7317,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/leases"
-										origElem := elem
+
 										if l := len("/leases"); len(elem) >= l && elem[0:l] == "/leases" {
 											elem = elem[l:]
 										} else {
@@ -7650,7 +7338,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -7681,15 +7369,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -7701,7 +7386,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'l': // Prefix: "leases"
-										origElem := elem
+
 										if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 											elem = elem[l:]
 										} else {
@@ -7720,9 +7405,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -7743,7 +7427,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/leases"
-											origElem := elem
+
 											if l := len("/leases"); len(elem) >= l && elem[0:l] == "/leases" {
 												elem = elem[l:]
 											} else {
@@ -7764,7 +7448,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -7795,27 +7479,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'd': // Prefix: "discovery.k8s.io/"
-						origElem := elem
+
 						if l := len("discovery.k8s.io/"); len(elem) >= l && elem[0:l] == "discovery.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -7834,7 +7511,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -7846,7 +7523,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -7865,7 +7542,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "endpointslices"
-									origElem := elem
+
 									if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 										elem = elem[l:]
 									} else {
@@ -7884,9 +7561,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -7907,7 +7583,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/endpointslices"
-										origElem := elem
+
 										if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -7928,7 +7604,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -7959,15 +7635,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -7979,7 +7652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "endpointslices"
-										origElem := elem
+
 										if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -7998,9 +7671,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -8021,7 +7693,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/endpointslices"
-											origElem := elem
+
 											if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 												elem = elem[l:]
 											} else {
@@ -8042,7 +7714,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -8073,21 +7745,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -8106,7 +7773,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "endpointslices"
-									origElem := elem
+
 									if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 										elem = elem[l:]
 									} else {
@@ -8125,9 +7792,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -8148,7 +7814,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/endpointslices"
-										origElem := elem
+
 										if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -8169,7 +7835,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -8200,15 +7866,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -8220,7 +7883,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "endpointslices"
-										origElem := elem
+
 										if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -8239,9 +7902,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -8262,7 +7924,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/endpointslices"
-											origElem := elem
+
 											if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 												elem = elem[l:]
 											} else {
@@ -8283,7 +7945,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -8314,27 +7976,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "events.k8s.io/"
-						origElem := elem
+
 						if l := len("events.k8s.io/"); len(elem) >= l && elem[0:l] == "events.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -8353,7 +8008,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -8365,7 +8020,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -8384,7 +8039,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "events"
-									origElem := elem
+
 									if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 										elem = elem[l:]
 									} else {
@@ -8403,9 +8058,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -8426,7 +8080,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/events"
-										origElem := elem
+
 										if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 											elem = elem[l:]
 										} else {
@@ -8447,7 +8101,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -8478,15 +8132,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -8498,7 +8149,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "events"
-										origElem := elem
+
 										if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 											elem = elem[l:]
 										} else {
@@ -8517,9 +8168,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -8540,7 +8190,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/events"
-											origElem := elem
+
 											if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 												elem = elem[l:]
 											} else {
@@ -8561,7 +8211,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -8592,21 +8242,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -8625,7 +8270,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "events"
-									origElem := elem
+
 									if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 										elem = elem[l:]
 									} else {
@@ -8644,9 +8289,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -8667,7 +8311,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/events"
-										origElem := elem
+
 										if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 											elem = elem[l:]
 										} else {
@@ -8688,7 +8332,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -8719,15 +8363,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -8739,7 +8380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "events"
-										origElem := elem
+
 										if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 											elem = elem[l:]
 										} else {
@@ -8758,9 +8399,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -8781,7 +8421,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/events"
-											origElem := elem
+
 											if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 												elem = elem[l:]
 											} else {
@@ -8802,7 +8442,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -8833,27 +8473,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "flowcontrol.apiserver.k8s.io/"
-						origElem := elem
+
 						if l := len("flowcontrol.apiserver.k8s.io/"); len(elem) >= l && elem[0:l] == "flowcontrol.apiserver.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -8872,7 +8505,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1beta"
-							origElem := elem
+
 							if l := len("v1beta"); len(elem) >= l && elem[0:l] == "v1beta" {
 								elem = elem[l:]
 							} else {
@@ -8884,7 +8517,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '1': // Prefix: "1/"
-								origElem := elem
+
 								if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 									elem = elem[l:]
 								} else {
@@ -8903,7 +8536,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'f': // Prefix: "flowschemas"
-									origElem := elem
+
 									if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 										elem = elem[l:]
 									} else {
@@ -8922,7 +8555,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -8952,7 +8585,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -8973,15 +8606,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "prioritylevelconfigurations"
-									origElem := elem
+
 									if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -9000,7 +8630,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -9030,7 +8660,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -9051,15 +8681,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -9071,7 +8698,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'f': // Prefix: "flowschemas"
-										origElem := elem
+
 										if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 											elem = elem[l:]
 										} else {
@@ -9090,7 +8717,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9120,12 +8747,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "prioritylevelconfigurations"
-										origElem := elem
+
 										if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -9144,7 +8769,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9174,18 +8799,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case '2': // Prefix: "2/"
-								origElem := elem
+
 								if l := len("2/"); len(elem) >= l && elem[0:l] == "2/" {
 									elem = elem[l:]
 								} else {
@@ -9204,7 +8825,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'f': // Prefix: "flowschemas"
-									origElem := elem
+
 									if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 										elem = elem[l:]
 									} else {
@@ -9223,7 +8844,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -9253,7 +8874,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -9274,15 +8895,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "prioritylevelconfigurations"
-									origElem := elem
+
 									if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -9301,7 +8919,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -9331,7 +8949,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -9352,15 +8970,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -9372,7 +8987,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'f': // Prefix: "flowschemas"
-										origElem := elem
+
 										if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 											elem = elem[l:]
 										} else {
@@ -9391,7 +9006,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9421,12 +9036,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "prioritylevelconfigurations"
-										origElem := elem
+
 										if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -9445,7 +9058,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9475,24 +9088,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "internal.apiserver.k8s.io/"
-						origElem := elem
+
 						if l := len("internal.apiserver.k8s.io/"); len(elem) >= l && elem[0:l] == "internal.apiserver.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -9511,7 +9118,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1alpha1/"
-							origElem := elem
+
 							if l := len("v1alpha1/"); len(elem) >= l && elem[0:l] == "v1alpha1/" {
 								elem = elem[l:]
 							} else {
@@ -9530,7 +9137,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 's': // Prefix: "storageversions"
-								origElem := elem
+
 								if l := len("storageversions"); len(elem) >= l && elem[0:l] == "storageversions" {
 									elem = elem[l:]
 								} else {
@@ -9549,7 +9156,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -9579,7 +9186,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/status"
-										origElem := elem
+
 										if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 											elem = elem[l:]
 										} else {
@@ -9600,15 +9207,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'w': // Prefix: "watch/storageversions"
-								origElem := elem
+
 								if l := len("watch/storageversions"); len(elem) >= l && elem[0:l] == "watch/storageversions" {
 									elem = elem[l:]
 								} else {
@@ -9627,7 +9231,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -9657,18 +9261,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "n"
-						origElem := elem
+
 						if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 							elem = elem[l:]
 						} else {
@@ -9680,7 +9280,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "etworking.k8s.io/"
-							origElem := elem
+
 							if l := len("etworking.k8s.io/"); len(elem) >= l && elem[0:l] == "etworking.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -9699,7 +9299,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -9718,7 +9318,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "ingress"
-									origElem := elem
+
 									if l := len("ingress"); len(elem) >= l && elem[0:l] == "ingress" {
 										elem = elem[l:]
 									} else {
@@ -9730,7 +9330,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "classes"
-										origElem := elem
+
 										if l := len("classes"); len(elem) >= l && elem[0:l] == "classes" {
 											elem = elem[l:]
 										} else {
@@ -9749,7 +9349,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9779,12 +9379,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "es"
-										origElem := elem
+
 										if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 											elem = elem[l:]
 										} else {
@@ -9803,12 +9401,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "n"
-									origElem := elem
+
 									if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 										elem = elem[l:]
 									} else {
@@ -9820,7 +9416,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "amespaces/"
-										origElem := elem
+
 										if l := len("amespaces/"); len(elem) >= l && elem[0:l] == "amespaces/" {
 											elem = elem[l:]
 										} else {
@@ -9841,7 +9437,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -9853,7 +9449,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'i': // Prefix: "ingresses"
-												origElem := elem
+
 												if l := len("ingresses"); len(elem) >= l && elem[0:l] == "ingresses" {
 													elem = elem[l:]
 												} else {
@@ -9874,7 +9470,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -9905,7 +9501,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -9927,15 +9523,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "networkpolicies"
-												origElem := elem
+
 												if l := len("networkpolicies"); len(elem) >= l && elem[0:l] == "networkpolicies" {
 													elem = elem[l:]
 												} else {
@@ -9956,7 +9549,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -9987,18 +9580,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "etworkpolicies"
-										origElem := elem
+
 										if l := len("etworkpolicies"); len(elem) >= l && elem[0:l] == "etworkpolicies" {
 											elem = elem[l:]
 										} else {
@@ -10017,12 +9606,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -10034,7 +9621,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "ingress"
-										origElem := elem
+
 										if l := len("ingress"); len(elem) >= l && elem[0:l] == "ingress" {
 											elem = elem[l:]
 										} else {
@@ -10046,7 +9633,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "classes"
-											origElem := elem
+
 											if l := len("classes"); len(elem) >= l && elem[0:l] == "classes" {
 												elem = elem[l:]
 											} else {
@@ -10065,7 +9652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -10095,12 +9682,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "es"
-											origElem := elem
+
 											if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 												elem = elem[l:]
 											} else {
@@ -10119,12 +9704,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "n"
-										origElem := elem
+
 										if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 											elem = elem[l:]
 										} else {
@@ -10136,7 +9719,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "amespaces/"
-											origElem := elem
+
 											if l := len("amespaces/"); len(elem) >= l && elem[0:l] == "amespaces/" {
 												elem = elem[l:]
 											} else {
@@ -10157,7 +9740,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -10169,7 +9752,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'i': // Prefix: "ingresses"
-													origElem := elem
+
 													if l := len("ingresses"); len(elem) >= l && elem[0:l] == "ingresses" {
 														elem = elem[l:]
 													} else {
@@ -10190,7 +9773,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -10221,12 +9804,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "networkpolicies"
-													origElem := elem
+
 													if l := len("networkpolicies"); len(elem) >= l && elem[0:l] == "networkpolicies" {
 														elem = elem[l:]
 													} else {
@@ -10247,7 +9828,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -10278,18 +9859,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "etworkpolicies"
-											origElem := elem
+
 											if l := len("etworkpolicies"); len(elem) >= l && elem[0:l] == "etworkpolicies" {
 												elem = elem[l:]
 											} else {
@@ -10308,21 +9885,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'o': // Prefix: "ode.k8s.io/"
-							origElem := elem
+
 							if l := len("ode.k8s.io/"); len(elem) >= l && elem[0:l] == "ode.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -10341,7 +9913,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1"
-								origElem := elem
+
 								if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 									elem = elem[l:]
 								} else {
@@ -10353,7 +9925,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -10372,7 +9944,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10391,7 +9963,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10421,12 +9993,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10445,7 +10015,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10475,15 +10045,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'a': // Prefix: "alpha1/"
-									origElem := elem
+
 									if l := len("alpha1/"); len(elem) >= l && elem[0:l] == "alpha1/" {
 										elem = elem[l:]
 									} else {
@@ -10502,7 +10069,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10521,7 +10088,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10551,12 +10118,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10575,7 +10140,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10605,15 +10170,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "beta1/"
-									origElem := elem
+
 									if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 										elem = elem[l:]
 									} else {
@@ -10632,7 +10194,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10651,7 +10213,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10681,12 +10243,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -10705,7 +10265,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10735,24 +10295,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "policy/"
-						origElem := elem
+
 						if l := len("policy/"); len(elem) >= l && elem[0:l] == "policy/" {
 							elem = elem[l:]
 						} else {
@@ -10771,7 +10325,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -10783,7 +10337,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -10802,7 +10356,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -10823,7 +10377,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -10844,7 +10398,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -10875,7 +10429,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -10897,18 +10451,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "poddisruptionbudgets"
-									origElem := elem
+
 									if l := len("poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "poddisruptionbudgets" {
 										elem = elem[l:]
 									} else {
@@ -10927,9 +10477,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -10941,7 +10490,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -10962,7 +10511,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/poddisruptionbudgets"
-											origElem := elem
+
 											if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -10983,7 +10532,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11014,15 +10563,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -11041,15 +10587,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -11068,7 +10611,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -11089,7 +10632,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -11110,7 +10653,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11141,7 +10684,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -11163,18 +10706,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pod"
-									origElem := elem
+
 									if l := len("pod"); len(elem) >= l && elem[0:l] == "pod" {
 										elem = elem[l:]
 									} else {
@@ -11186,7 +10725,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'd': // Prefix: "disruptionbudgets"
-										origElem := elem
+
 										if l := len("disruptionbudgets"); len(elem) >= l && elem[0:l] == "disruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -11205,9 +10744,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "securitypolicies"
-										origElem := elem
+
 										if l := len("securitypolicies"); len(elem) >= l && elem[0:l] == "securitypolicies" {
 											elem = elem[l:]
 										} else {
@@ -11226,7 +10764,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11256,15 +10794,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -11276,7 +10811,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -11297,7 +10832,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/poddisruptionbudgets"
-											origElem := elem
+
 											if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -11318,7 +10853,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11349,15 +10884,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "pod"
-										origElem := elem
+
 										if l := len("pod"); len(elem) >= l && elem[0:l] == "pod" {
 											elem = elem[l:]
 										} else {
@@ -11369,7 +10901,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'd': // Prefix: "disruptionbudgets"
-											origElem := elem
+
 											if l := len("disruptionbudgets"); len(elem) >= l && elem[0:l] == "disruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -11388,9 +10920,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 's': // Prefix: "securitypolicies"
-											origElem := elem
+
 											if l := len("securitypolicies"); len(elem) >= l && elem[0:l] == "securitypolicies" {
 												elem = elem[l:]
 											} else {
@@ -11409,7 +10940,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -11439,27 +10970,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "rbac.authorization.k8s.io/"
-						origElem := elem
+
 						if l := len("rbac.authorization.k8s.io/"); len(elem) >= l && elem[0:l] == "rbac.authorization.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -11478,7 +11002,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1/"
-							origElem := elem
+
 							if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 								elem = elem[l:]
 							} else {
@@ -11497,7 +11021,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "clusterrole"
-								origElem := elem
+
 								if l := len("clusterrole"); len(elem) >= l && elem[0:l] == "clusterrole" {
 									elem = elem[l:]
 								} else {
@@ -11509,7 +11033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'b': // Prefix: "bindings"
-									origElem := elem
+
 									if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 										elem = elem[l:]
 									} else {
@@ -11528,7 +11052,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -11558,12 +11082,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -11582,7 +11104,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -11612,15 +11134,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "namespaces/"
-								origElem := elem
+
 								if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 									elem = elem[l:]
 								} else {
@@ -11641,7 +11160,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/role"
-									origElem := elem
+
 									if l := len("/role"); len(elem) >= l && elem[0:l] == "/role" {
 										elem = elem[l:]
 									} else {
@@ -11653,7 +11172,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -11674,7 +11193,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11705,12 +11224,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -11731,7 +11248,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11762,18 +11279,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "role"
-								origElem := elem
+
 								if l := len("role"); len(elem) >= l && elem[0:l] == "role" {
 									elem = elem[l:]
 								} else {
@@ -11785,7 +11298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'b': // Prefix: "bindings"
-									origElem := elem
+
 									if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 										elem = elem[l:]
 									} else {
@@ -11804,9 +11317,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -11825,12 +11337,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'w': // Prefix: "watch/"
-								origElem := elem
+
 								if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 									elem = elem[l:]
 								} else {
@@ -11842,7 +11352,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "clusterrole"
-									origElem := elem
+
 									if l := len("clusterrole"); len(elem) >= l && elem[0:l] == "clusterrole" {
 										elem = elem[l:]
 									} else {
@@ -11854,7 +11364,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -11873,7 +11383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11903,12 +11413,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -11927,7 +11435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -11957,15 +11465,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -11986,7 +11491,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/role"
-										origElem := elem
+
 										if l := len("/role"); len(elem) >= l && elem[0:l] == "/role" {
 											elem = elem[l:]
 										} else {
@@ -11998,7 +11503,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'b': // Prefix: "bindings"
-											origElem := elem
+
 											if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 												elem = elem[l:]
 											} else {
@@ -12019,7 +11524,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12050,12 +11555,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -12076,7 +11579,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12107,18 +11610,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "role"
-									origElem := elem
+
 									if l := len("role"); len(elem) >= l && elem[0:l] == "role" {
 										elem = elem[l:]
 									} else {
@@ -12130,7 +11629,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -12149,9 +11648,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -12170,21 +11668,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s"
-						origElem := elem
+
 						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 							elem = elem[l:]
 						} else {
@@ -12196,7 +11689,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cheduling.k8s.io/"
-							origElem := elem
+
 							if l := len("cheduling.k8s.io/"); len(elem) >= l && elem[0:l] == "cheduling.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -12215,7 +11708,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -12234,7 +11727,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "priorityclasses"
-									origElem := elem
+
 									if l := len("priorityclasses"); len(elem) >= l && elem[0:l] == "priorityclasses" {
 										elem = elem[l:]
 									} else {
@@ -12253,7 +11746,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -12283,12 +11776,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/priorityclasses"
-									origElem := elem
+
 									if l := len("watch/priorityclasses"); len(elem) >= l && elem[0:l] == "watch/priorityclasses" {
 										elem = elem[l:]
 									} else {
@@ -12307,7 +11798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -12337,18 +11828,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 't': // Prefix: "torage.k8s.io/"
-							origElem := elem
+
 							if l := len("torage.k8s.io/"); len(elem) >= l && elem[0:l] == "torage.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -12367,7 +11854,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1"
-								origElem := elem
+
 								if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 									elem = elem[l:]
 								} else {
@@ -12379,7 +11866,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -12398,7 +11885,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csi"
-										origElem := elem
+
 										if l := len("csi"); len(elem) >= l && elem[0:l] == "csi" {
 											elem = elem[l:]
 										} else {
@@ -12410,7 +11897,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'd': // Prefix: "drivers"
-											origElem := elem
+
 											if l := len("drivers"); len(elem) >= l && elem[0:l] == "drivers" {
 												elem = elem[l:]
 											} else {
@@ -12429,7 +11916,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12459,12 +11946,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nodes"
-											origElem := elem
+
 											if l := len("nodes"); len(elem) >= l && elem[0:l] == "nodes" {
 												elem = elem[l:]
 											} else {
@@ -12483,7 +11968,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12513,15 +11998,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "storageclasses"
-										origElem := elem
+
 										if l := len("storageclasses"); len(elem) >= l && elem[0:l] == "storageclasses" {
 											elem = elem[l:]
 										} else {
@@ -12540,7 +12022,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -12570,12 +12052,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "volumeattachments"
-										origElem := elem
+
 										if l := len("volumeattachments"); len(elem) >= l && elem[0:l] == "volumeattachments" {
 											elem = elem[l:]
 										} else {
@@ -12594,7 +12074,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -12624,7 +12104,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -12645,15 +12125,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -12665,7 +12142,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csi"
-											origElem := elem
+
 											if l := len("csi"); len(elem) >= l && elem[0:l] == "csi" {
 												elem = elem[l:]
 											} else {
@@ -12677,7 +12154,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "drivers"
-												origElem := elem
+
 												if l := len("drivers"); len(elem) >= l && elem[0:l] == "drivers" {
 													elem = elem[l:]
 												} else {
@@ -12696,7 +12173,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -12726,12 +12203,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nodes"
-												origElem := elem
+
 												if l := len("nodes"); len(elem) >= l && elem[0:l] == "nodes" {
 													elem = elem[l:]
 												} else {
@@ -12750,7 +12225,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -12780,15 +12255,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "storageclasses"
-											origElem := elem
+
 											if l := len("storageclasses"); len(elem) >= l && elem[0:l] == "storageclasses" {
 												elem = elem[l:]
 											} else {
@@ -12807,7 +12279,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12837,12 +12309,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "volumeattachments"
-											origElem := elem
+
 											if l := len("volumeattachments"); len(elem) >= l && elem[0:l] == "volumeattachments" {
 												elem = elem[l:]
 											} else {
@@ -12861,7 +12331,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -12891,18 +12361,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'a': // Prefix: "alpha1/"
-									origElem := elem
+
 									if l := len("alpha1/"); len(elem) >= l && elem[0:l] == "alpha1/" {
 										elem = elem[l:]
 									} else {
@@ -12921,7 +12387,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csistoragecapacities"
-										origElem := elem
+
 										if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 											elem = elem[l:]
 										} else {
@@ -12940,9 +12406,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -12963,7 +12428,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/csistoragecapacities"
-											origElem := elem
+
 											if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -12984,7 +12449,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -13015,15 +12480,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -13035,7 +12497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csistoragecapacities"
-											origElem := elem
+
 											if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -13054,9 +12516,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -13077,7 +12538,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/csistoragecapacities"
-												origElem := elem
+
 												if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 													elem = elem[l:]
 												} else {
@@ -13098,7 +12559,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -13129,21 +12590,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "beta1/"
-									origElem := elem
+
 									if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 										elem = elem[l:]
 									} else {
@@ -13162,7 +12618,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csistoragecapacities"
-										origElem := elem
+
 										if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 											elem = elem[l:]
 										} else {
@@ -13181,9 +12637,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -13204,7 +12659,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/csistoragecapacities"
-											origElem := elem
+
 											if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -13225,7 +12680,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -13256,15 +12711,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -13276,7 +12728,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csistoragecapacities"
-											origElem := elem
+
 											if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -13295,9 +12747,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -13318,7 +12769,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/csistoragecapacities"
-												origElem := elem
+
 												if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 													elem = elem[l:]
 												} else {
@@ -13339,7 +12790,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -13370,36 +12821,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "logs/"
-				origElem := elem
+
 				if l := len("logs/"); len(elem) >= l && elem[0:l] == "logs/" {
 					elem = elem[l:]
 				} else {
@@ -13439,9 +12880,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "openid/v1/jwks/"
-				origElem := elem
+
 				if l := len("openid/v1/jwks/"); len(elem) >= l && elem[0:l] == "openid/v1/jwks/" {
 					elem = elem[l:]
 				} else {
@@ -13460,9 +12900,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'v': // Prefix: "version/"
-				origElem := elem
+
 				if l := len("version/"); len(elem) >= l && elem[0:l] == "version/" {
 					elem = elem[l:]
 				} else {
@@ -13481,10 +12920,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -13566,7 +13003,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -13578,7 +13015,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '.': // Prefix: ".well-known/openid-configuration/"
-				origElem := elem
+
 				if l := len(".well-known/openid-configuration/"); len(elem) >= l && elem[0:l] == ".well-known/openid-configuration/" {
 					elem = elem[l:]
 				} else {
@@ -13601,9 +13038,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'a': // Prefix: "api"
-				origElem := elem
+
 				if l := len("api"); len(elem) >= l && elem[0:l] == "api" {
 					elem = elem[l:]
 				} else {
@@ -13615,7 +13051,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -13638,7 +13074,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'v': // Prefix: "v1/"
-						origElem := elem
+
 						if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 							elem = elem[l:]
 						} else {
@@ -13661,7 +13097,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "co"
-							origElem := elem
+
 							if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 								elem = elem[l:]
 							} else {
@@ -13673,7 +13109,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'm': // Prefix: "mponentstatuses"
-								origElem := elem
+
 								if l := len("mponentstatuses"); len(elem) >= l && elem[0:l] == "mponentstatuses" {
 									elem = elem[l:]
 								} else {
@@ -13696,7 +13132,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -13728,12 +13164,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nfigmaps"
-								origElem := elem
+
 								if l := len("nfigmaps"); len(elem) >= l && elem[0:l] == "nfigmaps" {
 									elem = elem[l:]
 								} else {
@@ -13756,12 +13190,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'e': // Prefix: "e"
-							origElem := elem
+
 							if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 								elem = elem[l:]
 							} else {
@@ -13773,7 +13205,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "ndpoints"
-								origElem := elem
+
 								if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 									elem = elem[l:]
 								} else {
@@ -13796,9 +13228,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'v': // Prefix: "vents"
-								origElem := elem
+
 								if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 									elem = elem[l:]
 								} else {
@@ -13821,12 +13252,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'l': // Prefix: "limitranges"
-							origElem := elem
+
 							if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 								elem = elem[l:]
 							} else {
@@ -13849,9 +13278,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "n"
-							origElem := elem
+
 							if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 								elem = elem[l:]
 							} else {
@@ -13863,7 +13291,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "amespaces"
-								origElem := elem
+
 								if l := len("amespaces"); len(elem) >= l && elem[0:l] == "amespaces" {
 									elem = elem[l:]
 								} else {
@@ -13886,7 +13314,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -13918,7 +13346,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -13930,7 +13358,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "configmaps"
-											origElem := elem
+
 											if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 												elem = elem[l:]
 											} else {
@@ -13953,7 +13381,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -13985,12 +13413,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "e"
-											origElem := elem
+
 											if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 												elem = elem[l:]
 											} else {
@@ -14002,7 +13428,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'n': // Prefix: "ndpoints"
-												origElem := elem
+
 												if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 													elem = elem[l:]
 												} else {
@@ -14025,7 +13451,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -14057,12 +13483,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'v': // Prefix: "vents"
-												origElem := elem
+
 												if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 													elem = elem[l:]
 												} else {
@@ -14085,7 +13509,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -14117,15 +13541,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'l': // Prefix: "limitranges"
-											origElem := elem
+
 											if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 												elem = elem[l:]
 											} else {
@@ -14148,7 +13569,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -14180,12 +13601,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'p': // Prefix: "p"
-											origElem := elem
+
 											if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 												elem = elem[l:]
 											} else {
@@ -14197,7 +13616,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'e': // Prefix: "ersistentvolumeclaims"
-												origElem := elem
+
 												if l := len("ersistentvolumeclaims"); len(elem) >= l && elem[0:l] == "ersistentvolumeclaims" {
 													elem = elem[l:]
 												} else {
@@ -14220,7 +13639,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -14252,7 +13671,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -14275,15 +13694,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'o': // Prefix: "od"
-												origElem := elem
+
 												if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 													elem = elem[l:]
 												} else {
@@ -14295,7 +13711,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 's': // Prefix: "s"
-													origElem := elem
+
 													if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 														elem = elem[l:]
 													} else {
@@ -14318,7 +13734,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -14350,7 +13766,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -14362,7 +13778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case 'a': // Prefix: "attach"
-																origElem := elem
+
 																if l := len("attach"); len(elem) >= l && elem[0:l] == "attach" {
 																	elem = elem[l:]
 																} else {
@@ -14393,9 +13809,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'e': // Prefix: "e"
-																origElem := elem
+
 																if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 																	elem = elem[l:]
 																} else {
@@ -14407,7 +13822,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "phemeralcontainers"
-																	origElem := elem
+
 																	if l := len("phemeralcontainers"); len(elem) >= l && elem[0:l] == "phemeralcontainers" {
 																		elem = elem[l:]
 																	} else {
@@ -14430,9 +13845,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 'x': // Prefix: "xec"
-																	origElem := elem
+
 																	if l := len("xec"); len(elem) >= l && elem[0:l] == "xec" {
 																		elem = elem[l:]
 																	} else {
@@ -14463,12 +13877,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 'l': // Prefix: "log"
-																origElem := elem
+
 																if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
 																	elem = elem[l:]
 																} else {
@@ -14491,9 +13903,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 'p': // Prefix: "p"
-																origElem := elem
+
 																if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 																	elem = elem[l:]
 																} else {
@@ -14505,7 +13916,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'o': // Prefix: "ortforward"
-																	origElem := elem
+
 																	if l := len("ortforward"); len(elem) >= l && elem[0:l] == "ortforward" {
 																		elem = elem[l:]
 																	} else {
@@ -14536,9 +13947,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																case 'r': // Prefix: "roxy"
-																	origElem := elem
+
 																	if l := len("roxy"); len(elem) >= l && elem[0:l] == "roxy" {
 																		elem = elem[l:]
 																	} else {
@@ -14609,7 +14019,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -14689,15 +14099,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															case 's': // Prefix: "status"
-																origElem := elem
+
 																if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																	elem = elem[l:]
 																} else {
@@ -14720,18 +14127,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 't': // Prefix: "templates"
-													origElem := elem
+
 													if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 														elem = elem[l:]
 													} else {
@@ -14754,7 +14157,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -14786,18 +14189,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "re"
-											origElem := elem
+
 											if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 												elem = elem[l:]
 											} else {
@@ -14809,7 +14208,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'p': // Prefix: "plicationcontrollers"
-												origElem := elem
+
 												if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 													elem = elem[l:]
 												} else {
@@ -14832,7 +14231,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -14864,7 +14263,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -14876,7 +14275,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -14899,9 +14298,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -14924,18 +14322,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "sourcequotas"
-												origElem := elem
+
 												if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 													elem = elem[l:]
 												} else {
@@ -14958,7 +14352,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -14990,7 +14384,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -15013,18 +14407,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -15036,7 +14426,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'e': // Prefix: "e"
-												origElem := elem
+
 												if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 													elem = elem[l:]
 												} else {
@@ -15048,7 +14438,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "crets"
-													origElem := elem
+
 													if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 														elem = elem[l:]
 													} else {
@@ -15071,7 +14461,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -15103,12 +14493,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rvice"
-													origElem := elem
+
 													if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 														elem = elem[l:]
 													} else {
@@ -15120,7 +14508,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "accounts"
-														origElem := elem
+
 														if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 															elem = elem[l:]
 														} else {
@@ -15143,7 +14531,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -15175,12 +14563,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -15203,7 +14589,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -15235,7 +14621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '/': // Prefix: "/"
-																origElem := elem
+
 																if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																	elem = elem[l:]
 																} else {
@@ -15247,7 +14633,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case 'p': // Prefix: "proxy"
-																	origElem := elem
+
 																	if l := len("proxy"); len(elem) >= l && elem[0:l] == "proxy" {
 																		elem = elem[l:]
 																	} else {
@@ -15318,7 +14704,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																	switch elem[0] {
 																	case '/': // Prefix: "/"
-																		origElem := elem
+
 																		if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																			elem = elem[l:]
 																		} else {
@@ -15398,12 +14784,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																			}
 																		}
 
-																		elem = origElem
 																	}
 
-																	elem = origElem
 																case 's': // Prefix: "status"
-																	origElem := elem
+
 																	if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 																		elem = elem[l:]
 																	} else {
@@ -15426,24 +14810,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 't': // Prefix: "tatus"
-												origElem := elem
+
 												if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 													elem = elem[l:]
 												} else {
@@ -15466,21 +14844,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "odes"
-								origElem := elem
+
 								if l := len("odes"); len(elem) >= l && elem[0:l] == "odes" {
 									elem = elem[l:]
 								} else {
@@ -15503,7 +14876,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -15535,7 +14908,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -15547,7 +14920,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'p': // Prefix: "proxy"
-											origElem := elem
+
 											if l := len("proxy"); len(elem) >= l && elem[0:l] == "proxy" {
 												elem = elem[l:]
 											} else {
@@ -15618,7 +14991,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -15698,12 +15071,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "status"
-											origElem := elem
+
 											if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 												elem = elem[l:]
 											} else {
@@ -15726,21 +15097,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "p"
-							origElem := elem
+
 							if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 								elem = elem[l:]
 							} else {
@@ -15752,7 +15118,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "ersistentvolume"
-								origElem := elem
+
 								if l := len("ersistentvolume"); len(elem) >= l && elem[0:l] == "ersistentvolume" {
 									elem = elem[l:]
 								} else {
@@ -15764,7 +15130,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "claims"
-									origElem := elem
+
 									if l := len("claims"); len(elem) >= l && elem[0:l] == "claims" {
 										elem = elem[l:]
 									} else {
@@ -15787,9 +15153,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -15812,7 +15177,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -15844,7 +15209,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -15867,18 +15232,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "od"
-								origElem := elem
+
 								if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 									elem = elem[l:]
 								} else {
@@ -15890,7 +15251,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -15913,9 +15274,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 't': // Prefix: "templates"
-									origElem := elem
+
 									if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 										elem = elem[l:]
 									} else {
@@ -15938,15 +15298,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'r': // Prefix: "re"
-							origElem := elem
+
 							if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 								elem = elem[l:]
 							} else {
@@ -15958,7 +15315,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'p': // Prefix: "plicationcontrollers"
-								origElem := elem
+
 								if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 									elem = elem[l:]
 								} else {
@@ -15981,9 +15338,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 's': // Prefix: "sourcequotas"
-								origElem := elem
+
 								if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 									elem = elem[l:]
 								} else {
@@ -16006,12 +15362,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "se"
-							origElem := elem
+
 							if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 								elem = elem[l:]
 							} else {
@@ -16023,7 +15377,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "crets"
-								origElem := elem
+
 								if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 									elem = elem[l:]
 								} else {
@@ -16046,9 +15400,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "rvice"
-								origElem := elem
+
 								if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 									elem = elem[l:]
 								} else {
@@ -16060,7 +15413,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "accounts"
-									origElem := elem
+
 									if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 										elem = elem[l:]
 									} else {
@@ -16083,9 +15436,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -16108,15 +15460,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'w': // Prefix: "watch/"
-							origElem := elem
+
 							if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 								elem = elem[l:]
 							} else {
@@ -16128,7 +15477,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "configmaps"
-								origElem := elem
+
 								if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 									elem = elem[l:]
 								} else {
@@ -16151,9 +15500,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "e"
-								origElem := elem
+
 								if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 									elem = elem[l:]
 								} else {
@@ -16165,7 +15513,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "ndpoints"
-									origElem := elem
+
 									if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 										elem = elem[l:]
 									} else {
@@ -16188,9 +15536,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'v': // Prefix: "vents"
-									origElem := elem
+
 									if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 										elem = elem[l:]
 									} else {
@@ -16213,12 +15560,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'l': // Prefix: "limitranges"
-								origElem := elem
+
 								if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 									elem = elem[l:]
 								} else {
@@ -16241,9 +15586,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "n"
-								origElem := elem
+
 								if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 									elem = elem[l:]
 								} else {
@@ -16255,7 +15599,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "amespaces"
-									origElem := elem
+
 									if l := len("amespaces"); len(elem) >= l && elem[0:l] == "amespaces" {
 										elem = elem[l:]
 									} else {
@@ -16278,7 +15622,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -16310,7 +15654,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -16322,7 +15666,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "configmaps"
-												origElem := elem
+
 												if l := len("configmaps"); len(elem) >= l && elem[0:l] == "configmaps" {
 													elem = elem[l:]
 												} else {
@@ -16345,7 +15689,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -16377,12 +15721,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'e': // Prefix: "e"
-												origElem := elem
+
 												if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 													elem = elem[l:]
 												} else {
@@ -16394,7 +15736,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'n': // Prefix: "ndpoints"
-													origElem := elem
+
 													if l := len("ndpoints"); len(elem) >= l && elem[0:l] == "ndpoints" {
 														elem = elem[l:]
 													} else {
@@ -16417,7 +15759,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16449,12 +15791,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'v': // Prefix: "vents"
-													origElem := elem
+
 													if l := len("vents"); len(elem) >= l && elem[0:l] == "vents" {
 														elem = elem[l:]
 													} else {
@@ -16477,7 +15817,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16509,15 +15849,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "limitranges"
-												origElem := elem
+
 												if l := len("limitranges"); len(elem) >= l && elem[0:l] == "limitranges" {
 													elem = elem[l:]
 												} else {
@@ -16540,7 +15877,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -16572,12 +15909,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'p': // Prefix: "p"
-												origElem := elem
+
 												if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 													elem = elem[l:]
 												} else {
@@ -16589,7 +15924,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'e': // Prefix: "ersistentvolumeclaims"
-													origElem := elem
+
 													if l := len("ersistentvolumeclaims"); len(elem) >= l && elem[0:l] == "ersistentvolumeclaims" {
 														elem = elem[l:]
 													} else {
@@ -16612,7 +15947,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16644,12 +15979,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'o': // Prefix: "od"
-													origElem := elem
+
 													if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 														elem = elem[l:]
 													} else {
@@ -16661,7 +15994,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -16684,7 +16017,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -16716,12 +16049,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 't': // Prefix: "templates"
-														origElem := elem
+
 														if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 															elem = elem[l:]
 														} else {
@@ -16744,7 +16075,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -16776,18 +16107,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "re"
-												origElem := elem
+
 												if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 													elem = elem[l:]
 												} else {
@@ -16799,7 +16126,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'p': // Prefix: "plicationcontrollers"
-													origElem := elem
+
 													if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 														elem = elem[l:]
 													} else {
@@ -16822,7 +16149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16854,12 +16181,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "sourcequotas"
-													origElem := elem
+
 													if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 														elem = elem[l:]
 													} else {
@@ -16882,7 +16207,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16914,15 +16239,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "se"
-												origElem := elem
+
 												if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 													elem = elem[l:]
 												} else {
@@ -16934,7 +16256,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "crets"
-													origElem := elem
+
 													if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 														elem = elem[l:]
 													} else {
@@ -16957,7 +16279,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -16989,12 +16311,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "rvice"
-													origElem := elem
+
 													if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 														elem = elem[l:]
 													} else {
@@ -17006,7 +16326,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "accounts"
-														origElem := elem
+
 														if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 															elem = elem[l:]
 														} else {
@@ -17029,7 +16349,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -17061,12 +16381,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 's': // Prefix: "s"
-														origElem := elem
+
 														if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 															elem = elem[l:]
 														} else {
@@ -17089,7 +16407,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -17121,27 +16439,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "odes"
-									origElem := elem
+
 									if l := len("odes"); len(elem) >= l && elem[0:l] == "odes" {
 										elem = elem[l:]
 									} else {
@@ -17164,7 +16475,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -17196,15 +16507,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "p"
-								origElem := elem
+
 								if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 									elem = elem[l:]
 								} else {
@@ -17216,7 +16524,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ersistentvolume"
-									origElem := elem
+
 									if l := len("ersistentvolume"); len(elem) >= l && elem[0:l] == "ersistentvolume" {
 										elem = elem[l:]
 									} else {
@@ -17228,7 +16536,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "claims"
-										origElem := elem
+
 										if l := len("claims"); len(elem) >= l && elem[0:l] == "claims" {
 											elem = elem[l:]
 										} else {
@@ -17251,9 +16559,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -17276,7 +16583,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -17308,15 +16615,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "od"
-									origElem := elem
+
 									if l := len("od"); len(elem) >= l && elem[0:l] == "od" {
 										elem = elem[l:]
 									} else {
@@ -17328,7 +16632,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -17351,9 +16655,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 't': // Prefix: "templates"
-										origElem := elem
+
 										if l := len("templates"); len(elem) >= l && elem[0:l] == "templates" {
 											elem = elem[l:]
 										} else {
@@ -17376,15 +16679,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "re"
-								origElem := elem
+
 								if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 									elem = elem[l:]
 								} else {
@@ -17396,7 +16696,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "plicationcontrollers"
-									origElem := elem
+
 									if l := len("plicationcontrollers"); len(elem) >= l && elem[0:l] == "plicationcontrollers" {
 										elem = elem[l:]
 									} else {
@@ -17419,9 +16719,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "sourcequotas"
-									origElem := elem
+
 									if l := len("sourcequotas"); len(elem) >= l && elem[0:l] == "sourcequotas" {
 										elem = elem[l:]
 									} else {
@@ -17444,12 +16743,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 's': // Prefix: "se"
-								origElem := elem
+
 								if l := len("se"); len(elem) >= l && elem[0:l] == "se" {
 									elem = elem[l:]
 								} else {
@@ -17461,7 +16758,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "crets"
-									origElem := elem
+
 									if l := len("crets"); len(elem) >= l && elem[0:l] == "crets" {
 										elem = elem[l:]
 									} else {
@@ -17484,9 +16781,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "rvice"
-									origElem := elem
+
 									if l := len("rvice"); len(elem) >= l && elem[0:l] == "rvice" {
 										elem = elem[l:]
 									} else {
@@ -17498,7 +16794,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "accounts"
-										origElem := elem
+
 										if l := len("accounts"); len(elem) >= l && elem[0:l] == "accounts" {
 											elem = elem[l:]
 										} else {
@@ -17521,9 +16817,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -17546,24 +16841,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s/"
-					origElem := elem
+
 					if l := len("s/"); len(elem) >= l && elem[0:l] == "s/" {
 						elem = elem[l:]
 					} else {
@@ -17586,7 +16875,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "a"
-						origElem := elem
+
 						if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 							elem = elem[l:]
 						} else {
@@ -17598,7 +16887,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'd': // Prefix: "dmissionregistration.k8s.io/"
-							origElem := elem
+
 							if l := len("dmissionregistration.k8s.io/"); len(elem) >= l && elem[0:l] == "dmissionregistration.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -17621,7 +16910,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -17644,7 +16933,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'm': // Prefix: "mutatingwebhookconfigurations"
-									origElem := elem
+
 									if l := len("mutatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "mutatingwebhookconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -17667,7 +16956,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -17699,12 +16988,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'v': // Prefix: "validatingwebhookconfigurations"
-									origElem := elem
+
 									if l := len("validatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "validatingwebhookconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -17727,7 +17014,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -17759,12 +17046,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -17776,7 +17061,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'm': // Prefix: "mutatingwebhookconfigurations"
-										origElem := elem
+
 										if l := len("mutatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "mutatingwebhookconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -17799,7 +17084,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -17831,12 +17116,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "validatingwebhookconfigurations"
-										origElem := elem
+
 										if l := len("validatingwebhookconfigurations"); len(elem) >= l && elem[0:l] == "validatingwebhookconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -17859,7 +17142,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -17891,21 +17174,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'p': // Prefix: "p"
-							origElem := elem
+
 							if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 								elem = elem[l:]
 							} else {
@@ -17917,7 +17195,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -17929,7 +17207,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "extensions.k8s.io/"
-									origElem := elem
+
 									if l := len("extensions.k8s.io/"); len(elem) >= l && elem[0:l] == "extensions.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -17952,7 +17230,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -17975,7 +17253,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "customresourcedefinitions"
-											origElem := elem
+
 											if l := len("customresourcedefinitions"); len(elem) >= l && elem[0:l] == "customresourcedefinitions" {
 												elem = elem[l:]
 											} else {
@@ -17998,7 +17276,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -18030,7 +17308,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -18053,15 +17331,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/customresourcedefinitions"
-											origElem := elem
+
 											if l := len("watch/customresourcedefinitions"); len(elem) >= l && elem[0:l] == "watch/customresourcedefinitions" {
 												elem = elem[l:]
 											} else {
@@ -18084,7 +17359,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -18116,18 +17391,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "registration.k8s.io/"
-									origElem := elem
+
 									if l := len("registration.k8s.io/"); len(elem) >= l && elem[0:l] == "registration.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -18150,7 +17421,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -18173,7 +17444,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "apiservices"
-											origElem := elem
+
 											if l := len("apiservices"); len(elem) >= l && elem[0:l] == "apiservices" {
 												elem = elem[l:]
 											} else {
@@ -18196,7 +17467,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -18228,7 +17499,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -18251,15 +17522,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/apiservices"
-											origElem := elem
+
 											if l := len("watch/apiservices"); len(elem) >= l && elem[0:l] == "watch/apiservices" {
 												elem = elem[l:]
 											} else {
@@ -18282,7 +17550,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -18314,21 +17582,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "ps/"
-								origElem := elem
+
 								if l := len("ps/"); len(elem) >= l && elem[0:l] == "ps/" {
 									elem = elem[l:]
 								} else {
@@ -18351,7 +17614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'v': // Prefix: "v1/"
-									origElem := elem
+
 									if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 										elem = elem[l:]
 									} else {
@@ -18374,7 +17637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "controllerrevisions"
-										origElem := elem
+
 										if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 											elem = elem[l:]
 										} else {
@@ -18397,9 +17660,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "d"
-										origElem := elem
+
 										if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 											elem = elem[l:]
 										} else {
@@ -18411,7 +17673,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "aemonsets"
-											origElem := elem
+
 											if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 												elem = elem[l:]
 											} else {
@@ -18434,9 +17696,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "eployments"
-											origElem := elem
+
 											if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 												elem = elem[l:]
 											} else {
@@ -18459,12 +17720,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -18485,7 +17744,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -18497,7 +17756,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "controllerrevisions"
-												origElem := elem
+
 												if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 													elem = elem[l:]
 												} else {
@@ -18520,7 +17779,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -18552,12 +17811,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'd': // Prefix: "d"
-												origElem := elem
+
 												if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 													elem = elem[l:]
 												} else {
@@ -18569,7 +17826,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "aemonsets"
-													origElem := elem
+
 													if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 														elem = elem[l:]
 													} else {
@@ -18592,7 +17849,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -18624,7 +17881,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -18647,15 +17904,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'e': // Prefix: "eployments"
-													origElem := elem
+
 													if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 														elem = elem[l:]
 													} else {
@@ -18678,7 +17932,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -18710,7 +17964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/s"
-															origElem := elem
+
 															if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 																elem = elem[l:]
 															} else {
@@ -18722,7 +17976,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case 'c': // Prefix: "cale"
-																origElem := elem
+
 																if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																	elem = elem[l:]
 																} else {
@@ -18745,9 +17999,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															case 't': // Prefix: "tatus"
-																origElem := elem
+
 																if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																	elem = elem[l:]
 																} else {
@@ -18770,21 +18023,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'r': // Prefix: "replicasets"
-												origElem := elem
+
 												if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 													elem = elem[l:]
 												} else {
@@ -18807,7 +18055,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -18839,7 +18087,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -18851,7 +18099,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -18874,9 +18122,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -18899,18 +18146,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "statefulsets"
-												origElem := elem
+
 												if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 													elem = elem[l:]
 												} else {
@@ -18933,7 +18176,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -18965,7 +18208,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/s"
-														origElem := elem
+
 														if l := len("/s"); len(elem) >= l && elem[0:l] == "/s" {
 															elem = elem[l:]
 														} else {
@@ -18977,7 +18220,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'c': // Prefix: "cale"
-															origElem := elem
+
 															if l := len("cale"); len(elem) >= l && elem[0:l] == "cale" {
 																elem = elem[l:]
 															} else {
@@ -19000,9 +18243,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														case 't': // Prefix: "tatus"
-															origElem := elem
+
 															if l := len("tatus"); len(elem) >= l && elem[0:l] == "tatus" {
 																elem = elem[l:]
 															} else {
@@ -19025,24 +18267,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "replicasets"
-										origElem := elem
+
 										if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 											elem = elem[l:]
 										} else {
@@ -19065,9 +18301,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "statefulsets"
-										origElem := elem
+
 										if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 											elem = elem[l:]
 										} else {
@@ -19090,9 +18325,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -19104,7 +18338,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "controllerrevisions"
-											origElem := elem
+
 											if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 												elem = elem[l:]
 											} else {
@@ -19127,9 +18361,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'd': // Prefix: "d"
-											origElem := elem
+
 											if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 												elem = elem[l:]
 											} else {
@@ -19141,7 +18374,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "aemonsets"
-												origElem := elem
+
 												if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 													elem = elem[l:]
 												} else {
@@ -19164,9 +18397,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'e': // Prefix: "eployments"
-												origElem := elem
+
 												if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 													elem = elem[l:]
 												} else {
@@ -19189,12 +18421,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -19215,7 +18445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -19227,7 +18457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "controllerrevisions"
-													origElem := elem
+
 													if l := len("controllerrevisions"); len(elem) >= l && elem[0:l] == "controllerrevisions" {
 														elem = elem[l:]
 													} else {
@@ -19250,7 +18480,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -19282,12 +18512,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'd': // Prefix: "d"
-													origElem := elem
+
 													if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 														elem = elem[l:]
 													} else {
@@ -19299,7 +18527,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "aemonsets"
-														origElem := elem
+
 														if l := len("aemonsets"); len(elem) >= l && elem[0:l] == "aemonsets" {
 															elem = elem[l:]
 														} else {
@@ -19322,7 +18550,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -19354,12 +18582,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'e': // Prefix: "eployments"
-														origElem := elem
+
 														if l := len("eployments"); len(elem) >= l && elem[0:l] == "eployments" {
 															elem = elem[l:]
 														} else {
@@ -19382,7 +18608,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -19414,15 +18640,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'r': // Prefix: "replicasets"
-													origElem := elem
+
 													if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 														elem = elem[l:]
 													} else {
@@ -19445,7 +18668,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -19477,12 +18700,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 's': // Prefix: "statefulsets"
-													origElem := elem
+
 													if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 														elem = elem[l:]
 													} else {
@@ -19505,7 +18726,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -19537,18 +18758,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'r': // Prefix: "replicasets"
-											origElem := elem
+
 											if l := len("replicasets"); len(elem) >= l && elem[0:l] == "replicasets" {
 												elem = elem[l:]
 											} else {
@@ -19571,9 +18788,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 's': // Prefix: "statefulsets"
-											origElem := elem
+
 											if l := len("statefulsets"); len(elem) >= l && elem[0:l] == "statefulsets" {
 												elem = elem[l:]
 											} else {
@@ -19596,21 +18812,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'u': // Prefix: "ut"
-							origElem := elem
+
 							if l := len("ut"); len(elem) >= l && elem[0:l] == "ut" {
 								elem = elem[l:]
 							} else {
@@ -19622,7 +18833,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "h"
-								origElem := elem
+
 								if l := len("h"); len(elem) >= l && elem[0:l] == "h" {
 									elem = elem[l:]
 								} else {
@@ -19634,7 +18845,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "entication.k8s.io/"
-									origElem := elem
+
 									if l := len("entication.k8s.io/"); len(elem) >= l && elem[0:l] == "entication.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -19657,7 +18868,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -19680,12 +18891,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'o': // Prefix: "orization.k8s.io/"
-									origElem := elem
+
 									if l := len("orization.k8s.io/"); len(elem) >= l && elem[0:l] == "orization.k8s.io/" {
 										elem = elem[l:]
 									} else {
@@ -19708,7 +18917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'v': // Prefix: "v1/"
-										origElem := elem
+
 										if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 											elem = elem[l:]
 										} else {
@@ -19731,15 +18940,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oscaling/"
-								origElem := elem
+
 								if l := len("oscaling/"); len(elem) >= l && elem[0:l] == "oscaling/" {
 									elem = elem[l:]
 								} else {
@@ -19762,7 +18968,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'v': // Prefix: "v"
-									origElem := elem
+
 									if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 										elem = elem[l:]
 									} else {
@@ -19774,7 +18980,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "1/"
-										origElem := elem
+
 										if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 											elem = elem[l:]
 										} else {
@@ -19797,7 +19003,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'h': // Prefix: "horizontalpodautoscalers"
-											origElem := elem
+
 											if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 												elem = elem[l:]
 											} else {
@@ -19820,9 +19026,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -19843,7 +19048,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -19866,7 +19071,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -19898,7 +19103,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -19921,18 +19126,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'w': // Prefix: "watch/"
-											origElem := elem
+
 											if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 												elem = elem[l:]
 											} else {
@@ -19944,7 +19145,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -19967,9 +19168,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -19990,7 +19190,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -20013,7 +19213,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -20045,21 +19245,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '2': // Prefix: "2beta"
-										origElem := elem
+
 										if l := len("2beta"); len(elem) >= l && elem[0:l] == "2beta" {
 											elem = elem[l:]
 										} else {
@@ -20071,7 +19266,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "1/"
-											origElem := elem
+
 											if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 												elem = elem[l:]
 											} else {
@@ -20094,7 +19289,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -20117,9 +19312,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -20140,7 +19334,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -20163,7 +19357,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -20195,7 +19389,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -20218,18 +19412,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "watch/"
-												origElem := elem
+
 												if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 													elem = elem[l:]
 												} else {
@@ -20241,7 +19431,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -20264,9 +19454,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "namespaces/"
-													origElem := elem
+
 													if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 														elem = elem[l:]
 													} else {
@@ -20287,7 +19476,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/horizontalpodautoscalers"
-														origElem := elem
+
 														if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 															elem = elem[l:]
 														} else {
@@ -20310,7 +19499,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -20342,21 +19531,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '2': // Prefix: "2/"
-											origElem := elem
+
 											if l := len("2/"); len(elem) >= l && elem[0:l] == "2/" {
 												elem = elem[l:]
 											} else {
@@ -20379,7 +19563,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'h': // Prefix: "horizontalpodautoscalers"
-												origElem := elem
+
 												if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 													elem = elem[l:]
 												} else {
@@ -20402,9 +19586,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "namespaces/"
-												origElem := elem
+
 												if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 													elem = elem[l:]
 												} else {
@@ -20425,7 +19608,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -20448,7 +19631,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -20480,7 +19663,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/status"
-															origElem := elem
+
 															if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 																elem = elem[l:]
 															} else {
@@ -20503,18 +19686,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'w': // Prefix: "watch/"
-												origElem := elem
+
 												if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 													elem = elem[l:]
 												} else {
@@ -20526,7 +19705,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'h': // Prefix: "horizontalpodautoscalers"
-													origElem := elem
+
 													if l := len("horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "horizontalpodautoscalers" {
 														elem = elem[l:]
 													} else {
@@ -20549,9 +19728,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "namespaces/"
-													origElem := elem
+
 													if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 														elem = elem[l:]
 													} else {
@@ -20572,7 +19750,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/horizontalpodautoscalers"
-														origElem := elem
+
 														if l := len("/horizontalpodautoscalers"); len(elem) >= l && elem[0:l] == "/horizontalpodautoscalers" {
 															elem = elem[l:]
 														} else {
@@ -20595,7 +19773,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '/': // Prefix: "/"
-															origElem := elem
+
 															if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 																elem = elem[l:]
 															} else {
@@ -20627,36 +19805,26 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "batch/"
-						origElem := elem
+
 						if l := len("batch/"); len(elem) >= l && elem[0:l] == "batch/" {
 							elem = elem[l:]
 						} else {
@@ -20679,7 +19847,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -20691,7 +19859,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -20714,7 +19882,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cronjobs"
-									origElem := elem
+
 									if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 										elem = elem[l:]
 									} else {
@@ -20737,9 +19905,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'j': // Prefix: "jobs"
-									origElem := elem
+
 									if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 										elem = elem[l:]
 									} else {
@@ -20762,9 +19929,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -20785,7 +19951,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -20797,7 +19963,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "cronjobs"
-											origElem := elem
+
 											if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 												elem = elem[l:]
 											} else {
@@ -20820,7 +19986,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -20852,7 +20018,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -20875,15 +20041,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'j': // Prefix: "jobs"
-											origElem := elem
+
 											if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 												elem = elem[l:]
 											} else {
@@ -20906,7 +20069,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -20938,7 +20101,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/status"
-													origElem := elem
+
 													if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 														elem = elem[l:]
 													} else {
@@ -20961,21 +20124,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -20987,7 +20145,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "cronjobs"
-										origElem := elem
+
 										if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -21010,9 +20168,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'j': // Prefix: "jobs"
-										origElem := elem
+
 										if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 											elem = elem[l:]
 										} else {
@@ -21035,9 +20192,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -21058,7 +20214,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21070,7 +20226,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cronjobs"
-												origElem := elem
+
 												if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 													elem = elem[l:]
 												} else {
@@ -21093,7 +20249,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -21125,12 +20281,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'j': // Prefix: "jobs"
-												origElem := elem
+
 												if l := len("jobs"); len(elem) >= l && elem[0:l] == "jobs" {
 													elem = elem[l:]
 												} else {
@@ -21153,7 +20307,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -21185,24 +20339,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -21225,7 +20373,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "cronjobs"
-									origElem := elem
+
 									if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 										elem = elem[l:]
 									} else {
@@ -21248,9 +20396,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -21271,7 +20418,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/cronjobs"
-										origElem := elem
+
 										if l := len("/cronjobs"); len(elem) >= l && elem[0:l] == "/cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -21294,7 +20441,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21326,7 +20473,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -21349,18 +20496,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -21372,7 +20515,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "cronjobs"
-										origElem := elem
+
 										if l := len("cronjobs"); len(elem) >= l && elem[0:l] == "cronjobs" {
 											elem = elem[l:]
 										} else {
@@ -21395,9 +20538,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -21418,7 +20560,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/cronjobs"
-											origElem := elem
+
 											if l := len("/cronjobs"); len(elem) >= l && elem[0:l] == "/cronjobs" {
 												elem = elem[l:]
 											} else {
@@ -21441,7 +20583,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -21473,27 +20615,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'c': // Prefix: "c"
-						origElem := elem
+
 						if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 							elem = elem[l:]
 						} else {
@@ -21505,7 +20640,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "ertificates.k8s.io/"
-							origElem := elem
+
 							if l := len("ertificates.k8s.io/"); len(elem) >= l && elem[0:l] == "ertificates.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -21528,7 +20663,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -21551,7 +20686,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "certificatesigningrequests"
-									origElem := elem
+
 									if l := len("certificatesigningrequests"); len(elem) >= l && elem[0:l] == "certificatesigningrequests" {
 										elem = elem[l:]
 									} else {
@@ -21574,7 +20709,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -21606,7 +20741,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21618,7 +20753,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "approval"
-												origElem := elem
+
 												if l := len("approval"); len(elem) >= l && elem[0:l] == "approval" {
 													elem = elem[l:]
 												} else {
@@ -21641,9 +20776,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											case 's': // Prefix: "status"
-												origElem := elem
+
 												if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
 													elem = elem[l:]
 												} else {
@@ -21666,18 +20800,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/certificatesigningrequests"
-									origElem := elem
+
 									if l := len("watch/certificatesigningrequests"); len(elem) >= l && elem[0:l] == "watch/certificatesigningrequests" {
 										elem = elem[l:]
 									} else {
@@ -21700,7 +20830,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -21732,18 +20862,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'o': // Prefix: "oordination.k8s.io/"
-							origElem := elem
+
 							if l := len("oordination.k8s.io/"); len(elem) >= l && elem[0:l] == "oordination.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -21766,7 +20892,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -21789,7 +20915,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'l': // Prefix: "leases"
-									origElem := elem
+
 									if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 										elem = elem[l:]
 									} else {
@@ -21812,9 +20938,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -21835,7 +20960,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/leases"
-										origElem := elem
+
 										if l := len("/leases"); len(elem) >= l && elem[0:l] == "/leases" {
 											elem = elem[l:]
 										} else {
@@ -21858,7 +20983,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -21890,15 +21015,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -21910,7 +21032,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'l': // Prefix: "leases"
-										origElem := elem
+
 										if l := len("leases"); len(elem) >= l && elem[0:l] == "leases" {
 											elem = elem[l:]
 										} else {
@@ -21933,9 +21055,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -21956,7 +21077,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/leases"
-											origElem := elem
+
 											if l := len("/leases"); len(elem) >= l && elem[0:l] == "/leases" {
 												elem = elem[l:]
 											} else {
@@ -21979,7 +21100,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -22011,27 +21132,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'd': // Prefix: "discovery.k8s.io/"
-						origElem := elem
+
 						if l := len("discovery.k8s.io/"); len(elem) >= l && elem[0:l] == "discovery.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -22054,7 +21168,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -22066,7 +21180,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -22089,7 +21203,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "endpointslices"
-									origElem := elem
+
 									if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 										elem = elem[l:]
 									} else {
@@ -22112,9 +21226,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -22135,7 +21248,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/endpointslices"
-										origElem := elem
+
 										if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -22158,7 +21271,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -22190,15 +21303,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -22210,7 +21320,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "endpointslices"
-										origElem := elem
+
 										if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -22233,9 +21343,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -22256,7 +21365,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/endpointslices"
-											origElem := elem
+
 											if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 												elem = elem[l:]
 											} else {
@@ -22279,7 +21388,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -22311,21 +21420,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -22348,7 +21452,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "endpointslices"
-									origElem := elem
+
 									if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 										elem = elem[l:]
 									} else {
@@ -22371,9 +21475,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -22394,7 +21497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/endpointslices"
-										origElem := elem
+
 										if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -22417,7 +21520,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -22449,15 +21552,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -22469,7 +21569,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "endpointslices"
-										origElem := elem
+
 										if l := len("endpointslices"); len(elem) >= l && elem[0:l] == "endpointslices" {
 											elem = elem[l:]
 										} else {
@@ -22492,9 +21592,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -22515,7 +21614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/endpointslices"
-											origElem := elem
+
 											if l := len("/endpointslices"); len(elem) >= l && elem[0:l] == "/endpointslices" {
 												elem = elem[l:]
 											} else {
@@ -22538,7 +21637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -22570,27 +21669,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'e': // Prefix: "events.k8s.io/"
-						origElem := elem
+
 						if l := len("events.k8s.io/"); len(elem) >= l && elem[0:l] == "events.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -22613,7 +21705,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -22625,7 +21717,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -22648,7 +21740,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "events"
-									origElem := elem
+
 									if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 										elem = elem[l:]
 									} else {
@@ -22671,9 +21763,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -22694,7 +21785,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/events"
-										origElem := elem
+
 										if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 											elem = elem[l:]
 										} else {
@@ -22717,7 +21808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -22749,15 +21840,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -22769,7 +21857,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "events"
-										origElem := elem
+
 										if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 											elem = elem[l:]
 										} else {
@@ -22792,9 +21880,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -22815,7 +21902,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/events"
-											origElem := elem
+
 											if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 												elem = elem[l:]
 											} else {
@@ -22838,7 +21925,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -22870,21 +21957,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -22907,7 +21989,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "events"
-									origElem := elem
+
 									if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 										elem = elem[l:]
 									} else {
@@ -22930,9 +22012,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -22953,7 +22034,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/events"
-										origElem := elem
+
 										if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 											elem = elem[l:]
 										} else {
@@ -22976,7 +22057,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -23008,15 +22089,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -23028,7 +22106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'e': // Prefix: "events"
-										origElem := elem
+
 										if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 											elem = elem[l:]
 										} else {
@@ -23051,9 +22129,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -23074,7 +22151,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/events"
-											origElem := elem
+
 											if l := len("/events"); len(elem) >= l && elem[0:l] == "/events" {
 												elem = elem[l:]
 											} else {
@@ -23097,7 +22174,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -23129,27 +22206,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'f': // Prefix: "flowcontrol.apiserver.k8s.io/"
-						origElem := elem
+
 						if l := len("flowcontrol.apiserver.k8s.io/"); len(elem) >= l && elem[0:l] == "flowcontrol.apiserver.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -23172,7 +22242,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1beta"
-							origElem := elem
+
 							if l := len("v1beta"); len(elem) >= l && elem[0:l] == "v1beta" {
 								elem = elem[l:]
 							} else {
@@ -23184,7 +22254,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '1': // Prefix: "1/"
-								origElem := elem
+
 								if l := len("1/"); len(elem) >= l && elem[0:l] == "1/" {
 									elem = elem[l:]
 								} else {
@@ -23207,7 +22277,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'f': // Prefix: "flowschemas"
-									origElem := elem
+
 									if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 										elem = elem[l:]
 									} else {
@@ -23230,7 +22300,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -23262,7 +22332,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -23285,15 +22355,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "prioritylevelconfigurations"
-									origElem := elem
+
 									if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -23316,7 +22383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -23348,7 +22415,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -23371,15 +22438,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -23391,7 +22455,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'f': // Prefix: "flowschemas"
-										origElem := elem
+
 										if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 											elem = elem[l:]
 										} else {
@@ -23414,7 +22478,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -23446,12 +22510,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "prioritylevelconfigurations"
-										origElem := elem
+
 										if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -23474,7 +22536,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -23506,18 +22568,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case '2': // Prefix: "2/"
-								origElem := elem
+
 								if l := len("2/"); len(elem) >= l && elem[0:l] == "2/" {
 									elem = elem[l:]
 								} else {
@@ -23540,7 +22598,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'f': // Prefix: "flowschemas"
-									origElem := elem
+
 									if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 										elem = elem[l:]
 									} else {
@@ -23563,7 +22621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -23595,7 +22653,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -23618,15 +22676,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "prioritylevelconfigurations"
-									origElem := elem
+
 									if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 										elem = elem[l:]
 									} else {
@@ -23649,7 +22704,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -23681,7 +22736,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/status"
-											origElem := elem
+
 											if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 												elem = elem[l:]
 											} else {
@@ -23704,15 +22759,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -23724,7 +22776,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'f': // Prefix: "flowschemas"
-										origElem := elem
+
 										if l := len("flowschemas"); len(elem) >= l && elem[0:l] == "flowschemas" {
 											elem = elem[l:]
 										} else {
@@ -23747,7 +22799,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -23779,12 +22831,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "prioritylevelconfigurations"
-										origElem := elem
+
 										if l := len("prioritylevelconfigurations"); len(elem) >= l && elem[0:l] == "prioritylevelconfigurations" {
 											elem = elem[l:]
 										} else {
@@ -23807,7 +22857,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -23839,24 +22889,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "internal.apiserver.k8s.io/"
-						origElem := elem
+
 						if l := len("internal.apiserver.k8s.io/"); len(elem) >= l && elem[0:l] == "internal.apiserver.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -23879,7 +22923,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1alpha1/"
-							origElem := elem
+
 							if l := len("v1alpha1/"); len(elem) >= l && elem[0:l] == "v1alpha1/" {
 								elem = elem[l:]
 							} else {
@@ -23902,7 +22946,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 's': // Prefix: "storageversions"
-								origElem := elem
+
 								if l := len("storageversions"); len(elem) >= l && elem[0:l] == "storageversions" {
 									elem = elem[l:]
 								} else {
@@ -23925,7 +22969,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -23957,7 +23001,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/status"
-										origElem := elem
+
 										if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 											elem = elem[l:]
 										} else {
@@ -23980,15 +23024,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'w': // Prefix: "watch/storageversions"
-								origElem := elem
+
 								if l := len("watch/storageversions"); len(elem) >= l && elem[0:l] == "watch/storageversions" {
 									elem = elem[l:]
 								} else {
@@ -24011,7 +23052,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -24043,18 +23084,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "n"
-						origElem := elem
+
 						if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 							elem = elem[l:]
 						} else {
@@ -24066,7 +23103,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "etworking.k8s.io/"
-							origElem := elem
+
 							if l := len("etworking.k8s.io/"); len(elem) >= l && elem[0:l] == "etworking.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -24089,7 +23126,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -24112,7 +23149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "ingress"
-									origElem := elem
+
 									if l := len("ingress"); len(elem) >= l && elem[0:l] == "ingress" {
 										elem = elem[l:]
 									} else {
@@ -24124,7 +23161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "classes"
-										origElem := elem
+
 										if l := len("classes"); len(elem) >= l && elem[0:l] == "classes" {
 											elem = elem[l:]
 										} else {
@@ -24147,7 +23184,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -24179,12 +23216,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "es"
-										origElem := elem
+
 										if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 											elem = elem[l:]
 										} else {
@@ -24207,12 +23242,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "n"
-									origElem := elem
+
 									if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 										elem = elem[l:]
 									} else {
@@ -24224,7 +23257,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "amespaces/"
-										origElem := elem
+
 										if l := len("amespaces/"); len(elem) >= l && elem[0:l] == "amespaces/" {
 											elem = elem[l:]
 										} else {
@@ -24245,7 +23278,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -24257,7 +23290,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'i': // Prefix: "ingresses"
-												origElem := elem
+
 												if l := len("ingresses"); len(elem) >= l && elem[0:l] == "ingresses" {
 													elem = elem[l:]
 												} else {
@@ -24280,7 +23313,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -24312,7 +23345,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/status"
-														origElem := elem
+
 														if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 															elem = elem[l:]
 														} else {
@@ -24335,15 +23368,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "networkpolicies"
-												origElem := elem
+
 												if l := len("networkpolicies"); len(elem) >= l && elem[0:l] == "networkpolicies" {
 													elem = elem[l:]
 												} else {
@@ -24366,7 +23396,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -24398,18 +23428,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'e': // Prefix: "etworkpolicies"
-										origElem := elem
+
 										if l := len("etworkpolicies"); len(elem) >= l && elem[0:l] == "etworkpolicies" {
 											elem = elem[l:]
 										} else {
@@ -24432,12 +23458,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -24449,7 +23473,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "ingress"
-										origElem := elem
+
 										if l := len("ingress"); len(elem) >= l && elem[0:l] == "ingress" {
 											elem = elem[l:]
 										} else {
@@ -24461,7 +23485,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "classes"
-											origElem := elem
+
 											if l := len("classes"); len(elem) >= l && elem[0:l] == "classes" {
 												elem = elem[l:]
 											} else {
@@ -24484,7 +23508,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -24516,12 +23540,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "es"
-											origElem := elem
+
 											if l := len("es"); len(elem) >= l && elem[0:l] == "es" {
 												elem = elem[l:]
 											} else {
@@ -24544,12 +23566,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "n"
-										origElem := elem
+
 										if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 											elem = elem[l:]
 										} else {
@@ -24561,7 +23581,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "amespaces/"
-											origElem := elem
+
 											if l := len("amespaces/"); len(elem) >= l && elem[0:l] == "amespaces/" {
 												elem = elem[l:]
 											} else {
@@ -24582,7 +23602,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -24594,7 +23614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'i': // Prefix: "ingresses"
-													origElem := elem
+
 													if l := len("ingresses"); len(elem) >= l && elem[0:l] == "ingresses" {
 														elem = elem[l:]
 													} else {
@@ -24617,7 +23637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -24649,12 +23669,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "networkpolicies"
-													origElem := elem
+
 													if l := len("networkpolicies"); len(elem) >= l && elem[0:l] == "networkpolicies" {
 														elem = elem[l:]
 													} else {
@@ -24677,7 +23695,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '/': // Prefix: "/"
-														origElem := elem
+
 														if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 															elem = elem[l:]
 														} else {
@@ -24709,18 +23727,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'e': // Prefix: "etworkpolicies"
-											origElem := elem
+
 											if l := len("etworkpolicies"); len(elem) >= l && elem[0:l] == "etworkpolicies" {
 												elem = elem[l:]
 											} else {
@@ -24743,21 +23757,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'o': // Prefix: "ode.k8s.io/"
-							origElem := elem
+
 							if l := len("ode.k8s.io/"); len(elem) >= l && elem[0:l] == "ode.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -24780,7 +23789,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1"
-								origElem := elem
+
 								if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 									elem = elem[l:]
 								} else {
@@ -24792,7 +23801,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -24815,7 +23824,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -24838,7 +23847,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -24870,12 +23879,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -24898,7 +23905,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -24930,15 +23937,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'a': // Prefix: "alpha1/"
-									origElem := elem
+
 									if l := len("alpha1/"); len(elem) >= l && elem[0:l] == "alpha1/" {
 										elem = elem[l:]
 									} else {
@@ -24961,7 +23965,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -24984,7 +23988,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25016,12 +24020,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -25044,7 +24046,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25076,15 +24078,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "beta1/"
-									origElem := elem
+
 									if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 										elem = elem[l:]
 									} else {
@@ -25107,7 +24106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'r': // Prefix: "runtimeclasses"
-										origElem := elem
+
 										if l := len("runtimeclasses"); len(elem) >= l && elem[0:l] == "runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -25130,7 +24129,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25162,12 +24161,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/runtimeclasses"
-										origElem := elem
+
 										if l := len("watch/runtimeclasses"); len(elem) >= l && elem[0:l] == "watch/runtimeclasses" {
 											elem = elem[l:]
 										} else {
@@ -25190,7 +24187,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25222,24 +24219,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "policy/"
-						origElem := elem
+
 						if l := len("policy/"); len(elem) >= l && elem[0:l] == "policy/" {
 							elem = elem[l:]
 						} else {
@@ -25262,7 +24253,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1"
-							origElem := elem
+
 							if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 								elem = elem[l:]
 							} else {
@@ -25274,7 +24265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '/': // Prefix: "/"
-								origElem := elem
+
 								if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 									elem = elem[l:]
 								} else {
@@ -25297,7 +24288,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -25318,7 +24309,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -25341,7 +24332,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25373,7 +24364,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -25396,18 +24387,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "poddisruptionbudgets"
-									origElem := elem
+
 									if l := len("poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "poddisruptionbudgets" {
 										elem = elem[l:]
 									} else {
@@ -25430,9 +24417,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -25444,7 +24430,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -25465,7 +24451,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/poddisruptionbudgets"
-											origElem := elem
+
 											if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -25488,7 +24474,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -25520,15 +24506,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -25551,15 +24534,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "beta1/"
-								origElem := elem
+
 								if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 									elem = elem[l:]
 								} else {
@@ -25582,7 +24562,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -25603,7 +24583,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/poddisruptionbudgets"
-										origElem := elem
+
 										if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -25626,7 +24606,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25658,7 +24638,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -25681,18 +24661,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "pod"
-									origElem := elem
+
 									if l := len("pod"); len(elem) >= l && elem[0:l] == "pod" {
 										elem = elem[l:]
 									} else {
@@ -25704,7 +24680,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'd': // Prefix: "disruptionbudgets"
-										origElem := elem
+
 										if l := len("disruptionbudgets"); len(elem) >= l && elem[0:l] == "disruptionbudgets" {
 											elem = elem[l:]
 										} else {
@@ -25727,9 +24703,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "securitypolicies"
-										origElem := elem
+
 										if l := len("securitypolicies"); len(elem) >= l && elem[0:l] == "securitypolicies" {
 											elem = elem[l:]
 										} else {
@@ -25752,7 +24727,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -25784,15 +24759,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/"
-									origElem := elem
+
 									if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 										elem = elem[l:]
 									} else {
@@ -25804,7 +24776,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -25825,7 +24797,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/poddisruptionbudgets"
-											origElem := elem
+
 											if l := len("/poddisruptionbudgets"); len(elem) >= l && elem[0:l] == "/poddisruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -25848,7 +24820,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -25880,15 +24852,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "pod"
-										origElem := elem
+
 										if l := len("pod"); len(elem) >= l && elem[0:l] == "pod" {
 											elem = elem[l:]
 										} else {
@@ -25900,7 +24869,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'd': // Prefix: "disruptionbudgets"
-											origElem := elem
+
 											if l := len("disruptionbudgets"); len(elem) >= l && elem[0:l] == "disruptionbudgets" {
 												elem = elem[l:]
 											} else {
@@ -25923,9 +24892,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 's': // Prefix: "securitypolicies"
-											origElem := elem
+
 											if l := len("securitypolicies"); len(elem) >= l && elem[0:l] == "securitypolicies" {
 												elem = elem[l:]
 											} else {
@@ -25948,7 +24916,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -25980,27 +24948,20 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "rbac.authorization.k8s.io/"
-						origElem := elem
+
 						if l := len("rbac.authorization.k8s.io/"); len(elem) >= l && elem[0:l] == "rbac.authorization.k8s.io/" {
 							elem = elem[l:]
 						} else {
@@ -26023,7 +24984,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'v': // Prefix: "v1/"
-							origElem := elem
+
 							if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 								elem = elem[l:]
 							} else {
@@ -26046,7 +25007,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "clusterrole"
-								origElem := elem
+
 								if l := len("clusterrole"); len(elem) >= l && elem[0:l] == "clusterrole" {
 									elem = elem[l:]
 								} else {
@@ -26058,7 +25019,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'b': // Prefix: "bindings"
-									origElem := elem
+
 									if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 										elem = elem[l:]
 									} else {
@@ -26081,7 +25042,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -26113,12 +25074,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -26141,7 +25100,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -26173,15 +25132,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "namespaces/"
-								origElem := elem
+
 								if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 									elem = elem[l:]
 								} else {
@@ -26202,7 +25158,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/role"
-									origElem := elem
+
 									if l := len("/role"); len(elem) >= l && elem[0:l] == "/role" {
 										elem = elem[l:]
 									} else {
@@ -26214,7 +25170,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -26237,7 +25193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -26269,12 +25225,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -26297,7 +25251,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -26329,18 +25283,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'r': // Prefix: "role"
-								origElem := elem
+
 								if l := len("role"); len(elem) >= l && elem[0:l] == "role" {
 									elem = elem[l:]
 								} else {
@@ -26352,7 +25302,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'b': // Prefix: "bindings"
-									origElem := elem
+
 									if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 										elem = elem[l:]
 									} else {
@@ -26375,9 +25325,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 's': // Prefix: "s"
-									origElem := elem
+
 									if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 										elem = elem[l:]
 									} else {
@@ -26400,12 +25349,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'w': // Prefix: "watch/"
-								origElem := elem
+
 								if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 									elem = elem[l:]
 								} else {
@@ -26417,7 +25364,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'c': // Prefix: "clusterrole"
-									origElem := elem
+
 									if l := len("clusterrole"); len(elem) >= l && elem[0:l] == "clusterrole" {
 										elem = elem[l:]
 									} else {
@@ -26429,7 +25376,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -26452,7 +25399,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -26484,12 +25431,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -26512,7 +25457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -26544,15 +25489,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "namespaces/"
-									origElem := elem
+
 									if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 										elem = elem[l:]
 									} else {
@@ -26573,7 +25515,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/role"
-										origElem := elem
+
 										if l := len("/role"); len(elem) >= l && elem[0:l] == "/role" {
 											elem = elem[l:]
 										} else {
@@ -26585,7 +25527,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'b': // Prefix: "bindings"
-											origElem := elem
+
 											if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 												elem = elem[l:]
 											} else {
@@ -26608,7 +25550,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -26640,12 +25582,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "s"
-											origElem := elem
+
 											if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 												elem = elem[l:]
 											} else {
@@ -26668,7 +25608,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -26700,18 +25640,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "role"
-									origElem := elem
+
 									if l := len("role"); len(elem) >= l && elem[0:l] == "role" {
 										elem = elem[l:]
 									} else {
@@ -26723,7 +25659,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'b': // Prefix: "bindings"
-										origElem := elem
+
 										if l := len("bindings"); len(elem) >= l && elem[0:l] == "bindings" {
 											elem = elem[l:]
 										} else {
@@ -26746,9 +25682,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 's': // Prefix: "s"
-										origElem := elem
+
 										if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 											elem = elem[l:]
 										} else {
@@ -26771,21 +25706,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "s"
-						origElem := elem
+
 						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 							elem = elem[l:]
 						} else {
@@ -26797,7 +25727,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cheduling.k8s.io/"
-							origElem := elem
+
 							if l := len("cheduling.k8s.io/"); len(elem) >= l && elem[0:l] == "cheduling.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -26820,7 +25750,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1/"
-								origElem := elem
+
 								if l := len("v1/"); len(elem) >= l && elem[0:l] == "v1/" {
 									elem = elem[l:]
 								} else {
@@ -26843,7 +25773,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'p': // Prefix: "priorityclasses"
-									origElem := elem
+
 									if l := len("priorityclasses"); len(elem) >= l && elem[0:l] == "priorityclasses" {
 										elem = elem[l:]
 									} else {
@@ -26866,7 +25796,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -26898,12 +25828,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'w': // Prefix: "watch/priorityclasses"
-									origElem := elem
+
 									if l := len("watch/priorityclasses"); len(elem) >= l && elem[0:l] == "watch/priorityclasses" {
 										elem = elem[l:]
 									} else {
@@ -26926,7 +25854,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '/': // Prefix: "/"
-										origElem := elem
+
 										if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 											elem = elem[l:]
 										} else {
@@ -26958,18 +25886,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 't': // Prefix: "torage.k8s.io/"
-							origElem := elem
+
 							if l := len("torage.k8s.io/"); len(elem) >= l && elem[0:l] == "torage.k8s.io/" {
 								elem = elem[l:]
 							} else {
@@ -26992,7 +25916,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'v': // Prefix: "v1"
-								origElem := elem
+
 								if l := len("v1"); len(elem) >= l && elem[0:l] == "v1" {
 									elem = elem[l:]
 								} else {
@@ -27004,7 +25928,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '/': // Prefix: "/"
-									origElem := elem
+
 									if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 										elem = elem[l:]
 									} else {
@@ -27027,7 +25951,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csi"
-										origElem := elem
+
 										if l := len("csi"); len(elem) >= l && elem[0:l] == "csi" {
 											elem = elem[l:]
 										} else {
@@ -27039,7 +25963,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'd': // Prefix: "drivers"
-											origElem := elem
+
 											if l := len("drivers"); len(elem) >= l && elem[0:l] == "drivers" {
 												elem = elem[l:]
 											} else {
@@ -27062,7 +25986,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27094,12 +26018,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nodes"
-											origElem := elem
+
 											if l := len("nodes"); len(elem) >= l && elem[0:l] == "nodes" {
 												elem = elem[l:]
 											} else {
@@ -27122,7 +26044,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27154,15 +26076,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 's': // Prefix: "storageclasses"
-										origElem := elem
+
 										if l := len("storageclasses"); len(elem) >= l && elem[0:l] == "storageclasses" {
 											elem = elem[l:]
 										} else {
@@ -27185,7 +26104,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -27217,12 +26136,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "volumeattachments"
-										origElem := elem
+
 										if l := len("volumeattachments"); len(elem) >= l && elem[0:l] == "volumeattachments" {
 											elem = elem[l:]
 										} else {
@@ -27245,7 +26162,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/"
-											origElem := elem
+
 											if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 												elem = elem[l:]
 											} else {
@@ -27277,7 +26194,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/status"
-												origElem := elem
+
 												if l := len("/status"); len(elem) >= l && elem[0:l] == "/status" {
 													elem = elem[l:]
 												} else {
@@ -27300,15 +26217,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -27320,7 +26234,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csi"
-											origElem := elem
+
 											if l := len("csi"); len(elem) >= l && elem[0:l] == "csi" {
 												elem = elem[l:]
 											} else {
@@ -27332,7 +26246,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'd': // Prefix: "drivers"
-												origElem := elem
+
 												if l := len("drivers"); len(elem) >= l && elem[0:l] == "drivers" {
 													elem = elem[l:]
 												} else {
@@ -27355,7 +26269,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27387,12 +26301,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nodes"
-												origElem := elem
+
 												if l := len("nodes"); len(elem) >= l && elem[0:l] == "nodes" {
 													elem = elem[l:]
 												} else {
@@ -27415,7 +26327,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27447,15 +26359,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "storageclasses"
-											origElem := elem
+
 											if l := len("storageclasses"); len(elem) >= l && elem[0:l] == "storageclasses" {
 												elem = elem[l:]
 											} else {
@@ -27478,7 +26387,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27510,12 +26419,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "volumeattachments"
-											origElem := elem
+
 											if l := len("volumeattachments"); len(elem) >= l && elem[0:l] == "volumeattachments" {
 												elem = elem[l:]
 											} else {
@@ -27538,7 +26445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27570,18 +26477,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'a': // Prefix: "alpha1/"
-									origElem := elem
+
 									if l := len("alpha1/"); len(elem) >= l && elem[0:l] == "alpha1/" {
 										elem = elem[l:]
 									} else {
@@ -27604,7 +26507,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csistoragecapacities"
-										origElem := elem
+
 										if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 											elem = elem[l:]
 										} else {
@@ -27627,9 +26530,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -27650,7 +26552,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/csistoragecapacities"
-											origElem := elem
+
 											if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -27673,7 +26575,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27705,15 +26607,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -27725,7 +26624,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csistoragecapacities"
-											origElem := elem
+
 											if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -27748,9 +26647,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -27771,7 +26669,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/csistoragecapacities"
-												origElem := elem
+
 												if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 													elem = elem[l:]
 												} else {
@@ -27794,7 +26692,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -27826,21 +26724,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "beta1/"
-									origElem := elem
+
 									if l := len("beta1/"); len(elem) >= l && elem[0:l] == "beta1/" {
 										elem = elem[l:]
 									} else {
@@ -27863,7 +26756,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'c': // Prefix: "csistoragecapacities"
-										origElem := elem
+
 										if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 											elem = elem[l:]
 										} else {
@@ -27886,9 +26779,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "namespaces/"
-										origElem := elem
+
 										if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 											elem = elem[l:]
 										} else {
@@ -27909,7 +26801,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '/': // Prefix: "/csistoragecapacities"
-											origElem := elem
+
 											if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -27932,7 +26824,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/"
-												origElem := elem
+
 												if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 													elem = elem[l:]
 												} else {
@@ -27964,15 +26856,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'w': // Prefix: "watch/"
-										origElem := elem
+
 										if l := len("watch/"); len(elem) >= l && elem[0:l] == "watch/" {
 											elem = elem[l:]
 										} else {
@@ -27984,7 +26873,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'c': // Prefix: "csistoragecapacities"
-											origElem := elem
+
 											if l := len("csistoragecapacities"); len(elem) >= l && elem[0:l] == "csistoragecapacities" {
 												elem = elem[l:]
 											} else {
@@ -28007,9 +26896,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "namespaces/"
-											origElem := elem
+
 											if l := len("namespaces/"); len(elem) >= l && elem[0:l] == "namespaces/" {
 												elem = elem[l:]
 											} else {
@@ -28030,7 +26918,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '/': // Prefix: "/csistoragecapacities"
-												origElem := elem
+
 												if l := len("/csistoragecapacities"); len(elem) >= l && elem[0:l] == "/csistoragecapacities" {
 													elem = elem[l:]
 												} else {
@@ -28053,7 +26941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '/': // Prefix: "/"
-													origElem := elem
+
 													if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 														elem = elem[l:]
 													} else {
@@ -28085,36 +26973,26 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "logs/"
-				origElem := elem
+
 				if l := len("logs/"); len(elem) >= l && elem[0:l] == "logs/" {
 					elem = elem[l:]
 				} else {
@@ -28160,9 +27038,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "openid/v1/jwks/"
-				origElem := elem
+
 				if l := len("openid/v1/jwks/"); len(elem) >= l && elem[0:l] == "openid/v1/jwks/" {
 					elem = elem[l:]
 				} else {
@@ -28185,9 +27062,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'v': // Prefix: "version/"
-				origElem := elem
+
 				if l := len("version/"); len(elem) >= l && elem[0:l] == "version/" {
 					elem = elem[l:]
 				} else {
@@ -28210,10 +27086,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_manga/oas_router_gen.go
+++ b/examples/ex_manga/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "api/galler"
-				origElem := elem
+
 				if l := len("api/galler"); len(elem) >= l && elem[0:l] == "api/galler" {
 					elem = elem[l:]
 				} else {
@@ -74,7 +74,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "ies/"
-					origElem := elem
+
 					if l := len("ies/"); len(elem) >= l && elem[0:l] == "ies/" {
 						elem = elem[l:]
 					} else {
@@ -86,7 +86,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 's': // Prefix: "search"
-						origElem := elem
+
 						if l := len("search"); len(elem) >= l && elem[0:l] == "search" {
 							elem = elem[l:]
 						} else {
@@ -105,9 +105,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 't': // Prefix: "tagged"
-						origElem := elem
+
 						if l := len("tagged"); len(elem) >= l && elem[0:l] == "tagged" {
 							elem = elem[l:]
 						} else {
@@ -126,12 +125,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'y': // Prefix: "y/"
-					origElem := elem
+
 					if l := len("y/"); len(elem) >= l && elem[0:l] == "y/" {
 						elem = elem[l:]
 					} else {
@@ -161,12 +158,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "galleries/"
-				origElem := elem
+
 				if l := len("galleries/"); len(elem) >= l && elem[0:l] == "galleries/" {
 					elem = elem[l:]
 				} else {
@@ -187,7 +182,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -246,7 +241,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '.': // Prefix: "."
-						origElem := elem
+
 						if l := len("."); len(elem) >= l && elem[0:l] == "." {
 							elem = elem[l:]
 						} else {
@@ -278,9 +273,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t."
-						origElem := elem
+
 						if l := len("t."); len(elem) >= l && elem[0:l] == "t." {
 							elem = elem[l:]
 						} else {
@@ -312,16 +306,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -403,7 +393,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -415,7 +405,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "api/galler"
-				origElem := elem
+
 				if l := len("api/galler"); len(elem) >= l && elem[0:l] == "api/galler" {
 					elem = elem[l:]
 				} else {
@@ -427,7 +417,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "ies/"
-					origElem := elem
+
 					if l := len("ies/"); len(elem) >= l && elem[0:l] == "ies/" {
 						elem = elem[l:]
 					} else {
@@ -439,7 +429,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 's': // Prefix: "search"
-						origElem := elem
+
 						if l := len("search"); len(elem) >= l && elem[0:l] == "search" {
 							elem = elem[l:]
 						} else {
@@ -462,9 +452,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 't': // Prefix: "tagged"
-						origElem := elem
+
 						if l := len("tagged"); len(elem) >= l && elem[0:l] == "tagged" {
 							elem = elem[l:]
 						} else {
@@ -487,12 +476,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'y': // Prefix: "y/"
-					origElem := elem
+
 					if l := len("y/"); len(elem) >= l && elem[0:l] == "y/" {
 						elem = elem[l:]
 					} else {
@@ -524,12 +511,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "galleries/"
-				origElem := elem
+
 				if l := len("galleries/"); len(elem) >= l && elem[0:l] == "galleries/" {
 					elem = elem[l:]
 				} else {
@@ -550,7 +535,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -610,7 +595,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '.': // Prefix: "."
-						origElem := elem
+
 						if l := len("."); len(elem) >= l && elem[0:l] == "." {
 							elem = elem[l:]
 						} else {
@@ -642,9 +627,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t."
-						origElem := elem
+
 						if l := len("t."); len(elem) >= l && elem[0:l] == "t." {
 							elem = elem[l:]
 						} else {
@@ -676,16 +660,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_oauth2/oas_router_gen.go
+++ b/examples/ex_oauth2/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -71,7 +71,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -105,10 +105,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -190,7 +188,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -221,7 +219,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -261,10 +259,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_openai/oas_router_gen.go
+++ b/examples/ex_openai/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -74,7 +74,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "nswers"
-					origElem := elem
+
 					if l := len("nswers"); len(elem) >= l && elem[0:l] == "nswers" {
 						elem = elem[l:]
 					} else {
@@ -93,9 +93,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "udio/trans"
-					origElem := elem
+
 					if l := len("udio/trans"); len(elem) >= l && elem[0:l] == "udio/trans" {
 						elem = elem[l:]
 					} else {
@@ -107,7 +106,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "criptions"
-						origElem := elem
+
 						if l := len("criptions"); len(elem) >= l && elem[0:l] == "criptions" {
 							elem = elem[l:]
 						} else {
@@ -126,9 +125,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "lations"
-						origElem := elem
+
 						if l := len("lations"); len(elem) >= l && elem[0:l] == "lations" {
 							elem = elem[l:]
 						} else {
@@ -147,15 +145,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -167,7 +162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'h': // Prefix: "hat/completions"
-					origElem := elem
+
 					if l := len("hat/completions"); len(elem) >= l && elem[0:l] == "hat/completions" {
 						elem = elem[l:]
 					} else {
@@ -186,9 +181,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lassifications"
-					origElem := elem
+
 					if l := len("lassifications"); len(elem) >= l && elem[0:l] == "lassifications" {
 						elem = elem[l:]
 					} else {
@@ -207,9 +201,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ompletions"
-					origElem := elem
+
 					if l := len("ompletions"); len(elem) >= l && elem[0:l] == "ompletions" {
 						elem = elem[l:]
 					} else {
@@ -228,12 +221,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -245,7 +236,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dits"
-					origElem := elem
+
 					if l := len("dits"); len(elem) >= l && elem[0:l] == "dits" {
 						elem = elem[l:]
 					} else {
@@ -264,9 +255,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mbeddings"
-					origElem := elem
+
 					if l := len("mbeddings"); len(elem) >= l && elem[0:l] == "mbeddings" {
 						elem = elem[l:]
 					} else {
@@ -285,9 +275,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ngines"
-					origElem := elem
+
 					if l := len("ngines"); len(elem) >= l && elem[0:l] == "ngines" {
 						elem = elem[l:]
 					} else {
@@ -306,7 +295,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -336,7 +325,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/search"
-							origElem := elem
+
 							if l := len("/search"); len(elem) >= l && elem[0:l] == "/search" {
 								elem = elem[l:]
 							} else {
@@ -357,18 +346,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "fi"
-				origElem := elem
+
 				if l := len("fi"); len(elem) >= l && elem[0:l] == "fi" {
 					elem = elem[l:]
 				} else {
@@ -380,7 +365,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "les"
-					origElem := elem
+
 					if l := len("les"); len(elem) >= l && elem[0:l] == "les" {
 						elem = elem[l:]
 					} else {
@@ -401,7 +386,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -435,7 +420,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/content"
-							origElem := elem
+
 							if l := len("/content"); len(elem) >= l && elem[0:l] == "/content" {
 								elem = elem[l:]
 							} else {
@@ -456,15 +441,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ne-tunes"
-					origElem := elem
+
 					if l := len("ne-tunes"); len(elem) >= l && elem[0:l] == "ne-tunes" {
 						elem = elem[l:]
 					} else {
@@ -485,7 +467,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -515,7 +497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -527,7 +509,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "cancel"
-								origElem := elem
+
 								if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 									elem = elem[l:]
 								} else {
@@ -548,9 +530,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -571,21 +552,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "images/"
-				origElem := elem
+
 				if l := len("images/"); len(elem) >= l && elem[0:l] == "images/" {
 					elem = elem[l:]
 				} else {
@@ -597,7 +573,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "edits"
-					origElem := elem
+
 					if l := len("edits"); len(elem) >= l && elem[0:l] == "edits" {
 						elem = elem[l:]
 					} else {
@@ -616,9 +592,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'g': // Prefix: "generations"
-					origElem := elem
+
 					if l := len("generations"); len(elem) >= l && elem[0:l] == "generations" {
 						elem = elem[l:]
 					} else {
@@ -637,9 +612,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "variations"
-					origElem := elem
+
 					if l := len("variations"); len(elem) >= l && elem[0:l] == "variations" {
 						elem = elem[l:]
 					} else {
@@ -658,12 +632,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "mode"
-				origElem := elem
+
 				if l := len("mode"); len(elem) >= l && elem[0:l] == "mode" {
 					elem = elem[l:]
 				} else {
@@ -675,7 +647,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "ls"
-					origElem := elem
+
 					if l := len("ls"); len(elem) >= l && elem[0:l] == "ls" {
 						elem = elem[l:]
 					} else {
@@ -694,7 +666,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -728,12 +700,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rations"
-					origElem := elem
+
 					if l := len("rations"); len(elem) >= l && elem[0:l] == "rations" {
 						elem = elem[l:]
 					} else {
@@ -752,13 +722,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -840,7 +807,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -852,7 +819,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -864,7 +831,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "nswers"
-					origElem := elem
+
 					if l := len("nswers"); len(elem) >= l && elem[0:l] == "nswers" {
 						elem = elem[l:]
 					} else {
@@ -887,9 +854,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "udio/trans"
-					origElem := elem
+
 					if l := len("udio/trans"); len(elem) >= l && elem[0:l] == "udio/trans" {
 						elem = elem[l:]
 					} else {
@@ -901,7 +867,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'c': // Prefix: "criptions"
-						origElem := elem
+
 						if l := len("criptions"); len(elem) >= l && elem[0:l] == "criptions" {
 							elem = elem[l:]
 						} else {
@@ -924,9 +890,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'l': // Prefix: "lations"
-						origElem := elem
+
 						if l := len("lations"); len(elem) >= l && elem[0:l] == "lations" {
 							elem = elem[l:]
 						} else {
@@ -949,15 +914,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -969,7 +931,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'h': // Prefix: "hat/completions"
-					origElem := elem
+
 					if l := len("hat/completions"); len(elem) >= l && elem[0:l] == "hat/completions" {
 						elem = elem[l:]
 					} else {
@@ -992,9 +954,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lassifications"
-					origElem := elem
+
 					if l := len("lassifications"); len(elem) >= l && elem[0:l] == "lassifications" {
 						elem = elem[l:]
 					} else {
@@ -1017,9 +978,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ompletions"
-					origElem := elem
+
 					if l := len("ompletions"); len(elem) >= l && elem[0:l] == "ompletions" {
 						elem = elem[l:]
 					} else {
@@ -1042,12 +1002,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -1059,7 +1017,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dits"
-					origElem := elem
+
 					if l := len("dits"); len(elem) >= l && elem[0:l] == "dits" {
 						elem = elem[l:]
 					} else {
@@ -1082,9 +1040,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'm': // Prefix: "mbeddings"
-					origElem := elem
+
 					if l := len("mbeddings"); len(elem) >= l && elem[0:l] == "mbeddings" {
 						elem = elem[l:]
 					} else {
@@ -1107,9 +1064,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ngines"
-					origElem := elem
+
 					if l := len("ngines"); len(elem) >= l && elem[0:l] == "ngines" {
 						elem = elem[l:]
 					} else {
@@ -1132,7 +1088,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1164,7 +1120,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/search"
-							origElem := elem
+
 							if l := len("/search"); len(elem) >= l && elem[0:l] == "/search" {
 								elem = elem[l:]
 							} else {
@@ -1187,18 +1143,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "fi"
-				origElem := elem
+
 				if l := len("fi"); len(elem) >= l && elem[0:l] == "fi" {
 					elem = elem[l:]
 				} else {
@@ -1210,7 +1162,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "les"
-					origElem := elem
+
 					if l := len("les"); len(elem) >= l && elem[0:l] == "les" {
 						elem = elem[l:]
 					} else {
@@ -1241,7 +1193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1281,7 +1233,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/content"
-							origElem := elem
+
 							if l := len("/content"); len(elem) >= l && elem[0:l] == "/content" {
 								elem = elem[l:]
 							} else {
@@ -1304,15 +1256,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ne-tunes"
-					origElem := elem
+
 					if l := len("ne-tunes"); len(elem) >= l && elem[0:l] == "ne-tunes" {
 						elem = elem[l:]
 					} else {
@@ -1343,7 +1292,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1375,7 +1324,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/"
-							origElem := elem
+
 							if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 								elem = elem[l:]
 							} else {
@@ -1387,7 +1336,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'c': // Prefix: "cancel"
-								origElem := elem
+
 								if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 									elem = elem[l:]
 								} else {
@@ -1410,9 +1359,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "events"
-								origElem := elem
+
 								if l := len("events"); len(elem) >= l && elem[0:l] == "events" {
 									elem = elem[l:]
 								} else {
@@ -1435,21 +1383,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "images/"
-				origElem := elem
+
 				if l := len("images/"); len(elem) >= l && elem[0:l] == "images/" {
 					elem = elem[l:]
 				} else {
@@ -1461,7 +1404,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "edits"
-					origElem := elem
+
 					if l := len("edits"); len(elem) >= l && elem[0:l] == "edits" {
 						elem = elem[l:]
 					} else {
@@ -1484,9 +1427,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'g': // Prefix: "generations"
-					origElem := elem
+
 					if l := len("generations"); len(elem) >= l && elem[0:l] == "generations" {
 						elem = elem[l:]
 					} else {
@@ -1509,9 +1451,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "variations"
-					origElem := elem
+
 					if l := len("variations"); len(elem) >= l && elem[0:l] == "variations" {
 						elem = elem[l:]
 					} else {
@@ -1534,12 +1475,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "mode"
-				origElem := elem
+
 				if l := len("mode"); len(elem) >= l && elem[0:l] == "mode" {
 					elem = elem[l:]
 				} else {
@@ -1551,7 +1490,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "ls"
-					origElem := elem
+
 					if l := len("ls"); len(elem) >= l && elem[0:l] == "ls" {
 						elem = elem[l:]
 					} else {
@@ -1574,7 +1513,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1614,12 +1553,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rations"
-					origElem := elem
+
 					if l := len("rations"); len(elem) >= l && elem[0:l] == "rations" {
 						elem = elem[l:]
 					} else {
@@ -1642,13 +1579,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_petstore/oas_router_gen.go
+++ b/examples/ex_petstore/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -71,7 +71,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -101,10 +101,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -186,7 +184,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -217,7 +215,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -249,10 +247,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_petstore_expanded/oas_router_gen.go
+++ b/examples/ex_petstore_expanded/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -71,7 +71,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -105,10 +105,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -190,7 +188,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/pets"
-			origElem := elem
+
 			if l := len("/pets"); len(elem) >= l && elem[0:l] == "/pets" {
 				elem = elem[l:]
 			} else {
@@ -221,7 +219,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -261,10 +259,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_route_params/oas_router_gen.go
+++ b/examples/ex_route_params/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/name"
-			origElem := elem
+
 			if l := len("/name"); len(elem) >= l && elem[0:l] == "/name" {
 				elem = elem[l:]
 			} else {
@@ -69,7 +69,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -99,7 +99,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -130,13 +130,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -218,7 +215,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/name"
-			origElem := elem
+
 			if l := len("/name"); len(elem) >= l && elem[0:l] == "/name" {
 				elem = elem[l:]
 			} else {
@@ -241,7 +238,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/"
-				origElem := elem
+
 				if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 					elem = elem[l:]
 				} else {
@@ -273,7 +270,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
-					origElem := elem
+
 					if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 						elem = elem[l:]
 					} else {
@@ -305,13 +302,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_telegram/oas_router_gen.go
+++ b/examples/ex_telegram/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -73,7 +73,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "ddStickerToSet"
-					origElem := elem
+
 					if l := len("ddStickerToSet"); len(elem) >= l && elem[0:l] == "ddStickerToSet" {
 						elem = elem[l:]
 					} else {
@@ -92,9 +92,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nswer"
-					origElem := elem
+
 					if l := len("nswer"); len(elem) >= l && elem[0:l] == "nswer" {
 						elem = elem[l:]
 					} else {
@@ -106,7 +105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CallbackQuery"
-						origElem := elem
+
 						if l := len("CallbackQuery"); len(elem) >= l && elem[0:l] == "CallbackQuery" {
 							elem = elem[l:]
 						} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'I': // Prefix: "InlineQuery"
-						origElem := elem
+
 						if l := len("InlineQuery"); len(elem) >= l && elem[0:l] == "InlineQuery" {
 							elem = elem[l:]
 						} else {
@@ -146,9 +144,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "PreCheckoutQuery"
-						origElem := elem
+
 						if l := len("PreCheckoutQuery"); len(elem) >= l && elem[0:l] == "PreCheckoutQuery" {
 							elem = elem[l:]
 						} else {
@@ -167,9 +164,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "ShippingQuery"
-						origElem := elem
+
 						if l := len("ShippingQuery"); len(elem) >= l && elem[0:l] == "ShippingQuery" {
 							elem = elem[l:]
 						} else {
@@ -188,12 +184,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "pproveChatJoinRequest"
-					origElem := elem
+
 					if l := len("pproveChatJoinRequest"); len(elem) >= l && elem[0:l] == "pproveChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -212,12 +206,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "banChat"
-				origElem := elem
+
 				if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 					elem = elem[l:]
 				} else {
@@ -229,7 +221,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'M': // Prefix: "Member"
-					origElem := elem
+
 					if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 						elem = elem[l:]
 					} else {
@@ -248,9 +240,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "SenderChat"
-					origElem := elem
+
 					if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 						elem = elem[l:]
 					} else {
@@ -269,12 +260,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -286,7 +275,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "lose"
-					origElem := elem
+
 					if l := len("lose"); len(elem) >= l && elem[0:l] == "lose" {
 						elem = elem[l:]
 					} else {
@@ -305,9 +294,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "opyMessage"
-					origElem := elem
+
 					if l := len("opyMessage"); len(elem) >= l && elem[0:l] == "opyMessage" {
 						elem = elem[l:]
 					} else {
@@ -326,9 +314,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "reate"
-					origElem := elem
+
 					if l := len("reate"); len(elem) >= l && elem[0:l] == "reate" {
 						elem = elem[l:]
 					} else {
@@ -340,7 +327,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -359,9 +346,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'N': // Prefix: "NewStickerSet"
-						origElem := elem
+
 						if l := len("NewStickerSet"); len(elem) >= l && elem[0:l] == "NewStickerSet" {
 							elem = elem[l:]
 						} else {
@@ -380,15 +366,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "de"
-				origElem := elem
+
 				if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 					elem = elem[l:]
 				} else {
@@ -400,7 +383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "clineChatJoinRequest"
-					origElem := elem
+
 					if l := len("clineChatJoinRequest"); len(elem) >= l && elem[0:l] == "clineChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -419,9 +402,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lete"
-					origElem := elem
+
 					if l := len("lete"); len(elem) >= l && elem[0:l] == "lete" {
 						elem = elem[l:]
 					} else {
@@ -433,7 +415,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "Chat"
-						origElem := elem
+
 						if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 							elem = elem[l:]
 						} else {
@@ -445,7 +427,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'P': // Prefix: "Photo"
-							origElem := elem
+
 							if l := len("Photo"); len(elem) >= l && elem[0:l] == "Photo" {
 								elem = elem[l:]
 							} else {
@@ -464,9 +446,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "StickerSet"
-							origElem := elem
+
 							if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 								elem = elem[l:]
 							} else {
@@ -485,12 +466,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "M"
-						origElem := elem
+
 						if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 							elem = elem[l:]
 						} else {
@@ -502,7 +481,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "essage"
-							origElem := elem
+
 							if l := len("essage"); len(elem) >= l && elem[0:l] == "essage" {
 								elem = elem[l:]
 							} else {
@@ -521,9 +500,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'y': // Prefix: "yCommands"
-							origElem := elem
+
 							if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 								elem = elem[l:]
 							} else {
@@ -542,12 +520,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "StickerFromSet"
-						origElem := elem
+
 						if l := len("StickerFromSet"); len(elem) >= l && elem[0:l] == "StickerFromSet" {
 							elem = elem[l:]
 						} else {
@@ -566,9 +542,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "Webhook"
-						origElem := elem
+
 						if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 							elem = elem[l:]
 						} else {
@@ -587,15 +562,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -607,7 +579,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dit"
-					origElem := elem
+
 					if l := len("dit"); len(elem) >= l && elem[0:l] == "dit" {
 						elem = elem[l:]
 					} else {
@@ -619,7 +591,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -638,9 +610,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Message"
-						origElem := elem
+
 						if l := len("Message"); len(elem) >= l && elem[0:l] == "Message" {
 							elem = elem[l:]
 						} else {
@@ -652,7 +623,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Caption"
-							origElem := elem
+
 							if l := len("Caption"); len(elem) >= l && elem[0:l] == "Caption" {
 								elem = elem[l:]
 							} else {
@@ -671,9 +642,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "LiveLocation"
-							origElem := elem
+
 							if l := len("LiveLocation"); len(elem) >= l && elem[0:l] == "LiveLocation" {
 								elem = elem[l:]
 							} else {
@@ -692,9 +662,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Media"
-							origElem := elem
+
 							if l := len("Media"); len(elem) >= l && elem[0:l] == "Media" {
 								elem = elem[l:]
 							} else {
@@ -713,9 +682,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'R': // Prefix: "ReplyMarkup"
-							origElem := elem
+
 							if l := len("ReplyMarkup"); len(elem) >= l && elem[0:l] == "ReplyMarkup" {
 								elem = elem[l:]
 							} else {
@@ -734,9 +702,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'T': // Prefix: "Text"
-							origElem := elem
+
 							if l := len("Text"); len(elem) >= l && elem[0:l] == "Text" {
 								elem = elem[l:]
 							} else {
@@ -755,15 +722,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'x': // Prefix: "xportChatInviteLink"
-					origElem := elem
+
 					if l := len("xportChatInviteLink"); len(elem) >= l && elem[0:l] == "xportChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -782,12 +746,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "forwardMessage"
-				origElem := elem
+
 				if l := len("forwardMessage"); len(elem) >= l && elem[0:l] == "forwardMessage" {
 					elem = elem[l:]
 				} else {
@@ -806,9 +768,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "get"
-				origElem := elem
+
 				if l := len("get"); len(elem) >= l && elem[0:l] == "get" {
 					elem = elem[l:]
 				} else {
@@ -820,7 +781,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'C': // Prefix: "Chat"
-					origElem := elem
+
 					if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 						elem = elem[l:]
 					} else {
@@ -839,7 +800,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Administrators"
-						origElem := elem
+
 						if l := len("Administrators"); len(elem) >= l && elem[0:l] == "Administrators" {
 							elem = elem[l:]
 						} else {
@@ -858,9 +819,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Member"
-						origElem := elem
+
 						if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 							elem = elem[l:]
 						} else {
@@ -879,7 +839,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Count"
-							origElem := elem
+
 							if l := len("Count"); len(elem) >= l && elem[0:l] == "Count" {
 								elem = elem[l:]
 							} else {
@@ -898,15 +858,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'F': // Prefix: "File"
-					origElem := elem
+
 					if l := len("File"); len(elem) >= l && elem[0:l] == "File" {
 						elem = elem[l:]
 					} else {
@@ -925,9 +882,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'G': // Prefix: "GameHighScores"
-					origElem := elem
+
 					if l := len("GameHighScores"); len(elem) >= l && elem[0:l] == "GameHighScores" {
 						elem = elem[l:]
 					} else {
@@ -946,9 +902,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "M"
-					origElem := elem
+
 					if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 						elem = elem[l:]
 					} else {
@@ -960,7 +915,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "e"
-						origElem := elem
+
 						if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 							elem = elem[l:]
 						} else {
@@ -979,9 +934,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'y': // Prefix: "yCommands"
-						origElem := elem
+
 						if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 							elem = elem[l:]
 						} else {
@@ -1000,12 +954,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "StickerSet"
-					origElem := elem
+
 					if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 						elem = elem[l:]
 					} else {
@@ -1024,9 +976,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "U"
-					origElem := elem
+
 					if l := len("U"); len(elem) >= l && elem[0:l] == "U" {
 						elem = elem[l:]
 					} else {
@@ -1038,7 +989,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'p': // Prefix: "pdates"
-						origElem := elem
+
 						if l := len("pdates"); len(elem) >= l && elem[0:l] == "pdates" {
 							elem = elem[l:]
 						} else {
@@ -1057,9 +1008,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "serProfilePhotos"
-						origElem := elem
+
 						if l := len("serProfilePhotos"); len(elem) >= l && elem[0:l] == "serProfilePhotos" {
 							elem = elem[l:]
 						} else {
@@ -1078,12 +1028,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'W': // Prefix: "WebhookInfo"
-					origElem := elem
+
 					if l := len("WebhookInfo"); len(elem) >= l && elem[0:l] == "WebhookInfo" {
 						elem = elem[l:]
 					} else {
@@ -1102,12 +1050,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "l"
-				origElem := elem
+
 				if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 					elem = elem[l:]
 				} else {
@@ -1119,7 +1065,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "eaveChat"
-					origElem := elem
+
 					if l := len("eaveChat"); len(elem) >= l && elem[0:l] == "eaveChat" {
 						elem = elem[l:]
 					} else {
@@ -1138,9 +1084,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ogOut"
-					origElem := elem
+
 					if l := len("ogOut"); len(elem) >= l && elem[0:l] == "ogOut" {
 						elem = elem[l:]
 					} else {
@@ -1159,12 +1104,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -1176,7 +1119,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "inChatMessage"
-					origElem := elem
+
 					if l := len("inChatMessage"); len(elem) >= l && elem[0:l] == "inChatMessage" {
 						elem = elem[l:]
 					} else {
@@ -1195,9 +1138,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "romoteChatMember"
-					origElem := elem
+
 					if l := len("romoteChatMember"); len(elem) >= l && elem[0:l] == "romoteChatMember" {
 						elem = elem[l:]
 					} else {
@@ -1216,12 +1158,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -1233,7 +1173,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "strictChatMember"
-					origElem := elem
+
 					if l := len("strictChatMember"); len(elem) >= l && elem[0:l] == "strictChatMember" {
 						elem = elem[l:]
 					} else {
@@ -1252,9 +1192,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vokeChatInviteLink"
-					origElem := elem
+
 					if l := len("vokeChatInviteLink"); len(elem) >= l && elem[0:l] == "vokeChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -1273,12 +1212,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -1290,7 +1227,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -1302,7 +1239,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nd"
-						origElem := elem
+
 						if l := len("nd"); len(elem) >= l && elem[0:l] == "nd" {
 							elem = elem[l:]
 						} else {
@@ -1314,7 +1251,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "A"
-							origElem := elem
+
 							if l := len("A"); len(elem) >= l && elem[0:l] == "A" {
 								elem = elem[l:]
 							} else {
@@ -1326,7 +1263,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "nimation"
-								origElem := elem
+
 								if l := len("nimation"); len(elem) >= l && elem[0:l] == "nimation" {
 									elem = elem[l:]
 								} else {
@@ -1345,9 +1282,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udio"
-								origElem := elem
+
 								if l := len("udio"); len(elem) >= l && elem[0:l] == "udio" {
 									elem = elem[l:]
 								} else {
@@ -1366,12 +1302,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "C"
-							origElem := elem
+
 							if l := len("C"); len(elem) >= l && elem[0:l] == "C" {
 								elem = elem[l:]
 							} else {
@@ -1383,7 +1317,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hatAction"
-								origElem := elem
+
 								if l := len("hatAction"); len(elem) >= l && elem[0:l] == "hatAction" {
 									elem = elem[l:]
 								} else {
@@ -1402,9 +1336,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ontact"
-								origElem := elem
+
 								if l := len("ontact"); len(elem) >= l && elem[0:l] == "ontact" {
 									elem = elem[l:]
 								} else {
@@ -1423,12 +1356,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "D"
-							origElem := elem
+
 							if l := len("D"); len(elem) >= l && elem[0:l] == "D" {
 								elem = elem[l:]
 							} else {
@@ -1440,7 +1371,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "ice"
-								origElem := elem
+
 								if l := len("ice"); len(elem) >= l && elem[0:l] == "ice" {
 									elem = elem[l:]
 								} else {
@@ -1459,9 +1390,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ocument"
-								origElem := elem
+
 								if l := len("ocument"); len(elem) >= l && elem[0:l] == "ocument" {
 									elem = elem[l:]
 								} else {
@@ -1480,12 +1410,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "Game"
-							origElem := elem
+
 							if l := len("Game"); len(elem) >= l && elem[0:l] == "Game" {
 								elem = elem[l:]
 							} else {
@@ -1504,9 +1432,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'I': // Prefix: "Invoice"
-							origElem := elem
+
 							if l := len("Invoice"); len(elem) >= l && elem[0:l] == "Invoice" {
 								elem = elem[l:]
 							} else {
@@ -1525,9 +1452,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "Location"
-							origElem := elem
+
 							if l := len("Location"); len(elem) >= l && elem[0:l] == "Location" {
 								elem = elem[l:]
 							} else {
@@ -1546,9 +1472,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Me"
-							origElem := elem
+
 							if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 								elem = elem[l:]
 							} else {
@@ -1560,7 +1485,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'd': // Prefix: "diaGroup"
-								origElem := elem
+
 								if l := len("diaGroup"); len(elem) >= l && elem[0:l] == "diaGroup" {
 									elem = elem[l:]
 								} else {
@@ -1579,9 +1504,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 's': // Prefix: "ssage"
-								origElem := elem
+
 								if l := len("ssage"); len(elem) >= l && elem[0:l] == "ssage" {
 									elem = elem[l:]
 								} else {
@@ -1600,12 +1524,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "P"
-							origElem := elem
+
 							if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 								elem = elem[l:]
 							} else {
@@ -1617,7 +1539,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hoto"
-								origElem := elem
+
 								if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 									elem = elem[l:]
 								} else {
@@ -1636,9 +1558,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oll"
-								origElem := elem
+
 								if l := len("oll"); len(elem) >= l && elem[0:l] == "oll" {
 									elem = elem[l:]
 								} else {
@@ -1657,12 +1578,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -1681,9 +1600,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'V': // Prefix: "V"
-							origElem := elem
+
 							if l := len("V"); len(elem) >= l && elem[0:l] == "V" {
 								elem = elem[l:]
 							} else {
@@ -1695,7 +1613,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "enue"
-								origElem := elem
+
 								if l := len("enue"); len(elem) >= l && elem[0:l] == "enue" {
 									elem = elem[l:]
 								} else {
@@ -1714,9 +1632,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "ideo"
-								origElem := elem
+
 								if l := len("ideo"); len(elem) >= l && elem[0:l] == "ideo" {
 									elem = elem[l:]
 								} else {
@@ -1735,7 +1652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'N': // Prefix: "Note"
-									origElem := elem
+
 									if l := len("Note"); len(elem) >= l && elem[0:l] == "Note" {
 										elem = elem[l:]
 									} else {
@@ -1754,12 +1671,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oice"
-								origElem := elem
+
 								if l := len("oice"); len(elem) >= l && elem[0:l] == "oice" {
 									elem = elem[l:]
 								} else {
@@ -1778,15 +1693,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t"
-						origElem := elem
+
 						if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 							elem = elem[l:]
 						} else {
@@ -1798,7 +1710,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Chat"
-							origElem := elem
+
 							if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 								elem = elem[l:]
 							} else {
@@ -1810,7 +1722,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "AdministratorCustomTitle"
-								origElem := elem
+
 								if l := len("AdministratorCustomTitle"); len(elem) >= l && elem[0:l] == "AdministratorCustomTitle" {
 									elem = elem[l:]
 								} else {
@@ -1829,9 +1741,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "Description"
-								origElem := elem
+
 								if l := len("Description"); len(elem) >= l && elem[0:l] == "Description" {
 									elem = elem[l:]
 								} else {
@@ -1850,9 +1761,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'P': // Prefix: "P"
-								origElem := elem
+
 								if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 									elem = elem[l:]
 								} else {
@@ -1864,7 +1774,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ermissions"
-									origElem := elem
+
 									if l := len("ermissions"); len(elem) >= l && elem[0:l] == "ermissions" {
 										elem = elem[l:]
 									} else {
@@ -1883,9 +1793,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hoto"
-									origElem := elem
+
 									if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 										elem = elem[l:]
 									} else {
@@ -1904,12 +1813,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "StickerSet"
-								origElem := elem
+
 								if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 									elem = elem[l:]
 								} else {
@@ -1928,9 +1835,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'T': // Prefix: "Title"
-								origElem := elem
+
 								if l := len("Title"); len(elem) >= l && elem[0:l] == "Title" {
 									elem = elem[l:]
 								} else {
@@ -1949,12 +1855,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "GameScore"
-							origElem := elem
+
 							if l := len("GameScore"); len(elem) >= l && elem[0:l] == "GameScore" {
 								elem = elem[l:]
 							} else {
@@ -1973,9 +1877,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "MyCommands"
-							origElem := elem
+
 							if l := len("MyCommands"); len(elem) >= l && elem[0:l] == "MyCommands" {
 								elem = elem[l:]
 							} else {
@@ -1994,9 +1897,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "PassportDataErrors"
-							origElem := elem
+
 							if l := len("PassportDataErrors"); len(elem) >= l && elem[0:l] == "PassportDataErrors" {
 								elem = elem[l:]
 							} else {
@@ -2015,9 +1917,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -2029,7 +1930,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'P': // Prefix: "PositionInSet"
-								origElem := elem
+
 								if l := len("PositionInSet"); len(elem) >= l && elem[0:l] == "PositionInSet" {
 									elem = elem[l:]
 								} else {
@@ -2048,9 +1949,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "SetThumb"
-								origElem := elem
+
 								if l := len("SetThumb"); len(elem) >= l && elem[0:l] == "SetThumb" {
 									elem = elem[l:]
 								} else {
@@ -2069,12 +1969,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'W': // Prefix: "Webhook"
-							origElem := elem
+
 							if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 								elem = elem[l:]
 							} else {
@@ -2093,15 +1991,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "top"
-					origElem := elem
+
 					if l := len("top"); len(elem) >= l && elem[0:l] == "top" {
 						elem = elem[l:]
 					} else {
@@ -2113,7 +2008,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'M': // Prefix: "MessageLiveLocation"
-						origElem := elem
+
 						if l := len("MessageLiveLocation"); len(elem) >= l && elem[0:l] == "MessageLiveLocation" {
 							elem = elem[l:]
 						} else {
@@ -2132,9 +2027,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "Poll"
-						origElem := elem
+
 						if l := len("Poll"); len(elem) >= l && elem[0:l] == "Poll" {
 							elem = elem[l:]
 						} else {
@@ -2153,15 +2047,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "u"
-				origElem := elem
+
 				if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 					elem = elem[l:]
 				} else {
@@ -2173,7 +2064,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "n"
-					origElem := elem
+
 					if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 						elem = elem[l:]
 					} else {
@@ -2185,7 +2076,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "banChat"
-						origElem := elem
+
 						if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 							elem = elem[l:]
 						} else {
@@ -2197,7 +2088,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'M': // Prefix: "Member"
-							origElem := elem
+
 							if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 								elem = elem[l:]
 							} else {
@@ -2216,9 +2107,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "SenderChat"
-							origElem := elem
+
 							if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 								elem = elem[l:]
 							} else {
@@ -2237,12 +2127,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pin"
-						origElem := elem
+
 						if l := len("pin"); len(elem) >= l && elem[0:l] == "pin" {
 							elem = elem[l:]
 						} else {
@@ -2254,7 +2142,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "AllChatMessages"
-							origElem := elem
+
 							if l := len("AllChatMessages"); len(elem) >= l && elem[0:l] == "AllChatMessages" {
 								elem = elem[l:]
 							} else {
@@ -2273,9 +2161,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "ChatMessage"
-							origElem := elem
+
 							if l := len("ChatMessage"); len(elem) >= l && elem[0:l] == "ChatMessage" {
 								elem = elem[l:]
 							} else {
@@ -2294,15 +2181,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ploadStickerFile"
-					origElem := elem
+
 					if l := len("ploadStickerFile"); len(elem) >= l && elem[0:l] == "ploadStickerFile" {
 						elem = elem[l:]
 					} else {
@@ -2321,13 +2205,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -2409,7 +2290,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -2421,7 +2302,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "a"
-				origElem := elem
+
 				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
 					elem = elem[l:]
 				} else {
@@ -2433,7 +2314,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "ddStickerToSet"
-					origElem := elem
+
 					if l := len("ddStickerToSet"); len(elem) >= l && elem[0:l] == "ddStickerToSet" {
 						elem = elem[l:]
 					} else {
@@ -2456,9 +2337,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "nswer"
-					origElem := elem
+
 					if l := len("nswer"); len(elem) >= l && elem[0:l] == "nswer" {
 						elem = elem[l:]
 					} else {
@@ -2470,7 +2350,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CallbackQuery"
-						origElem := elem
+
 						if l := len("CallbackQuery"); len(elem) >= l && elem[0:l] == "CallbackQuery" {
 							elem = elem[l:]
 						} else {
@@ -2493,9 +2373,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'I': // Prefix: "InlineQuery"
-						origElem := elem
+
 						if l := len("InlineQuery"); len(elem) >= l && elem[0:l] == "InlineQuery" {
 							elem = elem[l:]
 						} else {
@@ -2518,9 +2397,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "PreCheckoutQuery"
-						origElem := elem
+
 						if l := len("PreCheckoutQuery"); len(elem) >= l && elem[0:l] == "PreCheckoutQuery" {
 							elem = elem[l:]
 						} else {
@@ -2543,9 +2421,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "ShippingQuery"
-						origElem := elem
+
 						if l := len("ShippingQuery"); len(elem) >= l && elem[0:l] == "ShippingQuery" {
 							elem = elem[l:]
 						} else {
@@ -2568,12 +2445,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "pproveChatJoinRequest"
-					origElem := elem
+
 					if l := len("pproveChatJoinRequest"); len(elem) >= l && elem[0:l] == "pproveChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -2596,12 +2471,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "banChat"
-				origElem := elem
+
 				if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 					elem = elem[l:]
 				} else {
@@ -2613,7 +2486,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'M': // Prefix: "Member"
-					origElem := elem
+
 					if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 						elem = elem[l:]
 					} else {
@@ -2636,9 +2509,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "SenderChat"
-					origElem := elem
+
 					if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 						elem = elem[l:]
 					} else {
@@ -2661,12 +2533,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "c"
-				origElem := elem
+
 				if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 					elem = elem[l:]
 				} else {
@@ -2678,7 +2548,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'l': // Prefix: "lose"
-					origElem := elem
+
 					if l := len("lose"); len(elem) >= l && elem[0:l] == "lose" {
 						elem = elem[l:]
 					} else {
@@ -2701,9 +2571,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "opyMessage"
-					origElem := elem
+
 					if l := len("opyMessage"); len(elem) >= l && elem[0:l] == "opyMessage" {
 						elem = elem[l:]
 					} else {
@@ -2726,9 +2595,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "reate"
-					origElem := elem
+
 					if l := len("reate"); len(elem) >= l && elem[0:l] == "reate" {
 						elem = elem[l:]
 					} else {
@@ -2740,7 +2608,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -2763,9 +2631,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'N': // Prefix: "NewStickerSet"
-						origElem := elem
+
 						if l := len("NewStickerSet"); len(elem) >= l && elem[0:l] == "NewStickerSet" {
 							elem = elem[l:]
 						} else {
@@ -2788,15 +2655,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "de"
-				origElem := elem
+
 				if l := len("de"); len(elem) >= l && elem[0:l] == "de" {
 					elem = elem[l:]
 				} else {
@@ -2808,7 +2672,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "clineChatJoinRequest"
-					origElem := elem
+
 					if l := len("clineChatJoinRequest"); len(elem) >= l && elem[0:l] == "clineChatJoinRequest" {
 						elem = elem[l:]
 					} else {
@@ -2831,9 +2695,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'l': // Prefix: "lete"
-					origElem := elem
+
 					if l := len("lete"); len(elem) >= l && elem[0:l] == "lete" {
 						elem = elem[l:]
 					} else {
@@ -2845,7 +2708,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "Chat"
-						origElem := elem
+
 						if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 							elem = elem[l:]
 						} else {
@@ -2857,7 +2720,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'P': // Prefix: "Photo"
-							origElem := elem
+
 							if l := len("Photo"); len(elem) >= l && elem[0:l] == "Photo" {
 								elem = elem[l:]
 							} else {
@@ -2880,9 +2743,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "StickerSet"
-							origElem := elem
+
 							if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 								elem = elem[l:]
 							} else {
@@ -2905,12 +2767,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "M"
-						origElem := elem
+
 						if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 							elem = elem[l:]
 						} else {
@@ -2922,7 +2782,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'e': // Prefix: "essage"
-							origElem := elem
+
 							if l := len("essage"); len(elem) >= l && elem[0:l] == "essage" {
 								elem = elem[l:]
 							} else {
@@ -2945,9 +2805,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'y': // Prefix: "yCommands"
-							origElem := elem
+
 							if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 								elem = elem[l:]
 							} else {
@@ -2970,12 +2829,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "StickerFromSet"
-						origElem := elem
+
 						if l := len("StickerFromSet"); len(elem) >= l && elem[0:l] == "StickerFromSet" {
 							elem = elem[l:]
 						} else {
@@ -2998,9 +2855,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'W': // Prefix: "Webhook"
-						origElem := elem
+
 						if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 							elem = elem[l:]
 						} else {
@@ -3023,15 +2879,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "e"
-				origElem := elem
+
 				if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 					elem = elem[l:]
 				} else {
@@ -3043,7 +2896,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'd': // Prefix: "dit"
-					origElem := elem
+
 					if l := len("dit"); len(elem) >= l && elem[0:l] == "dit" {
 						elem = elem[l:]
 					} else {
@@ -3055,7 +2908,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "ChatInviteLink"
-						origElem := elem
+
 						if l := len("ChatInviteLink"); len(elem) >= l && elem[0:l] == "ChatInviteLink" {
 							elem = elem[l:]
 						} else {
@@ -3078,9 +2931,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Message"
-						origElem := elem
+
 						if l := len("Message"); len(elem) >= l && elem[0:l] == "Message" {
 							elem = elem[l:]
 						} else {
@@ -3092,7 +2944,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Caption"
-							origElem := elem
+
 							if l := len("Caption"); len(elem) >= l && elem[0:l] == "Caption" {
 								elem = elem[l:]
 							} else {
@@ -3115,9 +2967,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "LiveLocation"
-							origElem := elem
+
 							if l := len("LiveLocation"); len(elem) >= l && elem[0:l] == "LiveLocation" {
 								elem = elem[l:]
 							} else {
@@ -3140,9 +2991,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Media"
-							origElem := elem
+
 							if l := len("Media"); len(elem) >= l && elem[0:l] == "Media" {
 								elem = elem[l:]
 							} else {
@@ -3165,9 +3015,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'R': // Prefix: "ReplyMarkup"
-							origElem := elem
+
 							if l := len("ReplyMarkup"); len(elem) >= l && elem[0:l] == "ReplyMarkup" {
 								elem = elem[l:]
 							} else {
@@ -3190,9 +3039,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'T': // Prefix: "Text"
-							origElem := elem
+
 							if l := len("Text"); len(elem) >= l && elem[0:l] == "Text" {
 								elem = elem[l:]
 							} else {
@@ -3215,15 +3063,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'x': // Prefix: "xportChatInviteLink"
-					origElem := elem
+
 					if l := len("xportChatInviteLink"); len(elem) >= l && elem[0:l] == "xportChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -3246,12 +3091,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "forwardMessage"
-				origElem := elem
+
 				if l := len("forwardMessage"); len(elem) >= l && elem[0:l] == "forwardMessage" {
 					elem = elem[l:]
 				} else {
@@ -3274,9 +3117,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'g': // Prefix: "get"
-				origElem := elem
+
 				if l := len("get"); len(elem) >= l && elem[0:l] == "get" {
 					elem = elem[l:]
 				} else {
@@ -3288,7 +3130,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'C': // Prefix: "Chat"
-					origElem := elem
+
 					if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 						elem = elem[l:]
 					} else {
@@ -3311,7 +3153,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Administrators"
-						origElem := elem
+
 						if l := len("Administrators"); len(elem) >= l && elem[0:l] == "Administrators" {
 							elem = elem[l:]
 						} else {
@@ -3334,9 +3176,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'M': // Prefix: "Member"
-						origElem := elem
+
 						if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 							elem = elem[l:]
 						} else {
@@ -3359,7 +3200,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Count"
-							origElem := elem
+
 							if l := len("Count"); len(elem) >= l && elem[0:l] == "Count" {
 								elem = elem[l:]
 							} else {
@@ -3382,15 +3223,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'F': // Prefix: "File"
-					origElem := elem
+
 					if l := len("File"); len(elem) >= l && elem[0:l] == "File" {
 						elem = elem[l:]
 					} else {
@@ -3413,9 +3251,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'G': // Prefix: "GameHighScores"
-					origElem := elem
+
 					if l := len("GameHighScores"); len(elem) >= l && elem[0:l] == "GameHighScores" {
 						elem = elem[l:]
 					} else {
@@ -3438,9 +3275,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "M"
-					origElem := elem
+
 					if l := len("M"); len(elem) >= l && elem[0:l] == "M" {
 						elem = elem[l:]
 					} else {
@@ -3452,7 +3288,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "e"
-						origElem := elem
+
 						if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 							elem = elem[l:]
 						} else {
@@ -3475,9 +3311,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'y': // Prefix: "yCommands"
-						origElem := elem
+
 						if l := len("yCommands"); len(elem) >= l && elem[0:l] == "yCommands" {
 							elem = elem[l:]
 						} else {
@@ -3500,12 +3335,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "StickerSet"
-					origElem := elem
+
 					if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 						elem = elem[l:]
 					} else {
@@ -3528,9 +3361,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "U"
-					origElem := elem
+
 					if l := len("U"); len(elem) >= l && elem[0:l] == "U" {
 						elem = elem[l:]
 					} else {
@@ -3542,7 +3374,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'p': // Prefix: "pdates"
-						origElem := elem
+
 						if l := len("pdates"); len(elem) >= l && elem[0:l] == "pdates" {
 							elem = elem[l:]
 						} else {
@@ -3565,9 +3397,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "serProfilePhotos"
-						origElem := elem
+
 						if l := len("serProfilePhotos"); len(elem) >= l && elem[0:l] == "serProfilePhotos" {
 							elem = elem[l:]
 						} else {
@@ -3590,12 +3421,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'W': // Prefix: "WebhookInfo"
-					origElem := elem
+
 					if l := len("WebhookInfo"); len(elem) >= l && elem[0:l] == "WebhookInfo" {
 						elem = elem[l:]
 					} else {
@@ -3618,12 +3447,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'l': // Prefix: "l"
-				origElem := elem
+
 				if l := len("l"); len(elem) >= l && elem[0:l] == "l" {
 					elem = elem[l:]
 				} else {
@@ -3635,7 +3462,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "eaveChat"
-					origElem := elem
+
 					if l := len("eaveChat"); len(elem) >= l && elem[0:l] == "eaveChat" {
 						elem = elem[l:]
 					} else {
@@ -3658,9 +3485,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "ogOut"
-					origElem := elem
+
 					if l := len("ogOut"); len(elem) >= l && elem[0:l] == "ogOut" {
 						elem = elem[l:]
 					} else {
@@ -3683,12 +3509,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -3700,7 +3524,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "inChatMessage"
-					origElem := elem
+
 					if l := len("inChatMessage"); len(elem) >= l && elem[0:l] == "inChatMessage" {
 						elem = elem[l:]
 					} else {
@@ -3723,9 +3547,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "romoteChatMember"
-					origElem := elem
+
 					if l := len("romoteChatMember"); len(elem) >= l && elem[0:l] == "romoteChatMember" {
 						elem = elem[l:]
 					} else {
@@ -3748,12 +3571,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -3765,7 +3586,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 's': // Prefix: "strictChatMember"
-					origElem := elem
+
 					if l := len("strictChatMember"); len(elem) >= l && elem[0:l] == "strictChatMember" {
 						elem = elem[l:]
 					} else {
@@ -3788,9 +3609,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'v': // Prefix: "vokeChatInviteLink"
-					origElem := elem
+
 					if l := len("vokeChatInviteLink"); len(elem) >= l && elem[0:l] == "vokeChatInviteLink" {
 						elem = elem[l:]
 					} else {
@@ -3813,12 +3633,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -3830,7 +3648,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "e"
-					origElem := elem
+
 					if l := len("e"); len(elem) >= l && elem[0:l] == "e" {
 						elem = elem[l:]
 					} else {
@@ -3842,7 +3660,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nd"
-						origElem := elem
+
 						if l := len("nd"); len(elem) >= l && elem[0:l] == "nd" {
 							elem = elem[l:]
 						} else {
@@ -3854,7 +3672,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "A"
-							origElem := elem
+
 							if l := len("A"); len(elem) >= l && elem[0:l] == "A" {
 								elem = elem[l:]
 							} else {
@@ -3866,7 +3684,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'n': // Prefix: "nimation"
-								origElem := elem
+
 								if l := len("nimation"); len(elem) >= l && elem[0:l] == "nimation" {
 									elem = elem[l:]
 								} else {
@@ -3889,9 +3707,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "udio"
-								origElem := elem
+
 								if l := len("udio"); len(elem) >= l && elem[0:l] == "udio" {
 									elem = elem[l:]
 								} else {
@@ -3914,12 +3731,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "C"
-							origElem := elem
+
 							if l := len("C"); len(elem) >= l && elem[0:l] == "C" {
 								elem = elem[l:]
 							} else {
@@ -3931,7 +3746,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hatAction"
-								origElem := elem
+
 								if l := len("hatAction"); len(elem) >= l && elem[0:l] == "hatAction" {
 									elem = elem[l:]
 								} else {
@@ -3954,9 +3769,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ontact"
-								origElem := elem
+
 								if l := len("ontact"); len(elem) >= l && elem[0:l] == "ontact" {
 									elem = elem[l:]
 								} else {
@@ -3979,12 +3793,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'D': // Prefix: "D"
-							origElem := elem
+
 							if l := len("D"); len(elem) >= l && elem[0:l] == "D" {
 								elem = elem[l:]
 							} else {
@@ -3996,7 +3808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'i': // Prefix: "ice"
-								origElem := elem
+
 								if l := len("ice"); len(elem) >= l && elem[0:l] == "ice" {
 									elem = elem[l:]
 								} else {
@@ -4019,9 +3831,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "ocument"
-								origElem := elem
+
 								if l := len("ocument"); len(elem) >= l && elem[0:l] == "ocument" {
 									elem = elem[l:]
 								} else {
@@ -4044,12 +3855,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "Game"
-							origElem := elem
+
 							if l := len("Game"); len(elem) >= l && elem[0:l] == "Game" {
 								elem = elem[l:]
 							} else {
@@ -4072,9 +3881,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'I': // Prefix: "Invoice"
-							origElem := elem
+
 							if l := len("Invoice"); len(elem) >= l && elem[0:l] == "Invoice" {
 								elem = elem[l:]
 							} else {
@@ -4097,9 +3905,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'L': // Prefix: "Location"
-							origElem := elem
+
 							if l := len("Location"); len(elem) >= l && elem[0:l] == "Location" {
 								elem = elem[l:]
 							} else {
@@ -4122,9 +3929,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "Me"
-							origElem := elem
+
 							if l := len("Me"); len(elem) >= l && elem[0:l] == "Me" {
 								elem = elem[l:]
 							} else {
@@ -4136,7 +3942,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'd': // Prefix: "diaGroup"
-								origElem := elem
+
 								if l := len("diaGroup"); len(elem) >= l && elem[0:l] == "diaGroup" {
 									elem = elem[l:]
 								} else {
@@ -4159,9 +3965,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 's': // Prefix: "ssage"
-								origElem := elem
+
 								if l := len("ssage"); len(elem) >= l && elem[0:l] == "ssage" {
 									elem = elem[l:]
 								} else {
@@ -4184,12 +3989,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "P"
-							origElem := elem
+
 							if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 								elem = elem[l:]
 							} else {
@@ -4201,7 +4004,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'h': // Prefix: "hoto"
-								origElem := elem
+
 								if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 									elem = elem[l:]
 								} else {
@@ -4224,9 +4027,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oll"
-								origElem := elem
+
 								if l := len("oll"); len(elem) >= l && elem[0:l] == "oll" {
 									elem = elem[l:]
 								} else {
@@ -4249,12 +4051,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -4277,9 +4077,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'V': // Prefix: "V"
-							origElem := elem
+
 							if l := len("V"); len(elem) >= l && elem[0:l] == "V" {
 								elem = elem[l:]
 							} else {
@@ -4291,7 +4090,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'e': // Prefix: "enue"
-								origElem := elem
+
 								if l := len("enue"); len(elem) >= l && elem[0:l] == "enue" {
 									elem = elem[l:]
 								} else {
@@ -4314,9 +4113,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "ideo"
-								origElem := elem
+
 								if l := len("ideo"); len(elem) >= l && elem[0:l] == "ideo" {
 									elem = elem[l:]
 								} else {
@@ -4339,7 +4137,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'N': // Prefix: "Note"
-									origElem := elem
+
 									if l := len("Note"); len(elem) >= l && elem[0:l] == "Note" {
 										elem = elem[l:]
 									} else {
@@ -4362,12 +4160,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'o': // Prefix: "oice"
-								origElem := elem
+
 								if l := len("oice"); len(elem) >= l && elem[0:l] == "oice" {
 									elem = elem[l:]
 								} else {
@@ -4390,15 +4186,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "t"
-						origElem := elem
+
 						if l := len("t"); len(elem) >= l && elem[0:l] == "t" {
 							elem = elem[l:]
 						} else {
@@ -4410,7 +4203,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'C': // Prefix: "Chat"
-							origElem := elem
+
 							if l := len("Chat"); len(elem) >= l && elem[0:l] == "Chat" {
 								elem = elem[l:]
 							} else {
@@ -4422,7 +4215,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "AdministratorCustomTitle"
-								origElem := elem
+
 								if l := len("AdministratorCustomTitle"); len(elem) >= l && elem[0:l] == "AdministratorCustomTitle" {
 									elem = elem[l:]
 								} else {
@@ -4445,9 +4238,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'D': // Prefix: "Description"
-								origElem := elem
+
 								if l := len("Description"); len(elem) >= l && elem[0:l] == "Description" {
 									elem = elem[l:]
 								} else {
@@ -4470,9 +4262,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'P': // Prefix: "P"
-								origElem := elem
+
 								if l := len("P"); len(elem) >= l && elem[0:l] == "P" {
 									elem = elem[l:]
 								} else {
@@ -4484,7 +4275,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'e': // Prefix: "ermissions"
-									origElem := elem
+
 									if l := len("ermissions"); len(elem) >= l && elem[0:l] == "ermissions" {
 										elem = elem[l:]
 									} else {
@@ -4507,9 +4298,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hoto"
-									origElem := elem
+
 									if l := len("hoto"); len(elem) >= l && elem[0:l] == "hoto" {
 										elem = elem[l:]
 									} else {
@@ -4532,12 +4322,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "StickerSet"
-								origElem := elem
+
 								if l := len("StickerSet"); len(elem) >= l && elem[0:l] == "StickerSet" {
 									elem = elem[l:]
 								} else {
@@ -4560,9 +4348,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'T': // Prefix: "Title"
-								origElem := elem
+
 								if l := len("Title"); len(elem) >= l && elem[0:l] == "Title" {
 									elem = elem[l:]
 								} else {
@@ -4585,12 +4372,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'G': // Prefix: "GameScore"
-							origElem := elem
+
 							if l := len("GameScore"); len(elem) >= l && elem[0:l] == "GameScore" {
 								elem = elem[l:]
 							} else {
@@ -4613,9 +4398,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'M': // Prefix: "MyCommands"
-							origElem := elem
+
 							if l := len("MyCommands"); len(elem) >= l && elem[0:l] == "MyCommands" {
 								elem = elem[l:]
 							} else {
@@ -4638,9 +4422,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'P': // Prefix: "PassportDataErrors"
-							origElem := elem
+
 							if l := len("PassportDataErrors"); len(elem) >= l && elem[0:l] == "PassportDataErrors" {
 								elem = elem[l:]
 							} else {
@@ -4663,9 +4446,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "Sticker"
-							origElem := elem
+
 							if l := len("Sticker"); len(elem) >= l && elem[0:l] == "Sticker" {
 								elem = elem[l:]
 							} else {
@@ -4677,7 +4459,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'P': // Prefix: "PositionInSet"
-								origElem := elem
+
 								if l := len("PositionInSet"); len(elem) >= l && elem[0:l] == "PositionInSet" {
 									elem = elem[l:]
 								} else {
@@ -4700,9 +4482,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							case 'S': // Prefix: "SetThumb"
-								origElem := elem
+
 								if l := len("SetThumb"); len(elem) >= l && elem[0:l] == "SetThumb" {
 									elem = elem[l:]
 								} else {
@@ -4725,12 +4506,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'W': // Prefix: "Webhook"
-							origElem := elem
+
 							if l := len("Webhook"); len(elem) >= l && elem[0:l] == "Webhook" {
 								elem = elem[l:]
 							} else {
@@ -4753,15 +4532,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "top"
-					origElem := elem
+
 					if l := len("top"); len(elem) >= l && elem[0:l] == "top" {
 						elem = elem[l:]
 					} else {
@@ -4773,7 +4549,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'M': // Prefix: "MessageLiveLocation"
-						origElem := elem
+
 						if l := len("MessageLiveLocation"); len(elem) >= l && elem[0:l] == "MessageLiveLocation" {
 							elem = elem[l:]
 						} else {
@@ -4796,9 +4572,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'P': // Prefix: "Poll"
-						origElem := elem
+
 						if l := len("Poll"); len(elem) >= l && elem[0:l] == "Poll" {
 							elem = elem[l:]
 						} else {
@@ -4821,15 +4596,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "u"
-				origElem := elem
+
 				if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 					elem = elem[l:]
 				} else {
@@ -4841,7 +4613,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'n': // Prefix: "n"
-					origElem := elem
+
 					if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 						elem = elem[l:]
 					} else {
@@ -4853,7 +4625,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'b': // Prefix: "banChat"
-						origElem := elem
+
 						if l := len("banChat"); len(elem) >= l && elem[0:l] == "banChat" {
 							elem = elem[l:]
 						} else {
@@ -4865,7 +4637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'M': // Prefix: "Member"
-							origElem := elem
+
 							if l := len("Member"); len(elem) >= l && elem[0:l] == "Member" {
 								elem = elem[l:]
 							} else {
@@ -4888,9 +4660,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'S': // Prefix: "SenderChat"
-							origElem := elem
+
 							if l := len("SenderChat"); len(elem) >= l && elem[0:l] == "SenderChat" {
 								elem = elem[l:]
 							} else {
@@ -4913,12 +4684,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'p': // Prefix: "pin"
-						origElem := elem
+
 						if l := len("pin"); len(elem) >= l && elem[0:l] == "pin" {
 							elem = elem[l:]
 						} else {
@@ -4930,7 +4699,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "AllChatMessages"
-							origElem := elem
+
 							if l := len("AllChatMessages"); len(elem) >= l && elem[0:l] == "AllChatMessages" {
 								elem = elem[l:]
 							} else {
@@ -4953,9 +4722,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'C': // Prefix: "ChatMessage"
-							origElem := elem
+
 							if l := len("ChatMessage"); len(elem) >= l && elem[0:l] == "ChatMessage" {
 								elem = elem[l:]
 							} else {
@@ -4978,15 +4746,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ploadStickerFile"
-					origElem := elem
+
 					if l := len("ploadStickerFile"); len(elem) >= l && elem[0:l] == "ploadStickerFile" {
 						elem = elem[l:]
 					} else {
@@ -5009,13 +4774,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_test_format/oas_router_gen.go
+++ b/examples/ex_test_format/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/test_"
-			origElem := elem
+
 			if l := len("/test_"); len(elem) >= l && elem[0:l] == "/test_" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'q': // Prefix: "query_parameter"
-				origElem := elem
+
 				if l := len("query_parameter"); len(elem) >= l && elem[0:l] == "query_parameter" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -94,7 +93,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'q': // Prefix: "quest_"
-					origElem := elem
+
 					if l := len("quest_"); len(elem) >= l && elem[0:l] == "quest_" {
 						elem = elem[l:]
 					} else {
@@ -106,7 +105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Any"
-						origElem := elem
+
 						if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 							elem = elem[l:]
 						} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptyStruct"
-						origElem := elem
+
 						if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 							elem = elem[l:]
 						} else {
@@ -146,9 +144,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'F': // Prefix: "FormatTest"
-						origElem := elem
+
 						if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 							elem = elem[l:]
 						} else {
@@ -167,9 +164,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boolean"
-						origElem := elem
+
 						if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 							elem = elem[l:]
 						} else {
@@ -188,7 +184,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -200,7 +196,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -219,7 +215,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -238,12 +234,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -262,7 +256,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -281,7 +275,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -300,21 +294,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "integer"
-						origElem := elem
+
 						if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 							elem = elem[l:]
 						} else {
@@ -333,7 +322,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -345,7 +334,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -364,7 +353,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -383,12 +372,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "int"
-								origElem := elem
+
 								if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 									elem = elem[l:]
 								} else {
@@ -400,7 +387,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '1': // Prefix: "16"
-									origElem := elem
+
 									if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 										elem = elem[l:]
 									} else {
@@ -419,7 +406,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -431,7 +418,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -450,7 +437,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -469,12 +456,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -493,7 +478,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -512,7 +497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -531,21 +516,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -564,7 +544,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -576,7 +556,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -595,7 +575,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -614,12 +594,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -638,7 +616,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -657,7 +635,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -676,21 +654,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -709,7 +682,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -721,7 +694,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -740,7 +713,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -759,12 +732,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -783,7 +754,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -802,7 +773,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -821,21 +792,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '8': // Prefix: "8"
-									origElem := elem
+
 									if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 										elem = elem[l:]
 									} else {
@@ -854,7 +820,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -866,7 +832,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -885,7 +851,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -904,12 +870,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -928,7 +892,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -947,7 +911,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -966,24 +930,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -1002,7 +960,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -1021,7 +979,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -1040,15 +998,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -1060,7 +1015,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -1079,7 +1034,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -1098,7 +1053,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -1110,7 +1065,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -1129,7 +1084,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1148,12 +1103,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -1172,7 +1125,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1191,7 +1144,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -1210,21 +1163,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -1243,7 +1191,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -1255,7 +1203,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -1274,7 +1222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1293,12 +1241,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -1317,7 +1263,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1336,7 +1282,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -1355,21 +1301,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -1388,7 +1329,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -1400,7 +1341,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -1419,7 +1360,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1438,12 +1379,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -1462,7 +1401,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1481,7 +1420,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -1500,21 +1439,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -1533,7 +1467,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -1545,7 +1479,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -1564,7 +1498,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1583,12 +1517,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -1607,7 +1539,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1626,7 +1558,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -1645,21 +1577,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -1671,7 +1598,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -1690,7 +1617,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -1709,12 +1636,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -1733,7 +1658,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -1752,7 +1677,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -1771,21 +1696,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -1804,7 +1724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -1816,7 +1736,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -1828,7 +1748,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -1847,7 +1767,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -1859,7 +1779,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -1878,7 +1798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -1897,12 +1817,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -1921,7 +1839,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -1940,7 +1858,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -1959,21 +1877,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -1992,7 +1905,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -2004,7 +1917,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -2023,7 +1936,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -2042,12 +1955,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -2066,7 +1977,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -2085,7 +1996,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -2104,24 +2015,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -2140,7 +2045,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -2152,7 +2057,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -2171,7 +2076,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -2190,12 +2095,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -2214,7 +2117,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -2233,7 +2136,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -2252,21 +2155,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -2285,7 +2183,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -2297,7 +2195,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -2316,7 +2214,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -2335,12 +2233,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -2359,7 +2255,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -2378,7 +2274,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -2397,24 +2293,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -2426,7 +2316,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -2445,7 +2335,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -2464,12 +2354,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -2488,7 +2376,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -2507,7 +2395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -2526,30 +2414,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "nu"
-						origElem := elem
+
 						if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 							elem = elem[l:]
 						} else {
@@ -2561,7 +2441,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'l': // Prefix: "ll"
-							origElem := elem
+
 							if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 								elem = elem[l:]
 							} else {
@@ -2580,7 +2460,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -2592,7 +2472,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -2611,7 +2491,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -2630,12 +2510,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -2654,7 +2532,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -2673,7 +2551,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -2692,21 +2570,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -2725,7 +2598,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -2737,7 +2610,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -2756,7 +2629,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -2775,12 +2648,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "double"
-									origElem := elem
+
 									if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 										elem = elem[l:]
 									} else {
@@ -2799,7 +2670,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -2811,7 +2682,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -2830,7 +2701,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -2849,12 +2720,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -2873,7 +2742,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -2892,7 +2761,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -2911,21 +2780,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -2944,7 +2808,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -2956,7 +2820,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -2975,7 +2839,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -2994,12 +2858,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -3018,7 +2880,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -3037,7 +2899,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3056,21 +2918,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -3082,7 +2939,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -3101,7 +2958,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -3113,7 +2970,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -3132,7 +2989,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3151,12 +3008,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -3175,7 +3030,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3194,7 +3049,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -3213,21 +3068,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -3246,7 +3096,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -3258,7 +3108,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -3277,7 +3127,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3296,12 +3146,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -3320,7 +3168,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3339,7 +3187,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -3358,24 +3206,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -3394,7 +3236,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -3413,7 +3255,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -3432,24 +3274,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "required_"
-						origElem := elem
+
 						if l := len("required_"); len(elem) >= l && elem[0:l] == "required_" {
 							elem = elem[l:]
 						} else {
@@ -3461,7 +3297,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "Any"
-							origElem := elem
+
 							if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 								elem = elem[l:]
 							} else {
@@ -3480,9 +3316,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'E': // Prefix: "EmptyStruct"
-							origElem := elem
+
 							if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 								elem = elem[l:]
 							} else {
@@ -3501,9 +3336,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'F': // Prefix: "FormatTest"
-							origElem := elem
+
 							if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 								elem = elem[l:]
 							} else {
@@ -3522,9 +3356,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'b': // Prefix: "boolean"
-							origElem := elem
+
 							if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 								elem = elem[l:]
 							} else {
@@ -3543,7 +3376,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -3555,7 +3388,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -3574,7 +3407,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -3593,12 +3426,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -3617,7 +3448,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -3636,7 +3467,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -3655,21 +3486,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "integer"
-							origElem := elem
+
 							if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 								elem = elem[l:]
 							} else {
@@ -3688,7 +3514,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -3700,7 +3526,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -3719,7 +3545,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -3738,12 +3564,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -3755,7 +3579,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -3774,7 +3598,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -3786,7 +3610,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -3805,7 +3629,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3824,12 +3648,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -3848,7 +3670,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3867,7 +3689,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -3886,21 +3708,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -3919,7 +3736,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -3931,7 +3748,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -3950,7 +3767,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -3969,12 +3786,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -3993,7 +3808,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -4012,7 +3827,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4031,21 +3846,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -4064,7 +3874,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -4076,7 +3886,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -4095,7 +3905,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -4114,12 +3924,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -4138,7 +3946,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -4157,7 +3965,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4176,21 +3984,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -4209,7 +4012,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -4221,7 +4024,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -4240,7 +4043,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -4259,12 +4062,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -4283,7 +4084,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -4302,7 +4103,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4321,24 +4122,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -4357,7 +4152,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -4376,7 +4171,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -4395,15 +4190,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "u"
-									origElem := elem
+
 									if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 										elem = elem[l:]
 									} else {
@@ -4415,7 +4207,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -4434,7 +4226,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -4453,7 +4245,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -4465,7 +4257,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -4484,7 +4276,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4503,12 +4295,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -4527,7 +4317,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4546,7 +4336,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -4565,21 +4355,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -4598,7 +4383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -4610,7 +4395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -4629,7 +4414,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4648,12 +4433,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -4672,7 +4455,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4691,7 +4474,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -4710,21 +4493,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -4743,7 +4521,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -4755,7 +4533,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -4774,7 +4552,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4793,12 +4571,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -4817,7 +4593,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4836,7 +4612,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -4855,21 +4631,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -4888,7 +4659,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -4900,7 +4671,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -4919,7 +4690,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4938,12 +4709,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -4962,7 +4731,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -4981,7 +4750,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -5000,21 +4769,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -5026,7 +4790,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -5045,7 +4809,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -5064,12 +4828,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -5088,7 +4850,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -5107,7 +4869,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -5126,21 +4888,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nix"
-										origElem := elem
+
 										if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 											elem = elem[l:]
 										} else {
@@ -5159,7 +4916,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-"
-											origElem := elem
+
 											if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 												elem = elem[l:]
 											} else {
@@ -5171,7 +4928,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'm': // Prefix: "mi"
-												origElem := elem
+
 												if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 													elem = elem[l:]
 												} else {
@@ -5183,7 +4940,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "cro"
-													origElem := elem
+
 													if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 														elem = elem[l:]
 													} else {
@@ -5202,7 +4959,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -5214,7 +4971,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -5233,7 +4990,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5252,12 +5009,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -5276,7 +5031,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5295,7 +5050,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -5314,21 +5069,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "lli"
-													origElem := elem
+
 													if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 														elem = elem[l:]
 													} else {
@@ -5347,7 +5097,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -5359,7 +5109,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -5378,7 +5128,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5397,12 +5147,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -5421,7 +5169,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5440,7 +5188,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -5459,24 +5207,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nano"
-												origElem := elem
+
 												if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 													elem = elem[l:]
 												} else {
@@ -5495,7 +5237,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -5507,7 +5249,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -5526,7 +5268,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -5545,12 +5287,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -5569,7 +5309,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -5588,7 +5328,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5607,21 +5347,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "seconds"
-												origElem := elem
+
 												if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 													elem = elem[l:]
 												} else {
@@ -5640,7 +5375,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -5652,7 +5387,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -5671,7 +5406,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -5690,12 +5425,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -5714,7 +5447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -5733,7 +5466,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -5752,24 +5485,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -5781,7 +5508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -5800,7 +5527,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -5819,12 +5546,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -5843,7 +5568,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -5862,7 +5587,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -5881,30 +5606,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "nu"
-							origElem := elem
+
 							if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 								elem = elem[l:]
 							} else {
@@ -5916,7 +5633,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'l': // Prefix: "ll"
-								origElem := elem
+
 								if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 									elem = elem[l:]
 								} else {
@@ -5935,7 +5652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -5947,7 +5664,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -5966,7 +5683,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -5985,12 +5702,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -6009,7 +5724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -6028,7 +5743,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -6047,21 +5762,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mber"
-								origElem := elem
+
 								if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 									elem = elem[l:]
 								} else {
@@ -6080,7 +5790,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -6092,7 +5802,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -6111,7 +5821,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -6130,12 +5840,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "double"
-										origElem := elem
+
 										if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 											elem = elem[l:]
 										} else {
@@ -6154,7 +5862,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -6166,7 +5874,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -6185,7 +5893,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -6204,12 +5912,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -6228,7 +5934,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -6247,7 +5953,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6266,21 +5972,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'f': // Prefix: "float"
-										origElem := elem
+
 										if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 											elem = elem[l:]
 										} else {
@@ -6299,7 +6000,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -6311,7 +6012,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -6330,7 +6031,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -6349,12 +6050,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -6373,7 +6072,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -6392,7 +6091,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6411,21 +6110,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -6437,7 +6131,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -6456,7 +6150,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -6468,7 +6162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -6487,7 +6181,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6506,12 +6200,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -6530,7 +6222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6549,7 +6241,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -6568,21 +6260,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -6601,7 +6288,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -6613,7 +6300,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -6632,7 +6319,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6651,12 +6338,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -6675,7 +6360,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -6694,7 +6379,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -6713,24 +6398,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -6749,7 +6428,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -6768,7 +6447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -6787,24 +6466,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "string"
-							origElem := elem
+
 							if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 								elem = elem[l:]
 							} else {
@@ -6823,7 +6496,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -6835,7 +6508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -6854,7 +6527,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -6873,12 +6546,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "b"
-									origElem := elem
+
 									if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 										elem = elem[l:]
 									} else {
@@ -6890,7 +6561,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "ase64"
-										origElem := elem
+
 										if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 											elem = elem[l:]
 										} else {
@@ -6909,7 +6580,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -6921,7 +6592,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -6940,7 +6611,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -6959,12 +6630,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -6983,7 +6652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7002,7 +6671,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7021,21 +6690,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "inary"
-										origElem := elem
+
 										if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 											elem = elem[l:]
 										} else {
@@ -7054,7 +6718,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -7066,7 +6730,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -7085,7 +6749,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7104,12 +6768,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -7128,7 +6790,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7147,7 +6809,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7166,21 +6828,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'y': // Prefix: "yte"
-										origElem := elem
+
 										if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 											elem = elem[l:]
 										} else {
@@ -7199,7 +6856,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -7211,7 +6868,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -7230,7 +6887,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7249,12 +6906,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -7273,7 +6928,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7292,7 +6947,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7311,24 +6966,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "d"
-									origElem := elem
+
 									if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 										elem = elem[l:]
 									} else {
@@ -7340,7 +6989,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "ate"
-										origElem := elem
+
 										if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 											elem = elem[l:]
 										} else {
@@ -7359,7 +7008,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-time"
-											origElem := elem
+
 											if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 												elem = elem[l:]
 											} else {
@@ -7378,7 +7027,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -7390,7 +7039,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -7409,7 +7058,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7428,12 +7077,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -7452,7 +7099,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7471,7 +7118,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -7490,21 +7137,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -7516,7 +7158,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -7535,7 +7177,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7554,12 +7196,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -7578,7 +7218,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7597,7 +7237,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7616,21 +7256,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'u': // Prefix: "uration"
-										origElem := elem
+
 										if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 											elem = elem[l:]
 										} else {
@@ -7649,7 +7284,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -7661,7 +7296,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -7680,7 +7315,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7699,12 +7334,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -7723,7 +7356,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7742,7 +7375,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -7761,24 +7394,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'e': // Prefix: "email"
-									origElem := elem
+
 									if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 										elem = elem[l:]
 									} else {
@@ -7797,7 +7424,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -7809,7 +7436,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -7828,7 +7455,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -7847,12 +7474,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -7871,7 +7496,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -7890,7 +7515,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -7909,21 +7534,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -7935,7 +7555,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -7954,7 +7574,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -7966,7 +7586,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -7985,7 +7605,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -8004,12 +7624,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -8028,7 +7646,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -8047,7 +7665,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8066,21 +7684,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -8099,7 +7712,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -8111,7 +7724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -8130,7 +7743,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -8149,12 +7762,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -8173,7 +7784,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -8192,7 +7803,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8211,24 +7822,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hostname"
-									origElem := elem
+
 									if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 										elem = elem[l:]
 									} else {
@@ -8247,7 +7852,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -8259,7 +7864,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -8278,7 +7883,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -8297,12 +7902,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -8321,7 +7924,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -8340,7 +7943,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -8359,21 +7962,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "i"
-									origElem := elem
+
 									if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 										elem = elem[l:]
 									} else {
@@ -8385,7 +7983,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "nt"
-										origElem := elem
+
 										if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 											elem = elem[l:]
 										} else {
@@ -8404,7 +8002,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -8423,7 +8021,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -8435,7 +8033,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -8454,7 +8052,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8473,12 +8071,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -8497,7 +8093,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8516,7 +8112,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -8535,21 +8131,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -8568,7 +8159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -8580,7 +8171,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -8599,7 +8190,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8618,12 +8209,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -8642,7 +8231,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8661,7 +8250,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -8680,21 +8269,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -8713,7 +8297,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -8725,7 +8309,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -8744,7 +8328,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8763,12 +8347,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -8787,7 +8369,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8806,7 +8388,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -8825,21 +8407,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -8858,7 +8435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -8870,7 +8447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -8889,7 +8466,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8908,12 +8485,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -8932,7 +8507,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -8951,7 +8526,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -8970,21 +8545,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -8996,7 +8566,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -9015,7 +8585,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9034,12 +8604,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -9058,7 +8626,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9077,7 +8645,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -9096,21 +8664,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "p"
-										origElem := elem
+
 										if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 											elem = elem[l:]
 										} else {
@@ -9129,7 +8692,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -9141,7 +8704,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -9160,7 +8723,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9179,12 +8742,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -9203,7 +8764,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9222,7 +8783,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -9241,18 +8802,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "v"
-											origElem := elem
+
 											if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 												elem = elem[l:]
 											} else {
@@ -9264,7 +8821,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '4': // Prefix: "4"
-												origElem := elem
+
 												if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 													elem = elem[l:]
 												} else {
@@ -9283,7 +8840,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -9295,7 +8852,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -9314,7 +8871,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -9333,12 +8890,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -9357,7 +8912,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -9376,7 +8931,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -9395,21 +8950,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case '6': // Prefix: "6"
-												origElem := elem
+
 												if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 													elem = elem[l:]
 												} else {
@@ -9428,7 +8978,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -9440,7 +8990,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -9459,7 +9009,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -9478,12 +9028,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -9502,7 +9050,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -9521,7 +9069,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -9540,30 +9088,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'm': // Prefix: "mac"
-									origElem := elem
+
 									if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 										elem = elem[l:]
 									} else {
@@ -9582,7 +9122,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -9594,7 +9134,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -9613,7 +9153,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -9632,12 +9172,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -9656,7 +9194,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -9675,7 +9213,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9694,21 +9232,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -9727,7 +9260,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -9746,7 +9279,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -9765,15 +9298,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "password"
-									origElem := elem
+
 									if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 										elem = elem[l:]
 									} else {
@@ -9792,7 +9322,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -9804,7 +9334,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -9823,7 +9353,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -9842,12 +9372,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -9866,7 +9394,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -9885,7 +9413,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -9904,21 +9432,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 't': // Prefix: "time"
-									origElem := elem
+
 									if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 										elem = elem[l:]
 									} else {
@@ -9937,7 +9460,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -9949,7 +9472,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -9968,7 +9491,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -9987,12 +9510,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -10011,7 +9532,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -10030,7 +9551,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -10049,21 +9570,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "u"
-									origElem := elem
+
 									if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 										elem = elem[l:]
 									} else {
@@ -10075,7 +9591,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -10094,7 +9610,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -10113,7 +9629,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -10125,7 +9641,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -10144,7 +9660,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10163,12 +9679,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -10187,7 +9701,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10206,7 +9720,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -10225,21 +9739,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -10258,7 +9767,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -10270,7 +9779,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -10289,7 +9798,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10308,12 +9817,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -10332,7 +9839,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10351,7 +9858,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -10370,21 +9877,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -10403,7 +9905,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -10415,7 +9917,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -10434,7 +9936,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10453,12 +9955,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -10477,7 +9977,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10496,7 +9996,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -10515,21 +10015,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -10548,7 +10043,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -10560,7 +10055,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -10579,7 +10074,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10598,12 +10093,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -10622,7 +10115,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10641,7 +10134,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -10660,21 +10153,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -10686,7 +10174,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -10705,7 +10193,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -10724,12 +10212,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -10748,7 +10234,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -10767,7 +10253,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -10786,21 +10272,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nix"
-										origElem := elem
+
 										if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 											elem = elem[l:]
 										} else {
@@ -10819,7 +10300,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-"
-											origElem := elem
+
 											if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 												elem = elem[l:]
 											} else {
@@ -10831,7 +10312,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'm': // Prefix: "mi"
-												origElem := elem
+
 												if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 													elem = elem[l:]
 												} else {
@@ -10843,7 +10324,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "cro"
-													origElem := elem
+
 													if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 														elem = elem[l:]
 													} else {
@@ -10862,7 +10343,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -10874,7 +10355,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -10893,7 +10374,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -10912,12 +10393,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -10936,7 +10415,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -10955,7 +10434,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -10974,21 +10453,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "lli"
-													origElem := elem
+
 													if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 														elem = elem[l:]
 													} else {
@@ -11007,7 +10481,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -11019,7 +10493,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -11038,7 +10512,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -11057,12 +10531,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -11081,7 +10553,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -11100,7 +10572,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -11119,24 +10591,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																		return
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nano"
-												origElem := elem
+
 												if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 													elem = elem[l:]
 												} else {
@@ -11155,7 +10621,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -11167,7 +10633,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -11186,7 +10652,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -11205,12 +10671,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -11229,7 +10693,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -11248,7 +10712,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -11267,21 +10731,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "seconds"
-												origElem := elem
+
 												if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 													elem = elem[l:]
 												} else {
@@ -11300,7 +10759,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -11312,7 +10771,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -11331,7 +10790,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -11350,12 +10809,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -11374,7 +10831,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -11393,7 +10850,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -11412,24 +10869,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -11441,7 +10892,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -11460,7 +10911,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11479,12 +10930,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -11503,7 +10952,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11522,7 +10971,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -11541,21 +10990,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "ri"
-										origElem := elem
+
 										if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 											elem = elem[l:]
 										} else {
@@ -11574,7 +11018,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -11586,7 +11030,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -11605,7 +11049,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11624,12 +11068,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -11648,7 +11090,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11667,7 +11109,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -11686,21 +11128,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'u': // Prefix: "uid"
-										origElem := elem
+
 										if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 											elem = elem[l:]
 										} else {
@@ -11719,7 +11156,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -11731,7 +11168,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -11750,7 +11187,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11769,12 +11206,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -11793,7 +11228,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -11812,7 +11247,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -11831,33 +11266,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "string"
-						origElem := elem
+
 						if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 							elem = elem[l:]
 						} else {
@@ -11876,7 +11302,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -11888,7 +11314,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -11907,7 +11333,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -11926,12 +11352,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "b"
-								origElem := elem
+
 								if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 									elem = elem[l:]
 								} else {
@@ -11943,7 +11367,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ase64"
-									origElem := elem
+
 									if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 										elem = elem[l:]
 									} else {
@@ -11962,7 +11386,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -11974,7 +11398,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -11993,7 +11417,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12012,12 +11436,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -12036,7 +11458,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12055,7 +11477,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12074,21 +11496,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "inary"
-									origElem := elem
+
 									if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 										elem = elem[l:]
 									} else {
@@ -12107,7 +11524,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -12119,7 +11536,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -12138,7 +11555,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12157,12 +11574,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -12181,7 +11596,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12200,7 +11615,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12219,21 +11634,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'y': // Prefix: "yte"
-									origElem := elem
+
 									if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 										elem = elem[l:]
 									} else {
@@ -12252,7 +11662,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -12264,7 +11674,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -12283,7 +11693,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12302,12 +11712,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -12326,7 +11734,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12345,7 +11753,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12364,24 +11772,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "d"
-								origElem := elem
+
 								if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 									elem = elem[l:]
 								} else {
@@ -12393,7 +11795,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ate"
-									origElem := elem
+
 									if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 										elem = elem[l:]
 									} else {
@@ -12412,7 +11814,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-time"
-										origElem := elem
+
 										if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 											elem = elem[l:]
 										} else {
@@ -12431,7 +11833,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -12443,7 +11845,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -12462,7 +11864,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12481,12 +11883,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -12505,7 +11905,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12524,7 +11924,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -12543,21 +11943,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -12569,7 +11964,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -12588,7 +11983,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12607,12 +12002,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -12631,7 +12024,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12650,7 +12043,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12669,21 +12062,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uration"
-									origElem := elem
+
 									if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 										elem = elem[l:]
 									} else {
@@ -12702,7 +12090,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -12714,7 +12102,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -12733,7 +12121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12752,12 +12140,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -12776,7 +12162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12795,7 +12181,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -12814,24 +12200,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "email"
-								origElem := elem
+
 								if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 									elem = elem[l:]
 								} else {
@@ -12850,7 +12230,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -12862,7 +12242,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -12881,7 +12261,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -12900,12 +12280,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -12924,7 +12302,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -12943,7 +12321,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -12962,21 +12340,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "float"
-								origElem := elem
+
 								if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 									elem = elem[l:]
 								} else {
@@ -12988,7 +12361,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -13007,7 +12380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -13019,7 +12392,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -13038,7 +12411,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -13057,12 +12430,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -13081,7 +12452,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -13100,7 +12471,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13119,21 +12490,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -13152,7 +12518,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -13164,7 +12530,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -13183,7 +12549,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -13202,12 +12568,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -13226,7 +12590,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -13245,7 +12609,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13264,24 +12628,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hostname"
-								origElem := elem
+
 								if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 									elem = elem[l:]
 								} else {
@@ -13300,7 +12658,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -13312,7 +12670,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -13331,7 +12689,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -13350,12 +12708,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -13374,7 +12730,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -13393,7 +12749,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -13412,21 +12768,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -13438,7 +12789,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "nt"
-									origElem := elem
+
 									if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 										elem = elem[l:]
 									} else {
@@ -13457,7 +12808,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -13476,7 +12827,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -13488,7 +12839,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -13507,7 +12858,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13526,12 +12877,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -13550,7 +12899,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13569,7 +12918,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -13588,21 +12937,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -13621,7 +12965,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -13633,7 +12977,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -13652,7 +12996,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13671,12 +13015,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -13695,7 +13037,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13714,7 +13056,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -13733,21 +13075,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -13766,7 +13103,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -13778,7 +13115,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -13797,7 +13134,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13816,12 +13153,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -13840,7 +13175,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13859,7 +13194,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -13878,21 +13213,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -13911,7 +13241,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -13923,7 +13253,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -13942,7 +13272,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -13961,12 +13291,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -13985,7 +13313,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -14004,7 +13332,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -14023,21 +13351,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -14049,7 +13372,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -14068,7 +13391,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14087,12 +13410,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -14111,7 +13432,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14130,7 +13451,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -14149,21 +13470,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "p"
-									origElem := elem
+
 									if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 										elem = elem[l:]
 									} else {
@@ -14182,7 +13498,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -14194,7 +13510,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -14213,7 +13529,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14232,12 +13548,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -14256,7 +13570,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14275,7 +13589,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -14294,18 +13608,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "v"
-										origElem := elem
+
 										if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 											elem = elem[l:]
 										} else {
@@ -14317,7 +13627,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '4': // Prefix: "4"
-											origElem := elem
+
 											if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 												elem = elem[l:]
 											} else {
@@ -14336,7 +13646,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -14348,7 +13658,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -14367,7 +13677,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -14386,12 +13696,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -14410,7 +13718,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -14429,7 +13737,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -14448,21 +13756,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "6"
-											origElem := elem
+
 											if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 												elem = elem[l:]
 											} else {
@@ -14481,7 +13784,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -14493,7 +13796,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -14512,7 +13815,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -14531,12 +13834,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -14555,7 +13856,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -14574,7 +13875,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -14593,30 +13894,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mac"
-								origElem := elem
+
 								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 									elem = elem[l:]
 								} else {
@@ -14635,7 +13928,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -14647,7 +13940,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -14666,7 +13959,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -14685,12 +13978,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -14709,7 +14000,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -14728,7 +14019,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14747,21 +14038,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -14780,7 +14066,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -14799,7 +14085,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -14818,15 +14104,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "password"
-								origElem := elem
+
 								if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 									elem = elem[l:]
 								} else {
@@ -14845,7 +14128,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -14857,7 +14140,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -14876,7 +14159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -14895,12 +14178,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -14919,7 +14200,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -14938,7 +14219,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -14957,21 +14238,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "time"
-								origElem := elem
+
 								if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 									elem = elem[l:]
 								} else {
@@ -14990,7 +14266,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -15002,7 +14278,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -15021,7 +14297,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -15040,12 +14316,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -15064,7 +14338,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -15083,7 +14357,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -15102,21 +14376,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -15128,7 +14397,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -15147,7 +14416,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -15166,7 +14435,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -15178,7 +14447,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -15197,7 +14466,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15216,12 +14485,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -15240,7 +14507,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15259,7 +14526,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -15278,21 +14545,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -15311,7 +14573,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -15323,7 +14585,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -15342,7 +14604,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15361,12 +14623,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -15385,7 +14645,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15404,7 +14664,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -15423,21 +14683,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -15456,7 +14711,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -15468,7 +14723,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -15487,7 +14742,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15506,12 +14761,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -15530,7 +14783,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15549,7 +14802,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -15568,21 +14821,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -15601,7 +14849,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -15613,7 +14861,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -15632,7 +14880,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15651,12 +14899,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -15675,7 +14921,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15694,7 +14940,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -15713,21 +14959,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -15739,7 +14980,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -15758,7 +14999,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -15777,12 +15018,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -15801,7 +15040,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -15820,7 +15059,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -15839,21 +15078,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -15872,7 +15106,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -15884,7 +15118,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -15896,7 +15130,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -15915,7 +15149,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -15927,7 +15161,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -15946,7 +15180,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -15965,12 +15199,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -15989,7 +15221,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -16008,7 +15240,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -16027,21 +15259,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -16060,7 +15287,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -16072,7 +15299,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -16091,7 +15318,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -16110,12 +15337,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -16134,7 +15359,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -16153,7 +15378,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -16172,24 +15397,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -16208,7 +15427,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -16220,7 +15439,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -16239,7 +15458,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -16258,12 +15477,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -16282,7 +15499,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -16301,7 +15518,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -16320,21 +15537,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -16353,7 +15565,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -16365,7 +15577,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -16384,7 +15596,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -16403,12 +15615,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -16427,7 +15637,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -16446,7 +15656,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -16465,24 +15675,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -16494,7 +15698,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -16513,7 +15717,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16532,12 +15736,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -16556,7 +15758,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16575,7 +15777,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -16594,21 +15796,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "ri"
-									origElem := elem
+
 									if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 										elem = elem[l:]
 									} else {
@@ -16627,7 +15824,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -16639,7 +15836,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -16658,7 +15855,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16677,12 +15874,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -16701,7 +15896,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16720,7 +15915,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -16739,21 +15934,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uid"
-									origElem := elem
+
 									if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 										elem = elem[l:]
 									} else {
@@ -16772,7 +15962,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -16784,7 +15974,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -16803,7 +15993,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16822,12 +16012,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -16846,7 +16034,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -16865,7 +16053,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -16884,33 +16072,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "sponse_"
-					origElem := elem
+
 					if l := len("sponse_"); len(elem) >= l && elem[0:l] == "sponse_" {
 						elem = elem[l:]
 					} else {
@@ -16922,7 +16101,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Any"
-						origElem := elem
+
 						if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 							elem = elem[l:]
 						} else {
@@ -16941,9 +16120,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptyStruct"
-						origElem := elem
+
 						if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 							elem = elem[l:]
 						} else {
@@ -16962,9 +16140,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'F': // Prefix: "FormatTest"
-						origElem := elem
+
 						if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 							elem = elem[l:]
 						} else {
@@ -16983,9 +16160,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boolean"
-						origElem := elem
+
 						if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 							elem = elem[l:]
 						} else {
@@ -17004,7 +16180,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -17016,7 +16192,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -17035,7 +16211,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -17054,12 +16230,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -17078,7 +16252,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -17097,7 +16271,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -17116,21 +16290,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "integer"
-						origElem := elem
+
 						if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 							elem = elem[l:]
 						} else {
@@ -17149,7 +16318,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -17161,7 +16330,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -17180,7 +16349,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -17199,12 +16368,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "int"
-								origElem := elem
+
 								if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 									elem = elem[l:]
 								} else {
@@ -17216,7 +16383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '1': // Prefix: "16"
-									origElem := elem
+
 									if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 										elem = elem[l:]
 									} else {
@@ -17235,7 +16402,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -17247,7 +16414,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -17266,7 +16433,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17285,12 +16452,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -17309,7 +16474,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17328,7 +16493,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -17347,21 +16512,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -17380,7 +16540,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -17392,7 +16552,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -17411,7 +16571,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17430,12 +16590,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -17454,7 +16612,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17473,7 +16631,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -17492,21 +16650,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -17525,7 +16678,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -17537,7 +16690,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -17556,7 +16709,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17575,12 +16728,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -17599,7 +16750,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17618,7 +16769,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -17637,21 +16788,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '8': // Prefix: "8"
-									origElem := elem
+
 									if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 										elem = elem[l:]
 									} else {
@@ -17670,7 +16816,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -17682,7 +16828,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -17701,7 +16847,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17720,12 +16866,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -17744,7 +16888,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -17763,7 +16907,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -17782,24 +16926,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -17818,7 +16956,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -17837,7 +16975,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -17856,15 +16994,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -17876,7 +17011,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -17895,7 +17030,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -17914,7 +17049,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -17926,7 +17061,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -17945,7 +17080,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -17964,12 +17099,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -17988,7 +17121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18007,7 +17140,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -18026,21 +17159,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -18059,7 +17187,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -18071,7 +17199,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -18090,7 +17218,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18109,12 +17237,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -18133,7 +17259,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18152,7 +17278,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -18171,21 +17297,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -18204,7 +17325,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -18216,7 +17337,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -18235,7 +17356,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18254,12 +17375,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -18278,7 +17397,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18297,7 +17416,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -18316,21 +17435,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -18349,7 +17463,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -18361,7 +17475,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -18380,7 +17494,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18399,12 +17513,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -18423,7 +17535,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18442,7 +17554,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -18461,21 +17573,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -18487,7 +17594,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -18506,7 +17613,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -18525,12 +17632,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -18549,7 +17654,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -18568,7 +17673,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -18587,21 +17692,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -18620,7 +17720,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -18632,7 +17732,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -18644,7 +17744,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -18663,7 +17763,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -18675,7 +17775,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -18694,7 +17794,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -18713,12 +17813,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -18737,7 +17835,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -18756,7 +17854,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -18775,21 +17873,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -18808,7 +17901,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -18820,7 +17913,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -18839,7 +17932,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -18858,12 +17951,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -18882,7 +17973,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -18901,7 +17992,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -18920,24 +18011,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -18956,7 +18041,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -18968,7 +18053,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -18987,7 +18072,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -19006,12 +18091,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -19030,7 +18113,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -19049,7 +18132,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -19068,21 +18151,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -19101,7 +18179,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -19113,7 +18191,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -19132,7 +18210,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -19151,12 +18229,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -19175,7 +18251,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -19194,7 +18270,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -19213,24 +18289,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -19242,7 +18312,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -19261,7 +18331,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19280,12 +18350,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -19304,7 +18372,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19323,7 +18391,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -19342,30 +18410,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "nu"
-						origElem := elem
+
 						if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 							elem = elem[l:]
 						} else {
@@ -19377,7 +18437,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'l': // Prefix: "ll"
-							origElem := elem
+
 							if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 								elem = elem[l:]
 							} else {
@@ -19396,7 +18456,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -19408,7 +18468,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -19427,7 +18487,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -19446,12 +18506,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -19470,7 +18528,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -19489,7 +18547,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -19508,21 +18566,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -19541,7 +18594,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -19553,7 +18606,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -19572,7 +18625,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -19591,12 +18644,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "double"
-									origElem := elem
+
 									if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 										elem = elem[l:]
 									} else {
@@ -19615,7 +18666,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -19627,7 +18678,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -19646,7 +18697,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19665,12 +18716,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -19689,7 +18738,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19708,7 +18757,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -19727,21 +18776,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -19760,7 +18804,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -19772,7 +18816,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -19791,7 +18835,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19810,12 +18854,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -19834,7 +18876,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -19853,7 +18895,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -19872,21 +18914,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -19898,7 +18935,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -19917,7 +18954,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -19929,7 +18966,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -19948,7 +18985,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -19967,12 +19004,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -19991,7 +19026,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20010,7 +19045,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -20029,21 +19064,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -20062,7 +19092,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -20074,7 +19104,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -20093,7 +19123,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20112,12 +19142,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -20136,7 +19164,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20155,7 +19183,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -20174,24 +19202,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -20210,7 +19232,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -20229,7 +19251,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -20248,24 +19270,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "string"
-						origElem := elem
+
 						if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 							elem = elem[l:]
 						} else {
@@ -20284,7 +19300,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -20296,7 +19312,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -20315,7 +19331,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -20334,12 +19350,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "b"
-								origElem := elem
+
 								if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 									elem = elem[l:]
 								} else {
@@ -20351,7 +19365,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ase64"
-									origElem := elem
+
 									if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 										elem = elem[l:]
 									} else {
@@ -20370,7 +19384,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -20382,7 +19396,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -20401,7 +19415,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20420,12 +19434,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -20444,7 +19456,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20463,7 +19475,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20482,21 +19494,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "inary"
-									origElem := elem
+
 									if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 										elem = elem[l:]
 									} else {
@@ -20515,7 +19522,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -20527,7 +19534,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -20546,7 +19553,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20565,12 +19572,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -20589,7 +19594,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20608,7 +19613,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20627,21 +19632,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'y': // Prefix: "yte"
-									origElem := elem
+
 									if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 										elem = elem[l:]
 									} else {
@@ -20660,7 +19660,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -20672,7 +19672,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -20691,7 +19691,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20710,12 +19710,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -20734,7 +19732,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -20753,7 +19751,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20772,24 +19770,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "d"
-								origElem := elem
+
 								if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 									elem = elem[l:]
 								} else {
@@ -20801,7 +19793,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ate"
-									origElem := elem
+
 									if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 										elem = elem[l:]
 									} else {
@@ -20820,7 +19812,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-time"
-										origElem := elem
+
 										if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 											elem = elem[l:]
 										} else {
@@ -20839,7 +19831,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -20851,7 +19843,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -20870,7 +19862,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20889,12 +19881,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -20913,7 +19903,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -20932,7 +19922,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -20951,21 +19941,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -20977,7 +19962,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -20996,7 +19981,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21015,12 +20000,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -21039,7 +20022,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21058,7 +20041,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21077,21 +20060,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uration"
-									origElem := elem
+
 									if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 										elem = elem[l:]
 									} else {
@@ -21110,7 +20088,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -21122,7 +20100,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -21141,7 +20119,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21160,12 +20138,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -21184,7 +20160,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21203,7 +20179,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21222,24 +20198,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "email"
-								origElem := elem
+
 								if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 									elem = elem[l:]
 								} else {
@@ -21258,7 +20228,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -21270,7 +20240,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -21289,7 +20259,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -21308,12 +20278,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -21332,7 +20300,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -21351,7 +20319,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21370,21 +20338,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "float"
-								origElem := elem
+
 								if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 									elem = elem[l:]
 								} else {
@@ -21396,7 +20359,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -21415,7 +20378,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -21427,7 +20390,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -21446,7 +20409,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21465,12 +20428,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -21489,7 +20450,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21508,7 +20469,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21527,21 +20488,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -21560,7 +20516,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -21572,7 +20528,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -21591,7 +20547,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21610,12 +20566,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -21634,7 +20588,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21653,7 +20607,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21672,24 +20626,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hostname"
-								origElem := elem
+
 								if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 									elem = elem[l:]
 								} else {
@@ -21708,7 +20656,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -21720,7 +20668,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -21739,7 +20687,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -21758,12 +20706,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -21782,7 +20728,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -21801,7 +20747,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -21820,21 +20766,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -21846,7 +20787,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "nt"
-									origElem := elem
+
 									if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 										elem = elem[l:]
 									} else {
@@ -21865,7 +20806,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -21884,7 +20825,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -21896,7 +20837,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -21915,7 +20856,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21934,12 +20875,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -21958,7 +20897,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -21977,7 +20916,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -21996,21 +20935,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -22029,7 +20963,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -22041,7 +20975,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -22060,7 +20994,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22079,12 +21013,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -22103,7 +21035,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22122,7 +21054,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22141,21 +21073,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -22174,7 +21101,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -22186,7 +21113,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -22205,7 +21132,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22224,12 +21151,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -22248,7 +21173,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22267,7 +21192,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22286,21 +21211,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -22319,7 +21239,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -22331,7 +21251,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -22350,7 +21270,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22369,12 +21289,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -22393,7 +21311,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22412,7 +21330,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22431,21 +21349,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -22457,7 +21370,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -22476,7 +21389,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -22495,12 +21408,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -22519,7 +21430,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -22538,7 +21449,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22557,21 +21468,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "p"
-									origElem := elem
+
 									if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 										elem = elem[l:]
 									} else {
@@ -22590,7 +21496,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -22602,7 +21508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -22621,7 +21527,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -22640,12 +21546,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -22664,7 +21568,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -22683,7 +21587,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -22702,18 +21606,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "v"
-										origElem := elem
+
 										if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 											elem = elem[l:]
 										} else {
@@ -22725,7 +21625,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '4': // Prefix: "4"
-											origElem := elem
+
 											if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 												elem = elem[l:]
 											} else {
@@ -22744,7 +21644,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -22756,7 +21656,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -22775,7 +21675,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22794,12 +21694,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -22818,7 +21716,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22837,7 +21735,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -22856,21 +21754,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "6"
-											origElem := elem
+
 											if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 												elem = elem[l:]
 											} else {
@@ -22889,7 +21782,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -22901,7 +21794,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -22920,7 +21813,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22939,12 +21832,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -22963,7 +21854,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -22982,7 +21873,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -23001,30 +21892,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mac"
-								origElem := elem
+
 								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 									elem = elem[l:]
 								} else {
@@ -23043,7 +21926,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -23055,7 +21938,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -23074,7 +21957,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23093,12 +21976,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -23117,7 +21998,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23136,7 +22017,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -23155,21 +22036,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -23188,7 +22064,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -23207,7 +22083,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -23226,15 +22102,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											return
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "password"
-								origElem := elem
+
 								if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 									elem = elem[l:]
 								} else {
@@ -23253,7 +22126,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -23265,7 +22138,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -23284,7 +22157,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23303,12 +22176,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -23327,7 +22198,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23346,7 +22217,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -23365,21 +22236,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "time"
-								origElem := elem
+
 								if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 									elem = elem[l:]
 								} else {
@@ -23398,7 +22264,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -23410,7 +22276,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -23429,7 +22295,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23448,12 +22314,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												return
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -23472,7 +22336,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -23491,7 +22355,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -23510,21 +22374,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -23536,7 +22395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -23555,7 +22414,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -23574,7 +22433,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -23586,7 +22445,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -23605,7 +22464,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23624,12 +22483,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -23648,7 +22505,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23667,7 +22524,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -23686,21 +22543,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -23719,7 +22571,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -23731,7 +22583,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -23750,7 +22602,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23769,12 +22621,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -23793,7 +22643,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23812,7 +22662,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -23831,21 +22681,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -23864,7 +22709,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -23876,7 +22721,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -23895,7 +22740,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23914,12 +22759,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -23938,7 +22781,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -23957,7 +22800,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -23976,21 +22819,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -24009,7 +22847,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -24021,7 +22859,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -24040,7 +22878,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -24059,12 +22897,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -24083,7 +22919,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -24102,7 +22938,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -24121,21 +22957,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -24147,7 +22978,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -24166,7 +22997,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -24185,12 +23016,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -24209,7 +23038,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -24228,7 +23057,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -24247,21 +23076,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -24280,7 +23104,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -24292,7 +23116,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -24304,7 +23128,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -24323,7 +23147,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -24335,7 +23159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -24354,7 +23178,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24373,12 +23197,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -24397,7 +23219,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24416,7 +23238,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -24435,21 +23257,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -24468,7 +23285,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -24480,7 +23297,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -24499,7 +23316,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24518,12 +23335,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -24542,7 +23357,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24561,7 +23376,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -24580,24 +23395,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																	return
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -24616,7 +23425,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -24628,7 +23437,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -24647,7 +23456,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -24666,12 +23475,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -24690,7 +23497,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -24709,7 +23516,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24728,21 +23535,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -24761,7 +23563,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -24773,7 +23575,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -24792,7 +23594,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -24811,12 +23613,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 															return
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -24835,7 +23635,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -24854,7 +23654,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -24873,24 +23673,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 																return
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -24902,7 +23696,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -24921,7 +23715,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -24940,12 +23734,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -24964,7 +23756,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -24983,7 +23775,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -25002,21 +23794,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "ri"
-									origElem := elem
+
 									if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 										elem = elem[l:]
 									} else {
@@ -25035,7 +23822,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -25047,7 +23834,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -25066,7 +23853,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25085,12 +23872,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -25109,7 +23894,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25128,7 +23913,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -25147,21 +23932,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uid"
-									origElem := elem
+
 									if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 										elem = elem[l:]
 									} else {
@@ -25180,7 +23960,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -25192,7 +23972,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -25211,7 +23991,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25230,12 +24010,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 													return
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -25254,7 +24032,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25273,7 +24051,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -25292,37 +24070,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 														return
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -25404,7 +24171,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/test_"
-			origElem := elem
+
 			if l := len("/test_"); len(elem) >= l && elem[0:l] == "/test_" {
 				elem = elem[l:]
 			} else {
@@ -25416,7 +24183,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'q': // Prefix: "query_parameter"
-				origElem := elem
+
 				if l := len("query_parameter"); len(elem) >= l && elem[0:l] == "query_parameter" {
 					elem = elem[l:]
 				} else {
@@ -25439,9 +24206,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "re"
-				origElem := elem
+
 				if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 					elem = elem[l:]
 				} else {
@@ -25453,7 +24219,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'q': // Prefix: "quest_"
-					origElem := elem
+
 					if l := len("quest_"); len(elem) >= l && elem[0:l] == "quest_" {
 						elem = elem[l:]
 					} else {
@@ -25465,7 +24231,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Any"
-						origElem := elem
+
 						if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 							elem = elem[l:]
 						} else {
@@ -25488,9 +24254,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptyStruct"
-						origElem := elem
+
 						if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 							elem = elem[l:]
 						} else {
@@ -25513,9 +24278,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'F': // Prefix: "FormatTest"
-						origElem := elem
+
 						if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 							elem = elem[l:]
 						} else {
@@ -25538,9 +24302,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boolean"
-						origElem := elem
+
 						if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 							elem = elem[l:]
 						} else {
@@ -25563,7 +24326,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -25575,7 +24338,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -25598,7 +24361,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -25621,12 +24384,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -25649,7 +24410,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -25672,7 +24433,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -25695,21 +24456,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "integer"
-						origElem := elem
+
 						if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 							elem = elem[l:]
 						} else {
@@ -25732,7 +24488,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -25744,7 +24500,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -25767,7 +24523,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -25790,12 +24546,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "int"
-								origElem := elem
+
 								if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 									elem = elem[l:]
 								} else {
@@ -25807,7 +24561,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '1': // Prefix: "16"
-									origElem := elem
+
 									if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 										elem = elem[l:]
 									} else {
@@ -25830,7 +24584,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -25842,7 +24596,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -25865,7 +24619,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25888,12 +24642,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -25916,7 +24668,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -25939,7 +24691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -25962,21 +24714,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -25999,7 +24746,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -26011,7 +24758,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -26034,7 +24781,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26057,12 +24804,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -26085,7 +24830,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26108,7 +24853,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26131,21 +24876,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -26168,7 +24908,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -26180,7 +24920,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -26203,7 +24943,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26226,12 +24966,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -26254,7 +24992,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26277,7 +25015,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26300,21 +25038,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '8': // Prefix: "8"
-									origElem := elem
+
 									if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 										elem = elem[l:]
 									} else {
@@ -26337,7 +25070,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -26349,7 +25082,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -26372,7 +25105,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26395,12 +25128,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -26423,7 +25154,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -26446,7 +25177,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26469,24 +25200,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -26509,7 +25234,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -26532,7 +25257,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -26555,15 +25280,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -26575,7 +25297,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -26598,7 +25320,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -26621,7 +25343,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -26633,7 +25355,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -26656,7 +25378,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26679,12 +25401,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -26707,7 +25427,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26730,7 +25450,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -26753,21 +25473,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -26790,7 +25505,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -26802,7 +25517,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -26825,7 +25540,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26848,12 +25563,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -26876,7 +25589,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -26899,7 +25612,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -26922,21 +25635,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -26959,7 +25667,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -26971,7 +25679,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -26994,7 +25702,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -27017,12 +25725,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -27045,7 +25751,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -27068,7 +25774,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -27091,21 +25797,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -27128,7 +25829,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -27140,7 +25841,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -27163,7 +25864,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -27186,12 +25887,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -27214,7 +25913,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -27237,7 +25936,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -27260,21 +25959,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -27286,7 +25980,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -27309,7 +26003,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -27332,12 +26026,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -27360,7 +26052,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -27383,7 +26075,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -27406,21 +26098,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -27443,7 +26130,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -27455,7 +26142,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -27467,7 +26154,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -27490,7 +26177,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -27502,7 +26189,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -27525,7 +26212,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -27548,12 +26235,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -27576,7 +26261,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -27599,7 +26284,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -27622,21 +26307,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -27659,7 +26339,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -27671,7 +26351,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -27694,7 +26374,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -27717,12 +26397,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -27745,7 +26423,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -27768,7 +26446,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -27791,24 +26469,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -27831,7 +26503,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -27843,7 +26515,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -27866,7 +26538,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -27889,12 +26561,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -27917,7 +26587,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -27940,7 +26610,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -27963,21 +26633,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -28000,7 +26665,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -28012,7 +26677,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -28035,7 +26700,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -28058,12 +26723,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -28086,7 +26749,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -28109,7 +26772,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -28132,24 +26795,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -28161,7 +26818,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -28184,7 +26841,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28207,12 +26864,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -28235,7 +26890,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28258,7 +26913,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -28281,30 +26936,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "nu"
-						origElem := elem
+
 						if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 							elem = elem[l:]
 						} else {
@@ -28316,7 +26963,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'l': // Prefix: "ll"
-							origElem := elem
+
 							if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 								elem = elem[l:]
 							} else {
@@ -28339,7 +26986,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -28351,7 +26998,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -28374,7 +27021,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -28397,12 +27044,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -28425,7 +27070,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -28448,7 +27093,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -28471,21 +27116,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -28508,7 +27148,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -28520,7 +27160,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -28543,7 +27183,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -28566,12 +27206,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "double"
-									origElem := elem
+
 									if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 										elem = elem[l:]
 									} else {
@@ -28594,7 +27232,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -28606,7 +27244,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -28629,7 +27267,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28652,12 +27290,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -28680,7 +27316,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28703,7 +27339,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -28726,21 +27362,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -28763,7 +27394,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -28775,7 +27406,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -28798,7 +27429,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28821,12 +27452,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -28849,7 +27478,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -28872,7 +27501,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -28895,21 +27524,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -28921,7 +27545,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -28944,7 +27568,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -28956,7 +27580,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -28979,7 +27603,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29002,12 +27626,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -29030,7 +27652,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29053,7 +27675,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -29076,21 +27698,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -29113,7 +27730,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -29125,7 +27742,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -29148,7 +27765,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29171,12 +27788,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -29199,7 +27814,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29222,7 +27837,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -29245,24 +27860,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -29285,7 +27894,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -29308,7 +27917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -29331,24 +27940,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'r': // Prefix: "required_"
-						origElem := elem
+
 						if l := len("required_"); len(elem) >= l && elem[0:l] == "required_" {
 							elem = elem[l:]
 						} else {
@@ -29360,7 +27963,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'A': // Prefix: "Any"
-							origElem := elem
+
 							if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 								elem = elem[l:]
 							} else {
@@ -29383,9 +27986,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'E': // Prefix: "EmptyStruct"
-							origElem := elem
+
 							if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 								elem = elem[l:]
 							} else {
@@ -29408,9 +28010,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'F': // Prefix: "FormatTest"
-							origElem := elem
+
 							if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 								elem = elem[l:]
 							} else {
@@ -29433,9 +28034,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'b': // Prefix: "boolean"
-							origElem := elem
+
 							if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 								elem = elem[l:]
 							} else {
@@ -29458,7 +28058,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -29470,7 +28070,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -29493,7 +28093,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -29516,12 +28116,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -29544,7 +28142,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -29567,7 +28165,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -29590,21 +28188,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'i': // Prefix: "integer"
-							origElem := elem
+
 							if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 								elem = elem[l:]
 							} else {
@@ -29627,7 +28220,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -29639,7 +28232,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -29662,7 +28255,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -29685,12 +28278,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -29702,7 +28293,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -29725,7 +28316,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -29737,7 +28328,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -29760,7 +28351,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29783,12 +28374,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -29811,7 +28400,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29834,7 +28423,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -29857,21 +28446,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -29894,7 +28478,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -29906,7 +28490,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -29929,7 +28513,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -29952,12 +28536,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -29980,7 +28562,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -30003,7 +28585,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30026,21 +28608,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -30063,7 +28640,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -30075,7 +28652,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -30098,7 +28675,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -30121,12 +28698,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -30149,7 +28724,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -30172,7 +28747,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30195,21 +28770,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -30232,7 +28802,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -30244,7 +28814,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -30267,7 +28837,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -30290,12 +28860,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -30318,7 +28886,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -30341,7 +28909,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30364,24 +28932,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -30404,7 +28966,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -30427,7 +28989,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -30450,15 +29012,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "u"
-									origElem := elem
+
 									if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 										elem = elem[l:]
 									} else {
@@ -30470,7 +29029,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -30493,7 +29052,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -30516,7 +29075,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -30528,7 +29087,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -30551,7 +29110,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30574,12 +29133,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -30602,7 +29159,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30625,7 +29182,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -30648,21 +29205,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -30685,7 +29237,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -30697,7 +29249,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -30720,7 +29272,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30743,12 +29295,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -30771,7 +29321,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30794,7 +29344,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -30817,21 +29367,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -30854,7 +29399,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -30866,7 +29411,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -30889,7 +29434,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30912,12 +29457,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -30940,7 +29483,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -30963,7 +29506,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -30986,21 +29529,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -31023,7 +29561,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -31035,7 +29573,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -31058,7 +29596,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -31081,12 +29619,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -31109,7 +29645,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -31132,7 +29668,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -31155,21 +29691,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -31181,7 +29712,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -31204,7 +29735,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -31227,12 +29758,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -31255,7 +29784,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -31278,7 +29807,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -31301,21 +29830,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nix"
-										origElem := elem
+
 										if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 											elem = elem[l:]
 										} else {
@@ -31338,7 +29862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-"
-											origElem := elem
+
 											if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 												elem = elem[l:]
 											} else {
@@ -31350,7 +29874,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'm': // Prefix: "mi"
-												origElem := elem
+
 												if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 													elem = elem[l:]
 												} else {
@@ -31362,7 +29886,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "cro"
-													origElem := elem
+
 													if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 														elem = elem[l:]
 													} else {
@@ -31385,7 +29909,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -31397,7 +29921,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -31420,7 +29944,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -31443,12 +29967,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -31471,7 +29993,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -31494,7 +30016,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -31517,21 +30039,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "lli"
-													origElem := elem
+
 													if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 														elem = elem[l:]
 													} else {
@@ -31554,7 +30071,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -31566,7 +30083,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -31589,7 +30106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -31612,12 +30129,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -31640,7 +30155,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -31663,7 +30178,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -31686,24 +30201,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nano"
-												origElem := elem
+
 												if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 													elem = elem[l:]
 												} else {
@@ -31726,7 +30235,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -31738,7 +30247,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -31761,7 +30270,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -31784,12 +30293,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -31812,7 +30319,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -31835,7 +30342,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -31858,21 +30365,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "seconds"
-												origElem := elem
+
 												if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 													elem = elem[l:]
 												} else {
@@ -31895,7 +30397,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -31907,7 +30409,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -31930,7 +30432,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -31953,12 +30455,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -31981,7 +30481,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -32004,7 +30504,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -32027,24 +30527,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -32056,7 +30550,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -32079,7 +30573,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32102,12 +30596,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -32130,7 +30622,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32153,7 +30645,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -32176,30 +30668,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'n': // Prefix: "nu"
-							origElem := elem
+
 							if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 								elem = elem[l:]
 							} else {
@@ -32211,7 +30695,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'l': // Prefix: "ll"
-								origElem := elem
+
 								if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 									elem = elem[l:]
 								} else {
@@ -32234,7 +30718,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -32246,7 +30730,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -32269,7 +30753,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -32292,12 +30776,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -32320,7 +30802,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -32343,7 +30825,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -32366,21 +30848,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mber"
-								origElem := elem
+
 								if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 									elem = elem[l:]
 								} else {
@@ -32403,7 +30880,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -32415,7 +30892,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -32438,7 +30915,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -32461,12 +30938,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'd': // Prefix: "double"
-										origElem := elem
+
 										if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 											elem = elem[l:]
 										} else {
@@ -32489,7 +30964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -32501,7 +30976,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -32524,7 +30999,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32547,12 +31022,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -32575,7 +31048,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32598,7 +31071,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -32621,21 +31094,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'f': // Prefix: "float"
-										origElem := elem
+
 										if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 											elem = elem[l:]
 										} else {
@@ -32658,7 +31126,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -32670,7 +31138,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -32693,7 +31161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32716,12 +31184,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -32744,7 +31210,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -32767,7 +31233,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -32790,21 +31256,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -32816,7 +31277,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -32839,7 +31300,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -32851,7 +31312,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -32874,7 +31335,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -32897,12 +31358,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -32925,7 +31384,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -32948,7 +31407,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -32971,21 +31430,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -33008,7 +31462,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -33020,7 +31474,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -33043,7 +31497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33066,12 +31520,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -33094,7 +31546,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33117,7 +31569,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -33140,24 +31592,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -33180,7 +31626,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -33203,7 +31649,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -33226,24 +31672,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 's': // Prefix: "string"
-							origElem := elem
+
 							if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 								elem = elem[l:]
 							} else {
@@ -33266,7 +31706,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -33278,7 +31718,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -33301,7 +31741,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -33324,12 +31764,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'b': // Prefix: "b"
-									origElem := elem
+
 									if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 										elem = elem[l:]
 									} else {
@@ -33341,7 +31779,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "ase64"
-										origElem := elem
+
 										if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 											elem = elem[l:]
 										} else {
@@ -33364,7 +31802,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -33376,7 +31814,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -33399,7 +31837,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33422,12 +31860,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -33450,7 +31886,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33473,7 +31909,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33496,21 +31932,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'i': // Prefix: "inary"
-										origElem := elem
+
 										if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 											elem = elem[l:]
 										} else {
@@ -33533,7 +31964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -33545,7 +31976,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -33568,7 +31999,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33591,12 +32022,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -33619,7 +32048,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33642,7 +32071,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33665,21 +32094,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'y': // Prefix: "yte"
-										origElem := elem
+
 										if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 											elem = elem[l:]
 										} else {
@@ -33702,7 +32126,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -33714,7 +32138,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -33737,7 +32161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33760,12 +32184,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -33788,7 +32210,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -33811,7 +32233,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33834,24 +32256,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "d"
-									origElem := elem
+
 									if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 										elem = elem[l:]
 									} else {
@@ -33863,7 +32279,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "ate"
-										origElem := elem
+
 										if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 											elem = elem[l:]
 										} else {
@@ -33886,7 +32302,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-time"
-											origElem := elem
+
 											if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 												elem = elem[l:]
 											} else {
@@ -33909,7 +32325,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -33921,7 +32337,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -33944,7 +32360,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -33967,12 +32383,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -33995,7 +32409,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -34018,7 +32432,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -34041,21 +32455,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -34067,7 +32476,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -34090,7 +32499,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34113,12 +32522,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -34141,7 +32548,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34164,7 +32571,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -34187,21 +32594,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'u': // Prefix: "uration"
-										origElem := elem
+
 										if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 											elem = elem[l:]
 										} else {
@@ -34224,7 +32626,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -34236,7 +32638,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -34259,7 +32661,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34282,12 +32684,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -34310,7 +32710,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34333,7 +32733,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -34356,24 +32756,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'e': // Prefix: "email"
-									origElem := elem
+
 									if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 										elem = elem[l:]
 									} else {
@@ -34396,7 +32790,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -34408,7 +32802,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -34431,7 +32825,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -34454,12 +32848,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -34482,7 +32874,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -34505,7 +32897,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34528,21 +32920,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -34554,7 +32941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -34577,7 +32964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -34589,7 +32976,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -34612,7 +32999,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34635,12 +33022,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -34663,7 +33048,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34686,7 +33071,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -34709,21 +33094,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -34746,7 +33126,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -34758,7 +33138,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -34781,7 +33161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34804,12 +33184,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -34832,7 +33210,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -34855,7 +33233,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -34878,24 +33256,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'h': // Prefix: "hostname"
-									origElem := elem
+
 									if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 										elem = elem[l:]
 									} else {
@@ -34918,7 +33290,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -34930,7 +33302,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -34953,7 +33325,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -34976,12 +33348,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -35004,7 +33374,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -35027,7 +33397,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -35050,21 +33420,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "i"
-									origElem := elem
+
 									if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 										elem = elem[l:]
 									} else {
@@ -35076,7 +33441,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'n': // Prefix: "nt"
-										origElem := elem
+
 										if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 											elem = elem[l:]
 										} else {
@@ -35099,7 +33464,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -35122,7 +33487,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -35134,7 +33499,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -35157,7 +33522,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35180,12 +33545,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -35208,7 +33571,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35231,7 +33594,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -35254,21 +33617,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -35291,7 +33649,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -35303,7 +33661,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -35326,7 +33684,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35349,12 +33707,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -35377,7 +33733,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35400,7 +33756,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -35423,21 +33779,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -35460,7 +33811,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -35472,7 +33823,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -35495,7 +33846,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35518,12 +33869,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -35546,7 +33895,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35569,7 +33918,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -35592,21 +33941,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -35629,7 +33973,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -35641,7 +33985,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -35664,7 +34008,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35687,12 +34031,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -35715,7 +34057,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35738,7 +34080,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -35761,21 +34103,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -35787,7 +34124,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -35810,7 +34147,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -35833,12 +34170,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -35861,7 +34196,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -35884,7 +34219,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -35907,21 +34242,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'p': // Prefix: "p"
-										origElem := elem
+
 										if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 											elem = elem[l:]
 										} else {
@@ -35944,7 +34274,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -35956,7 +34286,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -35979,7 +34309,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -36002,12 +34332,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -36030,7 +34358,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -36053,7 +34381,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -36076,18 +34404,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'v': // Prefix: "v"
-											origElem := elem
+
 											if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 												elem = elem[l:]
 											} else {
@@ -36099,7 +34423,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '4': // Prefix: "4"
-												origElem := elem
+
 												if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 													elem = elem[l:]
 												} else {
@@ -36122,7 +34446,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -36134,7 +34458,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -36157,7 +34481,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -36180,12 +34504,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -36208,7 +34530,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -36231,7 +34553,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -36254,21 +34576,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case '6': // Prefix: "6"
-												origElem := elem
+
 												if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 													elem = elem[l:]
 												} else {
@@ -36291,7 +34608,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -36303,7 +34620,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -36326,7 +34643,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -36349,12 +34666,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -36377,7 +34692,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -36400,7 +34715,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -36423,30 +34738,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'm': // Prefix: "mac"
-									origElem := elem
+
 									if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 										elem = elem[l:]
 									} else {
@@ -36469,7 +34776,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -36481,7 +34788,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -36504,7 +34811,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36527,12 +34834,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -36555,7 +34860,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36578,7 +34883,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -36601,21 +34906,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -36638,7 +34938,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -36661,7 +34961,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -36684,15 +34984,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "password"
-									origElem := elem
+
 									if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 										elem = elem[l:]
 									} else {
@@ -36715,7 +35012,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -36727,7 +35024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -36750,7 +35047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36773,12 +35070,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -36801,7 +35096,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36824,7 +35119,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -36847,21 +35142,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 't': // Prefix: "time"
-									origElem := elem
+
 									if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 										elem = elem[l:]
 									} else {
@@ -36884,7 +35174,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -36896,7 +35186,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -36919,7 +35209,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36942,12 +35232,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -36970,7 +35258,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -36993,7 +35281,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -37016,21 +35304,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "u"
-									origElem := elem
+
 									if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 										elem = elem[l:]
 									} else {
@@ -37042,7 +35325,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'i': // Prefix: "int"
-										origElem := elem
+
 										if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 											elem = elem[l:]
 										} else {
@@ -37065,7 +35348,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '1': // Prefix: "16"
-											origElem := elem
+
 											if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 												elem = elem[l:]
 											} else {
@@ -37088,7 +35371,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -37100,7 +35383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -37123,7 +35406,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37146,12 +35429,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -37174,7 +35455,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37197,7 +35478,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -37220,21 +35501,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '3': // Prefix: "32"
-											origElem := elem
+
 											if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 												elem = elem[l:]
 											} else {
@@ -37257,7 +35533,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -37269,7 +35545,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -37292,7 +35568,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37315,12 +35591,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -37343,7 +35617,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37366,7 +35640,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -37389,21 +35663,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "64"
-											origElem := elem
+
 											if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 												elem = elem[l:]
 											} else {
@@ -37426,7 +35695,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -37438,7 +35707,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -37461,7 +35730,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37484,12 +35753,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -37512,7 +35779,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37535,7 +35802,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -37558,21 +35825,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '8': // Prefix: "8"
-											origElem := elem
+
 											if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 												elem = elem[l:]
 											} else {
@@ -37595,7 +35857,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -37607,7 +35869,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -37630,7 +35892,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37653,12 +35915,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -37681,7 +35941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37704,7 +35964,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -37727,21 +35987,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -37753,7 +36008,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -37776,7 +36031,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -37799,12 +36054,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -37827,7 +36080,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -37850,7 +36103,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -37873,21 +36126,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nix"
-										origElem := elem
+
 										if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 											elem = elem[l:]
 										} else {
@@ -37910,7 +36158,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '-': // Prefix: "-"
-											origElem := elem
+
 											if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 												elem = elem[l:]
 											} else {
@@ -37922,7 +36170,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'm': // Prefix: "mi"
-												origElem := elem
+
 												if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 													elem = elem[l:]
 												} else {
@@ -37934,7 +36182,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'c': // Prefix: "cro"
-													origElem := elem
+
 													if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 														elem = elem[l:]
 													} else {
@@ -37957,7 +36205,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -37969,7 +36217,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -37992,7 +36240,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38015,12 +36263,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -38043,7 +36289,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38066,7 +36312,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -38089,21 +36335,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'l': // Prefix: "lli"
-													origElem := elem
+
 													if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 														elem = elem[l:]
 													} else {
@@ -38126,7 +36367,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_"
-														origElem := elem
+
 														if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 															elem = elem[l:]
 														} else {
@@ -38138,7 +36379,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case 'a': // Prefix: "array"
-															origElem := elem
+
 															if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 																elem = elem[l:]
 															} else {
@@ -38161,7 +36402,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38184,12 +36425,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														case 'n': // Prefix: "nullable"
-															origElem := elem
+
 															if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 																elem = elem[l:]
 															} else {
@@ -38212,7 +36451,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38235,7 +36474,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 																switch elem[0] {
 																case '_': // Prefix: "_array"
-																	origElem := elem
+
 																	if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																		elem = elem[l:]
 																	} else {
@@ -38258,24 +36497,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																		}
 																	}
 
-																	elem = origElem
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nano"
-												origElem := elem
+
 												if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 													elem = elem[l:]
 												} else {
@@ -38298,7 +36531,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -38310,7 +36543,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -38333,7 +36566,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -38356,12 +36589,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -38384,7 +36615,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -38407,7 +36638,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38430,21 +36661,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 's': // Prefix: "seconds"
-												origElem := elem
+
 												if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 													elem = elem[l:]
 												} else {
@@ -38467,7 +36693,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -38479,7 +36705,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -38502,7 +36728,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -38525,12 +36751,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -38553,7 +36777,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -38576,7 +36800,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -38599,24 +36823,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -38628,7 +36846,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -38651,7 +36869,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -38674,12 +36892,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -38702,7 +36918,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -38725,7 +36941,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -38748,21 +36964,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'r': // Prefix: "ri"
-										origElem := elem
+
 										if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 											elem = elem[l:]
 										} else {
@@ -38785,7 +36996,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -38797,7 +37008,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -38820,7 +37031,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -38843,12 +37054,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -38871,7 +37080,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -38894,7 +37103,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -38917,21 +37126,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'u': // Prefix: "uid"
-										origElem := elem
+
 										if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 											elem = elem[l:]
 										} else {
@@ -38954,7 +37158,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -38966,7 +37170,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -38989,7 +37193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39012,12 +37216,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -39040,7 +37242,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39063,7 +37265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -39086,33 +37288,24 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "string"
-						origElem := elem
+
 						if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 							elem = elem[l:]
 						} else {
@@ -39135,7 +37328,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -39147,7 +37340,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -39170,7 +37363,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -39193,12 +37386,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "b"
-								origElem := elem
+
 								if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 									elem = elem[l:]
 								} else {
@@ -39210,7 +37401,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ase64"
-									origElem := elem
+
 									if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 										elem = elem[l:]
 									} else {
@@ -39233,7 +37424,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -39245,7 +37436,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -39268,7 +37459,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39291,12 +37482,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -39319,7 +37508,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39342,7 +37531,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39365,21 +37554,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "inary"
-									origElem := elem
+
 									if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 										elem = elem[l:]
 									} else {
@@ -39402,7 +37586,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -39414,7 +37598,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -39437,7 +37621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39460,12 +37644,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -39488,7 +37670,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39511,7 +37693,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39534,21 +37716,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'y': // Prefix: "yte"
-									origElem := elem
+
 									if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 										elem = elem[l:]
 									} else {
@@ -39571,7 +37748,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -39583,7 +37760,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -39606,7 +37783,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39629,12 +37806,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -39657,7 +37832,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39680,7 +37855,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39703,24 +37878,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "d"
-								origElem := elem
+
 								if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 									elem = elem[l:]
 								} else {
@@ -39732,7 +37901,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ate"
-									origElem := elem
+
 									if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 										elem = elem[l:]
 									} else {
@@ -39755,7 +37924,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-time"
-										origElem := elem
+
 										if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 											elem = elem[l:]
 										} else {
@@ -39778,7 +37947,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -39790,7 +37959,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -39813,7 +37982,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39836,12 +38005,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -39864,7 +38031,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -39887,7 +38054,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -39910,21 +38077,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -39936,7 +38098,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -39959,7 +38121,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -39982,12 +38144,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -40010,7 +38170,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40033,7 +38193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -40056,21 +38216,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uration"
-									origElem := elem
+
 									if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 										elem = elem[l:]
 									} else {
@@ -40093,7 +38248,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -40105,7 +38260,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -40128,7 +38283,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40151,12 +38306,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -40179,7 +38332,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40202,7 +38355,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -40225,24 +38378,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "email"
-								origElem := elem
+
 								if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 									elem = elem[l:]
 								} else {
@@ -40265,7 +38412,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -40277,7 +38424,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -40300,7 +38447,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -40323,12 +38470,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -40351,7 +38496,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -40374,7 +38519,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40397,21 +38542,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "float"
-								origElem := elem
+
 								if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 									elem = elem[l:]
 								} else {
@@ -40423,7 +38563,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -40446,7 +38586,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -40458,7 +38598,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -40481,7 +38621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40504,12 +38644,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -40532,7 +38670,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40555,7 +38693,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -40578,21 +38716,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -40615,7 +38748,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -40627,7 +38760,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -40650,7 +38783,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40673,12 +38806,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -40701,7 +38832,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40724,7 +38855,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -40747,24 +38878,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hostname"
-								origElem := elem
+
 								if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 									elem = elem[l:]
 								} else {
@@ -40787,7 +38912,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -40799,7 +38924,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -40822,7 +38947,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -40845,12 +38970,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -40873,7 +38996,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -40896,7 +39019,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -40919,21 +39042,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -40945,7 +39063,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "nt"
-									origElem := elem
+
 									if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 										elem = elem[l:]
 									} else {
@@ -40968,7 +39086,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -40991,7 +39109,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -41003,7 +39121,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -41026,7 +39144,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41049,12 +39167,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -41077,7 +39193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41100,7 +39216,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -41123,21 +39239,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -41160,7 +39271,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -41172,7 +39283,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -41195,7 +39306,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41218,12 +39329,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -41246,7 +39355,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41269,7 +39378,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -41292,21 +39401,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -41329,7 +39433,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -41341,7 +39445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -41364,7 +39468,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41387,12 +39491,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -41415,7 +39517,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41438,7 +39540,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -41461,21 +39563,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -41498,7 +39595,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -41510,7 +39607,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -41533,7 +39630,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41556,12 +39653,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -41584,7 +39679,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41607,7 +39702,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -41630,21 +39725,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -41656,7 +39746,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -41679,7 +39769,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -41702,12 +39792,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -41730,7 +39818,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -41753,7 +39841,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41776,21 +39864,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "p"
-									origElem := elem
+
 									if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 										elem = elem[l:]
 									} else {
@@ -41813,7 +39896,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -41825,7 +39908,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -41848,7 +39931,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -41871,12 +39954,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -41899,7 +39980,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -41922,7 +40003,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -41945,18 +40026,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "v"
-										origElem := elem
+
 										if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 											elem = elem[l:]
 										} else {
@@ -41968,7 +40045,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '4': // Prefix: "4"
-											origElem := elem
+
 											if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 												elem = elem[l:]
 											} else {
@@ -41991,7 +40068,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -42003,7 +40080,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -42026,7 +40103,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -42049,12 +40126,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -42077,7 +40152,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -42100,7 +40175,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -42123,21 +40198,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "6"
-											origElem := elem
+
 											if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 												elem = elem[l:]
 											} else {
@@ -42160,7 +40230,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -42172,7 +40242,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -42195,7 +40265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -42218,12 +40288,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -42246,7 +40314,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -42269,7 +40337,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -42292,30 +40360,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mac"
-								origElem := elem
+
 								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 									elem = elem[l:]
 								} else {
@@ -42338,7 +40398,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -42350,7 +40410,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -42373,7 +40433,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42396,12 +40456,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -42424,7 +40482,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42447,7 +40505,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -42470,21 +40528,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -42507,7 +40560,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -42530,7 +40583,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -42553,15 +40606,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "password"
-								origElem := elem
+
 								if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 									elem = elem[l:]
 								} else {
@@ -42584,7 +40634,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -42596,7 +40646,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -42619,7 +40669,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42642,12 +40692,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -42670,7 +40718,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42693,7 +40741,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -42716,21 +40764,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "time"
-								origElem := elem
+
 								if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 									elem = elem[l:]
 								} else {
@@ -42753,7 +40796,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -42765,7 +40808,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -42788,7 +40831,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42811,12 +40854,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -42839,7 +40880,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -42862,7 +40903,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -42885,21 +40926,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -42911,7 +40947,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -42934,7 +40970,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -42957,7 +40993,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -42969,7 +41005,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -42992,7 +41028,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43015,12 +41051,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -43043,7 +41077,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43066,7 +41100,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -43089,21 +41123,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -43126,7 +41155,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -43138,7 +41167,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -43161,7 +41190,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43184,12 +41213,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -43212,7 +41239,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43235,7 +41262,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -43258,21 +41285,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -43295,7 +41317,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -43307,7 +41329,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -43330,7 +41352,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43353,12 +41375,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -43381,7 +41401,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43404,7 +41424,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -43427,21 +41447,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -43464,7 +41479,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -43476,7 +41491,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -43499,7 +41514,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43522,12 +41537,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -43550,7 +41563,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43573,7 +41586,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -43596,21 +41609,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -43622,7 +41630,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -43645,7 +41653,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -43668,12 +41676,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -43696,7 +41702,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -43719,7 +41725,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -43742,21 +41748,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -43779,7 +41780,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -43791,7 +41792,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -43803,7 +41804,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -43826,7 +41827,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -43838,7 +41839,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -43861,7 +41862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -43884,12 +41885,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -43912,7 +41911,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -43935,7 +41934,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -43958,21 +41957,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -43995,7 +41989,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -44007,7 +42001,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -44030,7 +42024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -44053,12 +42047,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -44081,7 +42073,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -44104,7 +42096,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -44127,24 +42119,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -44167,7 +42153,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -44179,7 +42165,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -44202,7 +42188,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -44225,12 +42211,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -44253,7 +42237,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -44276,7 +42260,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -44299,21 +42283,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -44336,7 +42315,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -44348,7 +42327,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -44371,7 +42350,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -44394,12 +42373,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -44422,7 +42399,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -44445,7 +42422,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -44468,24 +42445,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -44497,7 +42468,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -44520,7 +42491,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44543,12 +42514,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -44571,7 +42540,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44594,7 +42563,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -44617,21 +42586,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "ri"
-									origElem := elem
+
 									if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 										elem = elem[l:]
 									} else {
@@ -44654,7 +42618,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -44666,7 +42630,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -44689,7 +42653,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44712,12 +42676,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -44740,7 +42702,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44763,7 +42725,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -44786,21 +42748,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uid"
-									origElem := elem
+
 									if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 										elem = elem[l:]
 									} else {
@@ -44823,7 +42780,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -44835,7 +42792,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -44858,7 +42815,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44881,12 +42838,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -44909,7 +42864,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -44932,7 +42887,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -44955,33 +42910,24 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 's': // Prefix: "sponse_"
-					origElem := elem
+
 					if l := len("sponse_"); len(elem) >= l && elem[0:l] == "sponse_" {
 						elem = elem[l:]
 					} else {
@@ -44993,7 +42939,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'A': // Prefix: "Any"
-						origElem := elem
+
 						if l := len("Any"); len(elem) >= l && elem[0:l] == "Any" {
 							elem = elem[l:]
 						} else {
@@ -45016,9 +42962,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptyStruct"
-						origElem := elem
+
 						if l := len("EmptyStruct"); len(elem) >= l && elem[0:l] == "EmptyStruct" {
 							elem = elem[l:]
 						} else {
@@ -45041,9 +42986,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'F': // Prefix: "FormatTest"
-						origElem := elem
+
 						if l := len("FormatTest"); len(elem) >= l && elem[0:l] == "FormatTest" {
 							elem = elem[l:]
 						} else {
@@ -45066,9 +43010,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'b': // Prefix: "boolean"
-						origElem := elem
+
 						if l := len("boolean"); len(elem) >= l && elem[0:l] == "boolean" {
 							elem = elem[l:]
 						} else {
@@ -45091,7 +43034,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -45103,7 +43046,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -45126,7 +43069,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -45149,12 +43092,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -45177,7 +43118,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -45200,7 +43141,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -45223,21 +43164,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'i': // Prefix: "integer"
-						origElem := elem
+
 						if l := len("integer"); len(elem) >= l && elem[0:l] == "integer" {
 							elem = elem[l:]
 						} else {
@@ -45260,7 +43196,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -45272,7 +43208,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -45295,7 +43231,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -45318,12 +43254,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "int"
-								origElem := elem
+
 								if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 									elem = elem[l:]
 								} else {
@@ -45335,7 +43269,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '1': // Prefix: "16"
-									origElem := elem
+
 									if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 										elem = elem[l:]
 									} else {
@@ -45358,7 +43292,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -45370,7 +43304,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -45393,7 +43327,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45416,12 +43350,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -45444,7 +43376,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45467,7 +43399,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -45490,21 +43422,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -45527,7 +43454,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -45539,7 +43466,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -45562,7 +43489,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45585,12 +43512,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -45613,7 +43538,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45636,7 +43561,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -45659,21 +43584,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -45696,7 +43616,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -45708,7 +43628,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -45731,7 +43651,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45754,12 +43674,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -45782,7 +43700,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45805,7 +43723,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -45828,21 +43746,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '8': // Prefix: "8"
-									origElem := elem
+
 									if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 										elem = elem[l:]
 									} else {
@@ -45865,7 +43778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -45877,7 +43790,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -45900,7 +43813,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45923,12 +43836,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -45951,7 +43862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -45974,7 +43885,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -45997,24 +43908,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -46037,7 +43942,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -46060,7 +43965,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -46083,15 +43988,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -46103,7 +44005,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -46126,7 +44028,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -46149,7 +44051,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -46161,7 +44063,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -46184,7 +44086,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46207,12 +44109,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -46235,7 +44135,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46258,7 +44158,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -46281,21 +44181,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -46318,7 +44213,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -46330,7 +44225,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -46353,7 +44248,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46376,12 +44271,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -46404,7 +44297,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46427,7 +44320,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -46450,21 +44343,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -46487,7 +44375,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -46499,7 +44387,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -46522,7 +44410,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46545,12 +44433,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -46573,7 +44459,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46596,7 +44482,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -46619,21 +44505,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -46656,7 +44537,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -46668,7 +44549,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -46691,7 +44572,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46714,12 +44595,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -46742,7 +44621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46765,7 +44644,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -46788,21 +44667,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -46814,7 +44688,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -46837,7 +44711,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -46860,12 +44734,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -46888,7 +44760,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -46911,7 +44783,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -46934,21 +44806,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -46971,7 +44838,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -46983,7 +44850,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -46995,7 +44862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -47018,7 +44885,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -47030,7 +44897,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -47053,7 +44920,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47076,12 +44943,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -47104,7 +44969,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47127,7 +44992,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -47150,21 +45015,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -47187,7 +45047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -47199,7 +45059,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -47222,7 +45082,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47245,12 +45105,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -47273,7 +45131,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47296,7 +45154,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -47319,24 +45177,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -47359,7 +45211,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -47371,7 +45223,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -47394,7 +45246,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -47417,12 +45269,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -47445,7 +45295,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -47468,7 +45318,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47491,21 +45341,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -47528,7 +45373,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -47540,7 +45385,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -47563,7 +45408,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -47586,12 +45431,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -47614,7 +45457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -47637,7 +45480,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -47660,24 +45503,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -47689,7 +45526,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -47712,7 +45549,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -47735,12 +45572,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -47763,7 +45598,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -47786,7 +45621,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -47809,30 +45644,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 'n': // Prefix: "nu"
-						origElem := elem
+
 						if l := len("nu"); len(elem) >= l && elem[0:l] == "nu" {
 							elem = elem[l:]
 						} else {
@@ -47844,7 +45671,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'l': // Prefix: "ll"
-							origElem := elem
+
 							if l := len("ll"); len(elem) >= l && elem[0:l] == "ll" {
 								elem = elem[l:]
 							} else {
@@ -47867,7 +45694,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -47879,7 +45706,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -47902,7 +45729,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -47925,12 +45752,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -47953,7 +45778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -47976,7 +45801,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -47999,21 +45824,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "mber"
-							origElem := elem
+
 							if l := len("mber"); len(elem) >= l && elem[0:l] == "mber" {
 								elem = elem[l:]
 							} else {
@@ -48036,7 +45856,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '_': // Prefix: "_"
-								origElem := elem
+
 								if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 									elem = elem[l:]
 								} else {
@@ -48048,7 +45868,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "array"
-									origElem := elem
+
 									if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 										elem = elem[l:]
 									} else {
@@ -48071,7 +45891,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -48094,12 +45914,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'd': // Prefix: "double"
-									origElem := elem
+
 									if l := len("double"); len(elem) >= l && elem[0:l] == "double" {
 										elem = elem[l:]
 									} else {
@@ -48122,7 +45940,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -48134,7 +45952,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -48157,7 +45975,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -48180,12 +45998,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -48208,7 +46024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -48231,7 +46047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48254,21 +46070,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'f': // Prefix: "float"
-									origElem := elem
+
 									if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 										elem = elem[l:]
 									} else {
@@ -48291,7 +46102,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -48303,7 +46114,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -48326,7 +46137,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -48349,12 +46160,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -48377,7 +46186,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -48400,7 +46209,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48423,21 +46232,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -48449,7 +46253,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -48472,7 +46276,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -48484,7 +46288,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -48507,7 +46311,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48530,12 +46334,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -48558,7 +46360,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48581,7 +46383,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -48604,21 +46406,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -48641,7 +46438,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -48653,7 +46450,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -48676,7 +46473,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48699,12 +46496,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -48727,7 +46522,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -48750,7 +46545,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -48773,24 +46568,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nullable"
-									origElem := elem
+
 									if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 										elem = elem[l:]
 									} else {
@@ -48813,7 +46602,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -48836,7 +46625,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -48859,24 +46648,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 's': // Prefix: "string"
-						origElem := elem
+
 						if l := len("string"); len(elem) >= l && elem[0:l] == "string" {
 							elem = elem[l:]
 						} else {
@@ -48899,7 +46682,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '_': // Prefix: "_"
-							origElem := elem
+
 							if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 								elem = elem[l:]
 							} else {
@@ -48911,7 +46694,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'a': // Prefix: "array"
-								origElem := elem
+
 								if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 									elem = elem[l:]
 								} else {
@@ -48934,7 +46717,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -48957,12 +46740,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'b': // Prefix: "b"
-								origElem := elem
+
 								if l := len("b"); len(elem) >= l && elem[0:l] == "b" {
 									elem = elem[l:]
 								} else {
@@ -48974,7 +46755,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ase64"
-									origElem := elem
+
 									if l := len("ase64"); len(elem) >= l && elem[0:l] == "ase64" {
 										elem = elem[l:]
 									} else {
@@ -48997,7 +46778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -49009,7 +46790,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -49032,7 +46813,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49055,12 +46836,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -49083,7 +46862,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49106,7 +46885,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49129,21 +46908,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'i': // Prefix: "inary"
-									origElem := elem
+
 									if l := len("inary"); len(elem) >= l && elem[0:l] == "inary" {
 										elem = elem[l:]
 									} else {
@@ -49166,7 +46940,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -49178,7 +46952,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -49201,7 +46975,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49224,12 +46998,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -49252,7 +47024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49275,7 +47047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49298,21 +47070,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'y': // Prefix: "yte"
-									origElem := elem
+
 									if l := len("yte"); len(elem) >= l && elem[0:l] == "yte" {
 										elem = elem[l:]
 									} else {
@@ -49335,7 +47102,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -49347,7 +47114,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -49370,7 +47137,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49393,12 +47160,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -49421,7 +47186,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49444,7 +47209,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49467,24 +47232,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'd': // Prefix: "d"
-								origElem := elem
+
 								if l := len("d"); len(elem) >= l && elem[0:l] == "d" {
 									elem = elem[l:]
 								} else {
@@ -49496,7 +47255,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'a': // Prefix: "ate"
-									origElem := elem
+
 									if l := len("ate"); len(elem) >= l && elem[0:l] == "ate" {
 										elem = elem[l:]
 									} else {
@@ -49519,7 +47278,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-time"
-										origElem := elem
+
 										if l := len("-time"); len(elem) >= l && elem[0:l] == "-time" {
 											elem = elem[l:]
 										} else {
@@ -49542,7 +47301,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -49554,7 +47313,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -49577,7 +47336,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49600,12 +47359,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -49628,7 +47385,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49651,7 +47408,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -49674,21 +47431,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -49700,7 +47452,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -49723,7 +47475,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49746,12 +47498,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -49774,7 +47524,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49797,7 +47547,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49820,21 +47570,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uration"
-									origElem := elem
+
 									if l := len("uration"); len(elem) >= l && elem[0:l] == "uration" {
 										elem = elem[l:]
 									} else {
@@ -49857,7 +47602,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -49869,7 +47614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -49892,7 +47637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49915,12 +47660,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -49943,7 +47686,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -49966,7 +47709,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -49989,24 +47732,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'e': // Prefix: "email"
-								origElem := elem
+
 								if l := len("email"); len(elem) >= l && elem[0:l] == "email" {
 									elem = elem[l:]
 								} else {
@@ -50029,7 +47766,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -50041,7 +47778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -50064,7 +47801,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -50087,12 +47824,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -50115,7 +47850,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -50138,7 +47873,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50161,21 +47896,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'f': // Prefix: "float"
-								origElem := elem
+
 								if l := len("float"); len(elem) >= l && elem[0:l] == "float" {
 									elem = elem[l:]
 								} else {
@@ -50187,7 +47917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '3': // Prefix: "32"
-									origElem := elem
+
 									if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 										elem = elem[l:]
 									} else {
@@ -50210,7 +47940,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -50222,7 +47952,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -50245,7 +47975,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50268,12 +47998,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -50296,7 +48024,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50319,7 +48047,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -50342,21 +48070,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case '6': // Prefix: "64"
-									origElem := elem
+
 									if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 										elem = elem[l:]
 									} else {
@@ -50379,7 +48102,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -50391,7 +48114,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -50414,7 +48137,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50437,12 +48160,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -50465,7 +48186,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50488,7 +48209,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -50511,24 +48232,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'h': // Prefix: "hostname"
-								origElem := elem
+
 								if l := len("hostname"); len(elem) >= l && elem[0:l] == "hostname" {
 									elem = elem[l:]
 								} else {
@@ -50551,7 +48266,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -50563,7 +48278,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -50586,7 +48301,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -50609,12 +48324,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -50637,7 +48350,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -50660,7 +48373,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -50683,21 +48396,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'i': // Prefix: "i"
-								origElem := elem
+
 								if l := len("i"); len(elem) >= l && elem[0:l] == "i" {
 									elem = elem[l:]
 								} else {
@@ -50709,7 +48417,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'n': // Prefix: "nt"
-									origElem := elem
+
 									if l := len("nt"); len(elem) >= l && elem[0:l] == "nt" {
 										elem = elem[l:]
 									} else {
@@ -50732,7 +48440,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -50755,7 +48463,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -50767,7 +48475,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -50790,7 +48498,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -50813,12 +48521,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -50841,7 +48547,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -50864,7 +48570,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -50887,21 +48593,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -50924,7 +48625,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -50936,7 +48637,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -50959,7 +48660,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -50982,12 +48683,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -51010,7 +48709,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51033,7 +48732,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51056,21 +48755,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -51093,7 +48787,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -51105,7 +48799,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -51128,7 +48822,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51151,12 +48845,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -51179,7 +48871,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51202,7 +48894,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51225,21 +48917,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -51262,7 +48949,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -51274,7 +48961,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -51297,7 +48984,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51320,12 +49007,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -51348,7 +49033,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51371,7 +49056,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51394,21 +49079,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -51420,7 +49100,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -51443,7 +49123,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -51466,12 +49146,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -51494,7 +49172,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -51517,7 +49195,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51540,21 +49218,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'p': // Prefix: "p"
-									origElem := elem
+
 									if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 										elem = elem[l:]
 									} else {
@@ -51577,7 +49250,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -51589,7 +49262,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -51612,7 +49285,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -51635,12 +49308,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -51663,7 +49334,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -51686,7 +49357,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -51709,18 +49380,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'v': // Prefix: "v"
-										origElem := elem
+
 										if l := len("v"); len(elem) >= l && elem[0:l] == "v" {
 											elem = elem[l:]
 										} else {
@@ -51732,7 +49399,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '4': // Prefix: "4"
-											origElem := elem
+
 											if l := len("4"); len(elem) >= l && elem[0:l] == "4" {
 												elem = elem[l:]
 											} else {
@@ -51755,7 +49422,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -51767,7 +49434,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -51790,7 +49457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51813,12 +49480,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -51841,7 +49506,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51864,7 +49529,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -51887,21 +49552,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case '6': // Prefix: "6"
-											origElem := elem
+
 											if l := len("6"); len(elem) >= l && elem[0:l] == "6" {
 												elem = elem[l:]
 											} else {
@@ -51924,7 +49584,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -51936,7 +49596,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -51959,7 +49619,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -51982,12 +49642,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -52010,7 +49668,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -52033,7 +49691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -52056,30 +49714,22 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'm': // Prefix: "mac"
-								origElem := elem
+
 								if l := len("mac"); len(elem) >= l && elem[0:l] == "mac" {
 									elem = elem[l:]
 								} else {
@@ -52102,7 +49752,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -52114,7 +49764,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -52137,7 +49787,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52160,12 +49810,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -52188,7 +49836,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52211,7 +49859,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -52234,21 +49882,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'n': // Prefix: "nullable"
-								origElem := elem
+
 								if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 									elem = elem[l:]
 								} else {
@@ -52271,7 +49914,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_array"
-									origElem := elem
+
 									if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 										elem = elem[l:]
 									} else {
@@ -52294,7 +49937,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_array"
-										origElem := elem
+
 										if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 											elem = elem[l:]
 										} else {
@@ -52317,15 +49960,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'p': // Prefix: "password"
-								origElem := elem
+
 								if l := len("password"); len(elem) >= l && elem[0:l] == "password" {
 									elem = elem[l:]
 								} else {
@@ -52348,7 +49988,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -52360,7 +50000,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -52383,7 +50023,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52406,12 +50046,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -52434,7 +50072,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52457,7 +50095,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -52480,21 +50118,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 't': // Prefix: "time"
-								origElem := elem
+
 								if l := len("time"); len(elem) >= l && elem[0:l] == "time" {
 									elem = elem[l:]
 								} else {
@@ -52517,7 +50150,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '_': // Prefix: "_"
-									origElem := elem
+
 									if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 										elem = elem[l:]
 									} else {
@@ -52529,7 +50162,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case 'a': // Prefix: "array"
-										origElem := elem
+
 										if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 											elem = elem[l:]
 										} else {
@@ -52552,7 +50185,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52575,12 +50208,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case 'n': // Prefix: "nullable"
-										origElem := elem
+
 										if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 											elem = elem[l:]
 										} else {
@@ -52603,7 +50234,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_array"
-											origElem := elem
+
 											if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 												elem = elem[l:]
 											} else {
@@ -52626,7 +50257,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -52649,21 +50280,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							case 'u': // Prefix: "u"
-								origElem := elem
+
 								if l := len("u"); len(elem) >= l && elem[0:l] == "u" {
 									elem = elem[l:]
 								} else {
@@ -52675,7 +50301,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case 'i': // Prefix: "int"
-									origElem := elem
+
 									if l := len("int"); len(elem) >= l && elem[0:l] == "int" {
 										elem = elem[l:]
 									} else {
@@ -52698,7 +50324,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '1': // Prefix: "16"
-										origElem := elem
+
 										if l := len("16"); len(elem) >= l && elem[0:l] == "16" {
 											elem = elem[l:]
 										} else {
@@ -52721,7 +50347,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -52733,7 +50359,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -52756,7 +50382,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -52779,12 +50405,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -52807,7 +50431,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -52830,7 +50454,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -52853,21 +50477,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '3': // Prefix: "32"
-										origElem := elem
+
 										if l := len("32"); len(elem) >= l && elem[0:l] == "32" {
 											elem = elem[l:]
 										} else {
@@ -52890,7 +50509,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -52902,7 +50521,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -52925,7 +50544,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -52948,12 +50567,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -52976,7 +50593,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -52999,7 +50616,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -53022,21 +50639,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '6': // Prefix: "64"
-										origElem := elem
+
 										if l := len("64"); len(elem) >= l && elem[0:l] == "64" {
 											elem = elem[l:]
 										} else {
@@ -53059,7 +50671,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -53071,7 +50683,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -53094,7 +50706,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -53117,12 +50729,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -53145,7 +50755,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -53168,7 +50778,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -53191,21 +50801,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '8': // Prefix: "8"
-										origElem := elem
+
 										if l := len("8"); len(elem) >= l && elem[0:l] == "8" {
 											elem = elem[l:]
 										} else {
@@ -53228,7 +50833,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case '_': // Prefix: "_"
-											origElem := elem
+
 											if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 												elem = elem[l:]
 											} else {
@@ -53240,7 +50845,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'a': // Prefix: "array"
-												origElem := elem
+
 												if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 													elem = elem[l:]
 												} else {
@@ -53263,7 +50868,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -53286,12 +50891,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'n': // Prefix: "nullable"
-												origElem := elem
+
 												if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 													elem = elem[l:]
 												} else {
@@ -53314,7 +50917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -53337,7 +50940,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -53360,21 +50963,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -53386,7 +50984,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -53409,7 +51007,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -53432,12 +51030,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -53460,7 +51056,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -53483,7 +51079,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -53506,21 +51102,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'n': // Prefix: "nix"
-									origElem := elem
+
 									if l := len("nix"); len(elem) >= l && elem[0:l] == "nix" {
 										elem = elem[l:]
 									} else {
@@ -53543,7 +51134,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '-': // Prefix: "-"
-										origElem := elem
+
 										if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 											elem = elem[l:]
 										} else {
@@ -53555,7 +51146,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'm': // Prefix: "mi"
-											origElem := elem
+
 											if l := len("mi"); len(elem) >= l && elem[0:l] == "mi" {
 												elem = elem[l:]
 											} else {
@@ -53567,7 +51158,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case 'c': // Prefix: "cro"
-												origElem := elem
+
 												if l := len("cro"); len(elem) >= l && elem[0:l] == "cro" {
 													elem = elem[l:]
 												} else {
@@ -53590,7 +51181,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -53602,7 +51193,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -53625,7 +51216,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -53648,12 +51239,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -53676,7 +51265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -53699,7 +51288,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -53722,21 +51311,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											case 'l': // Prefix: "lli"
-												origElem := elem
+
 												if l := len("lli"); len(elem) >= l && elem[0:l] == "lli" {
 													elem = elem[l:]
 												} else {
@@ -53759,7 +51343,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_"
-													origElem := elem
+
 													if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 														elem = elem[l:]
 													} else {
@@ -53771,7 +51355,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case 'a': // Prefix: "array"
-														origElem := elem
+
 														if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 															elem = elem[l:]
 														} else {
@@ -53794,7 +51378,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -53817,12 +51401,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													case 'n': // Prefix: "nullable"
-														origElem := elem
+
 														if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 															elem = elem[l:]
 														} else {
@@ -53845,7 +51427,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -53868,7 +51450,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 															switch elem[0] {
 															case '_': // Prefix: "_array"
-																origElem := elem
+
 																if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																	elem = elem[l:]
 																} else {
@@ -53891,24 +51473,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																	}
 																}
 
-																elem = origElem
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nano"
-											origElem := elem
+
 											if l := len("nano"); len(elem) >= l && elem[0:l] == "nano" {
 												elem = elem[l:]
 											} else {
@@ -53931,7 +51507,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -53943,7 +51519,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -53966,7 +51542,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -53989,12 +51565,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -54017,7 +51591,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -54040,7 +51614,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -54063,21 +51637,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 's': // Prefix: "seconds"
-											origElem := elem
+
 											if l := len("seconds"); len(elem) >= l && elem[0:l] == "seconds" {
 												elem = elem[l:]
 											} else {
@@ -54100,7 +51669,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_"
-												origElem := elem
+
 												if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 													elem = elem[l:]
 												} else {
@@ -54112,7 +51681,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case 'a': // Prefix: "array"
-													origElem := elem
+
 													if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 														elem = elem[l:]
 													} else {
@@ -54135,7 +51704,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -54158,12 +51727,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 															}
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												case 'n': // Prefix: "nullable"
-													origElem := elem
+
 													if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 														elem = elem[l:]
 													} else {
@@ -54186,7 +51753,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 													switch elem[0] {
 													case '_': // Prefix: "_array"
-														origElem := elem
+
 														if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 															elem = elem[l:]
 														} else {
@@ -54209,7 +51776,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 														switch elem[0] {
 														case '_': // Prefix: "_array"
-															origElem := elem
+
 															if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 																elem = elem[l:]
 															} else {
@@ -54232,24 +51799,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 																}
 															}
 
-															elem = origElem
 														}
 
-														elem = origElem
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -54261,7 +51822,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -54284,7 +51845,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54307,12 +51868,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -54335,7 +51894,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54358,7 +51917,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -54381,21 +51940,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'r': // Prefix: "ri"
-									origElem := elem
+
 									if l := len("ri"); len(elem) >= l && elem[0:l] == "ri" {
 										elem = elem[l:]
 									} else {
@@ -54418,7 +51972,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -54430,7 +51984,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -54453,7 +52007,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54476,12 +52030,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -54504,7 +52056,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54527,7 +52079,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -54550,21 +52102,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								case 'u': // Prefix: "uid"
-									origElem := elem
+
 									if l := len("uid"); len(elem) >= l && elem[0:l] == "uid" {
 										elem = elem[l:]
 									} else {
@@ -54587,7 +52134,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 									switch elem[0] {
 									case '_': // Prefix: "_"
-										origElem := elem
+
 										if l := len("_"); len(elem) >= l && elem[0:l] == "_" {
 											elem = elem[l:]
 										} else {
@@ -54599,7 +52146,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 										switch elem[0] {
 										case 'a': // Prefix: "array"
-											origElem := elem
+
 											if l := len("array"); len(elem) >= l && elem[0:l] == "array" {
 												elem = elem[l:]
 											} else {
@@ -54622,7 +52169,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54645,12 +52192,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 													}
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										case 'n': // Prefix: "nullable"
-											origElem := elem
+
 											if l := len("nullable"); len(elem) >= l && elem[0:l] == "nullable" {
 												elem = elem[l:]
 											} else {
@@ -54673,7 +52218,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											}
 											switch elem[0] {
 											case '_': // Prefix: "_array"
-												origElem := elem
+
 												if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 													elem = elem[l:]
 												} else {
@@ -54696,7 +52241,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												}
 												switch elem[0] {
 												case '_': // Prefix: "_array"
-													origElem := elem
+
 													if l := len("_array"); len(elem) >= l && elem[0:l] == "_array" {
 														elem = elem[l:]
 													} else {
@@ -54719,37 +52264,26 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 														}
 													}
 
-													elem = origElem
 												}
 
-												elem = origElem
 											}
 
-											elem = origElem
 										}
 
-										elem = origElem
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/examples/ex_tinkoff/oas_router_gen.go
+++ b/examples/ex_tinkoff/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'm': // Prefix: "market/"
-				origElem := elem
+
 				if l := len("market/"); len(elem) >= l && elem[0:l] == "market/" {
 					elem = elem[l:]
 				} else {
@@ -73,7 +73,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "bonds"
-					origElem := elem
+
 					if l := len("bonds"); len(elem) >= l && elem[0:l] == "bonds" {
 						elem = elem[l:]
 					} else {
@@ -92,9 +92,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'c': // Prefix: "c"
-					origElem := elem
+
 					if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 						elem = elem[l:]
 					} else {
@@ -106,7 +105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "andles"
-						origElem := elem
+
 						if l := len("andles"); len(elem) >= l && elem[0:l] == "andles" {
 							elem = elem[l:]
 						} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "urrencies"
-						origElem := elem
+
 						if l := len("urrencies"); len(elem) >= l && elem[0:l] == "urrencies" {
 							elem = elem[l:]
 						} else {
@@ -146,12 +144,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "etfs"
-					origElem := elem
+
 					if l := len("etfs"); len(elem) >= l && elem[0:l] == "etfs" {
 						elem = elem[l:]
 					} else {
@@ -170,9 +166,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "orderbook"
-					origElem := elem
+
 					if l := len("orderbook"); len(elem) >= l && elem[0:l] == "orderbook" {
 						elem = elem[l:]
 					} else {
@@ -191,9 +186,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s"
-					origElem := elem
+
 					if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 						elem = elem[l:]
 					} else {
@@ -205,7 +199,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "earch/by-"
-						origElem := elem
+
 						if l := len("earch/by-"); len(elem) >= l && elem[0:l] == "earch/by-" {
 							elem = elem[l:]
 						} else {
@@ -217,7 +211,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'f': // Prefix: "figi"
-							origElem := elem
+
 							if l := len("figi"); len(elem) >= l && elem[0:l] == "figi" {
 								elem = elem[l:]
 							} else {
@@ -236,9 +230,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 't': // Prefix: "ticker"
-							origElem := elem
+
 							if l := len("ticker"); len(elem) >= l && elem[0:l] == "ticker" {
 								elem = elem[l:]
 							} else {
@@ -257,12 +250,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "tocks"
-						origElem := elem
+
 						if l := len("tocks"); len(elem) >= l && elem[0:l] == "tocks" {
 							elem = elem[l:]
 						} else {
@@ -281,15 +272,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -301,7 +289,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "perations"
-					origElem := elem
+
 					if l := len("perations"); len(elem) >= l && elem[0:l] == "perations" {
 						elem = elem[l:]
 					} else {
@@ -320,9 +308,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rders"
-					origElem := elem
+
 					if l := len("rders"); len(elem) >= l && elem[0:l] == "rders" {
 						elem = elem[l:]
 					} else {
@@ -341,7 +328,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -353,7 +340,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cancel"
-							origElem := elem
+
 							if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 								elem = elem[l:]
 							} else {
@@ -372,9 +359,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'l': // Prefix: "limit-order"
-							origElem := elem
+
 							if l := len("limit-order"); len(elem) >= l && elem[0:l] == "limit-order" {
 								elem = elem[l:]
 							} else {
@@ -393,9 +379,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "market-order"
-							origElem := elem
+
 							if l := len("market-order"); len(elem) >= l && elem[0:l] == "market-order" {
 								elem = elem[l:]
 							} else {
@@ -414,18 +399,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "portfolio"
-				origElem := elem
+
 				if l := len("portfolio"); len(elem) >= l && elem[0:l] == "portfolio" {
 					elem = elem[l:]
 				} else {
@@ -444,7 +425,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/currencies"
-					origElem := elem
+
 					if l := len("/currencies"); len(elem) >= l && elem[0:l] == "/currencies" {
 						elem = elem[l:]
 					} else {
@@ -463,12 +444,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "sandbox/"
-				origElem := elem
+
 				if l := len("sandbox/"); len(elem) >= l && elem[0:l] == "sandbox/" {
 					elem = elem[l:]
 				} else {
@@ -480,7 +459,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "c"
-					origElem := elem
+
 					if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 						elem = elem[l:]
 					} else {
@@ -492,7 +471,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'l': // Prefix: "lear"
-						origElem := elem
+
 						if l := len("lear"); len(elem) >= l && elem[0:l] == "lear" {
 							elem = elem[l:]
 						} else {
@@ -511,9 +490,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "urrencies/balance"
-						origElem := elem
+
 						if l := len("urrencies/balance"); len(elem) >= l && elem[0:l] == "urrencies/balance" {
 							elem = elem[l:]
 						} else {
@@ -532,12 +510,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "positions/balance"
-					origElem := elem
+
 					if l := len("positions/balance"); len(elem) >= l && elem[0:l] == "positions/balance" {
 						elem = elem[l:]
 					} else {
@@ -556,9 +532,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "re"
-					origElem := elem
+
 					if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 						elem = elem[l:]
 					} else {
@@ -570,7 +545,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'g': // Prefix: "gister"
-						origElem := elem
+
 						if l := len("gister"); len(elem) >= l && elem[0:l] == "gister" {
 							elem = elem[l:]
 						} else {
@@ -589,9 +564,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "move"
-						origElem := elem
+
 						if l := len("move"); len(elem) >= l && elem[0:l] == "move" {
 							elem = elem[l:]
 						} else {
@@ -610,15 +584,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user/accounts"
-				origElem := elem
+
 				if l := len("user/accounts"); len(elem) >= l && elem[0:l] == "user/accounts" {
 					elem = elem[l:]
 				} else {
@@ -637,10 +608,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -722,7 +691,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -734,7 +703,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'm': // Prefix: "market/"
-				origElem := elem
+
 				if l := len("market/"); len(elem) >= l && elem[0:l] == "market/" {
 					elem = elem[l:]
 				} else {
@@ -746,7 +715,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "bonds"
-					origElem := elem
+
 					if l := len("bonds"); len(elem) >= l && elem[0:l] == "bonds" {
 						elem = elem[l:]
 					} else {
@@ -769,9 +738,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'c': // Prefix: "c"
-					origElem := elem
+
 					if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 						elem = elem[l:]
 					} else {
@@ -783,7 +751,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'a': // Prefix: "andles"
-						origElem := elem
+
 						if l := len("andles"); len(elem) >= l && elem[0:l] == "andles" {
 							elem = elem[l:]
 						} else {
@@ -806,9 +774,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "urrencies"
-						origElem := elem
+
 						if l := len("urrencies"); len(elem) >= l && elem[0:l] == "urrencies" {
 							elem = elem[l:]
 						} else {
@@ -831,12 +798,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "etfs"
-					origElem := elem
+
 					if l := len("etfs"); len(elem) >= l && elem[0:l] == "etfs" {
 						elem = elem[l:]
 					} else {
@@ -859,9 +824,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "orderbook"
-					origElem := elem
+
 					if l := len("orderbook"); len(elem) >= l && elem[0:l] == "orderbook" {
 						elem = elem[l:]
 					} else {
@@ -884,9 +848,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 's': // Prefix: "s"
-					origElem := elem
+
 					if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 						elem = elem[l:]
 					} else {
@@ -898,7 +861,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'e': // Prefix: "earch/by-"
-						origElem := elem
+
 						if l := len("earch/by-"); len(elem) >= l && elem[0:l] == "earch/by-" {
 							elem = elem[l:]
 						} else {
@@ -910,7 +873,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'f': // Prefix: "figi"
-							origElem := elem
+
 							if l := len("figi"); len(elem) >= l && elem[0:l] == "figi" {
 								elem = elem[l:]
 							} else {
@@ -933,9 +896,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 't': // Prefix: "ticker"
-							origElem := elem
+
 							if l := len("ticker"); len(elem) >= l && elem[0:l] == "ticker" {
 								elem = elem[l:]
 							} else {
@@ -958,12 +920,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					case 't': // Prefix: "tocks"
-						origElem := elem
+
 						if l := len("tocks"); len(elem) >= l && elem[0:l] == "tocks" {
 							elem = elem[l:]
 						} else {
@@ -986,15 +946,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -1006,7 +963,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'p': // Prefix: "perations"
-					origElem := elem
+
 					if l := len("perations"); len(elem) >= l && elem[0:l] == "perations" {
 						elem = elem[l:]
 					} else {
@@ -1029,9 +986,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "rders"
-					origElem := elem
+
 					if l := len("rders"); len(elem) >= l && elem[0:l] == "rders" {
 						elem = elem[l:]
 					} else {
@@ -1054,7 +1010,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1066,7 +1022,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case 'c': // Prefix: "cancel"
-							origElem := elem
+
 							if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
 								elem = elem[l:]
 							} else {
@@ -1089,9 +1045,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'l': // Prefix: "limit-order"
-							origElem := elem
+
 							if l := len("limit-order"); len(elem) >= l && elem[0:l] == "limit-order" {
 								elem = elem[l:]
 							} else {
@@ -1114,9 +1069,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						case 'm': // Prefix: "market-order"
-							origElem := elem
+
 							if l := len("market-order"); len(elem) >= l && elem[0:l] == "market-order" {
 								elem = elem[l:]
 							} else {
@@ -1139,18 +1093,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "portfolio"
-				origElem := elem
+
 				if l := len("portfolio"); len(elem) >= l && elem[0:l] == "portfolio" {
 					elem = elem[l:]
 				} else {
@@ -1173,7 +1123,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/currencies"
-					origElem := elem
+
 					if l := len("/currencies"); len(elem) >= l && elem[0:l] == "/currencies" {
 						elem = elem[l:]
 					} else {
@@ -1196,12 +1146,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "sandbox/"
-				origElem := elem
+
 				if l := len("sandbox/"); len(elem) >= l && elem[0:l] == "sandbox/" {
 					elem = elem[l:]
 				} else {
@@ -1213,7 +1161,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "c"
-					origElem := elem
+
 					if l := len("c"); len(elem) >= l && elem[0:l] == "c" {
 						elem = elem[l:]
 					} else {
@@ -1225,7 +1173,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'l': // Prefix: "lear"
-						origElem := elem
+
 						if l := len("lear"); len(elem) >= l && elem[0:l] == "lear" {
 							elem = elem[l:]
 						} else {
@@ -1248,9 +1196,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'u': // Prefix: "urrencies/balance"
-						origElem := elem
+
 						if l := len("urrencies/balance"); len(elem) >= l && elem[0:l] == "urrencies/balance" {
 							elem = elem[l:]
 						} else {
@@ -1273,12 +1220,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "positions/balance"
-					origElem := elem
+
 					if l := len("positions/balance"); len(elem) >= l && elem[0:l] == "positions/balance" {
 						elem = elem[l:]
 					} else {
@@ -1301,9 +1246,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'r': // Prefix: "re"
-					origElem := elem
+
 					if l := len("re"); len(elem) >= l && elem[0:l] == "re" {
 						elem = elem[l:]
 					} else {
@@ -1315,7 +1259,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'g': // Prefix: "gister"
-						origElem := elem
+
 						if l := len("gister"); len(elem) >= l && elem[0:l] == "gister" {
 							elem = elem[l:]
 						} else {
@@ -1338,9 +1282,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'm': // Prefix: "move"
-						origElem := elem
+
 						if l := len("move"); len(elem) >= l && elem[0:l] == "move" {
 							elem = elem[l:]
 						} else {
@@ -1363,15 +1306,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "user/accounts"
-				origElem := elem
+
 				if l := len("user/accounts"); len(elem) >= l && elem[0:l] == "user/accounts" {
 					elem = elem[l:]
 				} else {
@@ -1394,10 +1334,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/gen/_template/router.tmpl
+++ b/gen/_template/router.tmpl
@@ -217,7 +217,7 @@ func (s *WebhookServer) Handler(webhookName string) http.Handler {
 		switch elem[0] {
 		{{- range $c := $child }}
 		case {{ quote $c.Head }}: // Prefix: {{ quote $c.Prefix }}
-			origElem := elem
+			{{ if $r.ParamChildren -}} origElem := elem {{- end }}
 			if l := len({{ quote $c.Prefix }}); len(elem) >= l && elem[0:l] == {{ quote $c.Prefix }} {
 				elem = elem[l:]
 			} else {
@@ -225,7 +225,7 @@ func (s *WebhookServer) Handler(webhookName string) http.Handler {
 			}
 			{{ template "route_edge" router_elem $c $.ParameterIndex }}
 
-			elem = origElem
+			{{ if $r.ParamChildren -}} elem = origElem {{- end }}
 		{{- end }}
 		}
 	{{- end }}
@@ -306,7 +306,7 @@ func (s *WebhookServer) Handler(webhookName string) http.Handler {
 		switch elem[0] {
 		{{- range $c := $child }}
 		case {{ quote $c.Head }}: // Prefix: {{ quote $c.Prefix }}
-			origElem := elem
+			{{ if $r.ParamChildren -}} origElem := elem {{- end }}
 			if l := len({{ quote $c.Prefix }}); len(elem) >= l && elem[0:l] == {{ quote $c.Prefix }} {
 				elem = elem[l:]
 			} else {
@@ -314,7 +314,7 @@ func (s *WebhookServer) Handler(webhookName string) http.Handler {
 			}
 			{{ template "find_edge" router_elem $c $.ParameterIndex }}
 
-			elem = origElem
+			{{ if $r.ParamChildren -}} elem = origElem {{- end }}
 		{{- end }}
 		}
 	{{- end }}

--- a/internal/integration/referenced_path_item/oas_router_gen.go
+++ b/internal/integration/referenced_path_item/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo"
-			origElem := elem
+
 			if l := len("/foo"); len(elem) >= l && elem[0:l] == "/foo" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo"
-			origElem := elem
+
 			if l := len("/foo"); len(elem) >= l && elem[0:l] == "/foo" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/sample_api/oas_router_gen.go
+++ b/internal/integration/sample_api/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -81,9 +81,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -102,9 +101,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -127,9 +125,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -141,7 +138,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -162,7 +159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -183,7 +180,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -204,7 +201,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -225,7 +222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -259,21 +256,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -292,9 +284,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -313,12 +304,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -337,9 +326,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -351,7 +339,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -370,9 +358,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -393,7 +380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -511,7 +498,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -530,7 +517,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -558,7 +544,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -579,18 +565,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -602,7 +584,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -621,9 +603,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -642,12 +623,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -659,7 +638,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -678,9 +657,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -699,12 +677,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -716,7 +692,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -735,9 +711,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -749,7 +724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -768,9 +743,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -789,12 +763,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -813,9 +785,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -834,7 +805,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -853,12 +824,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -877,13 +846,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -965,7 +931,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -977,7 +943,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -1000,9 +966,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -1025,9 +990,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -1066,9 +1030,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -1080,7 +1043,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -1101,7 +1064,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1122,7 +1085,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -1143,7 +1106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -1164,7 +1127,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -1196,21 +1159,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -1233,9 +1191,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -1258,12 +1215,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -1286,9 +1241,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -1300,7 +1254,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -1323,9 +1277,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -1356,7 +1309,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1492,7 +1445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -1515,7 +1468,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -1545,7 +1497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -1568,18 +1520,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -1591,7 +1539,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -1614,9 +1562,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -1639,12 +1586,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -1656,7 +1601,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -1679,9 +1624,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -1704,12 +1648,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -1721,7 +1663,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -1744,9 +1686,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -1758,7 +1699,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -1781,9 +1722,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -1806,12 +1746,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -1834,9 +1772,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -1859,7 +1796,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -1882,12 +1819,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -1910,13 +1845,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/sample_api_nc/oas_router_gen.go
+++ b/internal/integration/sample_api_nc/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -81,9 +81,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -102,9 +101,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -127,9 +125,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -141,7 +138,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -162,7 +159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -183,7 +180,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -204,7 +201,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -225,7 +222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -259,21 +256,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -292,9 +284,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -313,12 +304,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -337,9 +326,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -351,7 +339,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -370,9 +358,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -393,7 +380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -511,7 +498,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -530,7 +517,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -558,7 +544,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -579,18 +565,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -602,7 +584,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -621,9 +603,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -642,12 +623,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -659,7 +638,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -678,9 +657,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -699,12 +677,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -716,7 +692,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -735,9 +711,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -749,7 +724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -768,9 +743,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -789,12 +763,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -813,9 +785,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -834,7 +805,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -853,12 +824,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -877,13 +846,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -965,7 +931,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -977,7 +943,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -1000,9 +966,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -1025,9 +990,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -1066,9 +1030,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -1080,7 +1043,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -1101,7 +1064,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1122,7 +1085,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -1143,7 +1106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -1164,7 +1127,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -1196,21 +1159,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -1233,9 +1191,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -1258,12 +1215,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -1286,9 +1241,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -1300,7 +1254,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -1323,9 +1277,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -1356,7 +1309,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1492,7 +1445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -1515,7 +1468,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -1545,7 +1497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -1568,18 +1520,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -1591,7 +1539,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -1614,9 +1562,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -1639,12 +1586,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -1656,7 +1601,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -1679,9 +1624,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -1704,12 +1648,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -1721,7 +1663,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -1744,9 +1686,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -1758,7 +1699,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -1781,9 +1722,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -1806,12 +1746,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -1834,9 +1772,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -1859,7 +1796,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -1882,12 +1819,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -1910,13 +1845,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/sample_api_no_otel/oas_router_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -81,9 +81,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -102,9 +101,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -127,9 +125,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -141,7 +138,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -162,7 +159,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -183,7 +180,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -204,7 +201,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -225,7 +222,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -259,21 +256,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -292,9 +284,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -313,12 +304,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -337,9 +326,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -351,7 +339,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -370,9 +358,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -393,7 +380,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -511,7 +498,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -530,7 +517,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									return
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -558,7 +544,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -579,18 +565,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -602,7 +584,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -621,9 +603,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -642,12 +623,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -659,7 +638,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -678,9 +657,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -699,12 +677,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -716,7 +692,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -735,9 +711,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -749,7 +724,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -768,9 +743,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -789,12 +763,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -813,9 +785,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -834,7 +805,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -853,12 +824,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -877,13 +846,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -965,7 +931,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -977,7 +943,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'd': // Prefix: "defaultTest"
-				origElem := elem
+
 				if l := len("defaultTest"); len(elem) >= l && elem[0:l] == "defaultTest" {
 					elem = elem[l:]
 				} else {
@@ -1000,9 +966,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'e': // Prefix: "error"
-				origElem := elem
+
 				if l := len("error"); len(elem) >= l && elem[0:l] == "error" {
 					elem = elem[l:]
 				} else {
@@ -1025,9 +990,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'f': // Prefix: "foobar"
-				origElem := elem
+
 				if l := len("foobar"); len(elem) >= l && elem[0:l] == "foobar" {
 					elem = elem[l:]
 				} else {
@@ -1066,9 +1030,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'n': // Prefix: "n"
-				origElem := elem
+
 				if l := len("n"); len(elem) >= l && elem[0:l] == "n" {
 					elem = elem[l:]
 				} else {
@@ -1080,7 +1043,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame/"
-					origElem := elem
+
 					if l := len("ame/"); len(elem) >= l && elem[0:l] == "ame/" {
 						elem = elem[l:]
 					} else {
@@ -1101,7 +1064,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1122,7 +1085,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '1': // Prefix: "1234"
-							origElem := elem
+
 							if l := len("1234"); len(elem) >= l && elem[0:l] == "1234" {
 								elem = elem[l:]
 							} else {
@@ -1143,7 +1106,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case '-': // Prefix: "-"
-								origElem := elem
+
 								if l := len("-"); len(elem) >= l && elem[0:l] == "-" {
 									elem = elem[l:]
 								} else {
@@ -1164,7 +1127,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 								switch elem[0] {
 								case '!': // Prefix: "!"
-									origElem := elem
+
 									if l := len("!"); len(elem) >= l && elem[0:l] == "!" {
 										elem = elem[l:]
 									} else {
@@ -1196,21 +1159,16 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										}
 									}
 
-									elem = origElem
 								}
 
-								elem = origElem
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "oAdditionalPropertiesTest"
-					origElem := elem
+
 					if l := len("oAdditionalPropertiesTest"); len(elem) >= l && elem[0:l] == "oAdditionalPropertiesTest" {
 						elem = elem[l:]
 					} else {
@@ -1233,9 +1191,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'u': // Prefix: "ullableDefaultResponse"
-					origElem := elem
+
 					if l := len("ullableDefaultResponse"); len(elem) >= l && elem[0:l] == "ullableDefaultResponse" {
 						elem = elem[l:]
 					} else {
@@ -1258,12 +1215,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneofBug"
-				origElem := elem
+
 				if l := len("oneofBug"); len(elem) >= l && elem[0:l] == "oneofBug" {
 					elem = elem[l:]
 				} else {
@@ -1286,9 +1241,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "p"
-				origElem := elem
+
 				if l := len("p"); len(elem) >= l && elem[0:l] == "p" {
 					elem = elem[l:]
 				} else {
@@ -1300,7 +1254,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "atternRecursiveMap"
-					origElem := elem
+
 					if l := len("atternRecursiveMap"); len(elem) >= l && elem[0:l] == "atternRecursiveMap" {
 						elem = elem[l:]
 					} else {
@@ -1323,9 +1277,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'e': // Prefix: "et"
-					origElem := elem
+
 					if l := len("et"); len(elem) >= l && elem[0:l] == "et" {
 						elem = elem[l:]
 					} else {
@@ -1356,7 +1309,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
-						origElem := elem
+
 						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
@@ -1492,7 +1445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 							switch elem[0] {
 							case 'A': // Prefix: "Alias"
-								origElem := elem
+
 								if l := len("Alias"); len(elem) >= l && elem[0:l] == "Alias" {
 									elem = elem[l:]
 								} else {
@@ -1515,7 +1468,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 								}
 
-								elem = origElem
 							}
 
 							elem = origElem
@@ -1545,7 +1497,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 						switch elem[0] {
 						case '/': // Prefix: "/avatar"
-							origElem := elem
+
 							if l := len("/avatar"); len(elem) >= l && elem[0:l] == "/avatar" {
 								elem = elem[l:]
 							} else {
@@ -1568,18 +1520,14 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								}
 							}
 
-							elem = origElem
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "recursive"
-				origElem := elem
+
 				if l := len("recursive"); len(elem) >= l && elem[0:l] == "recursive" {
 					elem = elem[l:]
 				} else {
@@ -1591,7 +1539,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "Array"
-					origElem := elem
+
 					if l := len("Array"); len(elem) >= l && elem[0:l] == "Array" {
 						elem = elem[l:]
 					} else {
@@ -1614,9 +1562,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Map"
-					origElem := elem
+
 					if l := len("Map"); len(elem) >= l && elem[0:l] == "Map" {
 						elem = elem[l:]
 					} else {
@@ -1639,12 +1586,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -1656,7 +1601,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'e': // Prefix: "ecurityTest"
-					origElem := elem
+
 					if l := len("ecurityTest"); len(elem) >= l && elem[0:l] == "ecurityTest" {
 						elem = elem[l:]
 					} else {
@@ -1679,9 +1624,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringIntMap"
-					origElem := elem
+
 					if l := len("tringIntMap"); len(elem) >= l && elem[0:l] == "tringIntMap" {
 						elem = elem[l:]
 					} else {
@@ -1704,12 +1648,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -1721,7 +1663,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FloatValidation"
-					origElem := elem
+
 					if l := len("FloatValidation"); len(elem) >= l && elem[0:l] == "FloatValidation" {
 						elem = elem[l:]
 					} else {
@@ -1744,9 +1686,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'I': // Prefix: "I"
-					origElem := elem
+
 					if l := len("I"); len(elem) >= l && elem[0:l] == "I" {
 						elem = elem[l:]
 					} else {
@@ -1758,7 +1699,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'n': // Prefix: "nlineOneof"
-						origElem := elem
+
 						if l := len("nlineOneof"); len(elem) >= l && elem[0:l] == "nlineOneof" {
 							elem = elem[l:]
 						} else {
@@ -1781,9 +1722,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 's': // Prefix: "ssue1310"
-						origElem := elem
+
 						if l := len("ssue1310"); len(elem) >= l && elem[0:l] == "ssue1310" {
 							elem = elem[l:]
 						} else {
@@ -1806,12 +1746,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'N': // Prefix: "NullableOneofs"
-					origElem := elem
+
 					if l := len("NullableOneofs"); len(elem) >= l && elem[0:l] == "NullableOneofs" {
 						elem = elem[l:]
 					} else {
@@ -1834,9 +1772,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'T': // Prefix: "Tuple"
-					origElem := elem
+
 					if l := len("Tuple"); len(elem) >= l && elem[0:l] == "Tuple" {
 						elem = elem[l:]
 					} else {
@@ -1859,7 +1796,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'N': // Prefix: "Named"
-						origElem := elem
+
 						if l := len("Named"); len(elem) >= l && elem[0:l] == "Named" {
 							elem = elem[l:]
 						} else {
@@ -1882,12 +1819,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'U': // Prefix: "UniqueItems"
-					origElem := elem
+
 					if l := len("UniqueItems"); len(elem) >= l && elem[0:l] == "UniqueItems" {
 						elem = elem[l:]
 					} else {
@@ -1910,13 +1845,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/sample_err/oas_router_gen.go
+++ b/internal/integration/sample_err/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/data"
-			origElem := elem
+
 			if l := len("/data"); len(elem) >= l && elem[0:l] == "/data" {
 				elem = elem[l:]
 			} else {
@@ -70,7 +70,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -152,7 +151,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/data"
-			origElem := elem
+
 			if l := len("/data"); len(elem) >= l && elem[0:l] == "/data" {
 				elem = elem[l:]
 			} else {
@@ -183,7 +182,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/security_reentrant/oas_router_gen.go
+++ b/internal/integration/security_reentrant/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "customSecurity"
-				origElem := elem
+
 				if l := len("customSecurity"); len(elem) >= l && elem[0:l] == "customSecurity" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "disjointSecurity"
-				origElem := elem
+
 				if l := len("disjointSecurity"); len(elem) >= l && elem[0:l] == "disjointSecurity" {
 					elem = elem[l:]
 				} else {
@@ -101,9 +100,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectSecurity"
-				origElem := elem
+
 				if l := len("intersectSecurity"); len(elem) >= l && elem[0:l] == "intersectSecurity" {
 					elem = elem[l:]
 				} else {
@@ -122,9 +120,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "optionalSecurity"
-				origElem := elem
+
 				if l := len("optionalSecurity"); len(elem) >= l && elem[0:l] == "optionalSecurity" {
 					elem = elem[l:]
 				} else {
@@ -143,10 +140,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -228,7 +223,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -240,7 +235,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "customSecurity"
-				origElem := elem
+
 				if l := len("customSecurity"); len(elem) >= l && elem[0:l] == "customSecurity" {
 					elem = elem[l:]
 				} else {
@@ -263,9 +258,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "disjointSecurity"
-				origElem := elem
+
 				if l := len("disjointSecurity"); len(elem) >= l && elem[0:l] == "disjointSecurity" {
 					elem = elem[l:]
 				} else {
@@ -288,9 +282,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectSecurity"
-				origElem := elem
+
 				if l := len("intersectSecurity"); len(elem) >= l && elem[0:l] == "intersectSecurity" {
 					elem = elem[l:]
 				} else {
@@ -313,9 +306,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "optionalSecurity"
-				origElem := elem
+
 				if l := len("optionalSecurity"); len(elem) >= l && elem[0:l] == "optionalSecurity" {
 					elem = elem[l:]
 				} else {
@@ -338,10 +330,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/techempower/oas_router_gen.go
+++ b/internal/integration/techempower/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "cached-worlds"
-				origElem := elem
+
 				if l := len("cached-worlds"); len(elem) >= l && elem[0:l] == "cached-worlds" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "db"
-				origElem := elem
+
 				if l := len("db"); len(elem) >= l && elem[0:l] == "db" {
 					elem = elem[l:]
 				} else {
@@ -101,9 +100,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'j': // Prefix: "json"
-				origElem := elem
+
 				if l := len("json"); len(elem) >= l && elem[0:l] == "json" {
 					elem = elem[l:]
 				} else {
@@ -122,9 +120,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'q': // Prefix: "queries"
-				origElem := elem
+
 				if l := len("queries"); len(elem) >= l && elem[0:l] == "queries" {
 					elem = elem[l:]
 				} else {
@@ -143,9 +140,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "updates"
-				origElem := elem
+
 				if l := len("updates"); len(elem) >= l && elem[0:l] == "updates" {
 					elem = elem[l:]
 				} else {
@@ -164,10 +160,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -249,7 +243,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -261,7 +255,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "cached-worlds"
-				origElem := elem
+
 				if l := len("cached-worlds"); len(elem) >= l && elem[0:l] == "cached-worlds" {
 					elem = elem[l:]
 				} else {
@@ -284,9 +278,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "db"
-				origElem := elem
+
 				if l := len("db"); len(elem) >= l && elem[0:l] == "db" {
 					elem = elem[l:]
 				} else {
@@ -309,9 +302,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'j': // Prefix: "json"
-				origElem := elem
+
 				if l := len("json"); len(elem) >= l && elem[0:l] == "json" {
 					elem = elem[l:]
 				} else {
@@ -334,9 +326,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'q': // Prefix: "queries"
-				origElem := elem
+
 				if l := len("queries"); len(elem) >= l && elem[0:l] == "queries" {
 					elem = elem[l:]
 				} else {
@@ -359,9 +350,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'u': // Prefix: "updates"
-				origElem := elem
+
 				if l := len("updates"); len(elem) >= l && elem[0:l] == "updates" {
 					elem = elem[l:]
 				} else {
@@ -384,10 +374,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_additionalpropertiespatternproperties/oas_router_gen.go
+++ b/internal/integration/test_additionalpropertiespatternproperties/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/api/alive"
-			origElem := elem
+
 			if l := len("/api/alive"); len(elem) >= l && elem[0:l] == "/api/alive" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/api/alive"
-			origElem := elem
+
 			if l := len("/api/alive"); len(elem) >= l && elem[0:l] == "/api/alive" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_allof/oas_router_gen.go
+++ b/internal/integration/test_allof/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'n': // Prefix: "nullableStrings"
-				origElem := elem
+
 				if l := len("nullableStrings"); len(elem) >= l && elem[0:l] == "nullableStrings" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "objectsWithConflicting"
-				origElem := elem
+
 				if l := len("objectsWithConflicting"); len(elem) >= l && elem[0:l] == "objectsWithConflicting" {
 					elem = elem[l:]
 				} else {
@@ -94,7 +93,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "ArrayProperty"
-					origElem := elem
+
 					if l := len("ArrayProperty"); len(elem) >= l && elem[0:l] == "ArrayProperty" {
 						elem = elem[l:]
 					} else {
@@ -113,9 +112,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'P': // Prefix: "Properties"
-					origElem := elem
+
 					if l := len("Properties"); len(elem) >= l && elem[0:l] == "Properties" {
 						elem = elem[l:]
 					} else {
@@ -134,12 +132,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "referencedAllof"
-				origElem := elem
+
 				if l := len("referencedAllof"); len(elem) >= l && elem[0:l] == "referencedAllof" {
 					elem = elem[l:]
 				} else {
@@ -158,7 +154,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -177,12 +173,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -194,7 +188,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "imple"
-					origElem := elem
+
 					if l := len("imple"); len(elem) >= l && elem[0:l] == "imple" {
 						elem = elem[l:]
 					} else {
@@ -206,7 +200,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'I': // Prefix: "Integer"
-						origElem := elem
+
 						if l := len("Integer"); len(elem) >= l && elem[0:l] == "Integer" {
 							elem = elem[l:]
 						} else {
@@ -225,9 +219,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'O': // Prefix: "Objects"
-						origElem := elem
+
 						if l := len("Objects"); len(elem) >= l && elem[0:l] == "Objects" {
 							elem = elem[l:]
 						} else {
@@ -246,12 +239,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringsNotype"
-					origElem := elem
+
 					if l := len("tringsNotype"); len(elem) >= l && elem[0:l] == "tringsNotype" {
 						elem = elem[l:]
 					} else {
@@ -270,13 +261,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -358,7 +346,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -370,7 +358,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'n': // Prefix: "nullableStrings"
-				origElem := elem
+
 				if l := len("nullableStrings"); len(elem) >= l && elem[0:l] == "nullableStrings" {
 					elem = elem[l:]
 				} else {
@@ -393,9 +381,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "objectsWithConflicting"
-				origElem := elem
+
 				if l := len("objectsWithConflicting"); len(elem) >= l && elem[0:l] == "objectsWithConflicting" {
 					elem = elem[l:]
 				} else {
@@ -407,7 +394,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'A': // Prefix: "ArrayProperty"
-					origElem := elem
+
 					if l := len("ArrayProperty"); len(elem) >= l && elem[0:l] == "ArrayProperty" {
 						elem = elem[l:]
 					} else {
@@ -430,9 +417,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'P': // Prefix: "Properties"
-					origElem := elem
+
 					if l := len("Properties"); len(elem) >= l && elem[0:l] == "Properties" {
 						elem = elem[l:]
 					} else {
@@ -455,12 +441,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "referencedAllof"
-				origElem := elem
+
 				if l := len("referencedAllof"); len(elem) >= l && elem[0:l] == "referencedAllof" {
 					elem = elem[l:]
 				} else {
@@ -483,7 +467,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -506,12 +490,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -523,7 +505,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'i': // Prefix: "imple"
-					origElem := elem
+
 					if l := len("imple"); len(elem) >= l && elem[0:l] == "imple" {
 						elem = elem[l:]
 					} else {
@@ -535,7 +517,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'I': // Prefix: "Integer"
-						origElem := elem
+
 						if l := len("Integer"); len(elem) >= l && elem[0:l] == "Integer" {
 							elem = elem[l:]
 						} else {
@@ -558,9 +540,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'O': // Prefix: "Objects"
-						origElem := elem
+
 						if l := len("Objects"); len(elem) >= l && elem[0:l] == "Objects" {
 							elem = elem[l:]
 						} else {
@@ -583,12 +564,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 't': // Prefix: "tringsNotype"
-					origElem := elem
+
 					if l := len("tringsNotype"); len(elem) >= l && elem[0:l] == "tringsNotype" {
 						elem = elem[l:]
 					} else {
@@ -611,13 +590,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_anyof/oas_router_gen.go
+++ b/internal/integration/test_anyof/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'i': // Prefix: "integerNumber"
-				origElem := elem
+
 				if l := len("integerNumber"); len(elem) >= l && elem[0:l] == "integerNumber" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'j': // Prefix: "jaegerAnyOf"
-				origElem := elem
+
 				if l := len("jaegerAnyOf"); len(elem) >= l && elem[0:l] == "jaegerAnyOf" {
 					elem = elem[l:]
 				} else {
@@ -101,9 +100,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneUUID"
-				origElem := elem
+
 				if l := len("oneUUID"); len(elem) >= l && elem[0:l] == "oneUUID" {
 					elem = elem[l:]
 				} else {
@@ -122,10 +120,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -207,7 +203,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -219,7 +215,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'i': // Prefix: "integerNumber"
-				origElem := elem
+
 				if l := len("integerNumber"); len(elem) >= l && elem[0:l] == "integerNumber" {
 					elem = elem[l:]
 				} else {
@@ -242,9 +238,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'j': // Prefix: "jaegerAnyOf"
-				origElem := elem
+
 				if l := len("jaegerAnyOf"); len(elem) >= l && elem[0:l] == "jaegerAnyOf" {
 					elem = elem[l:]
 				} else {
@@ -267,9 +262,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "oneUUID"
-				origElem := elem
+
 				if l := len("oneUUID"); len(elem) >= l && elem[0:l] == "oneUUID" {
 					elem = elem[l:]
 				} else {
@@ -292,10 +286,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_client_options/oas_router_gen.go
+++ b/internal/integration/test_client_options/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo"
-			origElem := elem
+
 			if l := len("/foo"); len(elem) >= l && elem[0:l] == "/foo" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo"
-			origElem := elem
+
 			if l := len("/foo"); len(elem) >= l && elem[0:l] == "/foo" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_enum_naming/oas_router_gen.go
+++ b/internal/integration/test_enum_naming/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_form/oas_router_gen.go
+++ b/internal/integration/test_form/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'o': // Prefix: "only"
-				origElem := elem
+
 				if l := len("only"); len(elem) >= l && elem[0:l] == "only" {
 					elem = elem[l:]
 				} else {
@@ -73,7 +73,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "Form"
-					origElem := elem
+
 					if l := len("Form"); len(elem) >= l && elem[0:l] == "Form" {
 						elem = elem[l:]
 					} else {
@@ -92,9 +92,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "MultipartF"
-					origElem := elem
+
 					if l := len("MultipartF"); len(elem) >= l && elem[0:l] == "MultipartF" {
 						elem = elem[l:]
 					} else {
@@ -106,7 +105,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'i': // Prefix: "ile"
-						origElem := elem
+
 						if l := len("ile"); len(elem) >= l && elem[0:l] == "ile" {
 							elem = elem[l:]
 						} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "orm"
-						origElem := elem
+
 						if l := len("orm"); len(elem) >= l && elem[0:l] == "orm" {
 							elem = elem[l:]
 						} else {
@@ -146,15 +144,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -166,7 +161,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FormURLEncoded"
-					origElem := elem
+
 					if l := len("FormURLEncoded"); len(elem) >= l && elem[0:l] == "FormURLEncoded" {
 						elem = elem[l:]
 					} else {
@@ -185,9 +180,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Multipart"
-					origElem := elem
+
 					if l := len("Multipart"); len(elem) >= l && elem[0:l] == "Multipart" {
 						elem = elem[l:]
 					} else {
@@ -206,7 +200,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'U': // Prefix: "Upload"
-						origElem := elem
+
 						if l := len("Upload"); len(elem) >= l && elem[0:l] == "Upload" {
 							elem = elem[l:]
 						} else {
@@ -225,12 +219,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'R': // Prefix: "ReuseForm"
-					origElem := elem
+
 					if l := len("ReuseForm"); len(elem) >= l && elem[0:l] == "ReuseForm" {
 						elem = elem[l:]
 					} else {
@@ -242,7 +234,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'O': // Prefix: "OptionalSchema"
-						origElem := elem
+
 						if l := len("OptionalSchema"); len(elem) >= l && elem[0:l] == "OptionalSchema" {
 							elem = elem[l:]
 						} else {
@@ -261,9 +253,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "Schema"
-						origElem := elem
+
 						if l := len("Schema"); len(elem) >= l && elem[0:l] == "Schema" {
 							elem = elem[l:]
 						} else {
@@ -282,12 +273,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "ShareFormSchema"
-					origElem := elem
+
 					if l := len("ShareFormSchema"); len(elem) >= l && elem[0:l] == "ShareFormSchema" {
 						elem = elem[l:]
 					} else {
@@ -306,13 +295,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -394,7 +380,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -406,7 +392,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'o': // Prefix: "only"
-				origElem := elem
+
 				if l := len("only"); len(elem) >= l && elem[0:l] == "only" {
 					elem = elem[l:]
 				} else {
@@ -418,7 +404,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "Form"
-					origElem := elem
+
 					if l := len("Form"); len(elem) >= l && elem[0:l] == "Form" {
 						elem = elem[l:]
 					} else {
@@ -441,9 +427,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "MultipartF"
-					origElem := elem
+
 					if l := len("MultipartF"); len(elem) >= l && elem[0:l] == "MultipartF" {
 						elem = elem[l:]
 					} else {
@@ -455,7 +440,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'i': // Prefix: "ile"
-						origElem := elem
+
 						if l := len("ile"); len(elem) >= l && elem[0:l] == "ile" {
 							elem = elem[l:]
 						} else {
@@ -478,9 +463,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'o': // Prefix: "orm"
-						origElem := elem
+
 						if l := len("orm"); len(elem) >= l && elem[0:l] == "orm" {
 							elem = elem[l:]
 						} else {
@@ -503,15 +487,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 't': // Prefix: "test"
-				origElem := elem
+
 				if l := len("test"); len(elem) >= l && elem[0:l] == "test" {
 					elem = elem[l:]
 				} else {
@@ -523,7 +504,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'F': // Prefix: "FormURLEncoded"
-					origElem := elem
+
 					if l := len("FormURLEncoded"); len(elem) >= l && elem[0:l] == "FormURLEncoded" {
 						elem = elem[l:]
 					} else {
@@ -546,9 +527,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'M': // Prefix: "Multipart"
-					origElem := elem
+
 					if l := len("Multipart"); len(elem) >= l && elem[0:l] == "Multipart" {
 						elem = elem[l:]
 					} else {
@@ -571,7 +551,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'U': // Prefix: "Upload"
-						origElem := elem
+
 						if l := len("Upload"); len(elem) >= l && elem[0:l] == "Upload" {
 							elem = elem[l:]
 						} else {
@@ -594,12 +574,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'R': // Prefix: "ReuseForm"
-					origElem := elem
+
 					if l := len("ReuseForm"); len(elem) >= l && elem[0:l] == "ReuseForm" {
 						elem = elem[l:]
 					} else {
@@ -611,7 +589,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'O': // Prefix: "OptionalSchema"
-						origElem := elem
+
 						if l := len("OptionalSchema"); len(elem) >= l && elem[0:l] == "OptionalSchema" {
 							elem = elem[l:]
 						} else {
@@ -634,9 +612,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'S': // Prefix: "Schema"
-						origElem := elem
+
 						if l := len("Schema"); len(elem) >= l && elem[0:l] == "Schema" {
 							elem = elem[l:]
 						} else {
@@ -659,12 +636,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'S': // Prefix: "ShareFormSchema"
-					origElem := elem
+
 					if l := len("ShareFormSchema"); len(elem) >= l && elem[0:l] == "ShareFormSchema" {
 						elem = elem[l:]
 					} else {
@@ -687,13 +662,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_http_requests/oas_router_gen.go
+++ b/internal/integration/test_http_requests/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "allRequestBodies"
-				origElem := elem
+
 				if l := len("allRequestBodies"); len(elem) >= l && elem[0:l] == "allRequestBodies" {
 					elem = elem[l:]
 				} else {
@@ -80,7 +80,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -99,12 +99,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "base64Request"
-				origElem := elem
+
 				if l := len("base64Request"); len(elem) >= l && elem[0:l] == "base64Request" {
 					elem = elem[l:]
 				} else {
@@ -123,9 +121,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "maskContentType"
-				origElem := elem
+
 				if l := len("maskContentType"); len(elem) >= l && elem[0:l] == "maskContentType" {
 					elem = elem[l:]
 				} else {
@@ -144,7 +141,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -163,12 +160,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "streamJSON"
-				origElem := elem
+
 				if l := len("streamJSON"); len(elem) >= l && elem[0:l] == "streamJSON" {
 					elem = elem[l:]
 				} else {
@@ -187,10 +182,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -272,7 +265,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -284,7 +277,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "allRequestBodies"
-				origElem := elem
+
 				if l := len("allRequestBodies"); len(elem) >= l && elem[0:l] == "allRequestBodies" {
 					elem = elem[l:]
 				} else {
@@ -307,7 +300,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -330,12 +323,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'b': // Prefix: "base64Request"
-				origElem := elem
+
 				if l := len("base64Request"); len(elem) >= l && elem[0:l] == "base64Request" {
 					elem = elem[l:]
 				} else {
@@ -358,9 +349,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "maskContentType"
-				origElem := elem
+
 				if l := len("maskContentType"); len(elem) >= l && elem[0:l] == "maskContentType" {
 					elem = elem[l:]
 				} else {
@@ -383,7 +373,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'O': // Prefix: "Optional"
-					origElem := elem
+
 					if l := len("Optional"); len(elem) >= l && elem[0:l] == "Optional" {
 						elem = elem[l:]
 					} else {
@@ -406,12 +396,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "streamJSON"
-				origElem := elem
+
 				if l := len("streamJSON"); len(elem) >= l && elem[0:l] == "streamJSON" {
 					elem = elem[l:]
 				} else {
@@ -434,10 +422,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_http_responses/oas_router_gen.go
+++ b/internal/integration/test_http_responses/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "anyContentTypeBinaryStringSchema"
-				origElem := elem
+
 				if l := len("anyContentTypeBinaryStringSchema"); len(elem) >= l && elem[0:l] == "anyContentTypeBinaryStringSchema" {
 					elem = elem[l:]
 				} else {
@@ -80,7 +80,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'D': // Prefix: "Default"
-					origElem := elem
+
 					if l := len("Default"); len(elem) >= l && elem[0:l] == "Default" {
 						elem = elem[l:]
 					} else {
@@ -99,12 +99,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "combined"
-				origElem := elem
+
 				if l := len("combined"); len(elem) >= l && elem[0:l] == "combined" {
 					elem = elem[l:]
 				} else {
@@ -123,9 +121,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'h': // Prefix: "headers"
-				origElem := elem
+
 				if l := len("headers"); len(elem) >= l && elem[0:l] == "headers" {
 					elem = elem[l:]
 				} else {
@@ -137,7 +134,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case '2': // Prefix: "200"
-					origElem := elem
+
 					if l := len("200"); len(elem) >= l && elem[0:l] == "200" {
 						elem = elem[l:]
 					} else {
@@ -156,9 +153,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'C': // Prefix: "Combined"
-					origElem := elem
+
 					if l := len("Combined"); len(elem) >= l && elem[0:l] == "Combined" {
 						elem = elem[l:]
 					} else {
@@ -177,9 +173,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'D': // Prefix: "Default"
-					origElem := elem
+
 					if l := len("Default"); len(elem) >= l && elem[0:l] == "Default" {
 						elem = elem[l:]
 					} else {
@@ -198,9 +193,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'J': // Prefix: "JSON"
-					origElem := elem
+
 					if l := len("JSON"); len(elem) >= l && elem[0:l] == "JSON" {
 						elem = elem[l:]
 					} else {
@@ -219,9 +213,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'P': // Prefix: "Pattern"
-					origElem := elem
+
 					if l := len("Pattern"); len(elem) >= l && elem[0:l] == "Pattern" {
 						elem = elem[l:]
 					} else {
@@ -240,12 +233,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectPatternCode"
-				origElem := elem
+
 				if l := len("intersectPatternCode"); len(elem) >= l && elem[0:l] == "intersectPatternCode" {
 					elem = elem[l:]
 				} else {
@@ -264,9 +255,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "multipleGenericResponses"
-				origElem := elem
+
 				if l := len("multipleGenericResponses"); len(elem) >= l && elem[0:l] == "multipleGenericResponses" {
 					elem = elem[l:]
 				} else {
@@ -285,9 +275,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -299,7 +288,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "ctetStream"
-					origElem := elem
+
 					if l := len("ctetStream"); len(elem) >= l && elem[0:l] == "ctetStream" {
 						elem = elem[l:]
 					} else {
@@ -311,7 +300,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'B': // Prefix: "BinaryStringSchema"
-						origElem := elem
+
 						if l := len("BinaryStringSchema"); len(elem) >= l && elem[0:l] == "BinaryStringSchema" {
 							elem = elem[l:]
 						} else {
@@ -330,9 +319,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptySchema"
-						origElem := elem
+
 						if l := len("EmptySchema"); len(elem) >= l && elem[0:l] == "EmptySchema" {
 							elem = elem[l:]
 						} else {
@@ -351,12 +339,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ptionalHeaders"
-					origElem := elem
+
 					if l := len("ptionalHeaders"); len(elem) >= l && elem[0:l] == "ptionalHeaders" {
 						elem = elem[l:]
 					} else {
@@ -375,12 +361,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "streamJSON"
-				origElem := elem
+
 				if l := len("streamJSON"); len(elem) >= l && elem[0:l] == "streamJSON" {
 					elem = elem[l:]
 				} else {
@@ -399,9 +383,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 't': // Prefix: "textPlainBinaryStringSchema"
-				origElem := elem
+
 				if l := len("textPlainBinaryStringSchema"); len(elem) >= l && elem[0:l] == "textPlainBinaryStringSchema" {
 					elem = elem[l:]
 				} else {
@@ -420,10 +403,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -505,7 +486,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -517,7 +498,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'a': // Prefix: "anyContentTypeBinaryStringSchema"
-				origElem := elem
+
 				if l := len("anyContentTypeBinaryStringSchema"); len(elem) >= l && elem[0:l] == "anyContentTypeBinaryStringSchema" {
 					elem = elem[l:]
 				} else {
@@ -540,7 +521,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'D': // Prefix: "Default"
-					origElem := elem
+
 					if l := len("Default"); len(elem) >= l && elem[0:l] == "Default" {
 						elem = elem[l:]
 					} else {
@@ -563,12 +544,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'c': // Prefix: "combined"
-				origElem := elem
+
 				if l := len("combined"); len(elem) >= l && elem[0:l] == "combined" {
 					elem = elem[l:]
 				} else {
@@ -591,9 +570,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'h': // Prefix: "headers"
-				origElem := elem
+
 				if l := len("headers"); len(elem) >= l && elem[0:l] == "headers" {
 					elem = elem[l:]
 				} else {
@@ -605,7 +583,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case '2': // Prefix: "200"
-					origElem := elem
+
 					if l := len("200"); len(elem) >= l && elem[0:l] == "200" {
 						elem = elem[l:]
 					} else {
@@ -628,9 +606,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'C': // Prefix: "Combined"
-					origElem := elem
+
 					if l := len("Combined"); len(elem) >= l && elem[0:l] == "Combined" {
 						elem = elem[l:]
 					} else {
@@ -653,9 +630,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'D': // Prefix: "Default"
-					origElem := elem
+
 					if l := len("Default"); len(elem) >= l && elem[0:l] == "Default" {
 						elem = elem[l:]
 					} else {
@@ -678,9 +654,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'J': // Prefix: "JSON"
-					origElem := elem
+
 					if l := len("JSON"); len(elem) >= l && elem[0:l] == "JSON" {
 						elem = elem[l:]
 					} else {
@@ -703,9 +678,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'P': // Prefix: "Pattern"
-					origElem := elem
+
 					if l := len("Pattern"); len(elem) >= l && elem[0:l] == "Pattern" {
 						elem = elem[l:]
 					} else {
@@ -728,12 +702,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectPatternCode"
-				origElem := elem
+
 				if l := len("intersectPatternCode"); len(elem) >= l && elem[0:l] == "intersectPatternCode" {
 					elem = elem[l:]
 				} else {
@@ -756,9 +728,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'm': // Prefix: "multipleGenericResponses"
-				origElem := elem
+
 				if l := len("multipleGenericResponses"); len(elem) >= l && elem[0:l] == "multipleGenericResponses" {
 					elem = elem[l:]
 				} else {
@@ -781,9 +752,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -795,7 +765,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'c': // Prefix: "ctetStream"
-					origElem := elem
+
 					if l := len("ctetStream"); len(elem) >= l && elem[0:l] == "ctetStream" {
 						elem = elem[l:]
 					} else {
@@ -807,7 +777,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'B': // Prefix: "BinaryStringSchema"
-						origElem := elem
+
 						if l := len("BinaryStringSchema"); len(elem) >= l && elem[0:l] == "BinaryStringSchema" {
 							elem = elem[l:]
 						} else {
@@ -830,9 +800,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'E': // Prefix: "EmptySchema"
-						origElem := elem
+
 						if l := len("EmptySchema"); len(elem) >= l && elem[0:l] == "EmptySchema" {
 							elem = elem[l:]
 						} else {
@@ -855,12 +824,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ptionalHeaders"
-					origElem := elem
+
 					if l := len("ptionalHeaders"); len(elem) >= l && elem[0:l] == "ptionalHeaders" {
 						elem = elem[l:]
 					} else {
@@ -883,12 +850,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 's': // Prefix: "streamJSON"
-				origElem := elem
+
 				if l := len("streamJSON"); len(elem) >= l && elem[0:l] == "streamJSON" {
 					elem = elem[l:]
 				} else {
@@ -911,9 +876,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 't': // Prefix: "textPlainBinaryStringSchema"
-				origElem := elem
+
 				if l := len("textPlainBinaryStringSchema"); len(elem) >= l && elem[0:l] == "textPlainBinaryStringSchema" {
 					elem = elem[l:]
 				} else {
@@ -936,10 +900,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_issue1161/oas_router_gen.go
+++ b/internal/integration/test_issue1161/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo/"
-			origElem := elem
+
 			if l := len("/foo/"); len(elem) >= l && elem[0:l] == "/foo/" {
 				elem = elem[l:]
 			} else {
@@ -74,7 +74,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "baz"
-					origElem := elem
+
 					if l := len("baz"); len(elem) >= l && elem[0:l] == "baz" {
 						elem = elem[l:]
 					} else {
@@ -93,9 +93,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'q': // Prefix: "qux"
-					origElem := elem
+
 					if l := len("qux"); len(elem) >= l && elem[0:l] == "qux" {
 						elem = elem[l:]
 					} else {
@@ -114,7 +113,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
 				elem = origElem
@@ -133,7 +131,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/xyz"
-				origElem := elem
+
 				if l := len("/xyz"); len(elem) >= l && elem[0:l] == "/xyz" {
 					elem = elem[l:]
 				} else {
@@ -154,10 +152,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -239,7 +235,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/foo/"
-			origElem := elem
+
 			if l := len("/foo/"); len(elem) >= l && elem[0:l] == "/foo/" {
 				elem = elem[l:]
 			} else {
@@ -263,7 +259,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "baz"
-					origElem := elem
+
 					if l := len("baz"); len(elem) >= l && elem[0:l] == "baz" {
 						elem = elem[l:]
 					} else {
@@ -286,9 +282,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'q': // Prefix: "qux"
-					origElem := elem
+
 					if l := len("qux"); len(elem) >= l && elem[0:l] == "qux" {
 						elem = elem[l:]
 					} else {
@@ -311,7 +306,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
 				elem = origElem
@@ -330,7 +324,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case '/': // Prefix: "/xyz"
-				origElem := elem
+
 				if l := len("/xyz"); len(elem) >= l && elem[0:l] == "/xyz" {
 					elem = elem[l:]
 				} else {
@@ -353,10 +347,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_naming_extensions/oas_router_gen.go
+++ b/internal/integration/test_naming_extensions/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_parameters/oas_router_gen.go
+++ b/internal/integration/test_parameters/oas_router_gen.go
@@ -50,7 +50,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -62,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "co"
-				origElem := elem
+
 				if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 					elem = elem[l:]
 				} else {
@@ -74,7 +74,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "mplicatedParameterName"
-					origElem := elem
+
 					if l := len("mplicatedParameterName"); len(elem) >= l && elem[0:l] == "mplicatedParameterName" {
 						elem = elem[l:]
 					} else {
@@ -93,9 +93,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ntentParameters/"
-					origElem := elem
+
 					if l := len("ntentParameters/"); len(elem) >= l && elem[0:l] == "ntentParameters/" {
 						elem = elem[l:]
 					} else {
@@ -125,9 +124,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "okieParameter"
-					origElem := elem
+
 					if l := len("okieParameter"); len(elem) >= l && elem[0:l] == "okieParameter" {
 						elem = elem[l:]
 					} else {
@@ -146,12 +144,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'h': // Prefix: "headerParameter"
-				origElem := elem
+
 				if l := len("headerParameter"); len(elem) >= l && elem[0:l] == "headerParameter" {
 					elem = elem[l:]
 				} else {
@@ -170,9 +166,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -184,7 +179,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "bject"
-					origElem := elem
+
 					if l := len("bject"); len(elem) >= l && elem[0:l] == "bject" {
 						elem = elem[l:]
 					} else {
@@ -196,7 +191,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CookieParameter"
-						origElem := elem
+
 						if l := len("CookieParameter"); len(elem) >= l && elem[0:l] == "CookieParameter" {
 							elem = elem[l:]
 						} else {
@@ -215,9 +210,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					case 'Q': // Prefix: "QueryParameter"
-						origElem := elem
+
 						if l := len("QueryParameter"); len(elem) >= l && elem[0:l] == "QueryParameter" {
 							elem = elem[l:]
 						} else {
@@ -236,12 +230,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ptionalArrayParameter"
-					origElem := elem
+
 					if l := len("ptionalArrayParameter"); len(elem) >= l && elem[0:l] == "ptionalArrayParameter" {
 						elem = elem[l:]
 					} else {
@@ -260,12 +252,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "pathParameter/"
-				origElem := elem
+
 				if l := len("pathParameter/"); len(elem) >= l && elem[0:l] == "pathParameter/" {
 					elem = elem[l:]
 				} else {
@@ -295,9 +285,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -309,7 +298,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame_name/"
-					origElem := elem
+
 					if l := len("ame_name/"); len(elem) >= l && elem[0:l] == "ame_name/" {
 						elem = elem[l:]
 					} else {
@@ -339,9 +328,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				case 'i': // Prefix: "imilarNames"
-					origElem := elem
+
 					if l := len("imilarNames"); len(elem) >= l && elem[0:l] == "imilarNames" {
 						elem = elem[l:]
 					} else {
@@ -360,13 +348,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -448,7 +433,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -460,7 +445,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "co"
-				origElem := elem
+
 				if l := len("co"); len(elem) >= l && elem[0:l] == "co" {
 					elem = elem[l:]
 				} else {
@@ -472,7 +457,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'm': // Prefix: "mplicatedParameterName"
-					origElem := elem
+
 					if l := len("mplicatedParameterName"); len(elem) >= l && elem[0:l] == "mplicatedParameterName" {
 						elem = elem[l:]
 					} else {
@@ -495,9 +480,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'n': // Prefix: "ntentParameters/"
-					origElem := elem
+
 					if l := len("ntentParameters/"); len(elem) >= l && elem[0:l] == "ntentParameters/" {
 						elem = elem[l:]
 					} else {
@@ -529,9 +513,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'o': // Prefix: "okieParameter"
-					origElem := elem
+
 					if l := len("okieParameter"); len(elem) >= l && elem[0:l] == "okieParameter" {
 						elem = elem[l:]
 					} else {
@@ -554,12 +537,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'h': // Prefix: "headerParameter"
-				origElem := elem
+
 				if l := len("headerParameter"); len(elem) >= l && elem[0:l] == "headerParameter" {
 					elem = elem[l:]
 				} else {
@@ -582,9 +563,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "o"
-				origElem := elem
+
 				if l := len("o"); len(elem) >= l && elem[0:l] == "o" {
 					elem = elem[l:]
 				} else {
@@ -596,7 +576,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'b': // Prefix: "bject"
-					origElem := elem
+
 					if l := len("bject"); len(elem) >= l && elem[0:l] == "bject" {
 						elem = elem[l:]
 					} else {
@@ -608,7 +588,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 					switch elem[0] {
 					case 'C': // Prefix: "CookieParameter"
-						origElem := elem
+
 						if l := len("CookieParameter"); len(elem) >= l && elem[0:l] == "CookieParameter" {
 							elem = elem[l:]
 						} else {
@@ -631,9 +611,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					case 'Q': // Prefix: "QueryParameter"
-						origElem := elem
+
 						if l := len("QueryParameter"); len(elem) >= l && elem[0:l] == "QueryParameter" {
 							elem = elem[l:]
 						} else {
@@ -656,12 +635,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-						elem = origElem
 					}
 
-					elem = origElem
 				case 'p': // Prefix: "ptionalArrayParameter"
-					origElem := elem
+
 					if l := len("ptionalArrayParameter"); len(elem) >= l && elem[0:l] == "ptionalArrayParameter" {
 						elem = elem[l:]
 					} else {
@@ -684,12 +661,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			case 'p': // Prefix: "pathParameter/"
-				origElem := elem
+
 				if l := len("pathParameter/"); len(elem) >= l && elem[0:l] == "pathParameter/" {
 					elem = elem[l:]
 				} else {
@@ -721,9 +696,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 's': // Prefix: "s"
-				origElem := elem
+
 				if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
 					elem = elem[l:]
 				} else {
@@ -735,7 +709,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 				switch elem[0] {
 				case 'a': // Prefix: "ame_name/"
-					origElem := elem
+
 					if l := len("ame_name/"); len(elem) >= l && elem[0:l] == "ame_name/" {
 						elem = elem[l:]
 					} else {
@@ -767,9 +741,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				case 'i': // Prefix: "imilarNames"
-					origElem := elem
+
 					if l := len("imilarNames"); len(elem) >= l && elem[0:l] == "imilarNames" {
 						elem = elem[l:]
 					} else {
@@ -792,13 +765,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-					elem = origElem
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_security/oas_router_gen.go
+++ b/internal/integration/test_security/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "customSecurity"
-				origElem := elem
+
 				if l := len("customSecurity"); len(elem) >= l && elem[0:l] == "customSecurity" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "disjointSecurity"
-				origElem := elem
+
 				if l := len("disjointSecurity"); len(elem) >= l && elem[0:l] == "disjointSecurity" {
 					elem = elem[l:]
 				} else {
@@ -101,9 +100,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectSecurity"
-				origElem := elem
+
 				if l := len("intersectSecurity"); len(elem) >= l && elem[0:l] == "intersectSecurity" {
 					elem = elem[l:]
 				} else {
@@ -122,9 +120,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "optionalSecurity"
-				origElem := elem
+
 				if l := len("optionalSecurity"); len(elem) >= l && elem[0:l] == "optionalSecurity" {
 					elem = elem[l:]
 				} else {
@@ -143,10 +140,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -228,7 +223,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -240,7 +235,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'c': // Prefix: "customSecurity"
-				origElem := elem
+
 				if l := len("customSecurity"); len(elem) >= l && elem[0:l] == "customSecurity" {
 					elem = elem[l:]
 				} else {
@@ -263,9 +258,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'd': // Prefix: "disjointSecurity"
-				origElem := elem
+
 				if l := len("disjointSecurity"); len(elem) >= l && elem[0:l] == "disjointSecurity" {
 					elem = elem[l:]
 				} else {
@@ -288,9 +282,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'i': // Prefix: "intersectSecurity"
-				origElem := elem
+
 				if l := len("intersectSecurity"); len(elem) >= l && elem[0:l] == "intersectSecurity" {
 					elem = elem[l:]
 				} else {
@@ -313,9 +306,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'o': // Prefix: "optionalSecurity"
-				origElem := elem
+
 				if l := len("optionalSecurity"); len(elem) >= l && elem[0:l] == "optionalSecurity" {
 					elem = elem[l:]
 				} else {
@@ -338,10 +330,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_servers/oas_router_gen.go
+++ b/internal/integration/test_servers/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_single_endpoint/oas_router_gen.go
+++ b/internal/integration/test_single_endpoint/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/healthz"
-			origElem := elem
+
 			if l := len("/healthz"); len(elem) >= l && elem[0:l] == "/healthz" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_time_extension/oas_router_gen.go
+++ b/internal/integration/test_time_extension/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -61,7 +61,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			switch elem[0] {
 			case 'o': // Prefix: "optional"
-				origElem := elem
+
 				if l := len("optional"); len(elem) >= l && elem[0:l] == "optional" {
 					elem = elem[l:]
 				} else {
@@ -80,9 +80,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "required"
-				origElem := elem
+
 				if l := len("required"); len(elem) >= l && elem[0:l] == "required" {
 					elem = elem[l:]
 				} else {
@@ -101,10 +100,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -186,7 +183,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/"
-			origElem := elem
+
 			if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 				elem = elem[l:]
 			} else {
@@ -198,7 +195,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 			}
 			switch elem[0] {
 			case 'o': // Prefix: "optional"
-				origElem := elem
+
 				if l := len("optional"); len(elem) >= l && elem[0:l] == "optional" {
 					elem = elem[l:]
 				} else {
@@ -221,9 +218,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			case 'r': // Prefix: "required"
-				origElem := elem
+
 				if l := len("required"); len(elem) >= l && elem[0:l] == "required" {
 					elem = elem[l:]
 				} else {
@@ -246,10 +242,8 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-				elem = origElem
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false

--- a/internal/integration/test_webhooks/oas_router_gen.go
+++ b/internal/integration/test_webhooks/oas_router_gen.go
@@ -49,7 +49,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/event"
-			origElem := elem
+
 			if l := len("/event"); len(elem) >= l && elem[0:l] == "/event" {
 				elem = elem[l:]
 			} else {
@@ -68,7 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			elem = origElem
 		}
 	}
 	s.notFound(w, r)
@@ -150,7 +149,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 		}
 		switch elem[0] {
 		case '/': // Prefix: "/event"
-			origElem := elem
+
 			if l := len("/event"); len(elem) >= l && elem[0:l] == "/event" {
 				elem = elem[l:]
 			} else {
@@ -173,7 +172,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 			}
 
-			elem = origElem
 		}
 	}
 	return r, false


### PR DESCRIPTION
The router uses a variable - origElem - to save the elem variable while potentially modifying it. After this elem is used in some cases. If it is not used, the staticcheck complains about a variable set without further use. This patch removes the origElem save in cases where elem is not used afterwards, fixing the staticcheck.