### PR TITLE
docs: fix example in path_regex

### DIFF
--- a/examples/_config/example_all.yml
+++ b/examples/_config/example_all.yml
@@ -57,7 +57,7 @@ generator:
 
   # contains filters to skip operations.
   filters:
-    path_regex: "*"
+    path_regex: ".*"
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE"]
 
   # functions to ignore


### PR DESCRIPTION
Without this change, example produces the following error:
```
# go generate ./...
load config:
    main.run
        /home/patrick/go/pkg/mod/github.com/ogen-go/ogen@v1.12.0/cmd/ogen/main.go:366
  - compile path regex "*":
    github.com/ogen-go/ogen/gen.(*Filters).UnmarshalYAML
        /home/patrick/go/pkg/mod/github.com/ogen-go/ogen@v1.12.0/gen/options.go:287
  - error parsing regexp: missing argument to repetition operator: `*`

```