### PR TITLE
Make response order stable

### DIFF
--- a/gen/ir/responses.go
+++ b/gen/ir/responses.go
@@ -40,7 +40,10 @@ func sortResponseInfos(result []ResponseInfo) {
 		if l.StatusCode != r.StatusCode {
 			return l.StatusCode - r.StatusCode
 		}
-		return strings.Compare(l.ContentType.String(), r.ContentType.String())
+		if cmp := strings.Compare(l.ContentType.String(), r.ContentType.String()); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(l.Type.Name, r.Type.Name)
 	})
 }
 


### PR DESCRIPTION
Previously, responses with no status code and the same content type were ordered randomly.