### PR TITLE
Generate a parameter for the Accept header when a response code has multiple content types

### DIFF
--- a/gen/_template/mediatypes.tmpl
+++ b/gen/_template/mediatypes.tmpl
@@ -1,0 +1,11 @@
+{{ define "mediatypes" }}
+{{- /*gotype: github.com/ogen-go/ogen/gen.TemplateConfig*/ -}}
+{{ template "header" $ }}
+
+const (
+	{{- range $op := $.MediaTypes }}
+	MediaType{{ $op.Name }} string = {{ quote $op.Value }}
+	{{- end }}
+)
+
+{{ end }}

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -30,6 +30,7 @@ type Generator struct {
 	defaultOperations []*ir.Operation // Operations without an operation group.
 	operationGroups   []*ir.OperationGroup
 	webhooks          []*ir.Operation
+	mediaTypes        map[ir.ContentType]*ir.MediaType
 	securities        map[string]*ir.Security
 	tstorage          *tstorage
 	errType           *ir.Response
@@ -98,6 +99,7 @@ func NewGenerator(spec *ogen.Spec, opts Options) (*Generator, error) {
 		servers:       nil,
 		operations:    nil,
 		webhooks:      nil,
+		mediaTypes:    map[ir.ContentType]*ir.MediaType{},
 		securities:    map[string]*ir.Security{},
 		tstorage:      newTStorage(),
 		errType:       nil,
@@ -187,6 +189,21 @@ func (g *Generator) makeOps(ops []*openapi.Operation) error {
 			return err
 		}
 
+		// Collect all media types used in responses to generate constants
+		for _, response := range op.Responses.StatusCode {
+			for contentType := range response.Contents {
+				if _, ok := g.mediaTypes[contentType]; !ok {
+					constantName, err := pascalNonEmpty(string(contentType))
+					if err != nil {
+						return errors.Wrap(err, "gather media types")
+					}
+					g.mediaTypes[contentType] = &ir.MediaType{
+						Name:  constantName,
+						Value: contentType,
+					}
+				}
+			}
+		}
 		g.operations = append(g.operations, op)
 	}
 
@@ -282,6 +299,12 @@ func sortOperations(ops []*ir.Operation) {
 	})
 }
 
+func sortMediaTypes(types []*ir.MediaType) {
+	slices.SortStableFunc(types, func(a, b *ir.MediaType) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
 func groupOperations(ops []*ir.Operation) (
 	defaultOperations []*ir.Operation,
 	operationGroups []*ir.OperationGroup,
@@ -318,6 +341,16 @@ func (g *Generator) Types() map[string]*ir.Type {
 // Operations returns generated operations.
 func (g *Generator) Operations() []*ir.Operation {
 	return g.operations
+}
+
+// MediaTypes returns generated media type constants.
+func (g *Generator) MediaTypes() []*ir.MediaType {
+	mediaTypesSorted := make([]*ir.MediaType, 0, len(g.mediaTypes))
+	for _, mt := range g.mediaTypes {
+		mediaTypesSorted = append(mediaTypesSorted, mt)
+	}
+	sortMediaTypes(mediaTypesSorted)
+	return mediaTypesSorted
 }
 
 // Webhooks returns generated webhooks.

--- a/gen/ir/operation.go
+++ b/gen/ir/operation.go
@@ -34,6 +34,11 @@ type OperationGroup struct {
 	Operations []*Operation
 }
 
+type MediaType struct {
+	Name  string      // Generated constant name
+	Value ContentType // Actual media type, e.g. application/xml
+}
+
 // OTELAttribute represents OpenTelemetry attribute defined by otelogen package.
 type OTELAttribute struct {
 	// Key is a name of the attribute constructor in otelogen package.

--- a/gen/write.go
+++ b/gen/write.go
@@ -27,6 +27,7 @@ type TemplateConfig struct {
 	DefaultOperations []*ir.Operation
 	OperationGroups   []*ir.OperationGroup
 	Webhooks          []*ir.Operation
+	MediaTypes        []*ir.MediaType
 	Types             map[string]*ir.Type
 	Interfaces        map[string]*ir.Type
 	Error             *ir.Response
@@ -257,6 +258,7 @@ func (g *Generator) WriteSource(fs FileSystem, pkgName string) error {
 		DefaultOperations:         g.defaultOperations,
 		OperationGroups:           g.operationGroups,
 		Webhooks:                  g.webhooks,
+		MediaTypes:                g.MediaTypes(),
 		Types:                     types,
 		Interfaces:                interfaces,
 		Error:                     g.errType,
@@ -335,6 +337,7 @@ func (g *Generator) WriteSource(fs FileSystem, pkgName string) error {
 		{"unimplemented", features.Has(OgenUnimplemented) && genServer},
 		{"labeler", features.Has(OgenOtel) && genServer},
 		{"operations", (genClient || genServer)},
+		{"mediatypes", (genClient || genServer)},
 	} {
 		t := t
 		if !t.enabled {

--- a/http/accept_header.go
+++ b/http/accept_header.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/go-faster/errors"
+	"github.com/ogen-go/ogen/uri"
+)
+
+// Represents the content of an HTTP Accept Header.
+// Supports multiple content types (comma separated) and wild cards.
+// Does NOT support q-factor weighting (these values are stripped and ignored).
+type AcceptHeader []string
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AcceptHeader) MarshalText() ([]byte, error) {
+	return []byte(strings.Join(s, ", ")), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AcceptHeader) UnmarshalText(data []byte) error {
+	*s = strings.Split(string(data), ",")
+	for i, segment := range *s {
+		// Remove q-factor weighting
+		if semicolonIndex := strings.IndexByte(segment, ';'); semicolonIndex >= 0 {
+			segment = segment[:semicolonIndex]
+		}
+		// Trim spaces to clean up leftovers from comma separation above (spaces are optional there)
+		(*s)[i] = strings.TrimSpace(segment)
+	}
+	return nil
+}
+
+func (s AcceptHeader) MatchesContentType(contentType string) bool {
+	return slices.ContainsFunc(s, func(pattern string) bool {
+		return MatchContentType(pattern, contentType)
+	})
+}
+
+func (s *AcceptHeader) DecodeURI(d uri.Decoder) error {
+	val, err := d.DecodeValue()
+	if err != nil {
+		return errors.Wrap(err, "decode accept header")
+	}
+	return s.UnmarshalText([]byte(val))
+}


### PR DESCRIPTION
This should fix #938

I'm currently still working on cleanup, documentation and more testing, so this PR is not ready yet.

Adds an automatic parameter for the HTTP Accept header, if at least one of the response codes for an operation defines more than one content type.
This can then be used to decide the actual response:
```go
func (h *ApiHandler) GetFileContent(ctx context.Context, params api.GetFileContentParams) (api.GetFileRes, error) {
	if params.Accept.MatchesContentType(api.MediaTypeApplicationVndOpenxmlformatsOfficedocumentSpreadsheetmlSheet) {
		// XLSX download
		// […] read/generate file
		buf *bytes.Buffer

		return &api.GetFileContentOKApplicationVndOpenxmlformatsOfficedocumentSpreadsheetmlSheet{
			Data: buf,
		}, nil

	} else {
		// JSON download
		// […] read/generate data

		res := &api.FileContent{
			// […] content
		}

		return res, nil

	}
}
```