### PR TITLE
Fix build error

### DIFF
--- a/_testdata/positive/discriminator_const_fields.json
+++ b/_testdata/positive/discriminator_const_fields.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Discriminator with const-only fields",
+    "version": "v0.1.0"
+  },
+  "paths": {
+    "/check": {
+      "post": {
+        "operationId": "check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Business error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckBusinessError"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CheckBusinessError": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/AmlBlockedError" },
+          { "$ref": "#/components/schemas/SoftBlockedError" },
+          { "$ref": "#/components/schemas/MixedError" }
+        ],
+        "discriminator": {
+          "propertyName": "code",
+          "mapping": {
+            "AML_BLOCKED": "#/components/schemas/AmlBlockedError",
+            "SOFT_BLOCKED": "#/components/schemas/SoftBlockedError",
+            "MIXED": "#/components/schemas/MixedError"
+          }
+        }
+      },
+      "AmlBlockedError": {
+        "type": "object",
+        "required": ["code", "type"],
+        "properties": {
+          "code": { "type": "string", "const": "AML_BLOCKED" },
+          "type": { "type": "string", "const": "general" }
+        }
+      },
+      "SoftBlockedError": {
+        "type": "object",
+        "required": ["code", "type"],
+        "properties": {
+          "code": { "type": "string", "const": "SOFT_BLOCKED" },
+          "type": { "type": "string", "const": "endpoint" }
+        }
+      },
+      "MixedError": {
+        "type": "object",
+        "required": ["code", "type", "message"],
+        "properties": {
+          "code": { "type": "string", "const": "MIXED" },
+          "type": { "type": "string", "const": "general" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/gen/_template/json/encoders_sum.tmpl
+++ b/gen/_template/json/encoders_sum.tmpl
@@ -48,7 +48,9 @@ func (s {{ $.ReadOnlyReceiver }}) encodeFields(e *jx.Encoder) {
 				{{- $j := $s.JSON.Except $.SumSpec.Discriminator }}
 				{{- if $j.AnyFields }}
 				{
+					{{- if $j.NeedsReceiver }}
 					s := s.{{ $s.Name }}
+					{{- end }}
 					{{- template "json/encode_struct_fields" $j }}
 				}
 			{{- end }}


### PR DESCRIPTION
This happens when discriminator has complete same field name and type.

## How to reproduce

```yaml
openapi: "3.1.3"
info:
  title: "Reproducer"
  version: "0.1.0"
paths:
  /check:
    post:
      operationId: "check"
      responses:
        "200":
          description: "OK"
          content:
            application/json:
              schema:
                type: "object"
                properties:
                  status:
                    type: "string"
        "412":
          description: "Business error"
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/BusinessError"
        default:
          description: "Error"
          content:
            application/json:
              schema:
                type: "object"
                properties:
                  message:
                    type: "string"
components:
  schemas:
    BusinessError:
      oneOf:
        - $ref: "#/components/schemas/NotFoundError"
        - $ref: "#/components/schemas/BlockedError"
      discriminator:
        propertyName: "code"
        mapping:
          NOT_FOUND: "#/components/schemas/NotFoundError"
          BLOCKED: "#/components/schemas/BlockedError"
    NotFoundError:
      type: "object"
      required:
        - "code"
        - "type"
      properties:
        code:
          type: "string"
          const: "NOT_FOUND"
        type:
          type: "string"
          const: "general"
    BlockedError:
      type: "object"
      required:
        - "code"
        - "type"
      properties:
        code:
          type: "string"
          const: "BLOCKED"
        type:
          type: "string"
          const: "endpoint"
```

Build the app using the below yaml, the generated go code are invalid, you will find error like

```bash
gen/oas_json_gen.go:140:4: declared and not used: s
gen/oas_json_gen.go:150:4: declared and not used: s
```

