### PR TITLE
fix: fixed schema alias template to really generate type aliases

### DIFF
--- a/gen/_template/schema/alias.tmpl
+++ b/gen/_template/schema/alias.tmpl
@@ -1,4 +1,4 @@
 {{- /*gotype: github.com/ogen-go/ogen/gen/ir.Type*/ -}}
 {{- define "schema/alias" }}
-type {{ $.Name }} {{ $.AliasTo.Go }}
+type {{ $.Name }} = {{ $.AliasTo.Go }}
 {{ end }}


### PR DESCRIPTION
Problem code example

```go
// Some schema type
type SomeType struct {
  SomeField string
}

func (s *SomeType) GetSomeField() string {
  return s.SomeField
}

// Aliases

type Foo SomeType
type Bar SomeType
```

```go
x := &Foo{}
y := &Bar{}

x.GetSomeField() // <- Compile Error: x.GetSomeField undefined (type *Foo has no field or method GetSomeField)
y.GetSomeField() // <- Compile Error: y.GetSomeField undefined (type *Bar has no field or method GetSomeField)
```

So, client can't use interface for this types and access SomeField in some cases.

Just generate real go type alias is fixing this problem.