### PR TITLE
feat: pass raw response body in UnexpectedStatusCodeError

### DIFF
--- a/gen/_template/response_decode.tmpl
+++ b/gen/_template/response_decode.tmpl
@@ -64,7 +64,7 @@ func decode{{ $op.Name }}Response(resp *http.Response) (res {{ $op.Responses.GoT
 		}
 		return res, errors.Wrap(defRes, "error")
 	{{- else }}
-		return res, validate.UnexpectedStatusCode(resp.StatusCode)
+		return res, validate.UnexpectedStatusCodeWithResponse(resp)
 	{{- end }}
 }
 {{ end }}

--- a/validate/error_test.go
+++ b/validate/error_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,16 @@ func TestInvalidContentType(t *testing.T) {
 func TestUnexpectedStatusCode(t *testing.T) {
 	a := require.New(t)
 	err := UnexpectedStatusCode(500)
+	var ctErr *UnexpectedStatusCodeError
+	a.EqualError(err, "unexpected status code: 500")
+	a.ErrorAs(err, &ctErr)
+	a.Equal(500, ctErr.StatusCode)
+}
+
+func TestUnexpectedStatusCodeWithResponse(t *testing.T) {
+	a := require.New(t)
+	resp := http.Response{StatusCode: 500}
+	err := UnexpectedStatusCodeWithResponse(&resp)
 	var ctErr *UnexpectedStatusCodeError
 	a.EqualError(err, "unexpected status code: 500")
 	a.ErrorAs(err, &ctErr)

--- a/validate/errors.go
+++ b/validate/errors.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/ogen-go/ogen/ogenregex"
@@ -64,8 +65,18 @@ func InvalidContentType(contentType string) error {
 // UnexpectedStatusCodeError reports that client got unexpected status code.
 type UnexpectedStatusCodeError struct {
 	StatusCode int
+	Payload    *http.Response
 }
 
+// UnexpectedStatusCodeWithResponse creates new UnexpectedStatusCode.
+func UnexpectedStatusCodeWithResponse(response *http.Response) error {
+	return &UnexpectedStatusCodeError{
+		StatusCode: response.StatusCode,
+		Payload:    response,
+	}
+}
+
+// (Remains here for backwards compatibility)
 // UnexpectedStatusCode creates new UnexpectedStatusCode.
 func UnexpectedStatusCode(statusCode int) error {
 	return &UnexpectedStatusCodeError{


### PR DESCRIPTION
A client sometimes encounters a truly unexpected status code from the server for various reasons.  The client should not trash the response away then, to instead let the caller know what was going on.  In such cases, that bit might be useful for for instance inspection, logging, and/or debugging purposes.