### PR TITLE
fix: JSON marshal errors of parameters with optional structs

### DIFF
--- a/_testdata/positive/parameters.json
+++ b/_testdata/positive/parameters.json
@@ -5,6 +5,82 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/optionalParameters": {
+      "get": {
+        "operationId": "optionalParameters",
+        "parameters": [
+          {
+            "name": "integer",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "string",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "boolean",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "object",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "array",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionalQueryParametersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/optionalArrayParameter": {
       "get": {
         "operationId": "optionalArrayParameter",
@@ -393,6 +469,39 @@
   },
   "components": {
     "schemas": {
+      "OptionalQueryParametersResponse": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "integer": {
+            "type": "integer"
+          },
+          "string": {
+            "type": "string"
+          },
+          "boolean": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              }
+            }
+          },
+          "timestamp": {
+              "type": "string",
+              "format": "date-time"
+          },
+          "array": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "Value": {
         "type": "object",
         "required": [

--- a/examples/ex_2ch/oas_parameters_gen.go
+++ b/examples/ex_2ch/oas_parameters_gen.go
@@ -17,9 +17,9 @@ import (
 // APICaptcha2chcaptchaIDGetParams is parameters of GET /api/captcha/2chcaptcha/id operation.
 type APICaptcha2chcaptchaIDGetParams struct {
 	// ID доски, например, b.
-	Board OptString
+	Board OptString `json:",omitempty,omitzero"`
 	// Номер треда.
-	Thread OptInt
+	Thread OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAPICaptcha2chcaptchaIDGetParams(packed middleware.Parameters) (params APICaptcha2chcaptchaIDGetParams) {
@@ -220,9 +220,9 @@ type APICaptchaAppIDPublicKeyGetParams struct {
 	// ваш клиент.
 	PublicKey string
 	// ID доски, например, b.
-	Board OptString
+	Board OptString `json:",omitempty,omitzero"`
 	// Номер треда.
-	Thread OptInt
+	Thread OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAPICaptchaAppIDPublicKeyGetParams(packed middleware.Parameters) (params APICaptchaAppIDPublicKeyGetParams) {
@@ -413,9 +413,9 @@ func decodeAPICaptchaAppIDPublicKeyGetParams(args [1]string, argsEscaped bool, r
 // APICaptchaInvisibleRecaptchaIDGetParams is parameters of GET /api/captcha/invisible_recaptcha/id operation.
 type APICaptchaInvisibleRecaptchaIDGetParams struct {
 	// ID доски, например, b.
-	Board OptString
+	Board OptString `json:",omitempty,omitzero"`
 	// Номер треда.
-	Thread OptInt
+	Thread OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAPICaptchaInvisibleRecaptchaIDGetParams(packed middleware.Parameters) (params APICaptchaInvisibleRecaptchaIDGetParams) {
@@ -554,9 +554,9 @@ func decodeAPICaptchaInvisibleRecaptchaIDGetParams(args [0]string, argsEscaped b
 // APICaptchaRecaptchaIDGetParams is parameters of GET /api/captcha/recaptcha/id operation.
 type APICaptchaRecaptchaIDGetParams struct {
 	// ID доски, например, b.
-	Board OptString
+	Board OptString `json:",omitempty,omitzero"`
 	// Номер треда.
-	Thread OptInt
+	Thread OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAPICaptchaRecaptchaIDGetParams(packed middleware.Parameters) (params APICaptchaRecaptchaIDGetParams) {

--- a/examples/ex_ent/oas_parameters_gen.go
+++ b/examples/ex_ent/oas_parameters_gen.go
@@ -347,9 +347,9 @@ func decodeDeletePetOwnerParams(args [1]string, argsEscaped bool, r *http.Reques
 // ListPetParams is parameters of listPet operation.
 type ListPetParams struct {
 	// What page to render.
-	Page OptInt32
+	Page OptInt32 `json:",omitempty,omitzero"`
 	// Item count to render per page.
-	ItemsPerPage OptInt32
+	ItemsPerPage OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackListPetParams(packed middleware.Parameters) (params ListPetParams) {
@@ -466,9 +466,9 @@ type ListPetCategoriesParams struct {
 	// ID of the Pet.
 	ID int
 	// What page to render.
-	Page OptInt32
+	Page OptInt32 `json:",omitempty,omitzero"`
 	// Item count to render per page.
-	ItemsPerPage OptInt32
+	ItemsPerPage OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackListPetCategoriesParams(packed middleware.Parameters) (params ListPetCategoriesParams) {
@@ -637,9 +637,9 @@ type ListPetFriendsParams struct {
 	// ID of the Pet.
 	ID int
 	// What page to render.
-	Page OptInt32
+	Page OptInt32 `json:",omitempty,omitzero"`
 	// Item count to render per page.
-	ItemsPerPage OptInt32
+	ItemsPerPage OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackListPetFriendsParams(packed middleware.Parameters) (params ListPetFriendsParams) {

--- a/examples/ex_github/oas_parameters_gen.go
+++ b/examples/ex_github/oas_parameters_gen.go
@@ -6374,9 +6374,9 @@ type ActionsListArtifactsForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListArtifactsForRepoParams(packed middleware.Parameters) (params ActionsListArtifactsForRepoParams) {
@@ -6608,9 +6608,9 @@ type ActionsListEnvironmentSecretsParams struct {
 	// The name of the environment.
 	EnvironmentName string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListEnvironmentSecretsParams(packed middleware.Parameters) (params ActionsListEnvironmentSecretsParams) {
@@ -6845,11 +6845,11 @@ type ActionsListJobsForWorkflowRunParams struct {
 	// Filters jobs by their `completed_at` timestamp. Can be one of:
 	// \* `latest`: Returns jobs from the most recent execution of the workflow run.
 	// \* `all`: Returns all jobs for a workflow run, including from old executions of the workflow run.
-	Filter OptActionsListJobsForWorkflowRunFilter
+	Filter OptActionsListJobsForWorkflowRunFilter `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListJobsForWorkflowRunParams(packed middleware.Parameters) (params ActionsListJobsForWorkflowRunParams) {
@@ -7201,9 +7201,9 @@ func decodeActionsListJobsForWorkflowRunParams(args [3]string, argsEscaped bool,
 type ActionsListOrgSecretsParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListOrgSecretsParams(packed middleware.Parameters) (params ActionsListOrgSecretsParams) {
@@ -7383,9 +7383,9 @@ type ActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams struct {
 	// Unique identifier of the self-hosted runner group.
 	RunnerGroupID int
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams(packed middleware.Parameters) (params ActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams) {
@@ -7616,9 +7616,9 @@ type ActionsListRepoSecretsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListRepoSecretsParams(packed middleware.Parameters) (params ActionsListRepoSecretsParams) {
@@ -7849,9 +7849,9 @@ type ActionsListRepoWorkflowsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListRepoWorkflowsParams(packed middleware.Parameters) (params ActionsListRepoWorkflowsParams) {
@@ -8266,9 +8266,9 @@ type ActionsListSelectedReposForOrgSecretParams struct {
 	// Secret_name parameter.
 	SecretName string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelectedReposForOrgSecretParams(packed middleware.Parameters) (params ActionsListSelectedReposForOrgSecretParams) {
@@ -8498,9 +8498,9 @@ func decodeActionsListSelectedReposForOrgSecretParams(args [2]string, argsEscape
 type ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams(packed middleware.Parameters) (params ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams) {
@@ -8678,9 +8678,9 @@ func decodeActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParams
 type ActionsListSelfHostedRunnerGroupsForOrgParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelfHostedRunnerGroupsForOrgParams(packed middleware.Parameters) (params ActionsListSelfHostedRunnerGroupsForOrgParams) {
@@ -8858,9 +8858,9 @@ func decodeActionsListSelfHostedRunnerGroupsForOrgParams(args [1]string, argsEsc
 type ActionsListSelfHostedRunnersForOrgParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelfHostedRunnersForOrgParams(packed middleware.Parameters) (params ActionsListSelfHostedRunnersForOrgParams) {
@@ -9039,9 +9039,9 @@ type ActionsListSelfHostedRunnersForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelfHostedRunnersForRepoParams(packed middleware.Parameters) (params ActionsListSelfHostedRunnersForRepoParams) {
@@ -9273,9 +9273,9 @@ type ActionsListSelfHostedRunnersInGroupForOrgParams struct {
 	// Unique identifier of the self-hosted runner group.
 	RunnerGroupID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListSelfHostedRunnersInGroupForOrgParams(packed middleware.Parameters) (params ActionsListSelfHostedRunnersInGroupForOrgParams) {
@@ -9508,9 +9508,9 @@ type ActionsListWorkflowRunArtifactsParams struct {
 	// The id of the workflow run.
 	RunID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListWorkflowRunArtifactsParams(packed middleware.Parameters) (params ActionsListWorkflowRunArtifactsParams) {
@@ -9794,23 +9794,23 @@ type ActionsListWorkflowRunsForRepoParams struct {
 	Repo  string
 	// Returns someone's workflow runs. Use the login for the user who created the `push` associated with
 	// the check suite or workflow run.
-	Actor OptString
+	Actor OptString `json:",omitempty,omitzero"`
 	// Returns workflow runs associated with a branch. Use the name of the branch of the `push`.
-	Branch OptString
+	Branch OptString `json:",omitempty,omitzero"`
 	// Returns workflow run triggered by the event you specify. For example, `push`, `pull_request` or
 	// `issue`. For more information, see "[Events that trigger workflows](https://help.github.
 	// com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows).".
-	Event OptString
+	Event OptString `json:",omitempty,omitzero"`
 	// Returns workflow runs with the check run `status` or `conclusion` that you specify. For example, a
 	// conclusion can be `success` or a status can be `in_progress`. Only GitHub can set a status of
 	// `waiting` or `requested`. For a list of the possible `status` and `conclusion` options, see
 	// "[Create a check run](https://docs.github.com/rest/reference/checks#create-a-check-run).".
-	Status OptWorkflowRunStatus
+	Status OptWorkflowRunStatus `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page    OptInt
-	Created OptDateTime
+	Page    OptInt      `json:",omitempty,omitzero"`
+	Created OptDateTime `json:",omitempty,omitzero"`
 }
 
 func unpackActionsListWorkflowRunsForRepoParams(packed middleware.Parameters) (params ActionsListWorkflowRunsForRepoParams) {
@@ -12797,9 +12797,9 @@ func decodeActivityGetThreadSubscriptionForAuthenticatedUserParams(args [1]strin
 type ActivityListEventsForAuthenticatedUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListEventsForAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListEventsForAuthenticatedUserParams) {
@@ -12976,19 +12976,19 @@ func decodeActivityListEventsForAuthenticatedUserParams(args [1]string, argsEsca
 // ActivityListNotificationsForAuthenticatedUserParams is parameters of activity/list-notifications-for-authenticated-user operation.
 type ActivityListNotificationsForAuthenticatedUserParams struct {
 	// If `true`, show notifications marked as read.
-	All OptBool
+	All OptBool `json:",omitempty,omitzero"`
 	// If `true`, only shows notifications in which the user is directly participating or mentioned.
-	Participating OptBool
+	Participating OptBool `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Only show notifications updated before the given time. This is a timestamp in [ISO
 	// 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Before OptDateTime
+	Before OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListNotificationsForAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListNotificationsForAuthenticatedUserParams) {
@@ -13325,9 +13325,9 @@ type ActivityListOrgEventsForAuthenticatedUserParams struct {
 	Username string
 	Org      string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListOrgEventsForAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListOrgEventsForAuthenticatedUserParams) {
@@ -13556,9 +13556,9 @@ func decodeActivityListOrgEventsForAuthenticatedUserParams(args [2]string, argsE
 // ActivityListPublicEventsParams is parameters of activity/list-public-events operation.
 type ActivityListPublicEventsParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListPublicEventsParams(packed middleware.Parameters) (params ActivityListPublicEventsParams) {
@@ -13685,9 +13685,9 @@ type ActivityListPublicEventsForRepoNetworkParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListPublicEventsForRepoNetworkParams(packed middleware.Parameters) (params ActivityListPublicEventsForRepoNetworkParams) {
@@ -13917,9 +13917,9 @@ func decodeActivityListPublicEventsForRepoNetworkParams(args [2]string, argsEsca
 type ActivityListPublicEventsForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListPublicEventsForUserParams(packed middleware.Parameters) (params ActivityListPublicEventsForUserParams) {
@@ -14097,9 +14097,9 @@ func decodeActivityListPublicEventsForUserParams(args [1]string, argsEscaped boo
 type ActivityListPublicOrgEventsParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListPublicOrgEventsParams(packed middleware.Parameters) (params ActivityListPublicOrgEventsParams) {
@@ -14277,9 +14277,9 @@ func decodeActivityListPublicOrgEventsParams(args [1]string, argsEscaped bool, r
 type ActivityListReceivedEventsForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListReceivedEventsForUserParams(packed middleware.Parameters) (params ActivityListReceivedEventsForUserParams) {
@@ -14457,9 +14457,9 @@ func decodeActivityListReceivedEventsForUserParams(args [1]string, argsEscaped b
 type ActivityListReceivedPublicEventsForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListReceivedPublicEventsForUserParams(packed middleware.Parameters) (params ActivityListReceivedPublicEventsForUserParams) {
@@ -14638,9 +14638,9 @@ type ActivityListRepoEventsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListRepoEventsParams(packed middleware.Parameters) (params ActivityListRepoEventsParams) {
@@ -14871,19 +14871,19 @@ type ActivityListRepoNotificationsForAuthenticatedUserParams struct {
 	Owner string
 	Repo  string
 	// If `true`, show notifications marked as read.
-	All OptBool
+	All OptBool `json:",omitempty,omitzero"`
 	// If `true`, only shows notifications in which the user is directly participating or mentioned.
-	Participating OptBool
+	Participating OptBool `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Only show notifications updated before the given time. This is a timestamp in [ISO
 	// 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Before OptDateTime
+	Before OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListRepoNotificationsForAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListRepoNotificationsForAuthenticatedUserParams) {
@@ -15322,13 +15322,13 @@ func decodeActivityListRepoNotificationsForAuthenticatedUserParams(args [2]strin
 // ActivityListReposStarredByAuthenticatedUserParams is parameters of activity/list-repos-starred-by-authenticated-user operation.
 type ActivityListReposStarredByAuthenticatedUserParams struct {
 	// One of `created` (when the repository was starred) or `updated` (when it was last pushed to).
-	Sort OptSort
+	Sort OptSort `json:",omitempty,omitzero"`
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListReposStarredByAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListReposStarredByAuthenticatedUserParams) {
@@ -15594,9 +15594,9 @@ func decodeActivityListReposStarredByAuthenticatedUserParams(args [0]string, arg
 type ActivityListReposWatchedByUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListReposWatchedByUserParams(packed middleware.Parameters) (params ActivityListReposWatchedByUserParams) {
@@ -15773,9 +15773,9 @@ func decodeActivityListReposWatchedByUserParams(args [1]string, argsEscaped bool
 // ActivityListWatchedReposForAuthenticatedUserParams is parameters of activity/list-watched-repos-for-authenticated-user operation.
 type ActivityListWatchedReposForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListWatchedReposForAuthenticatedUserParams(packed middleware.Parameters) (params ActivityListWatchedReposForAuthenticatedUserParams) {
@@ -15902,9 +15902,9 @@ type ActivityListWatchersForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackActivityListWatchersForRepoParams(packed middleware.Parameters) (params ActivityListWatchersForRepoParams) {
@@ -17691,14 +17691,14 @@ type AppsListAccountsForPlanParams struct {
 	// Plan_id parameter.
 	PlanID int
 	// One of `created` (when the repository was starred) or `updated` (when it was last pushed to).
-	Sort OptSort
+	Sort OptSort `json:",omitempty,omitzero"`
 	// To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without
 	// the `sort` parameter.
-	Direction OptAppsListAccountsForPlanDirection
+	Direction OptAppsListAccountsForPlanDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListAccountsForPlanParams(packed middleware.Parameters) (params AppsListAccountsForPlanParams) {
@@ -18012,14 +18012,14 @@ type AppsListAccountsForPlanStubbedParams struct {
 	// Plan_id parameter.
 	PlanID int
 	// One of `created` (when the repository was starred) or `updated` (when it was last pushed to).
-	Sort OptSort
+	Sort OptSort `json:",omitempty,omitzero"`
 	// To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without
 	// the `sort` parameter.
-	Direction OptAppsListAccountsForPlanStubbedDirection
+	Direction OptAppsListAccountsForPlanStubbedDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListAccountsForPlanStubbedParams(packed middleware.Parameters) (params AppsListAccountsForPlanStubbedParams) {
@@ -18333,9 +18333,9 @@ type AppsListInstallationReposForAuthenticatedUserParams struct {
 	// Installation_id parameter.
 	InstallationID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListInstallationReposForAuthenticatedUserParams(packed middleware.Parameters) (params AppsListInstallationReposForAuthenticatedUserParams) {
@@ -18512,9 +18512,9 @@ func decodeAppsListInstallationReposForAuthenticatedUserParams(args [1]string, a
 // AppsListPlansParams is parameters of apps/list-plans operation.
 type AppsListPlansParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListPlansParams(packed middleware.Parameters) (params AppsListPlansParams) {
@@ -18639,9 +18639,9 @@ func decodeAppsListPlansParams(args [0]string, argsEscaped bool, r *http.Request
 // AppsListPlansStubbedParams is parameters of apps/list-plans-stubbed operation.
 type AppsListPlansStubbedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListPlansStubbedParams(packed middleware.Parameters) (params AppsListPlansStubbedParams) {
@@ -18766,9 +18766,9 @@ func decodeAppsListPlansStubbedParams(args [0]string, argsEscaped bool, r *http.
 // AppsListReposAccessibleToInstallationParams is parameters of apps/list-repos-accessible-to-installation operation.
 type AppsListReposAccessibleToInstallationParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListReposAccessibleToInstallationParams(packed middleware.Parameters) (params AppsListReposAccessibleToInstallationParams) {
@@ -18893,9 +18893,9 @@ func decodeAppsListReposAccessibleToInstallationParams(args [0]string, argsEscap
 // AppsListSubscriptionsForAuthenticatedUserParams is parameters of apps/list-subscriptions-for-authenticated-user operation.
 type AppsListSubscriptionsForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListSubscriptionsForAuthenticatedUserParams(packed middleware.Parameters) (params AppsListSubscriptionsForAuthenticatedUserParams) {
@@ -19020,9 +19020,9 @@ func decodeAppsListSubscriptionsForAuthenticatedUserParams(args [0]string, argsE
 // AppsListSubscriptionsForAuthenticatedUserStubbedParams is parameters of apps/list-subscriptions-for-authenticated-user-stubbed operation.
 type AppsListSubscriptionsForAuthenticatedUserStubbedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListSubscriptionsForAuthenticatedUserStubbedParams(packed middleware.Parameters) (params AppsListSubscriptionsForAuthenticatedUserStubbedParams) {
@@ -19147,10 +19147,10 @@ func decodeAppsListSubscriptionsForAuthenticatedUserStubbedParams(args [0]string
 // AppsListWebhookDeliveriesParams is parameters of apps/list-webhook-deliveries operation.
 type AppsListWebhookDeliveriesParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Used for pagination: the starting delivery from which the page of deliveries is fetched. Refer to
 	// the `link` header for the next and previous page cursors.
-	Cursor OptString
+	Cursor OptString `json:",omitempty,omitzero"`
 }
 
 func unpackAppsListWebhookDeliveriesParams(packed middleware.Parameters) (params AppsListWebhookDeliveriesParams) {
@@ -20772,9 +20772,9 @@ type ChecksListAnnotationsParams struct {
 	// Check_run_id parameter.
 	CheckRunID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackChecksListAnnotationsParams(packed middleware.Parameters) (params ChecksListAnnotationsParams) {
@@ -21059,18 +21059,18 @@ type ChecksListForRefParams struct {
 	// Ref parameter.
 	Ref string
 	// Returns check runs with the specified `name`.
-	CheckName OptString
+	CheckName OptString `json:",omitempty,omitzero"`
 	// Returns check runs with the specified `status`. Can be one of `queued`, `in_progress`, or
 	// `completed`.
-	Status OptStatusParameter
+	Status OptStatusParameter `json:",omitempty,omitzero"`
 	// Filters check runs by their `completed_at` timestamp. Can be one of `latest` (returning the most
 	// recent check runs) or `all`.
-	Filter OptChecksListForRefFilter
+	Filter OptChecksListForRefFilter `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page  OptInt
-	AppID OptInt
+	Page  OptInt `json:",omitempty,omitzero"`
+	AppID OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackChecksListForRefParams(packed middleware.Parameters) (params ChecksListForRefParams) {
@@ -21590,17 +21590,17 @@ type ChecksListForSuiteParams struct {
 	// Check_suite_id parameter.
 	CheckSuiteID int
 	// Returns check runs with the specified `name`.
-	CheckName OptString
+	CheckName OptString `json:",omitempty,omitzero"`
 	// Returns check runs with the specified `status`. Can be one of `queued`, `in_progress`, or
 	// `completed`.
-	Status OptStatusParameter
+	Status OptStatusParameter `json:",omitempty,omitzero"`
 	// Filters check runs by their `completed_at` timestamp. Can be one of `latest` (returning the most
 	// recent check runs) or `all`.
-	Filter OptChecksListForSuiteFilter
+	Filter OptChecksListForSuiteFilter `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackChecksListForSuiteParams(packed middleware.Parameters) (params ChecksListForSuiteParams) {
@@ -22070,13 +22070,13 @@ type ChecksListSuitesForRefParams struct {
 	// Ref parameter.
 	Ref string
 	// Filters check suites by GitHub App `id`.
-	AppID OptInt
+	AppID OptInt `json:",omitempty,omitzero"`
 	// Returns check runs with the specified `name`.
-	CheckName OptString
+	CheckName OptString `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackChecksListSuitesForRefParams(packed middleware.Parameters) (params ChecksListSuitesForRefParams) {
@@ -22755,7 +22755,7 @@ type CodeScanningDeleteAnalysisParams struct {
 	// analysis in a set without setting this parameter to `true`, you'll get a 400 response with the
 	// message: `Analysis is last of its type and deletion may result in the loss of historical alert
 	// data. Please specify confirm_delete.`.
-	ConfirmDelete OptNilString
+	ConfirmDelete OptNilString `json:",omitempty,omitzero"`
 }
 
 func unpackCodeScanningDeleteAnalysisParams(packed middleware.Parameters) (params CodeScanningDeleteAnalysisParams) {
@@ -23508,13 +23508,13 @@ type CodeScanningListAlertInstancesParams struct {
 	// /repos/{owner}/{repo}/code-scanning/alerts` operation.
 	AlertNumber AlertNumber
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The Git reference for the results you want to list. The `ref` for a branch can be formatted either
 	// as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use
 	// `refs/pull/<number>/merge`.
-	Ref OptCodeScanningRef
+	Ref OptCodeScanningRef `json:",omitempty,omitzero"`
 }
 
 func unpackCodeScanningListAlertInstancesParams(packed middleware.Parameters) (params CodeScanningListAlertInstancesParams) {
@@ -23862,21 +23862,21 @@ type CodeScanningListAlertsForRepoParams struct {
 	Repo  string
 	// The name of a code scanning tool. Only results by this tool will be listed. You can specify the
 	// tool by using either `tool_name` or `tool_guid`, but not both.
-	ToolName OptCodeScanningAnalysisToolName
+	ToolName OptCodeScanningAnalysisToolName `json:",omitempty,omitzero"`
 	// The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code
 	// scanning tools may not include a GUID in their analysis data. You can specify the tool by using
 	// either `tool_guid` or `tool_name`, but not both.
-	ToolGUID OptNilCodeScanningAnalysisToolGUID
+	ToolGUID OptNilCodeScanningAnalysisToolGUID `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The Git reference for the results you want to list. The `ref` for a branch can be formatted either
 	// as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use
 	// `refs/pull/<number>/merge`.
-	Ref OptCodeScanningRef
+	Ref OptCodeScanningRef `json:",omitempty,omitzero"`
 	// Set to `open`, `fixed`, or `dismissed` to list code scanning alerts in a specific state.
-	State OptCodeScanningAlertState
+	State OptCodeScanningAlertState `json:",omitempty,omitzero"`
 }
 
 func unpackCodeScanningListAlertsForRepoParams(packed middleware.Parameters) (params CodeScanningListAlertsForRepoParams) {
@@ -24344,21 +24344,21 @@ type CodeScanningListRecentAnalysesParams struct {
 	Repo  string
 	// The name of a code scanning tool. Only results by this tool will be listed. You can specify the
 	// tool by using either `tool_name` or `tool_guid`, but not both.
-	ToolName OptCodeScanningAnalysisToolName
+	ToolName OptCodeScanningAnalysisToolName `json:",omitempty,omitzero"`
 	// The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code
 	// scanning tools may not include a GUID in their analysis data. You can specify the tool by using
 	// either `tool_guid` or `tool_name`, but not both.
-	ToolGUID OptNilCodeScanningAnalysisToolGUID
+	ToolGUID OptNilCodeScanningAnalysisToolGUID `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The Git reference for the analyses you want to list. The `ref` for a branch can be formatted
 	// either as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use
 	// `refs/pull/<number>/merge`.
-	Ref OptCodeScanningRef
+	Ref OptCodeScanningRef `json:",omitempty,omitzero"`
 	// Filter analyses belonging to the same SARIF upload.
-	SarifID OptCodeScanningAnalysisSarifID
+	SarifID OptCodeScanningAnalysisSarifID `json:",omitempty,omitzero"`
 }
 
 func unpackCodeScanningListRecentAnalysesParams(packed middleware.Parameters) (params CodeScanningListRecentAnalysesParams) {
@@ -26514,29 +26514,29 @@ type EnterpriseAdminGetAuditLogParams struct {
 	Enterprise string
 	// A search phrase. For more information, see [Searching the audit log](https://docs.github.
 	// com/github/setting-up-and-managing-organizations-and-teams/reviewing-the-audit-log-for-your-organization#searching-the-audit-log).
-	Phrase OptString
+	Phrase OptString `json:",omitempty,omitzero"`
 	// The event types to include:
 	// - `web` - returns web (non-Git) events
 	// - `git` - returns Git events
 	// - `all` - returns both web and Git events
 	// The default is `web`.
-	Include OptAuditLogInclude
+	Include OptAuditLogInclude `json:",omitempty,omitzero"`
 	// A cursor, as given in the [Link header](https://docs.github.
 	// com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches
 	// for events after this cursor.
-	After OptString
+	After OptString `json:",omitempty,omitzero"`
 	// A cursor, as given in the [Link header](https://docs.github.
 	// com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches
 	// for events before this cursor.
-	Before OptString
+	Before OptString `json:",omitempty,omitzero"`
 	// The order of audit log events. To list newest events first, specify `desc`. To list oldest events
 	// first, specify `asc`.
 	// The default is `desc`.
-	Order OptAuditLogOrder
+	Order OptAuditLogOrder `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminGetAuditLogParams(packed middleware.Parameters) (params EnterpriseAdminGetAuditLogParams) {
@@ -27063,7 +27063,7 @@ type EnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams struct {
 	// Identifier generated by the GitHub SCIM endpoint.
 	ScimGroupID string
 	// Attributes to exclude.
-	ExcludedAttributes OptString
+	ExcludedAttributes OptString `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams(packed middleware.Parameters) (params EnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams) {
@@ -27596,9 +27596,9 @@ type EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseParams struc
 	// Unique identifier of the self-hosted runner group.
 	RunnerGroupID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseParams) {
@@ -27829,13 +27829,13 @@ type EnterpriseAdminListProvisionedGroupsEnterpriseParams struct {
 	// The slug version of the enterprise name. You can also substitute this value with the enterprise id.
 	Enterprise string
 	// Used for pagination: the index of the first result to return.
-	StartIndex OptInt
+	StartIndex OptInt `json:",omitempty,omitzero"`
 	// Used for pagination: the number of results to return.
-	Count OptInt
+	Count OptInt `json:",omitempty,omitzero"`
 	// Filter results.
-	Filter OptString
+	Filter OptString `json:",omitempty,omitzero"`
 	// Attributes to exclude.
-	ExcludedAttributes OptString
+	ExcludedAttributes OptString `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListProvisionedGroupsEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListProvisionedGroupsEnterpriseParams) {
@@ -28104,11 +28104,11 @@ type EnterpriseAdminListProvisionedIdentitiesEnterpriseParams struct {
 	// The slug version of the enterprise name. You can also substitute this value with the enterprise id.
 	Enterprise string
 	// Used for pagination: the index of the first result to return.
-	StartIndex OptInt
+	StartIndex OptInt `json:",omitempty,omitzero"`
 	// Used for pagination: the number of results to return.
-	Count OptInt
+	Count OptInt `json:",omitempty,omitzero"`
 	// Filter results.
-	Filter OptString
+	Filter OptString `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListProvisionedIdentitiesEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListProvisionedIdentitiesEnterpriseParams) {
@@ -28393,9 +28393,9 @@ type EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseParam
 	// The slug version of the enterprise name. You can also substitute this value with the enterprise id.
 	Enterprise string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseParams) {
@@ -28574,9 +28574,9 @@ type EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseParams struct {
 	// The slug version of the enterprise name. You can also substitute this value with the enterprise id.
 	Enterprise string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListSelfHostedRunnerGroupsForEnterpriseParams) {
@@ -28755,9 +28755,9 @@ type EnterpriseAdminListSelfHostedRunnersForEnterpriseParams struct {
 	// The slug version of the enterprise name. You can also substitute this value with the enterprise id.
 	Enterprise string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListSelfHostedRunnersForEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListSelfHostedRunnersForEnterpriseParams) {
@@ -28938,9 +28938,9 @@ type EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams struct {
 	// Unique identifier of the self-hosted runner group.
 	RunnerGroupID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackEnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams(packed middleware.Parameters) (params EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams) {
@@ -31377,11 +31377,11 @@ func decodeGistsGetRevisionParams(args [2]string, argsEscaped bool, r *http.Requ
 type GistsListParams struct {
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListParams(packed middleware.Parameters) (params GistsListParams) {
@@ -31558,9 +31558,9 @@ type GistsListCommentsParams struct {
 	// Gist_id parameter.
 	GistID string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListCommentsParams(packed middleware.Parameters) (params GistsListCommentsParams) {
@@ -31739,9 +31739,9 @@ type GistsListCommitsParams struct {
 	// Gist_id parameter.
 	GistID string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListCommitsParams(packed middleware.Parameters) (params GistsListCommitsParams) {
@@ -31920,11 +31920,11 @@ type GistsListForUserParams struct {
 	Username string
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListForUserParams(packed middleware.Parameters) (params GistsListForUserParams) {
@@ -32153,9 +32153,9 @@ type GistsListForksParams struct {
 	// Gist_id parameter.
 	GistID string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListForksParams(packed middleware.Parameters) (params GistsListForksParams) {
@@ -32333,11 +32333,11 @@ func decodeGistsListForksParams(args [1]string, argsEscaped bool, r *http.Reques
 type GistsListPublicParams struct {
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListPublicParams(packed middleware.Parameters) (params GistsListPublicParams) {
@@ -32513,11 +32513,11 @@ func decodeGistsListPublicParams(args [0]string, argsEscaped bool, r *http.Reque
 type GistsListStarredParams struct {
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGistsListStarredParams(packed middleware.Parameters) (params GistsListStarredParams) {
@@ -34398,7 +34398,7 @@ type GitGetTreeParams struct {
 	// specified in `:tree_sha`. For example, setting `recursive` to any of the following will enable
 	// returning objects or subtrees: `0`, `1`, `"true"`, and `"false"`. Omit this parameter to prevent
 	// recursively returning objects or subtrees.
-	Recursive OptString
+	Recursive OptString `json:",omitempty,omitzero"`
 }
 
 func unpackGitGetTreeParams(packed middleware.Parameters) (params GitGetTreeParams) {
@@ -34623,9 +34623,9 @@ type GitListMatchingRefsParams struct {
 	// Ref parameter.
 	Ref string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackGitListMatchingRefsParams(packed middleware.Parameters) (params GitListMatchingRefsParams) {
@@ -37757,26 +37757,26 @@ type IssuesListParams struct {
 	// \* `subscribed`: Issues you're subscribed to updates for
 	// \* `all` or `repos`: All issues the authenticated user can see, regardless of participation or
 	// creation.
-	Filter OptIssuesListFilter
+	Filter OptIssuesListFilter `json:",omitempty,omitzero"`
 	// Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.
-	State OptIssuesListState
+	State OptIssuesListState `json:",omitempty,omitzero"`
 	// A list of comma separated label names. Example: `bug,ui,@high`.
-	Labels OptString
+	Labels OptString `json:",omitempty,omitzero"`
 	// What to sort results by. Can be either `created`, `updated`, `comments`.
-	Sort OptIssuesListSort
+	Sort OptIssuesListSort `json:",omitempty,omitzero"`
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since  OptDateTime
-	Collab OptBool
-	Orgs   OptBool
-	Owned  OptBool
-	Pulls  OptBool
+	Since  OptDateTime `json:",omitempty,omitzero"`
+	Collab OptBool     `json:",omitempty,omitzero"`
+	Orgs   OptBool     `json:",omitempty,omitzero"`
+	Owned  OptBool     `json:",omitempty,omitzero"`
+	Pulls  OptBool     `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListParams(packed middleware.Parameters) (params IssuesListParams) {
@@ -38483,9 +38483,9 @@ type IssuesListAssigneesParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListAssigneesParams(packed middleware.Parameters) (params IssuesListAssigneesParams) {
@@ -38719,11 +38719,11 @@ type IssuesListCommentsParams struct {
 	IssueNumber int
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListCommentsParams(packed middleware.Parameters) (params IssuesListCommentsParams) {
@@ -39056,16 +39056,16 @@ type IssuesListCommentsForRepoParams struct {
 	Owner string
 	Repo  string
 	// One of `created` (when the repository was starred) or `updated` (when it was last pushed to).
-	Sort OptSort
+	Sort OptSort `json:",omitempty,omitzero"`
 	// Either `asc` or `desc`. Ignored without the `sort` parameter.
-	Direction OptIssuesListCommentsForRepoDirection
+	Direction OptIssuesListCommentsForRepoDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListCommentsForRepoParams(packed middleware.Parameters) (params IssuesListCommentsForRepoParams) {
@@ -39481,9 +39481,9 @@ type IssuesListEventsForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListEventsForRepoParams(packed middleware.Parameters) (params IssuesListEventsForRepoParams) {
@@ -39718,22 +39718,22 @@ type IssuesListForAuthenticatedUserParams struct {
 	// \* `subscribed`: Issues you're subscribed to updates for
 	// \* `all` or `repos`: All issues the authenticated user can see, regardless of participation or
 	// creation.
-	Filter OptIssuesListForAuthenticatedUserFilter
+	Filter OptIssuesListForAuthenticatedUserFilter `json:",omitempty,omitzero"`
 	// Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.
-	State OptIssuesListForAuthenticatedUserState
+	State OptIssuesListForAuthenticatedUserState `json:",omitempty,omitzero"`
 	// A list of comma separated label names. Example: `bug,ui,@high`.
-	Labels OptString
+	Labels OptString `json:",omitempty,omitzero"`
 	// What to sort results by. Can be either `created`, `updated`, `comments`.
-	Sort OptIssuesListForAuthenticatedUserSort
+	Sort OptIssuesListForAuthenticatedUserSort `json:",omitempty,omitzero"`
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListForAuthenticatedUserParams(packed middleware.Parameters) (params IssuesListForAuthenticatedUserParams) {
@@ -40245,22 +40245,22 @@ type IssuesListForOrgParams struct {
 	// \* `subscribed`: Issues you're subscribed to updates for
 	// \* `all` or `repos`: All issues the authenticated user can see, regardless of participation or
 	// creation.
-	Filter OptIssuesListForOrgFilter
+	Filter OptIssuesListForOrgFilter `json:",omitempty,omitzero"`
 	// Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.
-	State OptIssuesListForOrgState
+	State OptIssuesListForOrgState `json:",omitempty,omitzero"`
 	// A list of comma separated label names. Example: `bug,ui,@high`.
-	Labels OptString
+	Labels OptString `json:",omitempty,omitzero"`
 	// What to sort results by. Can be either `created`, `updated`, `comments`.
-	Sort OptIssuesListForOrgSort
+	Sort OptIssuesListForOrgSort `json:",omitempty,omitzero"`
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListForOrgParams(packed middleware.Parameters) (params IssuesListForOrgParams) {
@@ -40821,29 +40821,29 @@ type IssuesListForRepoParams struct {
 	// If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*`
 	// is passed, issues with any milestone are accepted. If the string `none` is passed, issues without
 	// milestones are returned.
-	Milestone OptString
+	Milestone OptString `json:",omitempty,omitzero"`
 	// Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.
-	State OptIssuesListForRepoState
+	State OptIssuesListForRepoState `json:",omitempty,omitzero"`
 	// Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues
 	// assigned to any user.
-	Assignee OptString
+	Assignee OptString `json:",omitempty,omitzero"`
 	// The user that created the issue.
-	Creator OptString
+	Creator OptString `json:",omitempty,omitzero"`
 	// A user that's mentioned in the issue.
-	Mentioned OptString
+	Mentioned OptString `json:",omitempty,omitzero"`
 	// A list of comma separated label names. Example: `bug,ui,@high`.
-	Labels OptString
+	Labels OptString `json:",omitempty,omitzero"`
 	// What to sort results by. Can be either `created`, `updated`, `comments`.
-	Sort OptIssuesListForRepoSort
+	Sort OptIssuesListForRepoSort `json:",omitempty,omitzero"`
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListForRepoParams(packed middleware.Parameters) (params IssuesListForRepoParams) {
@@ -41586,9 +41586,9 @@ type IssuesListLabelsForMilestoneParams struct {
 	// Milestone_number parameter.
 	MilestoneNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListLabelsForMilestoneParams(packed middleware.Parameters) (params IssuesListLabelsForMilestoneParams) {
@@ -41871,9 +41871,9 @@ type IssuesListLabelsForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListLabelsForRepoParams(packed middleware.Parameters) (params IssuesListLabelsForRepoParams) {
@@ -42106,9 +42106,9 @@ type IssuesListLabelsOnIssueParams struct {
 	// Issue_number parameter.
 	IssueNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListLabelsOnIssueParams(packed middleware.Parameters) (params IssuesListLabelsOnIssueParams) {
@@ -42391,15 +42391,15 @@ type IssuesListMilestonesParams struct {
 	Owner string
 	Repo  string
 	// The state of the milestone. Either `open`, `closed`, or `all`.
-	State OptIssuesListMilestonesState
+	State OptIssuesListMilestonesState `json:",omitempty,omitzero"`
 	// What to sort results by. Either `due_on` or `completeness`.
-	Sort OptIssuesListMilestonesSort
+	Sort OptIssuesListMilestonesSort `json:",omitempty,omitzero"`
 	// The direction of the sort. Either `asc` or `desc`.
-	Direction OptIssuesListMilestonesDirection
+	Direction OptIssuesListMilestonesDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackIssuesListMilestonesParams(packed middleware.Parameters) (params IssuesListMilestonesParams) {
@@ -44502,11 +44502,11 @@ func decodeLicensesGetParams(args [1]string, argsEscaped bool, r *http.Request) 
 
 // LicensesGetAllCommonlyUsedParams is parameters of licenses/get-all-commonly-used operation.
 type LicensesGetAllCommonlyUsedParams struct {
-	Featured OptBool
+	Featured OptBool `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackLicensesGetAllCommonlyUsedParams(packed middleware.Parameters) (params LicensesGetAllCommonlyUsedParams) {
@@ -44799,7 +44799,7 @@ func decodeLicensesGetForRepoParams(args [2]string, argsEscaped bool, r *http.Re
 // MetaGetOctocatParams is parameters of meta/get-octocat operation.
 type MetaGetOctocatParams struct {
 	// The words to show in Octocat's speech bubble.
-	S OptString
+	S OptString `json:",omitempty,omitzero"`
 }
 
 func unpackMetaGetOctocatParams(packed middleware.Parameters) (params MetaGetOctocatParams) {
@@ -45354,7 +45354,7 @@ type MigrationsGetCommitAuthorsParams struct {
 	Owner string
 	Repo  string
 	// A user ID. Only return users with an ID greater than this ID.
-	Since OptInt
+	Since OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackMigrationsGetCommitAuthorsParams(packed middleware.Parameters) (params MigrationsGetCommitAuthorsParams) {
@@ -45760,7 +45760,7 @@ func decodeMigrationsGetLargeFilesParams(args [2]string, argsEscaped bool, r *ht
 type MigrationsGetStatusForAuthenticatedUserParams struct {
 	// Migration_id parameter.
 	MigrationID int
-	Exclude     []string
+	Exclude     []string `json:",omitempty"`
 }
 
 func unpackMigrationsGetStatusForAuthenticatedUserParams(packed middleware.Parameters) (params MigrationsGetStatusForAuthenticatedUserParams) {
@@ -45882,7 +45882,7 @@ type MigrationsGetStatusForOrgParams struct {
 	// Migration_id parameter.
 	MigrationID int
 	// Exclude attributes from the API response to improve performance.
-	Exclude []MigrationsGetStatusForOrgExcludeItem
+	Exclude []MigrationsGetStatusForOrgExcludeItem `json:",omitempty"`
 }
 
 func unpackMigrationsGetStatusForOrgParams(packed middleware.Parameters) (params MigrationsGetStatusForOrgParams) {
@@ -46075,9 +46075,9 @@ func decodeMigrationsGetStatusForOrgParams(args [2]string, argsEscaped bool, r *
 // MigrationsListForAuthenticatedUserParams is parameters of migrations/list-for-authenticated-user operation.
 type MigrationsListForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackMigrationsListForAuthenticatedUserParams(packed middleware.Parameters) (params MigrationsListForAuthenticatedUserParams) {
@@ -46203,11 +46203,11 @@ func decodeMigrationsListForAuthenticatedUserParams(args [0]string, argsEscaped 
 type MigrationsListForOrgParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Exclude attributes from the API response to improve performance.
-	Exclude []MigrationsListForOrgExcludeItem
+	Exclude []MigrationsListForOrgExcludeItem `json:",omitempty"`
 }
 
 func unpackMigrationsListForOrgParams(packed middleware.Parameters) (params MigrationsListForOrgParams) {
@@ -46461,9 +46461,9 @@ type MigrationsListReposForOrgParams struct {
 	// Migration_id parameter.
 	MigrationID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackMigrationsListReposForOrgParams(packed middleware.Parameters) (params MigrationsListReposForOrgParams) {
@@ -46694,9 +46694,9 @@ type MigrationsListReposForUserParams struct {
 	// Migration_id parameter.
 	MigrationID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackMigrationsListReposForUserParams(packed middleware.Parameters) (params MigrationsListReposForUserParams) {
@@ -48205,11 +48205,11 @@ func decodeOAuthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintParams
 // OAuthAuthorizationsListAuthorizationsParams is parameters of oauth-authorizations/list-authorizations operation.
 type OAuthAuthorizationsListAuthorizationsParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// The client ID of your GitHub app.
-	ClientID OptString
+	ClientID OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOAuthAuthorizationsListAuthorizationsParams(packed middleware.Parameters) (params OAuthAuthorizationsListAuthorizationsParams) {
@@ -48384,11 +48384,11 @@ func decodeOAuthAuthorizationsListAuthorizationsParams(args [0]string, argsEscap
 // OAuthAuthorizationsListGrantsParams is parameters of oauth-authorizations/list-grants operation.
 type OAuthAuthorizationsListGrantsParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// The client ID of your GitHub app.
-	ClientID OptString
+	ClientID OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOAuthAuthorizationsListGrantsParams(packed middleware.Parameters) (params OAuthAuthorizationsListGrantsParams) {
@@ -49653,29 +49653,29 @@ type OrgsGetAuditLogParams struct {
 	Org string
 	// A search phrase. For more information, see [Searching the audit log](https://docs.github.
 	// com/github/setting-up-and-managing-organizations-and-teams/reviewing-the-audit-log-for-your-organization#searching-the-audit-log).
-	Phrase OptString
+	Phrase OptString `json:",omitempty,omitzero"`
 	// The event types to include:
 	// - `web` - returns web (non-Git) events
 	// - `git` - returns Git events
 	// - `all` - returns both web and Git events
 	// The default is `web`.
-	Include OptAuditLogInclude
+	Include OptAuditLogInclude `json:",omitempty,omitzero"`
 	// A cursor, as given in the [Link header](https://docs.github.
 	// com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches
 	// for events after this cursor.
-	After OptString
+	After OptString `json:",omitempty,omitzero"`
 	// A cursor, as given in the [Link header](https://docs.github.
 	// com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches
 	// for events before this cursor.
-	Before OptString
+	Before OptString `json:",omitempty,omitzero"`
 	// The order of audit log events. To list newest events first, specify `desc`. To list oldest events
 	// first, specify `asc`.
 	// The default is `desc`.
-	Order OptAuditLogOrder
+	Order OptAuditLogOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsGetAuditLogParams(packed middleware.Parameters) (params OrgsGetAuditLogParams) {
@@ -50722,9 +50722,9 @@ func decodeOrgsGetWebhookDeliveryParams(args [3]string, argsEscaped bool, r *htt
 // OrgsListParams is parameters of orgs/list operation.
 type OrgsListParams struct {
 	// An organization ID. Only return organizations with an ID greater than this ID.
-	Since OptInt
+	Since OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListParams(packed middleware.Parameters) (params OrgsListParams) {
@@ -50910,9 +50910,9 @@ func decodeOrgsListBlockedUsersParams(args [1]string, argsEscaped bool, r *http.
 type OrgsListFailedInvitationsParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListFailedInvitationsParams(packed middleware.Parameters) (params OrgsListFailedInvitationsParams) {
@@ -51089,9 +51089,9 @@ func decodeOrgsListFailedInvitationsParams(args [1]string, argsEscaped bool, r *
 // OrgsListForAuthenticatedUserParams is parameters of orgs/list-for-authenticated-user operation.
 type OrgsListForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListForAuthenticatedUserParams(packed middleware.Parameters) (params OrgsListForAuthenticatedUserParams) {
@@ -51217,9 +51217,9 @@ func decodeOrgsListForAuthenticatedUserParams(args [0]string, argsEscaped bool, 
 type OrgsListForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListForUserParams(packed middleware.Parameters) (params OrgsListForUserParams) {
@@ -51399,9 +51399,9 @@ type OrgsListInvitationTeamsParams struct {
 	// Invitation_id parameter.
 	InvitationID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListInvitationTeamsParams(packed middleware.Parameters) (params OrgsListInvitationTeamsParams) {
@@ -51634,16 +51634,16 @@ type OrgsListMembersParams struct {
 	// \* `2fa_disabled` - Members without [two-factor authentication](https://github.
 	// com/blog/1614-two-factor-authentication) enabled. Available for organization owners.
 	// \* `all` - All members the authenticated user can see.
-	Filter OptOrgsListMembersFilter
+	Filter OptOrgsListMembersFilter `json:",omitempty,omitzero"`
 	// Filter members returned by their role. Can be one of:
 	// \* `all` - All members of the organization, regardless of role.
 	// \* `admin` - Organization owners.
 	// \* `member` - Non-owner organization members.
-	Role OptOrgsListMembersRole
+	Role OptOrgsListMembersRole `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListMembersParams(packed middleware.Parameters) (params OrgsListMembersParams) {
@@ -51961,11 +51961,11 @@ func decodeOrgsListMembersParams(args [1]string, argsEscaped bool, r *http.Reque
 type OrgsListMembershipsForAuthenticatedUserParams struct {
 	// Indicates the state of the memberships to return. Can be either `active` or `pending`. If not
 	// specified, the API returns both active and pending memberships.
-	State OptOrgsListMembershipsForAuthenticatedUserState
+	State OptOrgsListMembershipsForAuthenticatedUserState `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListMembershipsForAuthenticatedUserParams(packed middleware.Parameters) (params OrgsListMembershipsForAuthenticatedUserParams) {
@@ -52159,11 +52159,11 @@ type OrgsListOutsideCollaboratorsParams struct {
 	// \* `2fa_disabled`: Outside collaborators without [two-factor authentication](https://github.
 	// com/blog/1614-two-factor-authentication) enabled.
 	// \* `all`: All outside collaborators.
-	Filter OptOrgsListOutsideCollaboratorsFilter
+	Filter OptOrgsListOutsideCollaboratorsFilter `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListOutsideCollaboratorsParams(packed middleware.Parameters) (params OrgsListOutsideCollaboratorsParams) {
@@ -52411,9 +52411,9 @@ func decodeOrgsListOutsideCollaboratorsParams(args [1]string, argsEscaped bool, 
 type OrgsListPendingInvitationsParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListPendingInvitationsParams(packed middleware.Parameters) (params OrgsListPendingInvitationsParams) {
@@ -52591,9 +52591,9 @@ func decodeOrgsListPendingInvitationsParams(args [1]string, argsEscaped bool, r 
 type OrgsListPublicMembersParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListPublicMembersParams(packed middleware.Parameters) (params OrgsListPublicMembersParams) {
@@ -52837,10 +52837,10 @@ type OrgsListWebhookDeliveriesParams struct {
 	Org    string
 	HookID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Used for pagination: the starting delivery from which the page of deliveries is fetched. Refer to
 	// the `link` header for the next and previous page cursors.
-	Cursor OptString
+	Cursor OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListWebhookDeliveriesParams(packed middleware.Parameters) (params OrgsListWebhookDeliveriesParams) {
@@ -53065,9 +53065,9 @@ func decodeOrgsListWebhookDeliveriesParams(args [2]string, argsEscaped bool, r *
 type OrgsListWebhooksParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackOrgsListWebhooksParams(packed middleware.Parameters) (params OrgsListWebhooksParams) {
@@ -55952,11 +55952,11 @@ type PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams struc
 	// The name of the package.
 	PackageName string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The state of the package, either active or deleted.
-	State OptPackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserState
+	State OptPackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserState `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams(packed middleware.Parameters) (params PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParams) {
@@ -56272,11 +56272,11 @@ type PackagesGetAllPackageVersionsForPackageOwnedByOrgParams struct {
 	PackageName string
 	Org         string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The state of the package, either active or deleted.
-	State OptPackagesGetAllPackageVersionsForPackageOwnedByOrgState
+	State OptPackagesGetAllPackageVersionsForPackageOwnedByOrgState `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesGetAllPackageVersionsForPackageOwnedByOrgParams(packed middleware.Parameters) (params PackagesGetAllPackageVersionsForPackageOwnedByOrgParams) {
@@ -57995,7 +57995,7 @@ type PackagesListPackagesForAuthenticatedUserParams struct {
 	// `container` package_types currently support `internal` visibility properly. For other ecosystems
 	// `internal` is synonymous with `private`. This parameter is optional and only filters an existing
 	// result set.
-	Visibility OptPackageVisibilityParam
+	Visibility OptPackageVisibilityParam `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesListPackagesForAuthenticatedUserParams(packed middleware.Parameters) (params PackagesListPackagesForAuthenticatedUserParams) {
@@ -58136,7 +58136,7 @@ type PackagesListPackagesForOrganizationParams struct {
 	// `container` package_types currently support `internal` visibility properly. For other ecosystems
 	// `internal` is synonymous with `private`. This parameter is optional and only filters an existing
 	// result set.
-	Visibility OptPackageVisibilityParam
+	Visibility OptPackageVisibilityParam `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesListPackagesForOrganizationParams(packed middleware.Parameters) (params PackagesListPackagesForOrganizationParams) {
@@ -58328,7 +58328,7 @@ type PackagesListPackagesForUserParams struct {
 	// `container` package_types currently support `internal` visibility properly. For other ecosystems
 	// `internal` is synonymous with `private`. This parameter is optional and only filters an existing
 	// result set.
-	Visibility OptPackageVisibilityParam
+	Visibility OptPackageVisibilityParam `json:",omitempty,omitzero"`
 	Username   string
 }
 
@@ -58520,7 +58520,7 @@ type PackagesRestorePackageForAuthenticatedUserParams struct {
 	// The name of the package.
 	PackageName string
 	// Package token.
-	Token OptString
+	Token OptString `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesRestorePackageForAuthenticatedUserParams(packed middleware.Parameters) (params PackagesRestorePackageForAuthenticatedUserParams) {
@@ -58706,7 +58706,7 @@ type PackagesRestorePackageForOrgParams struct {
 	PackageName string
 	Org         string
 	// Package token.
-	Token OptString
+	Token OptString `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesRestorePackageForOrgParams(packed middleware.Parameters) (params PackagesRestorePackageForOrgParams) {
@@ -58944,7 +58944,7 @@ type PackagesRestorePackageForUserParams struct {
 	PackageName string
 	Username    string
 	// Package token.
-	Token OptString
+	Token OptString `json:",omitempty,omitzero"`
 }
 
 func unpackPackagesRestorePackageForUserParams(packed middleware.Parameters) (params PackagesRestorePackageForUserParams) {
@@ -60718,11 +60718,11 @@ type ProjectsListCardsParams struct {
 	ColumnID int
 	// Filters the project cards that are returned by the card's state. Can be one of `all`,`archived`,
 	// or `not_archived`.
-	ArchivedState OptProjectsListCardsArchivedState
+	ArchivedState OptProjectsListCardsArchivedState `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListCardsParams(packed middleware.Parameters) (params ProjectsListCardsParams) {
@@ -60975,11 +60975,11 @@ type ProjectsListCollaboratorsParams struct {
 	// \* `direct`: Collaborators with permissions to a project, regardless of organization membership
 	// status.
 	// \* `all`: All collaborators the authenticated user can see.
-	Affiliation OptProjectsListCollaboratorsAffiliation
+	Affiliation OptProjectsListCollaboratorsAffiliation `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListCollaboratorsParams(packed middleware.Parameters) (params ProjectsListCollaboratorsParams) {
@@ -61227,9 +61227,9 @@ func decodeProjectsListCollaboratorsParams(args [1]string, argsEscaped bool, r *
 type ProjectsListColumnsParams struct {
 	ProjectID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListColumnsParams(packed middleware.Parameters) (params ProjectsListColumnsParams) {
@@ -61407,11 +61407,11 @@ func decodeProjectsListColumnsParams(args [1]string, argsEscaped bool, r *http.R
 type ProjectsListForOrgParams struct {
 	Org string
 	// Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.
-	State OptProjectsListForOrgState
+	State OptProjectsListForOrgState `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListForOrgParams(packed middleware.Parameters) (params ProjectsListForOrgParams) {
@@ -61660,11 +61660,11 @@ type ProjectsListForRepoParams struct {
 	Owner string
 	Repo  string
 	// Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.
-	State OptProjectsListForRepoState
+	State OptProjectsListForRepoState `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListForRepoParams(packed middleware.Parameters) (params ProjectsListForRepoParams) {
@@ -61964,11 +61964,11 @@ func decodeProjectsListForRepoParams(args [2]string, argsEscaped bool, r *http.R
 type ProjectsListForUserParams struct {
 	Username string
 	// Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.
-	State OptProjectsListForUserState
+	State OptProjectsListForUserState `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackProjectsListForUserParams(packed middleware.Parameters) (params ProjectsListForUserParams) {
@@ -64710,22 +64710,22 @@ type PullsListParams struct {
 	Owner string
 	Repo  string
 	// Either `open`, `closed`, or `all` to filter by state.
-	State OptPullsListState
+	State OptPullsListState `json:",omitempty,omitzero"`
 	// Filter pulls by head user or head organization and branch name in the format of `user:ref-name` or
 	// `organization:ref-name`. For example: `github:new-script-format` or `octocat:test-branch`.
-	Head OptString
+	Head OptString `json:",omitempty,omitzero"`
 	// Filter pulls by base branch name. Example: `gh-pages`.
-	Base OptString
+	Base OptString `json:",omitempty,omitzero"`
 	// What to sort results by. Can be either `created`, `updated`, `popularity` (comment count) or
 	// `long-running` (age, filtering by pulls updated in the last month).
-	Sort OptPullsListSort
+	Sort OptPullsListSort `json:",omitempty,omitzero"`
 	// The direction of the sort. Can be either `asc` or `desc`. Default: `desc` when sort is `created`
 	// or sort is not specified, otherwise `asc`.
-	Direction OptPullsListDirection
+	Direction OptPullsListDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListParams(packed middleware.Parameters) (params PullsListParams) {
@@ -65264,9 +65264,9 @@ type PullsListCommentsForReviewParams struct {
 	// Review_id parameter.
 	ReviewID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListCommentsForReviewParams(packed middleware.Parameters) (params PullsListCommentsForReviewParams) {
@@ -65602,9 +65602,9 @@ type PullsListCommitsParams struct {
 	Repo       string
 	PullNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListCommitsParams(packed middleware.Parameters) (params PullsListCommitsParams) {
@@ -65888,9 +65888,9 @@ type PullsListFilesParams struct {
 	Repo       string
 	PullNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListFilesParams(packed middleware.Parameters) (params PullsListFilesParams) {
@@ -66174,9 +66174,9 @@ type PullsListRequestedReviewersParams struct {
 	Repo       string
 	PullNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListRequestedReviewersParams(packed middleware.Parameters) (params PullsListRequestedReviewersParams) {
@@ -66460,16 +66460,16 @@ type PullsListReviewCommentsParams struct {
 	Repo       string
 	PullNumber int
 	// One of `created` (when the repository was starred) or `updated` (when it was last pushed to).
-	Sort OptSort
+	Sort OptSort `json:",omitempty,omitzero"`
 	// Can be either `asc` or `desc`. Ignored without `sort` parameter.
-	Direction OptPullsListReviewCommentsDirection
+	Direction OptPullsListReviewCommentsDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListReviewCommentsParams(packed middleware.Parameters) (params PullsListReviewCommentsParams) {
@@ -66936,16 +66936,16 @@ func decodePullsListReviewCommentsParams(args [3]string, argsEscaped bool, r *ht
 type PullsListReviewCommentsForRepoParams struct {
 	Owner string
 	Repo  string
-	Sort  OptPullsListReviewCommentsForRepoSort
+	Sort  OptPullsListReviewCommentsForRepoSort `json:",omitempty,omitzero"`
 	// Can be either `asc` or `desc`. Ignored without `sort` parameter.
-	Direction OptPullsListReviewCommentsForRepoDirection
+	Direction OptPullsListReviewCommentsForRepoDirection `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListReviewCommentsForRepoParams(packed middleware.Parameters) (params PullsListReviewCommentsForRepoParams) {
@@ -67357,9 +67357,9 @@ type PullsListReviewsParams struct {
 	Repo       string
 	PullNumber int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackPullsListReviewsParams(packed middleware.Parameters) (params PullsListReviewsParams) {
@@ -71965,11 +71965,11 @@ type ReactionsListForCommitCommentParams struct {
 	CommentID int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a commit comment.
-	Content OptReactionsListForCommitCommentContent
+	Content OptReactionsListForCommitCommentContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForCommitCommentParams(packed middleware.Parameters) (params ReactionsListForCommitCommentParams) {
@@ -72320,11 +72320,11 @@ type ReactionsListForIssueParams struct {
 	IssueNumber int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to an issue.
-	Content OptReactionsListForIssueContent
+	Content OptReactionsListForIssueContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForIssueParams(packed middleware.Parameters) (params ReactionsListForIssueParams) {
@@ -72675,11 +72675,11 @@ type ReactionsListForIssueCommentParams struct {
 	CommentID int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to an issue comment.
-	Content OptReactionsListForIssueCommentContent
+	Content OptReactionsListForIssueCommentContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForIssueCommentParams(packed middleware.Parameters) (params ReactionsListForIssueCommentParams) {
@@ -73030,11 +73030,11 @@ type ReactionsListForPullRequestReviewCommentParams struct {
 	CommentID int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a pull request review comment.
-	Content OptReactionsListForPullRequestReviewCommentContent
+	Content OptReactionsListForPullRequestReviewCommentContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForPullRequestReviewCommentParams(packed middleware.Parameters) (params ReactionsListForPullRequestReviewCommentParams) {
@@ -73386,11 +73386,11 @@ type ReactionsListForTeamDiscussionCommentInOrgParams struct {
 	CommentNumber    int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a team discussion comment.
-	Content OptReactionsListForTeamDiscussionCommentInOrgContent
+	Content OptReactionsListForTeamDiscussionCommentInOrgContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForTeamDiscussionCommentInOrgParams(packed middleware.Parameters) (params ReactionsListForTeamDiscussionCommentInOrgParams) {
@@ -73792,11 +73792,11 @@ type ReactionsListForTeamDiscussionCommentLegacyParams struct {
 	CommentNumber    int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a team discussion comment.
-	Content OptReactionsListForTeamDiscussionCommentLegacyContent
+	Content OptReactionsListForTeamDiscussionCommentLegacyContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForTeamDiscussionCommentLegacyParams(packed middleware.Parameters) (params ReactionsListForTeamDiscussionCommentLegacyParams) {
@@ -74147,11 +74147,11 @@ type ReactionsListForTeamDiscussionInOrgParams struct {
 	DiscussionNumber int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a team discussion.
-	Content OptReactionsListForTeamDiscussionInOrgContent
+	Content OptReactionsListForTeamDiscussionInOrgContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForTeamDiscussionInOrgParams(packed middleware.Parameters) (params ReactionsListForTeamDiscussionInOrgParams) {
@@ -74500,11 +74500,11 @@ type ReactionsListForTeamDiscussionLegacyParams struct {
 	DiscussionNumber int
 	// Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types).
 	// Omit this parameter to list all reactions to a team discussion.
-	Content OptReactionsListForTeamDiscussionLegacyContent
+	Content OptReactionsListForTeamDiscussionLegacyContent `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReactionsListForTeamDiscussionLegacyParams(packed middleware.Parameters) (params ReactionsListForTeamDiscussionLegacyParams) {
@@ -76014,9 +76014,9 @@ type ReposCompareCommitsParams struct {
 	Owner string
 	Repo  string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// The base branch and head branch to compare. This parameter expects the format `{base}...{head}`.
 	Basehead string
 }
@@ -82852,9 +82852,9 @@ type ReposGetAllTopicsParams struct {
 	Owner string
 	Repo  string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetAllTopicsParams(packed middleware.Parameters) (params ReposGetAllTopicsParams) {
@@ -83773,7 +83773,7 @@ type ReposGetClonesParams struct {
 	Owner string
 	Repo  string
 	// Must be one of: `day`, `week`.
-	Per OptPer
+	Per OptPer `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetClonesParams(packed middleware.Parameters) (params ReposGetClonesParams) {
@@ -84255,9 +84255,9 @@ type ReposGetCombinedStatusForRefParams struct {
 	// Ref parameter.
 	Ref string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetCombinedStatusForRefParams(packed middleware.Parameters) (params ReposGetCombinedStatusForRefParams) {
@@ -84540,9 +84540,9 @@ type ReposGetCommitParams struct {
 	Owner string
 	Repo  string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Ref parameter.
 	Ref string
 }
@@ -87145,7 +87145,7 @@ type ReposGetReadmeParams struct {
 	Owner string
 	Repo  string
 	// The name of the commit/branch/tag. Default: the repository’s default branch (usually `master`).
-	Ref OptString
+	Ref OptString `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetReadmeParams(packed middleware.Parameters) (params ReposGetReadmeParams) {
@@ -87318,7 +87318,7 @@ type ReposGetReadmeInDirectoryParams struct {
 	// The alternate path to look for a README file.
 	Dir string
 	// The name of the commit/branch/tag. Default: the repository’s default branch (usually `master`).
-	Ref OptString
+	Ref OptString `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetReadmeInDirectoryParams(packed middleware.Parameters) (params ReposGetReadmeInDirectoryParams) {
@@ -88809,7 +88809,7 @@ type ReposGetViewsParams struct {
 	Owner string
 	Repo  string
 	// Must be one of: `day`, `week`.
-	Per OptPer
+	Per OptPer `json:",omitempty,omitzero"`
 }
 
 func unpackReposGetViewsParams(packed middleware.Parameters) (params ReposGetViewsParams) {
@@ -89566,7 +89566,7 @@ type ReposListAutolinksParams struct {
 	Owner string
 	Repo  string
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListAutolinksParams(packed middleware.Parameters) (params ReposListAutolinksParams) {
@@ -89743,11 +89743,11 @@ type ReposListBranchesParams struct {
 	Repo  string
 	// Setting to `true` returns only protected branches. When set to `false`, only unprotected branches
 	// are returned. Omitting this parameter returns all branches.
-	Protected OptBool
+	Protected OptBool `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListBranchesParams(packed middleware.Parameters) (params ReposListBranchesParams) {
@@ -90204,11 +90204,11 @@ type ReposListCollaboratorsParams struct {
 	// \* `direct`: All collaborators with permissions to an organization-owned repository, regardless of
 	// organization membership status.
 	// \* `all`: All collaborators the authenticated user can see.
-	Affiliation OptReposListCollaboratorsAffiliation
+	Affiliation OptReposListCollaboratorsAffiliation `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListCollaboratorsParams(packed middleware.Parameters) (params ReposListCollaboratorsParams) {
@@ -90511,9 +90511,9 @@ type ReposListCommentsForCommitParams struct {
 	// Commit_sha parameter.
 	CommitSha string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListCommentsForCommitParams(packed middleware.Parameters) (params ReposListCommentsForCommitParams) {
@@ -90796,9 +90796,9 @@ type ReposListCommitCommentsForRepoParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListCommitCommentsForRepoParams(packed middleware.Parameters) (params ReposListCommitCommentsForRepoParams) {
@@ -91031,9 +91031,9 @@ type ReposListCommitStatusesForRefParams struct {
 	// Ref parameter.
 	Ref string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListCommitStatusesForRefParams(packed middleware.Parameters) (params ReposListCommitStatusesForRefParams) {
@@ -91317,21 +91317,21 @@ type ReposListCommitsParams struct {
 	Repo  string
 	// SHA or branch to start listing commits from. Default: the repository’s default branch (usually
 	// `master`).
-	Sha OptString
+	Sha OptString `json:",omitempty,omitzero"`
 	// Only commits containing this file path will be returned.
-	Path OptString
+	Path OptString `json:",omitempty,omitzero"`
 	// GitHub login or email address by which to filter by commit author.
-	Author OptString
+	Author OptString `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Only commits before this date will be returned. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Until OptDateTime
+	Until OptDateTime `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListCommitsParams(packed middleware.Parameters) (params ReposListCommitsParams) {
@@ -91812,11 +91812,11 @@ type ReposListContributorsParams struct {
 	Owner string
 	Repo  string
 	// Set to `1` or `true` to include anonymous contributors in results.
-	Anon OptString
+	Anon OptString `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListContributorsParams(packed middleware.Parameters) (params ReposListContributorsParams) {
@@ -92097,9 +92097,9 @@ type ReposListDeployKeysParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListDeployKeysParams(packed middleware.Parameters) (params ReposListDeployKeysParams) {
@@ -92332,9 +92332,9 @@ type ReposListDeploymentStatusesParams struct {
 	// Deployment_id parameter.
 	DeploymentID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListDeploymentStatusesParams(packed middleware.Parameters) (params ReposListDeploymentStatusesParams) {
@@ -92617,17 +92617,17 @@ type ReposListDeploymentsParams struct {
 	Owner string
 	Repo  string
 	// The SHA recorded at creation time.
-	Sha OptString
+	Sha OptString `json:",omitempty,omitzero"`
 	// The name of the ref. This can be a branch, tag, or SHA.
-	Ref OptString
+	Ref OptString `json:",omitempty,omitzero"`
 	// The name of the task for the deployment (e.g., `deploy` or `deploy:migrations`).
-	Task OptString
+	Task OptString `json:",omitempty,omitzero"`
 	// The name of the environment that was deployed to (e.g., `staging` or `production`).
-	Environment OptNilString
+	Environment OptNilString `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListDeploymentsParams(packed middleware.Parameters) (params ReposListDeploymentsParams) {
@@ -93077,32 +93077,32 @@ func decodeReposListDeploymentsParams(args [2]string, argsEscaped bool, r *http.
 type ReposListForAuthenticatedUserParams struct {
 	// Can be one of `all`, `public`, or `private`. Note: For GitHub AE, can be one of `all`, `internal`,
 	// or `private`.
-	Visibility OptReposListForAuthenticatedUserVisibility
+	Visibility OptReposListForAuthenticatedUserVisibility `json:",omitempty,omitzero"`
 	// Comma-separated list of values. Can include:
 	// \* `owner`: Repositories that are owned by the authenticated user.
 	// \* `collaborator`: Repositories that the user has been added to as a collaborator.
 	// \* `organization_member`: Repositories that the user has access to through being a member of an
 	// organization. This includes every repository on every team that the user is on.
-	Affiliation OptString
+	Affiliation OptString `json:",omitempty,omitzero"`
 	// Can be one of `all`, `owner`, `public`, `private`, `member`. Note: For GitHub AE, can be one of
 	// `all`, `owner`, `internal`, `private`, `member`. Default: `all`
 	// Will cause a `422` error if used in the same request as **visibility** or **affiliation**. Will
 	// cause a `422` error if used in the same request as **visibility** or **affiliation**.
-	Type OptReposListForAuthenticatedUserType
+	Type OptReposListForAuthenticatedUserType `json:",omitempty,omitzero"`
 	// Can be one of `created`, `updated`, `pushed`, `full_name`.
-	Sort OptReposListForAuthenticatedUserSort
+	Sort OptReposListForAuthenticatedUserSort `json:",omitempty,omitzero"`
 	// Can be one of `asc` or `desc`. Default: `asc` when using `full_name`, otherwise `desc`.
-	Direction OptReposListForAuthenticatedUserDirection
+	Direction OptReposListForAuthenticatedUserDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Only show notifications updated after the given time. This is a timestamp in [ISO 8601](https://en.
 	// wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Since OptDateTime
+	Since OptDateTime `json:",omitempty,omitzero"`
 	// Only show notifications updated before the given time. This is a timestamp in [ISO
 	// 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
-	Before OptDateTime
+	Before OptDateTime `json:",omitempty,omitzero"`
 }
 
 func unpackReposListForAuthenticatedUserParams(packed middleware.Parameters) (params ReposListForAuthenticatedUserParams) {
@@ -93663,15 +93663,15 @@ type ReposListForOrgParams struct {
 	// an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `type` can
 	// also be `internal`. However, the `internal` value is not yet supported when a GitHub App calls
 	// this API with an installation access token.
-	Type OptReposListForOrgType
+	Type OptReposListForOrgType `json:",omitempty,omitzero"`
 	// Can be one of `created`, `updated`, `pushed`, `full_name`.
-	Sort OptReposListForOrgSort
+	Sort OptReposListForOrgSort `json:",omitempty,omitzero"`
 	// Can be one of `asc` or `desc`. Default: when using `full_name`: `asc`, otherwise `desc`.
-	Direction OptReposListForOrgDirection
+	Direction OptReposListForOrgDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListForOrgParams(packed middleware.Parameters) (params ReposListForOrgParams) {
@@ -94049,15 +94049,15 @@ func decodeReposListForOrgParams(args [1]string, argsEscaped bool, r *http.Reque
 type ReposListForUserParams struct {
 	Username string
 	// Can be one of `all`, `owner`, `member`.
-	Type OptReposListForUserType
+	Type OptReposListForUserType `json:",omitempty,omitzero"`
 	// Can be one of `created`, `updated`, `pushed`, `full_name`.
-	Sort OptReposListForUserSort
+	Sort OptReposListForUserSort `json:",omitempty,omitzero"`
 	// Can be one of `asc` or `desc`. Default: `asc` when using `full_name`, otherwise `desc`.
-	Direction OptReposListForUserDirection
+	Direction OptReposListForUserDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListForUserParams(packed middleware.Parameters) (params ReposListForUserParams) {
@@ -94441,11 +94441,11 @@ type ReposListForksParams struct {
 	Owner string
 	Repo  string
 	// The sort order. Can be either `newest`, `oldest`, or `stargazers`.
-	Sort OptReposListForksSort
+	Sort OptReposListForksSort `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListForksParams(packed middleware.Parameters) (params ReposListForksParams) {
@@ -94746,9 +94746,9 @@ type ReposListInvitationsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListInvitationsParams(packed middleware.Parameters) (params ReposListInvitationsParams) {
@@ -94977,9 +94977,9 @@ func decodeReposListInvitationsParams(args [2]string, argsEscaped bool, r *http.
 // ReposListInvitationsForAuthenticatedUserParams is parameters of repos/list-invitations-for-authenticated-user operation.
 type ReposListInvitationsForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListInvitationsForAuthenticatedUserParams(packed middleware.Parameters) (params ReposListInvitationsForAuthenticatedUserParams) {
@@ -95224,9 +95224,9 @@ type ReposListPagesBuildsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListPagesBuildsParams(packed middleware.Parameters) (params ReposListPagesBuildsParams) {
@@ -95455,7 +95455,7 @@ func decodeReposListPagesBuildsParams(args [2]string, argsEscaped bool, r *http.
 // ReposListPublicParams is parameters of repos/list-public operation.
 type ReposListPublicParams struct {
 	// A repository ID. Only return repositories with an ID greater than this ID.
-	Since OptInt
+	Since OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListPublicParams(packed middleware.Parameters) (params ReposListPublicParams) {
@@ -95524,9 +95524,9 @@ type ReposListPullRequestsAssociatedWithCommitParams struct {
 	// Commit_sha parameter.
 	CommitSha string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListPullRequestsAssociatedWithCommitParams(packed middleware.Parameters) (params ReposListPullRequestsAssociatedWithCommitParams) {
@@ -95811,9 +95811,9 @@ type ReposListReleaseAssetsParams struct {
 	// Release_id parameter.
 	ReleaseID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListReleaseAssetsParams(packed middleware.Parameters) (params ReposListReleaseAssetsParams) {
@@ -96096,9 +96096,9 @@ type ReposListReleasesParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListReleasesParams(packed middleware.Parameters) (params ReposListReleasesParams) {
@@ -96329,9 +96329,9 @@ type ReposListTagsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListTagsParams(packed middleware.Parameters) (params ReposListTagsParams) {
@@ -96562,9 +96562,9 @@ type ReposListTeamsParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListTeamsParams(packed middleware.Parameters) (params ReposListTeamsParams) {
@@ -96796,10 +96796,10 @@ type ReposListWebhookDeliveriesParams struct {
 	Repo   string
 	HookID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Used for pagination: the starting delivery from which the page of deliveries is fetched. Refer to
 	// the `link` header for the next and previous page cursors.
-	Cursor OptString
+	Cursor OptString `json:",omitempty,omitzero"`
 }
 
 func unpackReposListWebhookDeliveriesParams(packed middleware.Parameters) (params ReposListWebhookDeliveriesParams) {
@@ -97077,9 +97077,9 @@ type ReposListWebhooksParams struct {
 	Owner string
 	Repo  string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackReposListWebhooksParams(packed middleware.Parameters) (params ReposListWebhooksParams) {
@@ -102195,7 +102195,7 @@ type ReposUploadReleaseAssetParams struct {
 	// Release_id parameter.
 	ReleaseID int
 	Name      string
-	Label     OptString
+	Label     OptString `json:",omitempty,omitzero"`
 }
 
 func unpackReposUploadReleaseAssetParams(packed middleware.Parameters) (params ReposUploadReleaseAssetParams) {
@@ -102586,14 +102586,14 @@ type SearchCodeParams struct {
 	// Sorts the results of your query. Can only be `indexed`, which indicates how recently a file has
 	// been indexed by the GitHub search infrastructure. Default: [best match](https://docs.github.
 	// com/rest/reference/search#ranking-search-results).
-	Sort OptSearchCodeSort
+	Sort OptSearchCodeSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchCodeParams(packed middleware.Parameters) (params SearchCodeParams) {
@@ -102903,14 +102903,14 @@ type SearchCommitsParams struct {
 	Q string
 	// Sorts the results of your query by `author-date` or `committer-date`. Default: [best
 	// match](https://docs.github.com/rest/reference/search#ranking-search-results).
-	Sort OptSearchCommitsSort
+	Sort OptSearchCommitsSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchCommitsParams(packed middleware.Parameters) (params SearchCommitsParams) {
@@ -103223,14 +103223,14 @@ type SearchIssuesAndPullRequestsParams struct {
 	// `reactions--1`, `reactions-smile`, `reactions-thinking_face`, `reactions-heart`, `reactions-tada`,
 	// or `interactions`. You can also sort results by how recently the items were `created` or `updated`,
 	//  Default: [best match](https://docs.github.com/rest/reference/search#ranking-search-results).
-	Sort OptSearchIssuesAndPullRequestsSort
+	Sort OptSearchIssuesAndPullRequestsSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchIssuesAndPullRequestsParams(packed middleware.Parameters) (params SearchIssuesAndPullRequestsParams) {
@@ -103540,14 +103540,14 @@ type SearchLabelsParams struct {
 	Q string
 	// Sorts the results of your query by when the label was `created` or `updated`. Default: [best
 	// match](https://docs.github.com/rest/reference/search#ranking-search-results).
-	Sort OptSearchLabelsSort
+	Sort OptSearchLabelsSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchLabelsParams(packed middleware.Parameters) (params SearchLabelsParams) {
@@ -103902,14 +103902,14 @@ type SearchReposParams struct {
 	// Sorts the results of your query by number of `stars`, `forks`, or `help-wanted-issues` or how
 	// recently the items were `updated`. Default: [best match](https://docs.github.
 	// com/rest/reference/search#ranking-search-results).
-	Sort OptSearchReposSort
+	Sort OptSearchReposSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchReposParams(packed middleware.Parameters) (params SearchReposParams) {
@@ -104217,9 +104217,9 @@ type SearchTopicsParams struct {
 	// com/rest/reference/search#constructing-a-search-query).
 	Q string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchTopicsParams(packed middleware.Parameters) (params SearchTopicsParams) {
@@ -104395,14 +104395,14 @@ type SearchUsersParams struct {
 	// Sorts the results of your query by number of `followers` or `repositories`, or when the person
 	// `joined` GitHub. Default: [best match](https://docs.github.
 	// com/rest/reference/search#ranking-search-results).
-	Sort OptSearchUsersSort
+	Sort OptSearchUsersSort `json:",omitempty,omitzero"`
 	// Determines whether the first search result returned is the highest number of matches (`desc`) or
 	// lowest number of matches (`asc`). This parameter is ignored unless you provide `sort`.
-	Order OptOrder
+	Order OptOrder `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchUsersParams(packed middleware.Parameters) (params SearchUsersParams) {
@@ -104887,13 +104887,13 @@ func decodeSecretScanningGetAlertParams(args [3]string, argsEscaped bool, r *htt
 type SecretScanningListAlertsForOrgParams struct {
 	Org string
 	// Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
-	State OptSecretScanningListAlertsForOrgState
+	State OptSecretScanningListAlertsForOrgState `json:",omitempty,omitzero"`
 	// A comma separated list of secret types to return. By default all secret types are returned.
-	SecretType OptString
+	SecretType OptString `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSecretScanningListAlertsForOrgParams(packed middleware.Parameters) (params SecretScanningListAlertsForOrgParams) {
@@ -105187,15 +105187,15 @@ type SecretScanningListAlertsForRepoParams struct {
 	Owner string
 	Repo  string
 	// Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
-	State OptSecretScanningListAlertsForRepoState
+	State OptSecretScanningListAlertsForRepoState `json:",omitempty,omitzero"`
 	// A comma separated list of secret types to return. By default all secret types are returned. See
 	// "[About secret scanning for private repositories](https://docs.github.
 	// com/code-security/secret-security/about-secret-scanning#about-secret-scanning-for-private-repositories)" for a complete list of secret types (API slug).
-	SecretType OptString
+	SecretType OptString `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSecretScanningListAlertsForRepoParams(packed middleware.Parameters) (params SecretScanningListAlertsForRepoParams) {
@@ -110372,9 +110372,9 @@ func decodeTeamsGetMembershipForUserLegacyParams(args [2]string, argsEscaped boo
 type TeamsListParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListParams(packed middleware.Parameters) (params TeamsListParams) {
@@ -110554,9 +110554,9 @@ type TeamsListChildInOrgParams struct {
 	// Team_slug parameter.
 	TeamSlug string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListChildInOrgParams(packed middleware.Parameters) (params TeamsListChildInOrgParams) {
@@ -110786,9 +110786,9 @@ func decodeTeamsListChildInOrgParams(args [2]string, argsEscaped bool, r *http.R
 type TeamsListChildLegacyParams struct {
 	TeamID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListChildLegacyParams(packed middleware.Parameters) (params TeamsListChildLegacyParams) {
@@ -110969,11 +110969,11 @@ type TeamsListDiscussionCommentsInOrgParams struct {
 	TeamSlug         string
 	DiscussionNumber int
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListDiscussionCommentsInOrgParams(packed middleware.Parameters) (params TeamsListDiscussionCommentsInOrgParams) {
@@ -111326,11 +111326,11 @@ type TeamsListDiscussionCommentsLegacyParams struct {
 	TeamID           int
 	DiscussionNumber int
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListDiscussionCommentsLegacyParams(packed middleware.Parameters) (params TeamsListDiscussionCommentsLegacyParams) {
@@ -111632,13 +111632,13 @@ type TeamsListDiscussionsInOrgParams struct {
 	// Team_slug parameter.
 	TeamSlug string
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 	// Pinned discussions only filter.
-	Pinned OptString
+	Pinned OptString `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListDiscussionsInOrgParams(packed middleware.Parameters) (params TeamsListDiscussionsInOrgParams) {
@@ -111988,11 +111988,11 @@ func decodeTeamsListDiscussionsInOrgParams(args [2]string, argsEscaped bool, r *
 type TeamsListDiscussionsLegacyParams struct {
 	TeamID int
 	// One of `asc` (ascending) or `desc` (descending).
-	Direction OptDirection
+	Direction OptDirection `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListDiscussionsLegacyParams(packed middleware.Parameters) (params TeamsListDiscussionsLegacyParams) {
@@ -112239,9 +112239,9 @@ func decodeTeamsListDiscussionsLegacyParams(args [1]string, argsEscaped bool, r 
 // TeamsListForAuthenticatedUserParams is parameters of teams/list-for-authenticated-user operation.
 type TeamsListForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListForAuthenticatedUserParams(packed middleware.Parameters) (params TeamsListForAuthenticatedUserParams) {
@@ -112432,9 +112432,9 @@ func decodeTeamsListIdpGroupsForLegacyParams(args [1]string, argsEscaped bool, r
 type TeamsListIdpGroupsForOrgParams struct {
 	Org string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page token.
-	Page OptString
+	Page OptString `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListIdpGroupsForOrgParams(packed middleware.Parameters) (params TeamsListIdpGroupsForOrgParams) {
@@ -112731,11 +112731,11 @@ type TeamsListMembersInOrgParams struct {
 	// \* `member` - normal members of the team.
 	// \* `maintainer` - team maintainers.
 	// \* `all` - all members of the team.
-	Role OptTeamsListMembersInOrgRole
+	Role OptTeamsListMembersInOrgRole `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListMembersInOrgParams(packed middleware.Parameters) (params TeamsListMembersInOrgParams) {
@@ -113038,11 +113038,11 @@ type TeamsListMembersLegacyParams struct {
 	// \* `member` - normal members of the team.
 	// \* `maintainer` - team maintainers.
 	// \* `all` - all members of the team.
-	Role OptTeamsListMembersLegacyRole
+	Role OptTeamsListMembersLegacyRole `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListMembersLegacyParams(packed middleware.Parameters) (params TeamsListMembersLegacyParams) {
@@ -113292,9 +113292,9 @@ type TeamsListPendingInvitationsInOrgParams struct {
 	// Team_slug parameter.
 	TeamSlug string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListPendingInvitationsInOrgParams(packed middleware.Parameters) (params TeamsListPendingInvitationsInOrgParams) {
@@ -113524,9 +113524,9 @@ func decodeTeamsListPendingInvitationsInOrgParams(args [2]string, argsEscaped bo
 type TeamsListPendingInvitationsLegacyParams struct {
 	TeamID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListPendingInvitationsLegacyParams(packed middleware.Parameters) (params TeamsListPendingInvitationsLegacyParams) {
@@ -113706,9 +113706,9 @@ type TeamsListProjectsInOrgParams struct {
 	// Team_slug parameter.
 	TeamSlug string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListProjectsInOrgParams(packed middleware.Parameters) (params TeamsListProjectsInOrgParams) {
@@ -113938,9 +113938,9 @@ func decodeTeamsListProjectsInOrgParams(args [2]string, argsEscaped bool, r *htt
 type TeamsListProjectsLegacyParams struct {
 	TeamID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListProjectsLegacyParams(packed middleware.Parameters) (params TeamsListProjectsLegacyParams) {
@@ -114120,9 +114120,9 @@ type TeamsListReposInOrgParams struct {
 	// Team_slug parameter.
 	TeamSlug string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListReposInOrgParams(packed middleware.Parameters) (params TeamsListReposInOrgParams) {
@@ -114352,9 +114352,9 @@ func decodeTeamsListReposInOrgParams(args [2]string, argsEscaped bool, r *http.R
 type TeamsListReposLegacyParams struct {
 	TeamID int
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackTeamsListReposLegacyParams(packed middleware.Parameters) (params TeamsListReposLegacyParams) {
@@ -117072,9 +117072,9 @@ type UsersGetContextForUserParams struct {
 	Username string
 	// Identifies which additional information you'd like to receive about the person's hovercard. Can be
 	// `organization`, `repository`, `issue`, `pull_request`. **Required** when using `subject_id`.
-	SubjectType OptUsersGetContextForUserSubjectType
+	SubjectType OptUsersGetContextForUserSubjectType `json:",omitempty,omitzero"`
 	// Uses the ID for the `subject_type` you specified. **Required** when using `subject_type`.
-	SubjectID OptString
+	SubjectID OptString `json:",omitempty,omitzero"`
 }
 
 func unpackUsersGetContextForUserParams(packed middleware.Parameters) (params UsersGetContextForUserParams) {
@@ -117388,9 +117388,9 @@ func decodeUsersGetPublicSSHKeyForAuthenticatedParams(args [1]string, argsEscape
 // UsersListParams is parameters of users/list operation.
 type UsersListParams struct {
 	// A user ID. Only return users with an ID greater than this ID.
-	Since OptInt
+	Since OptInt `json:",omitempty,omitzero"`
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListParams(packed middleware.Parameters) (params UsersListParams) {
@@ -117510,9 +117510,9 @@ func decodeUsersListParams(args [0]string, argsEscaped bool, r *http.Request) (p
 // UsersListEmailsForAuthenticatedParams is parameters of users/list-emails-for-authenticated operation.
 type UsersListEmailsForAuthenticatedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListEmailsForAuthenticatedParams(packed middleware.Parameters) (params UsersListEmailsForAuthenticatedParams) {
@@ -117637,9 +117637,9 @@ func decodeUsersListEmailsForAuthenticatedParams(args [0]string, argsEscaped boo
 // UsersListFollowedByAuthenticatedParams is parameters of users/list-followed-by-authenticated operation.
 type UsersListFollowedByAuthenticatedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListFollowedByAuthenticatedParams(packed middleware.Parameters) (params UsersListFollowedByAuthenticatedParams) {
@@ -117764,9 +117764,9 @@ func decodeUsersListFollowedByAuthenticatedParams(args [0]string, argsEscaped bo
 // UsersListFollowersForAuthenticatedUserParams is parameters of users/list-followers-for-authenticated-user operation.
 type UsersListFollowersForAuthenticatedUserParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListFollowersForAuthenticatedUserParams(packed middleware.Parameters) (params UsersListFollowersForAuthenticatedUserParams) {
@@ -117892,9 +117892,9 @@ func decodeUsersListFollowersForAuthenticatedUserParams(args [0]string, argsEsca
 type UsersListFollowersForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListFollowersForUserParams(packed middleware.Parameters) (params UsersListFollowersForUserParams) {
@@ -118072,9 +118072,9 @@ func decodeUsersListFollowersForUserParams(args [1]string, argsEscaped bool, r *
 type UsersListFollowingForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListFollowingForUserParams(packed middleware.Parameters) (params UsersListFollowingForUserParams) {
@@ -118251,9 +118251,9 @@ func decodeUsersListFollowingForUserParams(args [1]string, argsEscaped bool, r *
 // UsersListGpgKeysForAuthenticatedParams is parameters of users/list-gpg-keys-for-authenticated operation.
 type UsersListGpgKeysForAuthenticatedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListGpgKeysForAuthenticatedParams(packed middleware.Parameters) (params UsersListGpgKeysForAuthenticatedParams) {
@@ -118379,9 +118379,9 @@ func decodeUsersListGpgKeysForAuthenticatedParams(args [0]string, argsEscaped bo
 type UsersListGpgKeysForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListGpgKeysForUserParams(packed middleware.Parameters) (params UsersListGpgKeysForUserParams) {
@@ -118558,9 +118558,9 @@ func decodeUsersListGpgKeysForUserParams(args [1]string, argsEscaped bool, r *ht
 // UsersListPublicEmailsForAuthenticatedParams is parameters of users/list-public-emails-for-authenticated operation.
 type UsersListPublicEmailsForAuthenticatedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListPublicEmailsForAuthenticatedParams(packed middleware.Parameters) (params UsersListPublicEmailsForAuthenticatedParams) {
@@ -118686,9 +118686,9 @@ func decodeUsersListPublicEmailsForAuthenticatedParams(args [0]string, argsEscap
 type UsersListPublicKeysForUserParams struct {
 	Username string
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListPublicKeysForUserParams(packed middleware.Parameters) (params UsersListPublicKeysForUserParams) {
@@ -118865,9 +118865,9 @@ func decodeUsersListPublicKeysForUserParams(args [1]string, argsEscaped bool, r 
 // UsersListPublicSSHKeysForAuthenticatedParams is parameters of users/list-public-ssh-keys-for-authenticated operation.
 type UsersListPublicSSHKeysForAuthenticatedParams struct {
 	// Results per page (max 100).
-	PerPage OptInt
+	PerPage OptInt `json:",omitempty,omitzero"`
 	// Page number of the results to fetch.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackUsersListPublicSSHKeysForAuthenticatedParams(packed middleware.Parameters) (params UsersListPublicSSHKeysForAuthenticatedParams) {

--- a/examples/ex_manga/oas_parameters_gen.go
+++ b/examples/ex_manga/oas_parameters_gen.go
@@ -678,7 +678,7 @@ type SearchParams struct {
 	// -tag:"big dogs".
 	Query string
 	// Number of result page.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchParams(packed middleware.Parameters) (params SearchParams) {
@@ -788,7 +788,7 @@ type SearchByTagIDParams struct {
 	// Tag ID.
 	TagID int
 	// Number of result page.
-	Page OptInt
+	Page OptInt `json:",omitempty,omitzero"`
 }
 
 func unpackSearchByTagIDParams(packed middleware.Parameters) (params SearchByTagIDParams) {

--- a/examples/ex_oauth2/oas_parameters_gen.go
+++ b/examples/ex_oauth2/oas_parameters_gen.go
@@ -149,9 +149,9 @@ func decodeFindPetByIDParams(args [1]string, argsEscaped bool, r *http.Request) 
 // FindPetsParams is parameters of findPets operation.
 type FindPetsParams struct {
 	// Tags to filter by.
-	Tags []string
+	Tags []string `json:",omitempty"`
 	// Maximum number of results to return.
-	Limit OptInt32
+	Limit OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackFindPetsParams(packed middleware.Parameters) (params FindPetsParams) {

--- a/examples/ex_openai/oas_parameters_gen.go
+++ b/examples/ex_openai/oas_parameters_gen.go
@@ -357,7 +357,7 @@ type ListFineTuneEventsParams struct {
 	// `data: [DONE]` message when the job is finished (succeeded, cancelled,
 	// or failed).
 	// If set to false, only events generated so far will be returned.
-	Stream OptBool
+	Stream OptBool `json:",omitempty,omitzero"`
 }
 
 func unpackListFineTuneEventsParams(packed middleware.Parameters) (params ListFineTuneEventsParams) {

--- a/examples/ex_petstore/oas_parameters_gen.go
+++ b/examples/ex_petstore/oas_parameters_gen.go
@@ -17,7 +17,7 @@ import (
 // ListPetsParams is parameters of listPets operation.
 type ListPetsParams struct {
 	// How many items to return at one time (max 100).
-	Limit OptInt32
+	Limit OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackListPetsParams(packed middleware.Parameters) (params ListPetsParams) {

--- a/examples/ex_petstore_expanded/oas_parameters_gen.go
+++ b/examples/ex_petstore_expanded/oas_parameters_gen.go
@@ -149,9 +149,9 @@ func decodeFindPetByIDParams(args [1]string, argsEscaped bool, r *http.Request) 
 // FindPetsParams is parameters of findPets operation.
 type FindPetsParams struct {
 	// Tags to filter by.
-	Tags []string
+	Tags []string `json:",omitempty"`
 	// Maximum number of results to return.
-	Limit OptInt32
+	Limit OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackFindPetsParams(packed middleware.Parameters) (params FindPetsParams) {

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -22,115 +22,115 @@ import (
 // TestQueryParameterParams is parameters of test_query_parameter operation.
 type TestQueryParameterParams struct {
 	Boolean                 bool
-	BooleanArray            []bool
+	BooleanArray            []bool `json:",omitempty"`
 	Integer                 int
-	IntegerArray            []int
+	IntegerArray            []int `json:",omitempty"`
 	IntegerInt16            int16
-	IntegerInt16Array       []int16
+	IntegerInt16Array       []int16 `json:",omitempty"`
 	IntegerInt32            int32
-	IntegerInt32Array       []int32
+	IntegerInt32Array       []int32 `json:",omitempty"`
 	IntegerInt64            int64
-	IntegerInt64Array       []int64
+	IntegerInt64Array       []int64 `json:",omitempty"`
 	IntegerInt8             int8
-	IntegerInt8Array        []int8
+	IntegerInt8Array        []int8 `json:",omitempty"`
 	IntegerUint             uint
 	IntegerUint16           uint16
-	IntegerUint16Array      []uint16
+	IntegerUint16Array      []uint16 `json:",omitempty"`
 	IntegerUint32           uint32
-	IntegerUint32Array      []uint32
+	IntegerUint32Array      []uint32 `json:",omitempty"`
 	IntegerUint64           uint64
-	IntegerUint64Array      []uint64
+	IntegerUint64Array      []uint64 `json:",omitempty"`
 	IntegerUint8            uint8
-	IntegerUint8Array       []uint8
-	IntegerUintArray        []uint
+	IntegerUint8Array       []uint8 `json:",omitempty"`
+	IntegerUintArray        []uint  `json:",omitempty"`
 	IntegerUnix             time.Time
 	IntegerUnixMicro        time.Time
-	IntegerUnixMicroArray   []time.Time
+	IntegerUnixMicroArray   []time.Time `json:",omitempty"`
 	IntegerUnixMilli        time.Time
-	IntegerUnixMilliArray   []time.Time
+	IntegerUnixMilliArray   []time.Time `json:",omitempty"`
 	IntegerUnixNano         time.Time
-	IntegerUnixNanoArray    []time.Time
+	IntegerUnixNanoArray    []time.Time `json:",omitempty"`
 	IntegerUnixSeconds      time.Time
-	IntegerUnixSecondsArray []time.Time
-	IntegerUnixArray        []time.Time
+	IntegerUnixSecondsArray []time.Time `json:",omitempty"`
+	IntegerUnixArray        []time.Time `json:",omitempty"`
 	Number                  float64
-	NumberArray             []float64
+	NumberArray             []float64 `json:",omitempty"`
 	NumberDouble            float64
-	NumberDoubleArray       []float64
+	NumberDoubleArray       []float64 `json:",omitempty"`
 	NumberFloat             float32
-	NumberFloatArray        []float32
+	NumberFloatArray        []float32 `json:",omitempty"`
 	NumberInt32             int32
-	NumberInt32Array        []int32
+	NumberInt32Array        []int32 `json:",omitempty"`
 	NumberInt64             int64
-	NumberInt64Array        []int64
+	NumberInt64Array        []int64 `json:",omitempty"`
 	String                  string
-	StringArray             []string
+	StringArray             []string `json:",omitempty"`
 	StringBase64            []byte
-	StringBase64Array       [][]byte
+	StringBase64Array       [][]byte `json:",omitempty"`
 	StringBinary            string
-	StringBinaryArray       []string
+	StringBinaryArray       []string `json:",omitempty"`
 	StringByte              []byte
-	StringByteArray         [][]byte
+	StringByteArray         [][]byte `json:",omitempty"`
 	StringDate              time.Time
 	StringDateTime          time.Time
-	StringDateTimeArray     []time.Time
-	StringDateArray         []time.Time
+	StringDateTimeArray     []time.Time `json:",omitempty"`
+	StringDateArray         []time.Time `json:",omitempty"`
 	StringDuration          time.Duration
-	StringDurationArray     []time.Duration
+	StringDurationArray     []time.Duration `json:",omitempty"`
 	StringEmail             string
-	StringEmailArray        []string
+	StringEmailArray        []string `json:",omitempty"`
 	StringFloat32           float32
-	StringFloat32Array      []float32
+	StringFloat32Array      []float32 `json:",omitempty"`
 	StringFloat64           float64
-	StringFloat64Array      []float64
+	StringFloat64Array      []float64 `json:",omitempty"`
 	StringHostname          string
-	StringHostnameArray     []string
+	StringHostnameArray     []string `json:",omitempty"`
 	StringInt               int
 	StringInt16             int16
-	StringInt16Array        []int16
+	StringInt16Array        []int16 `json:",omitempty"`
 	StringInt32             int32
-	StringInt32Array        []int32
+	StringInt32Array        []int32 `json:",omitempty"`
 	StringInt64             int64
-	StringInt64Array        []int64
+	StringInt64Array        []int64 `json:",omitempty"`
 	StringInt8              int8
-	StringInt8Array         []int8
-	StringIntArray          []int
+	StringInt8Array         []int8 `json:",omitempty"`
+	StringIntArray          []int  `json:",omitempty"`
 	StringIP                netip.Addr
-	StringIPArray           []netip.Addr
+	StringIPArray           []netip.Addr `json:",omitempty"`
 	StringIpv4              netip.Addr
-	StringIpv4Array         []netip.Addr
+	StringIpv4Array         []netip.Addr `json:",omitempty"`
 	StringIpv6              netip.Addr
-	StringIpv6Array         []netip.Addr
+	StringIpv6Array         []netip.Addr `json:",omitempty"`
 	StringMAC               net.HardwareAddr
-	StringMACArray          []net.HardwareAddr
+	StringMACArray          []net.HardwareAddr `json:",omitempty"`
 	StringPassword          string
-	StringPasswordArray     []string
+	StringPasswordArray     []string `json:",omitempty"`
 	StringTime              time.Time
-	StringTimeArray         []time.Time
+	StringTimeArray         []time.Time `json:",omitempty"`
 	StringUint              uint
 	StringUint16            uint16
-	StringUint16Array       []uint16
+	StringUint16Array       []uint16 `json:",omitempty"`
 	StringUint32            uint32
-	StringUint32Array       []uint32
+	StringUint32Array       []uint32 `json:",omitempty"`
 	StringUint64            uint64
-	StringUint64Array       []uint64
+	StringUint64Array       []uint64 `json:",omitempty"`
 	StringUint8             uint8
-	StringUint8Array        []uint8
-	StringUintArray         []uint
+	StringUint8Array        []uint8 `json:",omitempty"`
+	StringUintArray         []uint  `json:",omitempty"`
 	StringUnix              time.Time
 	StringUnixMicro         time.Time
-	StringUnixMicroArray    []time.Time
+	StringUnixMicroArray    []time.Time `json:",omitempty"`
 	StringUnixMilli         time.Time
-	StringUnixMilliArray    []time.Time
+	StringUnixMilliArray    []time.Time `json:",omitempty"`
 	StringUnixNano          time.Time
-	StringUnixNanoArray     []time.Time
+	StringUnixNanoArray     []time.Time `json:",omitempty"`
 	StringUnixSeconds       time.Time
-	StringUnixSecondsArray  []time.Time
-	StringUnixArray         []time.Time
+	StringUnixSecondsArray  []time.Time `json:",omitempty"`
+	StringUnixArray         []time.Time `json:",omitempty"`
 	StringURI               url.URL
-	StringURIArray          []url.URL
+	StringURIArray          []url.URL `json:",omitempty"`
 	StringUUID              uuid.UUID
-	StringUUIDArray         []uuid.UUID
+	StringUUIDArray         []uuid.UUID `json:",omitempty"`
 }
 
 func unpackTestQueryParameterParams(packed middleware.Parameters) (params TestQueryParameterParams) {

--- a/examples/ex_tinkoff/oas_parameters_gen.go
+++ b/examples/ex_tinkoff/oas_parameters_gen.go
@@ -439,9 +439,9 @@ type OperationsGetParams struct {
 	// Конец временного промежутка.
 	To time.Time
 	// Figi инструмента для фильтрации.
-	Figi OptString
+	Figi OptString `json:",omitempty,omitzero"`
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOperationsGetParams(packed middleware.Parameters) (params OperationsGetParams) {
@@ -644,7 +644,7 @@ type OrdersCancelPostParams struct {
 	// ID заявки.
 	OrderId string
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOrdersCancelPostParams(packed middleware.Parameters) (params OrdersCancelPostParams) {
@@ -752,7 +752,7 @@ func decodeOrdersCancelPostParams(args [0]string, argsEscaped bool, r *http.Requ
 // OrdersGetParams is parameters of GET /orders operation.
 type OrdersGetParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOrdersGetParams(packed middleware.Parameters) (params OrdersGetParams) {
@@ -819,7 +819,7 @@ type OrdersLimitOrderPostParams struct {
 	// FIGI инструмента.
 	Figi string
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOrdersLimitOrderPostParams(packed middleware.Parameters) (params OrdersLimitOrderPostParams) {
@@ -930,7 +930,7 @@ type OrdersMarketOrderPostParams struct {
 	Figi string
 	// Уникальный идентификатор счета (по умолчанию -
 	// Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackOrdersMarketOrderPostParams(packed middleware.Parameters) (params OrdersMarketOrderPostParams) {
@@ -1038,7 +1038,7 @@ func decodeOrdersMarketOrderPostParams(args [0]string, argsEscaped bool, r *http
 // PortfolioCurrenciesGetParams is parameters of GET /portfolio/currencies operation.
 type PortfolioCurrenciesGetParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackPortfolioCurrenciesGetParams(packed middleware.Parameters) (params PortfolioCurrenciesGetParams) {
@@ -1103,7 +1103,7 @@ func decodePortfolioCurrenciesGetParams(args [0]string, argsEscaped bool, r *htt
 // PortfolioGetParams is parameters of GET /portfolio operation.
 type PortfolioGetParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackPortfolioGetParams(packed middleware.Parameters) (params PortfolioGetParams) {
@@ -1168,7 +1168,7 @@ func decodePortfolioGetParams(args [0]string, argsEscaped bool, r *http.Request)
 // SandboxClearPostParams is parameters of POST /sandbox/clear operation.
 type SandboxClearPostParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackSandboxClearPostParams(packed middleware.Parameters) (params SandboxClearPostParams) {
@@ -1233,7 +1233,7 @@ func decodeSandboxClearPostParams(args [0]string, argsEscaped bool, r *http.Requ
 // SandboxCurrenciesBalancePostParams is parameters of POST /sandbox/currencies/balance operation.
 type SandboxCurrenciesBalancePostParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackSandboxCurrenciesBalancePostParams(packed middleware.Parameters) (params SandboxCurrenciesBalancePostParams) {
@@ -1298,7 +1298,7 @@ func decodeSandboxCurrenciesBalancePostParams(args [0]string, argsEscaped bool, 
 // SandboxPositionsBalancePostParams is parameters of POST /sandbox/positions/balance operation.
 type SandboxPositionsBalancePostParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackSandboxPositionsBalancePostParams(packed middleware.Parameters) (params SandboxPositionsBalancePostParams) {
@@ -1363,7 +1363,7 @@ func decodeSandboxPositionsBalancePostParams(args [0]string, argsEscaped bool, r
 // SandboxRemovePostParams is parameters of POST /sandbox/remove operation.
 type SandboxRemovePostParams struct {
 	// Номер счета (по умолчанию - Тинькофф).
-	BrokerAccountId OptString
+	BrokerAccountId OptString `json:",omitempty,omitzero"`
 }
 
 func unpackSandboxRemovePostParams(packed middleware.Parameters) (params SandboxRemovePostParams) {

--- a/gen/ir/operation.go
+++ b/gen/ir/operation.go
@@ -156,31 +156,6 @@ func (op Parameter) GoDoc() []string {
 	return prettyDoc(s.Description, notice)
 }
 
-// GoStructTag returns a Go struct tag for this parameter (if relevant).
-// Currently only returns emoempty of arrays, maps and nullable Type.GenericVariant,
-// and omitzero for parameters with optional Type.GenericVariant
-func (op Parameter) GoStructTag() string {
-	if op.Type == nil {
-		return ""
-	}
-	switch op.Type.Kind {
-	case KindArray, KindMap:
-		return `json:",omitempty"`
-	default:
-		return op.goStructTag()
-	}
-}
-
-func (op Parameter) goStructTag() string {
-	variant := op.Type.GenericVariant
-	if variant.OnlyNullable() {
-		return `json:",omitempty"`
-	} else if variant.Optional {
-		return `json:",omitempty,omitzero"`
-	}
-	return ""
-}
-
 // Default returns default value of this field, if it is set.
 func (op Parameter) Default() Default {
 	var schema *jsonschema.Schema

--- a/gen/ir/operation.go
+++ b/gen/ir/operation.go
@@ -156,6 +156,31 @@ func (op Parameter) GoDoc() []string {
 	return prettyDoc(s.Description, notice)
 }
 
+// GoStructTag returns a Go struct tag for this parameter (if relevant).
+// Currently only returns emoempty of arrays, maps and nullable Type.GenericVariant,
+// and omitzero for parameters with optional Type.GenericVariant
+func (op Parameter) GoStructTag() string {
+	if op.Type == nil {
+		return ""
+	}
+	switch op.Type.Kind {
+	case KindArray, KindMap:
+		return `json:",omitempty"`
+	default:
+		return op.goStructTag()
+	}
+}
+
+func (op Parameter) goStructTag() string {
+	variant := op.Type.GenericVariant
+	if variant.OnlyNullable() {
+		return `json:",omitempty"`
+	} else if variant.Optional {
+		return `json:",omitempty,omitzero"`
+	}
+	return ""
+}
+
 // Default returns default value of this field, if it is set.
 func (op Parameter) Default() Default {
 	var schema *jsonschema.Schema

--- a/internal/integration/parameters_test.go
+++ b/internal/integration/parameters_test.go
@@ -2,22 +2,29 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-faster/errors"
+	api "github.com/ogen-go/ogen/internal/integration/test_parameters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	api "github.com/ogen-go/ogen/internal/integration/test_parameters"
 )
 
 type testParameters struct{}
 
 var _ api.Handler = (*testParameters)(nil)
+
+func (s *testParameters) OptionalParameters(ctx context.Context, params api.OptionalParametersParams) (*api.OptionalQueryParametersResponse, error) {
+	return nil, nil
+}
 
 func (s *testParameters) OptionalArrayParameter(ctx context.Context, params api.OptionalArrayParameterParams) (string, error) {
 	return "", nil
@@ -209,4 +216,131 @@ func TestOptionalArrayParameter(t *testing.T) {
 	resp, err := client.OptionalArrayParameter(ctx, api.OptionalArrayParameterParams{})
 	require.NoError(t, err)
 	require.Equal(t, "ok", resp)
+}
+
+func TestParametersCanBeLogged(t *testing.T) {
+	testCases := []struct {
+		name         string
+		params       any
+		expectedJSON string
+	}{
+		{
+			name:         "ObjectQueryParameter empty",
+			params:       api.ObjectQueryParameterParams{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "ObjectQueryParameter all provided",
+			params: api.ObjectQueryParameterParams{
+				FormObject: api.NewOptOneLevelObject(api.OneLevelObject{Min: 1, Max: 5, Filter: "abc"}),
+				DeepObject: api.NewOptOneLevelObject(api.OneLevelObject{Min: 2, Max: 6, Filter: "def"}),
+			},
+			expectedJSON: `{"FormObject":{"min":1,"max":5,"filter":"abc"},"DeepObject":{"min":2,"max":6,"filter":"def"}}`,
+		},
+		{
+			name:         "ObjectCookieParameter",
+			params:       api.ObjectCookieParameterParams{Value: api.OneLevelObject{Min: 1, Max: 5, Filter: "abc"}},
+			expectedJSON: `{"Value":{"min":1,"max":5,"filter":"abc"}}`,
+		},
+		{
+			name: "ContentParameters",
+			params: api.ContentParametersParams{
+				Query:   api.User{ID: 1, Username: "admin", Role: api.UserRoleAdmin},
+				Path:    api.User{ID: 2, Username: "alice", Role: api.UserRoleUser},
+				XHeader: api.User{ID: 3, Username: "bob", Role: api.UserRoleBot},
+				Cookie:  api.User{ID: 4, Username: "charlie", Role: api.UserRoleAdmin},
+			},
+			expectedJSON: `{"Query":{"id":1,"username":"admin","role":"admin","friends":null},"Path":{"id":2,"username":"alice","role":"user","friends":null},"XHeader":{"id":3,"username":"bob","role":"bot","friends":null},"Cookie":{"id":4,"username":"charlie","role":"admin","friends":null}}`,
+		},
+		{
+			name:         "PathParameter",
+			params:       api.PathParameterParams{Value: "a string"},
+			expectedJSON: `{"Value":"a string"}`,
+		},
+		{
+			name:         "HeaderParameter",
+			params:       api.HeaderParameterParams{XValue: "a string"},
+			expectedJSON: `{"XValue":"a string"}`,
+		},
+		{
+			name:         "CookieParameter",
+			params:       api.CookieParameterParams{Value: "a string"},
+			expectedJSON: `{"Value":"a string"}`,
+		},
+		{
+			name:         "OptionalArrayParameter empty",
+			params:       api.OptionalArrayParameterParams{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "OptionalArrayParameter all provided",
+			params: api.OptionalArrayParameterParams{
+				Query:  []string{"a", "b", "c"},
+				Header: []string{"d", "e", "f"},
+			},
+			expectedJSON: `{"Query":["a","b","c"],"Header":["d","e","f"]}`,
+		},
+		{
+			name: "ComplicatedParameterNameGet",
+			params: api.ComplicatedParameterNameGetParams{
+				Eq:       "eq",
+				Plus:     "plus",
+				Question: "question",
+				And:      "and",
+				Percent:  "percent",
+			},
+			expectedJSON: `{"Eq":"eq","Plus":"plus","Question":"question","And":"and","Percent":"percent"}`,
+		},
+		{
+			name:         "OptionalParametersParams empty",
+			params:       api.OptionalParametersParams{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "OptionalParametersParams all provided",
+			params: api.OptionalParametersParams{
+				Integer: api.NewOptInt(1),
+				String:  api.NewOptString("a string"),
+				Boolean: api.NewOptBool(true),
+				Object: api.NewOptOptionalParametersObject(api.OptionalParametersObject{
+					Key: api.NewOptString("key"),
+				}),
+				Timestamp: api.NewOptDateTime(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+				Array:     []string{"a", "b", "c"},
+			},
+			expectedJSON: `{"Integer":1,"String":"a string","Boolean":true,"Object":{"Value":{"key":"key"},"Set":true},"Timestamp":"2021-01-01T00:00:00Z","Array":["a","b","c"]}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("can be marshaled with encoding/json", func(t *testing.T) {
+				got, err := json.Marshal(tc.params)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedJSON, string(got))
+			})
+
+			t.Run("can be logged with slog", func(t *testing.T) {
+				// init new logger
+				builder := &strings.Builder{}
+				loggerOpts := &slog.HandlerOptions{
+					ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+						// copy/paste of log/slog/internal/slogtest.RemoveTime
+						if a.Key == slog.TimeKey && len(groups) == 0 {
+							return slog.Attr{}
+						}
+						return a
+					},
+				}
+				logger := slog.New(slog.NewJSONHandler(builder, loggerOpts))
+
+				// log
+				logger.Info("test", "params", tc.params)
+
+				// assert
+				expectedLog := fmt.Sprintf(`{"level":"INFO","msg":"test","params":%s}`, tc.expectedJSON) + "\n"
+				assert.Equal(t, expectedLog, builder.String())
+			})
+		})
+	}
 }

--- a/internal/integration/sample_api/oas_parameters_gen.go
+++ b/internal/integration/sample_api/oas_parameters_gen.go
@@ -375,7 +375,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32
+	Default OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -616,9 +616,9 @@ type PetGetParams struct {
 	// ID of pet.
 	PetID int64
 	// Tags of pets.
-	XTags []uuid.UUID
+	XTags []uuid.UUID `json:",omitempty"`
 	// Pet scopes.
-	XScope []string
+	XScope []string `json:",omitempty"`
 	// Token.
 	Token string
 }

--- a/internal/integration/sample_api_nc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nc/oas_parameters_gen.go
@@ -375,7 +375,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32
+	Default OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -616,9 +616,9 @@ type PetGetParams struct {
 	// ID of pet.
 	PetID int64
 	// Tags of pets.
-	XTags []uuid.UUID
+	XTags []uuid.UUID `json:",omitempty"`
 	// Pet scopes.
-	XScope []string
+	XScope []string `json:",omitempty"`
 	// Token.
 	Token string
 }

--- a/internal/integration/sample_api_no_otel/oas_parameters_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_parameters_gen.go
@@ -375,7 +375,7 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32
+	Default OptInt32 `json:",omitempty,omitzero"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -616,9 +616,9 @@ type PetGetParams struct {
 	// ID of pet.
 	PetID int64
 	// Tags of pets.
-	XTags []uuid.UUID
+	XTags []uuid.UUID `json:",omitempty"`
 	// Pet scopes.
-	XScope []string
+	XScope []string `json:",omitempty"`
 	// Token.
 	Token string
 }

--- a/internal/integration/sample_api_ns/oas_parameters_gen.go
+++ b/internal/integration/sample_api_ns/oas_parameters_gen.go
@@ -17,7 +17,7 @@ type DataGetFormatParams struct {
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32
+	Default OptInt32 `json:",omitempty,omitzero"`
 }
 
 // FoobarGetParams is parameters of foobarGet operation.
@@ -39,9 +39,9 @@ type PetGetParams struct {
 	// ID of pet.
 	PetID int64
 	// Tags of pets.
-	XTags []uuid.UUID
+	XTags []uuid.UUID `json:",omitempty"`
 	// Pet scopes.
-	XScope []string
+	XScope []string `json:",omitempty"`
 	// Token.
 	Token string
 }

--- a/internal/integration/sample_api_nsnc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_parameters_gen.go
@@ -17,7 +17,7 @@ type DataGetFormatParams struct {
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32
+	Default OptInt32 `json:",omitempty,omitzero"`
 }
 
 // FoobarGetParams is parameters of foobarGet operation.
@@ -39,9 +39,9 @@ type PetGetParams struct {
 	// ID of pet.
 	PetID int64
 	// Tags of pets.
-	XTags []uuid.UUID
+	XTags []uuid.UUID `json:",omitempty"`
 	// Pet scopes.
-	XScope []string
+	XScope []string `json:",omitempty"`
 	// Token.
 	Token string
 }

--- a/internal/integration/test_additionalpropertiespatternproperties/oas_parameters_gen.go
+++ b/internal/integration/test_additionalpropertiespatternproperties/oas_parameters_gen.go
@@ -12,7 +12,7 @@ import (
 
 // AliveParams is parameters of alive operation.
 type AliveParams struct {
-	FlexData OptAliveFlexData
+	FlexData OptAliveFlexData `json:",omitempty,omitzero"`
 }
 
 func unpackAliveParams(packed middleware.Parameters) (params AliveParams) {

--- a/internal/integration/test_parameters/oas_client_gen.go
+++ b/internal/integration/test_parameters/oas_client_gen.go
@@ -60,6 +60,10 @@ type Invoker interface {
 	//
 	// GET /optionalArrayParameter
 	OptionalArrayParameter(ctx context.Context, params OptionalArrayParameterParams) (string, error)
+	// OptionalParameters invokes optionalParameters operation.
+	//
+	// GET /optionalParameters
+	OptionalParameters(ctx context.Context, params OptionalParametersParams) (*OptionalQueryParametersResponse, error)
 	// PathParameter invokes pathParameter operation.
 	//
 	// Test for path param.
@@ -912,6 +916,192 @@ func (c *Client) sendOptionalArrayParameter(ctx context.Context, params Optional
 
 	stage = "DecodeResponse"
 	result, err := decodeOptionalArrayParameterResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// OptionalParameters invokes optionalParameters operation.
+//
+// GET /optionalParameters
+func (c *Client) OptionalParameters(ctx context.Context, params OptionalParametersParams) (*OptionalQueryParametersResponse, error) {
+	res, err := c.sendOptionalParameters(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendOptionalParameters(ctx context.Context, params OptionalParametersParams) (res *OptionalQueryParametersResponse, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("optionalParameters"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/optionalParameters"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, OptionalParametersOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/optionalParameters"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeQueryParams"
+	q := uri.NewQueryEncoder()
+	{
+		// Encode "integer" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "integer",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Integer.Get(); ok {
+				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "string" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "string",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.String.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "boolean" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "boolean",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Boolean.Get(); ok {
+				return e.EncodeValue(conv.BoolToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "object" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "object",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Object.Get(); ok {
+				return val.EncodeURI(e)
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "timestamp" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "timestamp",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Timestamp.Get(); ok {
+				return e.EncodeValue(conv.DateTimeToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "array" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "array",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.Array != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.Array {
+						if err := func() error {
+							return e.EncodeValue(conv.StringToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	u.RawQuery = q.Values().Encode()
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeOptionalParametersResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/integration/test_parameters/oas_handlers_gen.go
+++ b/internal/integration/test_parameters/oas_handlers_gen.go
@@ -1041,6 +1041,165 @@ func (s *Server) handleOptionalArrayParameterRequest(args [0]string, argsEscaped
 	}
 }
 
+// handleOptionalParametersRequest handles optionalParameters operation.
+//
+// GET /optionalParameters
+func (s *Server) handleOptionalParametersRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("optionalParameters"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/optionalParameters"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), OptionalParametersOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: OptionalParametersOperation,
+			ID:   "optionalParameters",
+		}
+	)
+	params, err := decodeOptionalParametersParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response *OptionalQueryParametersResponse
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    OptionalParametersOperation,
+			OperationSummary: "",
+			OperationID:      "optionalParameters",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "integer",
+					In:   "query",
+				}: params.Integer,
+				{
+					Name: "string",
+					In:   "query",
+				}: params.String,
+				{
+					Name: "boolean",
+					In:   "query",
+				}: params.Boolean,
+				{
+					Name: "object",
+					In:   "query",
+				}: params.Object,
+				{
+					Name: "timestamp",
+					In:   "query",
+				}: params.Timestamp,
+				{
+					Name: "array",
+					In:   "query",
+				}: params.Array,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = OptionalParametersParams
+			Response = *OptionalQueryParametersResponse
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackOptionalParametersParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.OptionalParameters(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.OptionalParameters(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeOptionalParametersResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handlePathParameterRequest handles pathParameter operation.
 //
 // Test for path param.

--- a/internal/integration/test_parameters/oas_json_gen.go
+++ b/internal/integration/test_parameters/oas_json_gen.go
@@ -5,9 +5,11 @@ package api
 import (
 	"math/bits"
 	"strconv"
+	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
+	"github.com/ogen-go/ogen/json"
 	"github.com/ogen-go/ogen/validate"
 )
 
@@ -391,6 +393,111 @@ func (s *OneLevelObject) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes bool as json.
+func (o OptBool) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Bool(bool(o.Value))
+}
+
+// Decode decodes bool from json.
+func (o *OptBool) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptBool to nil")
+	}
+	o.Set = true
+	v, err := d.Bool()
+	if err != nil {
+		return err
+	}
+	o.Value = bool(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptBool) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptBool) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes time.Time as json.
+func (o OptDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
+	if !o.Set {
+		return
+	}
+	format(e, o.Value)
+}
+
+// Decode decodes time.Time from json.
+func (o *OptDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptDateTime to nil")
+	}
+	o.Set = true
+	v, err := format(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptDateTime) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e, json.EncodeDateTime)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptDateTime) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d, json.DecodeDateTime)
+}
+
+// Encode encodes int as json.
+func (o OptInt) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Int(int(o.Value))
+}
+
+// Decode decodes int from json.
+func (o *OptInt) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptInt to nil")
+	}
+	o.Set = true
+	v, err := d.Int()
+	if err != nil {
+		return err
+	}
+	o.Value = int(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptInt) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptInt) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes OneLevelObject as json.
 func (o OptOneLevelObject) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -420,6 +527,298 @@ func (s OptOneLevelObject) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptOneLevelObject) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes OptionalQueryParametersResponseObject as json.
+func (o OptOptionalQueryParametersResponseObject) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes OptionalQueryParametersResponseObject from json.
+func (o *OptOptionalQueryParametersResponseObject) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptOptionalQueryParametersResponseObject to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptOptionalQueryParametersResponseObject) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptOptionalQueryParametersResponseObject) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes string as json.
+func (o OptString) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes string from json.
+func (o *OptString) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptString to nil")
+	}
+	o.Set = true
+	v, err := d.Str()
+	if err != nil {
+		return err
+	}
+	o.Value = string(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptString) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptString) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *OptionalQueryParametersResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *OptionalQueryParametersResponse) encodeFields(e *jx.Encoder) {
+	{
+		if s.Integer.Set {
+			e.FieldStart("integer")
+			s.Integer.Encode(e)
+		}
+	}
+	{
+		if s.String.Set {
+			e.FieldStart("string")
+			s.String.Encode(e)
+		}
+	}
+	{
+		if s.Boolean.Set {
+			e.FieldStart("boolean")
+			s.Boolean.Encode(e)
+		}
+	}
+	{
+		if s.Object.Set {
+			e.FieldStart("object")
+			s.Object.Encode(e)
+		}
+	}
+	{
+		if s.Timestamp.Set {
+			e.FieldStart("timestamp")
+			s.Timestamp.Encode(e, json.EncodeDateTime)
+		}
+	}
+	{
+		if s.Array != nil {
+			e.FieldStart("array")
+			e.ArrStart()
+			for _, elem := range s.Array {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+}
+
+var jsonFieldsNameOfOptionalQueryParametersResponse = [6]string{
+	0: "integer",
+	1: "string",
+	2: "boolean",
+	3: "object",
+	4: "timestamp",
+	5: "array",
+}
+
+// Decode decodes OptionalQueryParametersResponse from json.
+func (s *OptionalQueryParametersResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode OptionalQueryParametersResponse to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "integer":
+			if err := func() error {
+				s.Integer.Reset()
+				if err := s.Integer.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"integer\"")
+			}
+		case "string":
+			if err := func() error {
+				s.String.Reset()
+				if err := s.String.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"string\"")
+			}
+		case "boolean":
+			if err := func() error {
+				s.Boolean.Reset()
+				if err := s.Boolean.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"boolean\"")
+			}
+		case "object":
+			if err := func() error {
+				s.Object.Reset()
+				if err := s.Object.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"object\"")
+			}
+		case "timestamp":
+			if err := func() error {
+				s.Timestamp.Reset()
+				if err := s.Timestamp.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"timestamp\"")
+			}
+		case "array":
+			if err := func() error {
+				s.Array = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Array = append(s.Array, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"array\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode OptionalQueryParametersResponse")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *OptionalQueryParametersResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptionalQueryParametersResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *OptionalQueryParametersResponseObject) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *OptionalQueryParametersResponseObject) encodeFields(e *jx.Encoder) {
+	{
+		if s.Key.Set {
+			e.FieldStart("key")
+			s.Key.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfOptionalQueryParametersResponseObject = [1]string{
+	0: "key",
+}
+
+// Decode decodes OptionalQueryParametersResponseObject from json.
+func (s *OptionalQueryParametersResponseObject) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode OptionalQueryParametersResponseObject to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "key":
+			if err := func() error {
+				s.Key.Reset()
+				if err := s.Key.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"key\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode OptionalQueryParametersResponseObject")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *OptionalQueryParametersResponseObject) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptionalQueryParametersResponseObject) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/test_parameters/oas_operations_gen.go
+++ b/internal/integration/test_parameters/oas_operations_gen.go
@@ -13,6 +13,7 @@ const (
 	ObjectCookieParameterOperation       OperationName = "ObjectCookieParameter"
 	ObjectQueryParameterOperation        OperationName = "ObjectQueryParameter"
 	OptionalArrayParameterOperation      OperationName = "OptionalArrayParameter"
+	OptionalParametersOperation          OperationName = "OptionalParameters"
 	PathParameterOperation               OperationName = "PathParameter"
 	SameNameOperation                    OperationName = "SameName"
 	SimilarNamesOperation                OperationName = "SimilarNames"

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -5,6 +5,7 @@ package api
 import (
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
@@ -841,6 +842,317 @@ func decodeOptionalArrayParameterParams(args [0]string, argsEscaped bool, r *htt
 		return params, &ogenerrors.DecodeParamError{
 			Name: "header",
 			In:   "header",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// OptionalParametersParams is parameters of optionalParameters operation.
+type OptionalParametersParams struct {
+	Integer   OptInt
+	String    OptString
+	Boolean   OptBool
+	Object    OptOptionalParametersObject
+	Timestamp OptDateTime
+	Array     []string
+}
+
+func unpackOptionalParametersParams(packed middleware.Parameters) (params OptionalParametersParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "integer",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Integer = v.(OptInt)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "string",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.String = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "boolean",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Boolean = v.(OptBool)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "object",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Object = v.(OptOptionalParametersObject)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "timestamp",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Timestamp = v.(OptDateTime)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "array",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Array = v.([]string)
+		}
+	}
+	return params
+}
+
+func decodeOptionalParametersParams(args [0]string, argsEscaped bool, r *http.Request) (params OptionalParametersParams, _ error) {
+	q := uri.NewQueryDecoder(r.URL.Query())
+	// Decode query: integer.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "integer",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotIntegerVal int
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToInt(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotIntegerVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Integer.SetTo(paramsDotIntegerVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "integer",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: string.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "string",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotStringVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotStringVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.String.SetTo(paramsDotStringVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "string",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: boolean.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "boolean",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotBooleanVal bool
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToBool(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotBooleanVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Boolean.SetTo(paramsDotBooleanVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "boolean",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: object.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "object",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+			Fields:  []uri.QueryParameterObjectField{{Name: "key", Required: false}},
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotObjectVal OptionalParametersObject
+				if err := func() error {
+					return paramsDotObjectVal.DecodeURI(d)
+				}(); err != nil {
+					return err
+				}
+				params.Object.SetTo(paramsDotObjectVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "object",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: timestamp.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "timestamp",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotTimestampVal time.Time
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToDateTime(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotTimestampVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Timestamp.SetTo(paramsDotTimestampVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "timestamp",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: array.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "array",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotArrayVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotArrayVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.Array = append(params.Array, paramsDotArrayVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "array",
+			In:   "query",
 			Err:  err,
 		}
 	}

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -637,8 +637,8 @@ func decodeObjectCookieParameterParams(args [0]string, argsEscaped bool, r *http
 
 // ObjectQueryParameterParams is parameters of objectQueryParameter operation.
 type ObjectQueryParameterParams struct {
-	FormObject OptOneLevelObject `customTag:"test"`
-	DeepObject OptOneLevelObject `customTag:"test"`
+	FormObject OptOneLevelObject `json:",omitempty,omitzero" customTag:"test"`
+	DeepObject OptOneLevelObject `json:",omitempty,omitzero" customTag:"test"`
 }
 
 func unpackObjectQueryParameterParams(packed middleware.Parameters) (params ObjectQueryParameterParams) {
@@ -732,8 +732,8 @@ func decodeObjectQueryParameterParams(args [0]string, argsEscaped bool, r *http.
 
 // OptionalArrayParameterParams is parameters of optionalArrayParameter operation.
 type OptionalArrayParameterParams struct {
-	Query  []string `customTag:"test"`
-	Header []string `customTag:"test"`
+	Query  []string `json:",omitempty" customTag:"test"`
+	Header []string `json:",omitempty" customTag:"test"`
 }
 
 func unpackOptionalArrayParameterParams(packed middleware.Parameters) (params OptionalArrayParameterParams) {
@@ -850,12 +850,12 @@ func decodeOptionalArrayParameterParams(args [0]string, argsEscaped bool, r *htt
 
 // OptionalParametersParams is parameters of optionalParameters operation.
 type OptionalParametersParams struct {
-	Integer   OptInt
-	String    OptString
-	Boolean   OptBool
-	Object    OptOptionalParametersObject
-	Timestamp OptDateTime
-	Array     []string
+	Integer   OptInt                      `json:",omitempty,omitzero"`
+	String    OptString                   `json:",omitempty,omitzero"`
+	Boolean   OptBool                     `json:",omitempty,omitzero"`
+	Object    OptOptionalParametersObject `json:",omitempty,omitzero"`
+	Timestamp OptDateTime                 `json:",omitempty,omitzero"`
+	Array     []string                    `json:",omitempty"`
 }
 
 func unpackOptionalParametersParams(packed middleware.Parameters) (params OptionalParametersParams) {

--- a/internal/integration/test_parameters/oas_response_decoders_gen.go
+++ b/internal/integration/test_parameters/oas_response_decoders_gen.go
@@ -279,6 +279,47 @@ func decodeOptionalArrayParameterResponse(resp *http.Response) (res string, _ er
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeOptionalParametersResponse(resp *http.Response) (res *OptionalQueryParametersResponse, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response OptionalQueryParametersResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodePathParameterResponse(resp *http.Response) (res *Value, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/integration/test_parameters/oas_response_encoders_gen.go
+++ b/internal/integration/test_parameters/oas_response_encoders_gen.go
@@ -102,6 +102,20 @@ func encodeOptionalArrayParameterResponse(response string, w http.ResponseWriter
 	return nil
 }
 
+func encodeOptionalParametersResponse(response *OptionalQueryParametersResponse, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
 func encodePathParameterResponse(response *Value, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)

--- a/internal/integration/test_parameters/oas_router_gen.go
+++ b/internal/integration/test_parameters/oas_router_gen.go
@@ -232,24 +232,58 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 					}
 
-				case 'p': // Prefix: "ptionalArrayParameter"
+				case 'p': // Prefix: "ptional"
 
-					if l := len("ptionalArrayParameter"); len(elem) >= l && elem[0:l] == "ptionalArrayParameter" {
+					if l := len("ptional"); len(elem) >= l && elem[0:l] == "ptional" {
 						elem = elem[l:]
 					} else {
 						break
 					}
 
 					if len(elem) == 0 {
-						// Leaf node.
-						switch r.Method {
-						case "GET":
-							s.handleOptionalArrayParameterRequest([0]string{}, elemIsEscaped, w, r)
-						default:
-							s.notAllowed(w, r, "GET")
+						break
+					}
+					switch elem[0] {
+					case 'A': // Prefix: "ArrayParameter"
+
+						if l := len("ArrayParameter"); len(elem) >= l && elem[0:l] == "ArrayParameter" {
+							elem = elem[l:]
+						} else {
+							break
 						}
 
-						return
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "GET":
+								s.handleOptionalArrayParameterRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, "GET")
+							}
+
+							return
+						}
+
+					case 'P': // Prefix: "Parameters"
+
+						if l := len("Parameters"); len(elem) >= l && elem[0:l] == "Parameters" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "GET":
+								s.handleOptionalParametersRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, "GET")
+							}
+
+							return
+						}
+
 					}
 
 				}
@@ -637,28 +671,66 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 
 					}
 
-				case 'p': // Prefix: "ptionalArrayParameter"
+				case 'p': // Prefix: "ptional"
 
-					if l := len("ptionalArrayParameter"); len(elem) >= l && elem[0:l] == "ptionalArrayParameter" {
+					if l := len("ptional"); len(elem) >= l && elem[0:l] == "ptional" {
 						elem = elem[l:]
 					} else {
 						break
 					}
 
 					if len(elem) == 0 {
-						// Leaf node.
-						switch method {
-						case "GET":
-							r.name = OptionalArrayParameterOperation
-							r.summary = ""
-							r.operationID = "optionalArrayParameter"
-							r.pathPattern = "/optionalArrayParameter"
-							r.args = args
-							r.count = 0
-							return r, true
-						default:
-							return
+						break
+					}
+					switch elem[0] {
+					case 'A': // Prefix: "ArrayParameter"
+
+						if l := len("ArrayParameter"); len(elem) >= l && elem[0:l] == "ArrayParameter" {
+							elem = elem[l:]
+						} else {
+							break
 						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "GET":
+								r.name = OptionalArrayParameterOperation
+								r.summary = ""
+								r.operationID = "optionalArrayParameter"
+								r.pathPattern = "/optionalArrayParameter"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
+						}
+
+					case 'P': // Prefix: "Parameters"
+
+						if l := len("Parameters"); len(elem) >= l && elem[0:l] == "Parameters" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "GET":
+								r.name = OptionalParametersOperation
+								r.summary = ""
+								r.operationID = "optionalParameters"
+								r.pathPattern = "/optionalParameters"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
+						}
+
 					}
 
 				}

--- a/internal/integration/test_parameters/oas_schemas_gen.go
+++ b/internal/integration/test_parameters/oas_schemas_gen.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/go-faster/errors"
 )
 
@@ -118,6 +120,144 @@ func (s *OneLevelObject) SetFilter(val string) {
 	s.Filter = val
 }
 
+// NewOptBool returns new OptBool with value set to v.
+func NewOptBool(v bool) OptBool {
+	return OptBool{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptBool is optional bool.
+type OptBool struct {
+	Value bool
+	Set   bool
+}
+
+// IsSet returns true if OptBool was set.
+func (o OptBool) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptBool) Reset() {
+	var v bool
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptBool) SetTo(v bool) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptBool) Get() (v bool, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptBool) Or(d bool) bool {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptDateTime returns new OptDateTime with value set to v.
+func NewOptDateTime(v time.Time) OptDateTime {
+	return OptDateTime{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptDateTime is optional time.Time.
+type OptDateTime struct {
+	Value time.Time
+	Set   bool
+}
+
+// IsSet returns true if OptDateTime was set.
+func (o OptDateTime) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptDateTime) Reset() {
+	var v time.Time
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptDateTime) SetTo(v time.Time) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptDateTime) Get() (v time.Time, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptDateTime) Or(d time.Time) time.Time {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptInt returns new OptInt with value set to v.
+func NewOptInt(v int) OptInt {
+	return OptInt{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptInt is optional int.
+type OptInt struct {
+	Value int
+	Set   bool
+}
+
+// IsSet returns true if OptInt was set.
+func (o OptInt) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptInt) Reset() {
+	var v int
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptInt) SetTo(v int) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptInt) Get() (v int, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptInt) Or(d int) int {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptOneLevelObject returns new OptOneLevelObject with value set to v.
 func NewOptOneLevelObject(v OneLevelObject) OptOneLevelObject {
 	return OptOneLevelObject{
@@ -162,6 +302,242 @@ func (o OptOneLevelObject) Or(d OneLevelObject) OneLevelObject {
 		return v
 	}
 	return d
+}
+
+// NewOptOptionalParametersObject returns new OptOptionalParametersObject with value set to v.
+func NewOptOptionalParametersObject(v OptionalParametersObject) OptOptionalParametersObject {
+	return OptOptionalParametersObject{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptOptionalParametersObject is optional OptionalParametersObject.
+type OptOptionalParametersObject struct {
+	Value OptionalParametersObject
+	Set   bool
+}
+
+// IsSet returns true if OptOptionalParametersObject was set.
+func (o OptOptionalParametersObject) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptOptionalParametersObject) Reset() {
+	var v OptionalParametersObject
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptOptionalParametersObject) SetTo(v OptionalParametersObject) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptOptionalParametersObject) Get() (v OptionalParametersObject, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptOptionalParametersObject) Or(d OptionalParametersObject) OptionalParametersObject {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptOptionalQueryParametersResponseObject returns new OptOptionalQueryParametersResponseObject with value set to v.
+func NewOptOptionalQueryParametersResponseObject(v OptionalQueryParametersResponseObject) OptOptionalQueryParametersResponseObject {
+	return OptOptionalQueryParametersResponseObject{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptOptionalQueryParametersResponseObject is optional OptionalQueryParametersResponseObject.
+type OptOptionalQueryParametersResponseObject struct {
+	Value OptionalQueryParametersResponseObject
+	Set   bool
+}
+
+// IsSet returns true if OptOptionalQueryParametersResponseObject was set.
+func (o OptOptionalQueryParametersResponseObject) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptOptionalQueryParametersResponseObject) Reset() {
+	var v OptionalQueryParametersResponseObject
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptOptionalQueryParametersResponseObject) SetTo(v OptionalQueryParametersResponseObject) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptOptionalQueryParametersResponseObject) Get() (v OptionalQueryParametersResponseObject, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptOptionalQueryParametersResponseObject) Or(d OptionalQueryParametersResponseObject) OptionalQueryParametersResponseObject {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptString returns new OptString with value set to v.
+func NewOptString(v string) OptString {
+	return OptString{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptString is optional string.
+type OptString struct {
+	Value string
+	Set   bool
+}
+
+// IsSet returns true if OptString was set.
+func (o OptString) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptString) Reset() {
+	var v string
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptString) SetTo(v string) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptString) Get() (v string, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptString) Or(d string) string {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+type OptionalParametersObject struct {
+	Key OptString `json:"key"`
+}
+
+// GetKey returns the value of Key.
+func (s *OptionalParametersObject) GetKey() OptString {
+	return s.Key
+}
+
+// SetKey sets the value of Key.
+func (s *OptionalParametersObject) SetKey(val OptString) {
+	s.Key = val
+}
+
+// Ref: #/components/schemas/OptionalQueryParametersResponse
+type OptionalQueryParametersResponse struct {
+	Integer   OptInt                                   `json:"integer"`
+	String    OptString                                `json:"string"`
+	Boolean   OptBool                                  `json:"boolean"`
+	Object    OptOptionalQueryParametersResponseObject `json:"object"`
+	Timestamp OptDateTime                              `json:"timestamp"`
+	Array     []string                                 `json:"array"`
+}
+
+// GetInteger returns the value of Integer.
+func (s *OptionalQueryParametersResponse) GetInteger() OptInt {
+	return s.Integer
+}
+
+// GetString returns the value of String.
+func (s *OptionalQueryParametersResponse) GetString() OptString {
+	return s.String
+}
+
+// GetBoolean returns the value of Boolean.
+func (s *OptionalQueryParametersResponse) GetBoolean() OptBool {
+	return s.Boolean
+}
+
+// GetObject returns the value of Object.
+func (s *OptionalQueryParametersResponse) GetObject() OptOptionalQueryParametersResponseObject {
+	return s.Object
+}
+
+// GetTimestamp returns the value of Timestamp.
+func (s *OptionalQueryParametersResponse) GetTimestamp() OptDateTime {
+	return s.Timestamp
+}
+
+// GetArray returns the value of Array.
+func (s *OptionalQueryParametersResponse) GetArray() []string {
+	return s.Array
+}
+
+// SetInteger sets the value of Integer.
+func (s *OptionalQueryParametersResponse) SetInteger(val OptInt) {
+	s.Integer = val
+}
+
+// SetString sets the value of String.
+func (s *OptionalQueryParametersResponse) SetString(val OptString) {
+	s.String = val
+}
+
+// SetBoolean sets the value of Boolean.
+func (s *OptionalQueryParametersResponse) SetBoolean(val OptBool) {
+	s.Boolean = val
+}
+
+// SetObject sets the value of Object.
+func (s *OptionalQueryParametersResponse) SetObject(val OptOptionalQueryParametersResponseObject) {
+	s.Object = val
+}
+
+// SetTimestamp sets the value of Timestamp.
+func (s *OptionalQueryParametersResponse) SetTimestamp(val OptDateTime) {
+	s.Timestamp = val
+}
+
+// SetArray sets the value of Array.
+func (s *OptionalQueryParametersResponse) SetArray(val []string) {
+	s.Array = val
+}
+
+type OptionalQueryParametersResponseObject struct {
+	Key OptString `json:"key"`
+}
+
+// GetKey returns the value of Key.
+func (s *OptionalQueryParametersResponseObject) GetKey() OptString {
+	return s.Key
+}
+
+// SetKey sets the value of Key.
+func (s *OptionalQueryParametersResponseObject) SetKey(val OptString) {
+	s.Key = val
 }
 
 // SameNameOK is response for SameName operation.

--- a/internal/integration/test_parameters/oas_server_gen.go
+++ b/internal/integration/test_parameters/oas_server_gen.go
@@ -40,6 +40,10 @@ type Handler interface {
 	//
 	// GET /optionalArrayParameter
 	OptionalArrayParameter(ctx context.Context, params OptionalArrayParameterParams) (string, error)
+	// OptionalParameters implements optionalParameters operation.
+	//
+	// GET /optionalParameters
+	OptionalParameters(ctx context.Context, params OptionalParametersParams) (*OptionalQueryParametersResponse, error)
 	// PathParameter implements pathParameter operation.
 	//
 	// Test for path param.

--- a/internal/integration/test_parameters/oas_unimplemented_gen.go
+++ b/internal/integration/test_parameters/oas_unimplemented_gen.go
@@ -66,6 +66,13 @@ func (UnimplementedHandler) OptionalArrayParameter(ctx context.Context, params O
 	return r, ht.ErrNotImplemented
 }
 
+// OptionalParameters implements optionalParameters operation.
+//
+// GET /optionalParameters
+func (UnimplementedHandler) OptionalParameters(ctx context.Context, params OptionalParametersParams) (r *OptionalQueryParametersResponse, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // PathParameter implements pathParameter operation.
 //
 // Test for path param.

--- a/internal/integration/test_parameters/oas_uri_gen.go
+++ b/internal/integration/test_parameters/oas_uri_gen.go
@@ -143,3 +143,63 @@ func (s *OneLevelObject) DecodeURI(d uri.Decoder) error {
 
 	return nil
 }
+
+// EncodeURI encodes OptionalParametersObject as URI form.
+func (s *OptionalParametersObject) EncodeURI(e uri.Encoder) error {
+	if err := e.EncodeField("key", func(e uri.Encoder) error {
+		if val, ok := s.Key.Get(); ok {
+			return e.EncodeValue(conv.StringToString(val))
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "encode field \"key\"")
+	}
+	return nil
+}
+
+var uriFieldsNameOfOptionalParametersObject = [1]string{
+	0: "key",
+}
+
+// DecodeURI decodes OptionalParametersObject from URI form.
+func (s *OptionalParametersObject) DecodeURI(d uri.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode OptionalParametersObject to nil")
+	}
+
+	if err := d.DecodeFields(func(k string, d uri.Decoder) error {
+		switch k {
+		case "key":
+			if err := func() error {
+				var sDotKeyVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					sDotKeyVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				s.Key.SetTo(sDotKeyVal)
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"key\"")
+			}
+		default:
+			return nil
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode OptionalParametersObject")
+	}
+
+	return nil
+}

--- a/internal/integration/test_time_extension/oas_parameters_gen.go
+++ b/internal/integration/test_time_extension/oas_parameters_gen.go
@@ -15,10 +15,10 @@ import (
 
 // OptionalParams is parameters of optional operation.
 type OptionalParams struct {
-	Date     OptDate
-	Time     OptTime
-	DateTime OptDateTime
-	Alias    OptAlias
+	Date     OptDate     `json:",omitempty,omitzero"`
+	Time     OptTime     `json:",omitempty,omitzero"`
+	DateTime OptDateTime `json:",omitempty,omitzero"`
+	Alias    OptAlias    `json:",omitempty,omitzero"`
 }
 
 func unpackOptionalParams(packed middleware.Parameters) (params OptionalParams) {

--- a/internal/integration/test_type_extension/oas_parameters_gen.go
+++ b/internal/integration/test_type_extension/oas_parameters_gen.go
@@ -17,20 +17,20 @@ import (
 
 // OptionalParams is parameters of optional operation.
 type OptionalParams struct {
-	OgenString   OptStringOgen
-	OgenNumber   OptNumberOgen
-	JsonString   OptStringJSON
-	JsonNumber   OptNumberJSON
-	TextString   OptText
-	TextNumber   OptText
-	BinaryByte   OptBinary
-	BinaryBase64 OptBinary
-	String       OptString
-	Number       OptNumber
-	Alias        OptAlias
-	Pointer      OptPointer
-	AliasPointer OptAliasPointer
-	Array        []testtypes.StringJSON
+	OgenString   OptStringOgen          `json:",omitempty,omitzero"`
+	OgenNumber   OptNumberOgen          `json:",omitempty,omitzero"`
+	JsonString   OptStringJSON          `json:",omitempty,omitzero"`
+	JsonNumber   OptNumberJSON          `json:",omitempty,omitzero"`
+	TextString   OptText                `json:",omitempty,omitzero"`
+	TextNumber   OptText                `json:",omitempty,omitzero"`
+	BinaryByte   OptBinary              `json:",omitempty,omitzero"`
+	BinaryBase64 OptBinary              `json:",omitempty,omitzero"`
+	String       OptString              `json:",omitempty,omitzero"`
+	Number       OptNumber              `json:",omitempty,omitzero"`
+	Alias        OptAlias               `json:",omitempty,omitzero"`
+	Pointer      OptPointer             `json:",omitempty,omitzero"`
+	AliasPointer OptAliasPointer        `json:",omitempty,omitzero"`
+	Array        []testtypes.StringJSON `json:",omitempty"`
 }
 
 func unpackOptionalParams(packed middleware.Parameters) (params OptionalParams) {
@@ -838,7 +838,7 @@ type RequiredParams struct {
 	Alias        Alias
 	Pointer      testtypes.NumberOgen
 	AliasPointer AliasPointer
-	Array        []testtypes.StringJSON
+	Array        []testtypes.StringJSON `json:",omitempty"`
 }
 
 func unpackRequiredParams(packed middleware.Parameters) (params RequiredParams) {

--- a/internal/integration/test_type_extension_name/oas_parameters_gen.go
+++ b/internal/integration/test_type_extension_name/oas_parameters_gen.go
@@ -17,8 +17,8 @@ import (
 
 // OptionalParams is parameters of optional operation.
 type OptionalParams struct {
-	Foo OptDecimal
-	Bar OptDecimal2
+	Foo OptDecimal  `json:",omitempty,omitzero"`
+	Bar OptDecimal2 `json:",omitempty,omitzero"`
 }
 
 func unpackOptionalParams(packed middleware.Parameters) (params OptionalParams) {

--- a/internal/integration/test_webhooks/oas_parameters_gen.go
+++ b/internal/integration/test_webhooks/oas_parameters_gen.go
@@ -14,7 +14,7 @@ import (
 // UpdateWebhookParams is parameters of updateWebhook operation.
 type UpdateWebhookParams struct {
 	EventType     string
-	XWebhookToken OptString
+	XWebhookToken OptString `json:",omitempty,omitzero"`
 }
 
 func unpackUpdateWebhookParams(packed middleware.Parameters) (params UpdateWebhookParams) {


### PR DESCRIPTION
I experienced an issue similar to #660 when passing a parameter struct to stdlib slog (using a JSONHandler).

From what I was able to reproduce, the error occurs when calling encoding/json.Marshal on missing optional parameters that the Opt* struct is used in response types. The problem does not seem to occur if there are no response objects including the optional type (because the Encode/Decode methods are not generated on the Opt* types).

For me the error occurred when using slog with a JSONHandler inside an ogen handler:
```go
logger := slog.New(slog.NewJSONHandler(&strings.Builder{}, &slog.HandlerOptions{}))
[...]
logger.Info("test", "params", params)
```
Which gives this type of log output:
```json
{"time":"2025-03-17T16:13:56.22672301+01:00","level":"INFO","msg":"test","params":"!ERROR:json: error calling MarshalJSON for type api.OptInt: unexpected end of JSON input"}
```

This PR includes:
* test to reproduce the problem
  * both with encoding/json and slog
  * test can be run without the fix with maelick/ogen@e772bdb
  * the problem specifically occurs when the optional struct is used both as a param and as part of a return type
  * I had to add an endpoint that also returns each value type (see maelick/ogen@14db8891a58daa2686f658fe04d58e77ef497cd9), otherwise the Encode/Decode methods that use go-faster/jx are not generated
* a (partial) fix for #660
  * based on Go 1.24 omitzero tag
  * change limited to parameter structs (i.e. does not affect schema structs)
  * add default JSON tag to generated parameters in Generator:
    * omitempty for slices, maps and non-optional nullable fields
    * omitempty and omitzero for optional nullable fields
    * nothing for other fields

Notes:
* ~~I didn't change the minimum Go version in go.mod~~
  * not sure whether the new tag is backward compatible and whether Go 1.23 would just ignore it or not
  * edit: tests are failing in the pipeline, I assume because Go 1.23 is used to execute them
* I only partially squashed my branch to keep a working commit with the test but without the fix
  * if needed I can re-squash to have one commit with the changes and one with the generated files
  * edit: did more squashing