### PR TITLE
fix(ogenregex): Support `\p{...}` and `\P{...}` format for Go regexp

### DIFF
--- a/ogenregex/convert.go
+++ b/ogenregex/convert.go
@@ -375,6 +375,30 @@ func (p *parser) scanEscape(inClass bool) {
 		p.writeString("[^" + whitespaceChars + "]")
 		p.read()
 		return
+	case 'p', 'P':
+		p.writeByte('\\')
+		p.pass()
+		if p.chr != '{' {
+			p.error(false, "re2: Invalid \\p/\\P format")
+			return
+		}
+		p.pass()
+		if p.chr == '}' {
+			p.error(false, "re2: Empty {} is not allowed")
+			return
+		}
+		for {
+			p.pass()
+			if p.chr == -1 {
+				p.error(true, "re2: Unterminated \\p/\\P")
+				return
+			}
+			if p.chr == '}' {
+				break
+			}
+		}
+		p.pass()
+		return
 	default:
 		// $ is an identifier character, so we have to have
 		// a special case for it here

--- a/ogenregex/ogenregex_test.go
+++ b/ogenregex/ogenregex_test.go
@@ -64,6 +64,9 @@ func TestCompile(t *testing.T) {
 		{`\s`, goRegexp{}, false},
 		{`\S`, goRegexp{}, false},
 		{`[\s]`, goRegexp{}, false},
+		// Unicode character class escape ,\p{...}/\P{...}, in ECMA-262
+		{`\p{L}`, goRegexp{}, false},
+		{`\P{N}`, goRegexp{}, false},
 
 		// Use regexp2.
 		{`^(?!examples/)`, regexp2Regexp{}, false},


### PR DESCRIPTION
Fix #1466 

Go's regexp supports `\p{...}` and `\P{...}`, so `ogenregex.Convert` function should keep these formats in regexp pattern.
This patch doesn't check actual properties because supported properties depend on Go version.
e.g. Go v1.25 supports more properties: https://github.com/golang/go/issues/70780