### PR TITLE
feat: generate OAuth2 Scopes and Descriptions variables

### DIFF
--- a/examples/ex_oauth2/oas_security_gen.go
+++ b/examples/ex_oauth2/oas_security_gen.go
@@ -33,18 +33,30 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 	return "", false
 }
 
+type ScopeName = string
+
+const (
+	ScopeNameAdmin ScopeName = "admin"
+	ScopeNameUser  ScopeName = "user"
+)
+
+var oauth2ScopesDescriptionOAuth2 = map[string]string{
+	ScopeNameAdmin: "Grants write access",
+	ScopeNameUser:  "Grants read access",
+}
+
 var oauth2ScopesOAuth2 = map[string][]string{
 	AddPetOperation: []string{
-		"admin",
+		ScopeNameAdmin,
 	},
 	DeletePetOperation: []string{
-		"admin",
+		ScopeNameAdmin,
 	},
 	FindPetByIDOperation: []string{
-		"user",
+		ScopeNameUser,
 	},
 	FindPetsOperation: []string{
-		"user",
+		ScopeNameUser,
 	},
 }
 

--- a/examples/ex_oauth2_scopes_and_or/oas_security_gen.go
+++ b/examples/ex_oauth2_scopes_and_or/oas_security_gen.go
@@ -33,11 +33,25 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 	return "", false
 }
 
+type ScopeName = string
+
+const (
+	ScopeNameScope1 ScopeName = "scope1"
+	ScopeNameScope2 ScopeName = "scope2"
+	ScopeNameScope3 ScopeName = "scope3"
+)
+
+var oauth2ScopesDescriptionOauth2Alt = map[string]string{
+	ScopeNameScope1: "Grants scope1 access",
+	ScopeNameScope2: "Grants scope2 access",
+	ScopeNameScope3: "Grants scope3 access",
+}
+
 var oauth2ScopesOauth2Alt = map[string][]string{
 	TesttestOperation: []string{
-		"scope1",
-		"scope2",
-		"scope3",
+		ScopeNameScope1,
+		ScopeNameScope2,
+		ScopeNameScope3,
 	},
 }
 

--- a/examples/ex_oauth2_with_client_editors/oas_security_gen.go
+++ b/examples/ex_oauth2_with_client_editors/oas_security_gen.go
@@ -33,11 +33,25 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 	return "", false
 }
 
+type ScopeName = string
+
+const (
+	ScopeNameScope1 ScopeName = "scope1"
+	ScopeNameScope2 ScopeName = "scope2"
+	ScopeNameScope3 ScopeName = "scope3"
+)
+
+var oauth2ScopesDescriptionOauth2Alt = map[string]string{
+	ScopeNameScope1: "Grants scope1 access",
+	ScopeNameScope2: "Grants scope2 access",
+	ScopeNameScope3: "Grants scope3 access",
+}
+
 var oauth2ScopesOauth2Alt = map[string][]string{
 	TesttestOperation: []string{
-		"scope1",
-		"scope2",
-		"scope3",
+		ScopeNameScope1,
+		ScopeNameScope2,
+		ScopeNameScope3,
 	},
 }
 

--- a/gen/_template/security.tmpl
+++ b/gen/_template/security.tmpl
@@ -34,17 +34,44 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 
 {{ range $s := $.Securities }}
 
+{{ if gt (len $s.ScopeDescriptions) 0 }}
+
+type ScopeName = string
+
+const (
+{{- range $scopeName, $scopeDescription := $s.ScopeDescriptions }}
+    ScopeName{{ stripNonAlphaNumeric $scopeName }} ScopeName = {{ quote $scopeName }}
+{{- end }}
+)
+
+{{if $s.Format.IsOAuth2Security}}
+var oauth2ScopesDescription{{ $s.Type.Name }} = map[string]string {
+{{- range $scopeName, $scopeDescription := $s.ScopeDescriptions }}
+    ScopeName{{ stripNonAlphaNumeric $scopeName }}: {{ quote $scopeDescription }},
+{{- end }}
+}
+{{- end }}
+
+{{- end }}
+
 {{if $s.Format.IsOAuth2Security}}
 var oauth2Scopes{{ $s.Type.Name }} = map[string][]string {
-{{- else}}
+{{- range $operationName, $scopes := $s.OperationScopes }}
+    {{ $operationName }}Operation: []string{
+    {{- range $scopeName := $scopes }}
+        ScopeName{{ stripNonAlphaNumeric $scopeName }},
+    {{- end }}
+},
+{{- end }}
+{{- else }}
 var operationRoles{{ $s.Type.Name }} = map[string][]string {
-{{- end}}
-{{- range $operationName, $scopes := $s.Scopes }}
+{{- range $operationName, $scopes := $s.OperationScopes }}
 	{{ $operationName }}Operation: []string{
-		{{- range $scope := $scopes }}
-			{{ quote $scope }},
-		{{- end}}
+		{{- range $scopeName := $scopes }}
+			{{ quote $scopeName }},
+		{{- end }}
 	},
+{{- end }}
 {{- end }}
 }
 

--- a/gen/gen_security_test.go
+++ b/gen/gen_security_test.go
@@ -89,28 +89,28 @@ func TestGenerateSecurities(t *testing.T) {
 		{
 			Kind:   ir.HeaderSecurity,
 			Format: ir.Oauth2SecurityFormat,
-			Scopes: map[string][]string{
+			OperationScopes: map[string][]string{
 				"testOp": {"scope1", "scope2", "scope3"},
 			},
 		},
 		{
 			Kind:   ir.QuerySecurity,
 			Format: ir.APIKeySecurityFormat,
-			Scopes: map[string][]string{
+			OperationScopes: map[string][]string{
 				"testOp": {"scope4"},
 			},
 		},
 		{
 			Kind:   ir.HeaderSecurity,
 			Format: ir.BasicHTTPSecurityFormat,
-			Scopes: map[string][]string{
+			OperationScopes: map[string][]string{
 				"testOp": {"scope5"},
 			},
 		},
 		{
 			Kind:   ir.HeaderSecurity,
 			Format: ir.BearerSecurityFormat,
-			Scopes: map[string][]string{
+			OperationScopes: map[string][]string{
 				"testOp": {"scope6"},
 			},
 		},
@@ -130,7 +130,7 @@ func TestGenerateSecurities(t *testing.T) {
 
 		require.Equal(t, wantSec.Kind, sec.Kind)
 		require.Equal(t, wantSec.Format, sec.Format)
-		require.Contains(t, sec.Scopes, "testOp")
-		require.Equal(t, wantSec.Scopes["testOp"], sec.Scopes["testOp"])
+		require.Contains(t, sec.OperationScopes, "testOp")
+		require.Equal(t, wantSec.OperationScopes["testOp"], sec.OperationScopes["testOp"])
 	}
 }

--- a/gen/ir/security.go
+++ b/gen/ir/security.go
@@ -93,12 +93,13 @@ func (s SecurityFormat) IsCustomSecurity() bool {
 }
 
 type Security struct {
-	Kind          SecurityKind
-	Format        SecurityFormat
-	ParameterName string
-	Description   string
-	Type          *Type
-	Scopes        map[string][]string
+	Kind              SecurityKind
+	Format            SecurityFormat
+	ParameterName     string
+	Description       string
+	Type              *Type
+	ScopeDescriptions map[string]string
+	OperationScopes   map[string][]string
 }
 
 func (s *Security) GoDoc() []string {

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"embed"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -208,6 +209,33 @@ func templateFunctions() template.FuncMap {
 		},
 		"isObjectParam":     isObjectParam,
 		"paramObjectFields": paramObjectFields,
+		"stripNonAlphaNumeric": func(s string) string {
+			// Remove all non-alphabetical characters.
+			// This is used to generate valid Go identifiers.
+
+			shouldCapitalize := true
+			scopeName := ""
+			for idx, chr := range s {
+				var reg *regexp.Regexp
+				if idx == 0 {
+					reg = regexp.MustCompile("[a-zA-Z]")
+				} else {
+					reg = regexp.MustCompile("[a-zA-Z0-9]")
+				}
+
+				if !reg.MatchString(string(chr)) {
+					shouldCapitalize = true
+				} else {
+					if shouldCapitalize {
+						scopeName += strings.ToUpper(string(chr))
+						shouldCapitalize = false
+					} else {
+						scopeName += string(chr)
+					}
+				}
+			}
+			return scopeName
+		},
 	}
 }
 


### PR DESCRIPTION
This change is underpinned by a new `ScopeDescriptions` map on the `Security` struct that contains a mapping of `scope => scopeDescription`.

We leverage this in three areas:
1) When there are one or more scopes with a description, we create a `type ScopeName = string` alias.
2) Using the `ScopeName` alias, we iterate over all Scopes and create consts for each Scope (with its corresponding scope string) and create a Map containing a mapping of `ScopeName => ScopeDescription`. 
3) We update the `oauth2Scopes` Map to include `ScopeName` aliased Scopes, rather than raw strings.