### PR TITLE
fix: generate sum type for single-value oneOf with discriminator

### DIFF
--- a/_testdata/positive/oneOf_single.json
+++ b/_testdata/positive/oneOf_single.json
@@ -22,6 +22,24 @@
           }
         }
       }
+    },
+    "/test-oneof-single-discriminator": {
+      "get": {
+        "operationId": "testOneOfSingleDiscriminator",
+        "description": "Test oneOf with single reference and discriminator",
+        "responses": {
+          "200": {
+            "description": "Success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjC"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -42,6 +60,21 @@
             "$ref": "#/components/schemas/ObjA"
           }
         ]
+      },
+      "ObjC": {
+        "type": "object",
+        "readOnly": true,
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ObjA"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "a": "#/components/schemas/ObjA"
+          }
+        }
       }
     }
   }

--- a/gen/schema_transform.go
+++ b/gen/schema_transform.go
@@ -22,7 +22,7 @@ func transformSchema(schema *jsonschema.Schema) *jsonschema.Schema {
 //
 // if such pattern is detected, this function will return the inner schema.
 func transformSingleOneOf(schema *jsonschema.Schema) *jsonschema.Schema {
-	if len(schema.OneOf) == 1 {
+	if schema.Discriminator == nil && len(schema.OneOf) == 1 {
 		return schema.OneOf[0]
 	}
 	return schema


### PR DESCRIPTION
While https://github.com/ogen-go/ogen/pull/1498 fixed https://github.com/ogen-go/ogen/issues/1442, it also caused `ogen` to stop generating sum types for single-value `oneOf`s with discriminator, which had previously been generated correctly anyway.