### PR TITLE
fix(gen): properly handle `ir.Map` when generating parameter encoders

### DIFF
--- a/gen/_template/uri.tmpl
+++ b/gen/_template/uri.tmpl
@@ -3,7 +3,7 @@
 {{- template "header" $ }}
 
 {{- range $_, $t := $.Types }}
-	{{- if and ($t.HasFeature "uri") $t.IsStruct }}
+	{{- if and ($t.HasFeature "uri") (or $t.IsStruct $t.IsMap) }}
 	{{- template "uri/encoders" $t }}
 	{{- end }}
 {{- end }}

--- a/gen/_template/uri/decode.tmpl
+++ b/gen/_template/uri/decode.tmpl
@@ -73,6 +73,8 @@
 	return nil
 {{- else if $t.IsStruct }}
 	return {{ $var }}.DecodeURI(d)
+{{- else if $t.IsMap }}
+	return {{ $var }}.DecodeURI(d)
 {{- else }}
     {{ errorf "unexpected kind" $t.Kind }}
 {{- end }}

--- a/gen/_template/uri/encode.tmpl
+++ b/gen/_template/uri/encode.tmpl
@@ -38,6 +38,8 @@
 	return nil
 {{- else if $t.IsStruct }}
 	return {{ $var }}.EncodeURI(e)
+{{- else if $t.IsMap }}
+	return {{ $var }}.EncodeURI(e)
 {{- else }}
 	{{ errorf "unexpected kind %s" $t.Kind }}
 {{- end }}

--- a/gen/_template/uri/encoders_map.tmpl
+++ b/gen/_template/uri/encoders_map.tmpl
@@ -33,7 +33,7 @@ func (s *{{ $.Name }}) DecodeURI(d uri.Decoder) error {
 		propertiesCount++
 		{{- end }}
 		{{- if $.MapPattern }}
-		switch match, err := pattern.Match(k); {
+		switch match, err := pattern.MatchString(k); {
 		case err != nil:
 			return errors.Wrap(err, "execute regex")
 		case !match:

--- a/gen/write.go
+++ b/gen/write.go
@@ -385,6 +385,6 @@ func (g *Generator) hasParams() bool {
 
 func (g *Generator) hasURIObjectParams() bool {
 	return g.hasAnyType(func(t *ir.Type) bool {
-		return t.IsStruct() && t.HasFeature("uri")
+		return (t.IsStruct() || t.IsMap()) && t.HasFeature("uri")
 	})
 }

--- a/internal/integration/test_additionalpropertiespatternproperties/oas_uri_gen.go
+++ b/internal/integration/test_additionalpropertiespatternproperties/oas_uri_gen.go
@@ -131,3 +131,102 @@ func (s *AliveFlexData) DecodeURI(d uri.Decoder) error {
 
 	return nil
 }
+
+// EncodeURI encodes AliveFlexDataAdditional as URI form.
+func (s AliveFlexDataAdditional) EncodeURI(e uri.Encoder) error {
+	for k, elem := range s {
+		if err := e.EncodeField(k, func(e uri.Encoder) error {
+
+			return e.EncodeValue(conv.StringToString(elem))
+		}); err != nil {
+			return errors.Wrapf(err, "encode field %q", k)
+		}
+	}
+	return nil
+}
+
+// DecodeURI decodes AliveFlexDataAdditional from URI form.
+func (s *AliveFlexDataAdditional) DecodeURI(d uri.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AliveFlexDataAdditional to nil")
+	}
+	m := s.init()
+	if err := d.DecodeFields(func(k string, d uri.Decoder) error {
+		var elem string
+		if err := func() error {
+			val, err := d.DecodeValue()
+			if err != nil {
+				return err
+			}
+
+			c, err := conv.ToString(val)
+			if err != nil {
+				return err
+			}
+
+			elem = c
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AliveFlexDataAdditional")
+	}
+
+	return nil
+}
+
+// EncodeURI encodes AliveFlexDataPattern0 as URI form.
+func (s AliveFlexDataPattern0) EncodeURI(e uri.Encoder) error {
+	for k, elem := range s {
+		if err := e.EncodeField(k, func(e uri.Encoder) error {
+
+			return e.EncodeValue(conv.StringToString(elem))
+		}); err != nil {
+			return errors.Wrapf(err, "encode field %q", k)
+		}
+	}
+	return nil
+}
+
+// DecodeURI decodes AliveFlexDataPattern0 from URI form.
+func (s *AliveFlexDataPattern0) DecodeURI(d uri.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AliveFlexDataPattern0 to nil")
+	}
+	m := s.init()
+	pattern := regexMap["^pat-.*"]
+	if err := d.DecodeFields(func(k string, d uri.Decoder) error {
+		switch match, err := pattern.MatchString(k); {
+		case err != nil:
+			return errors.Wrap(err, "execute regex")
+		case !match:
+			return nil
+		}
+		var elem string
+		if err := func() error {
+			val, err := d.DecodeValue()
+			if err != nil {
+				return err
+			}
+
+			c, err := conv.ToString(val)
+			if err != nil {
+				return err
+			}
+
+			elem = c
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AliveFlexDataPattern0")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #1428