### PR TITLE
feat: encode numeric discriminators as an integer value

### DIFF
--- a/gen/_template/json/encoders_sum.tmpl
+++ b/gen/_template/json/encoders_sum.tmpl
@@ -26,14 +26,22 @@ func (s {{ $.ReadOnlyReceiver }}) encodeFields(e *jx.Encoder) {
 				{{- if eq (len $entries) 1}}
 					{{- range $e := $entries }}
 						e.FieldStart({{ quote $.SumSpec.Discriminator }})
-						e.Str({{ quote $e.Key }})
+						{{- if $e.DiscriminatorType.IsInteger }}
+							e.Int({{ $e.Key }})
+						{{- else }}
+							e.Str({{ quote $e.Key }})
+						{{- end }}
 					{{- end }}
 				{{- else }}
 				switch s.Type {
 				{{- range $e := $entries }}
 				case {{ $e.Name }}:
 					e.FieldStart({{ quote $.SumSpec.Discriminator }})
-					e.Str({{ quote $e.Key }})
+					{{- if $e.DiscriminatorType.IsInteger }}
+						e.Int({{ $e.Key }})
+					{{- else }}
+						e.Str({{ quote $e.Key }})
+					{{- end }}
 				{{- end }}
 				}
 				{{- end }}

--- a/gen/ir/type.go
+++ b/gen/ir/type.go
@@ -27,9 +27,10 @@ const (
 )
 
 type SumSpecMap struct {
-	Key  string
-	Type *Type
-	Name string
+	Key               string
+	Type              *Type
+	DiscriminatorType *Type
+	Name              string
 }
 
 // UniqueFieldVariant represents a variant that has a specific unique field.
@@ -91,8 +92,9 @@ type ValueDiscriminator struct {
 }
 
 type ResolvedSumSpecMap struct {
-	Name string
-	Key  string
+	Name              string
+	Key               string
+	DiscriminatorType *Type
 }
 
 type PickedMappingEntries []*ResolvedSumSpecMap
@@ -117,6 +119,7 @@ func (s SumSpec) PickMappingEntriesFor(t, sumOf *Type) PickedMappingEntries {
 	buildEntry := func(e *tmpEntry) *ResolvedSumSpecMap {
 		var name []string
 		var value string
+		var discriminatorType = e.typ
 		switch {
 		case e.sumSpecMap == nil || e.sumSpecMap.Key == e.sumOf.Go():
 			name = []string{e.sumOf.Name, e.typ.Name}
@@ -128,9 +131,15 @@ func (s SumSpec) PickMappingEntriesFor(t, sumOf *Type) PickedMappingEntries {
 			name = []string{e.sumSpecMap.Name, e.typ.Name}
 			value = e.sumSpecMap.Key
 		}
+
+		if e.sumSpecMap != nil && e.sumSpecMap.DiscriminatorType != nil {
+			discriminatorType = e.sumSpecMap.DiscriminatorType
+		}
+
 		return &ResolvedSumSpecMap{
-			Name: strings.Join(name, ""),
-			Key:  value,
+			Name:              strings.Join(name, ""),
+			Key:               value,
+			DiscriminatorType: discriminatorType,
 		}
 	}
 

--- a/gen/schema_gen_sum.go
+++ b/gen/schema_gen_sum.go
@@ -338,11 +338,19 @@ func (g *schemaGen) handleExplicitDiscriminator(sum *ir.Type, schema *jsonschema
 				vschema = variants[i]
 			}
 
+			var discriminatorType *ir.Type
+			for _, field := range s.Fields {
+				if field.Spec != nil && field.Spec.Name == propName {
+					discriminatorType = field.Type
+				}
+			}
+
 			if vschema.Ref == v.Ref {
 				found = true
 				sum.SumSpec.Mapping = append(sum.SumSpec.Mapping, ir.SumSpecMap{
-					Key:  k,
-					Type: s,
+					Key:               k,
+					Type:              s,
+					DiscriminatorType: discriminatorType,
 				})
 				mappingKeys = append(mappingKeys, k)
 				break


### PR DESCRIPTION
I've encountered an issue with the typing of discriminators. To illustrate the issue here's a minimum reproducible example.

```yaml
openapi: 3.0.0

paths:
  /example:
    post:
      responses:
        400:
          content:
            application/json:
              schema:
                oneof:
                  - $ref: "#/components/schemas/apple"
                  - $ref: "#/components/schemas/banana"
                  - $ref: "#/components/schemas/orange"
                discriminator:
                  propertyname: code
                  mapping:
                    1: "#/components/schemas/apple"
                    2: "#/components/schemas/banana"
                    3: "#/components/schemas/orange"

components:
  schemas:
    apple:
      type: object
      required: [code, fruit]
      properties:
        code:
          const: 1
          type: integer
        fruit:
          const: apple
          type: string
    banana:
      type: object
      required: [code, fruit]
      properties:
        code:
          const: 2
          type: integer
        fruit:
          const: banana
          type: string
    orange:
      type: object
      required: [code, fruit]
      properties:
        code:
          const: 3
          type: integer
        fruit:
          const: orange
          type: string
```

Ogen now generates an `encodeFields` method on `ExamplePostBadRequest`. It will encode the field `code` as a string while the api specification says it will be an `integer`.

```go
func (s ExamplePostBadRequest) encodeFields(e *jx.Encoder) {
	switch s.Type {
	case AppleExamplePostBadRequest:
		e.FieldStart("code")
		e.Str("1")
		{
			s := s.Apple
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	case BananaExamplePostBadRequest:
		e.FieldStart("code")
		e.Str("2")
		{
			s := s.Banana
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	case OrangeExamplePostBadRequest:
		e.FieldStart("code")
		e.Str("3")
		{
			s := s.Orange
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	}
}
```


This PR creates a fix for this by testing if the discriminator can be parsed as an integer. If that is the case a slightly altered template is used and the following code is generated.

```go
func (s ExamplePostBadRequest) encodeFields(e *jx.Encoder) {
	switch s.Type {
	case AppleExamplePostBadRequest:
		e.FieldStart("code")
		e.Int(1)
		{
			s := s.Apple
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	case BananaExamplePostBadRequest:
		e.FieldStart("code")
		e.Int(2)
		{
			s := s.Banana
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	case OrangeExamplePostBadRequest:
		e.FieldStart("code")
		e.Int(3)
		{
			s := s.Orange
			{
				e.FieldStart("fruit")
				e.Str(s.Fruit)
			}
		}
	}
}
```

I suppose this is a bit of a naive fix, what if we want to use `3` but need it to be of a string type. However this completely fixes my issue.

If this PR is good as is it would be great if it could be merged. If this solution is no good it would be great if someone could nudge me in the right direction to tackle this issue.