### PR TITLE
feat(parser): adds IsEmpty() method for OptNil* generated wrappers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ version: "2"
 linters:
   enable:
     - dogsled
-    - goconst
     - gocritic
     - gosec
     - lll

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Multiple convenience helper methods and functions are generated, some of them:
 func (OptNilString) Get() (v string, ok bool)
 func (OptNilString) IsNull() bool
 func (OptNilString) IsSet() bool
+func (OptNilString) IsEmpty() bool
 
 func NewOptNilString(v string) OptNilString
 ```

--- a/examples/ex_github/oas_schemas_gen.go
+++ b/examples/ex_github/oas_schemas_gen.go
@@ -48988,6 +48988,11 @@ func (o *OptNilBool) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilBool) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilBool) Get() (v bool, ok bool) {
 	if o.Null {
@@ -49049,6 +49054,11 @@ func (o *OptNilCodeScanningAlertDismissedReason) SetToNull() {
 	o.Null = true
 	var v CodeScanningAlertDismissedReason
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAlertDismissedReason) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49114,6 +49124,11 @@ func (o *OptNilCodeScanningAlertRuleSecuritySeverityLevel) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAlertRuleSecuritySeverityLevel) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCodeScanningAlertRuleSecuritySeverityLevel) Get() (v CodeScanningAlertRuleSecuritySeverityLevel, ok bool) {
 	if o.Null {
@@ -49175,6 +49190,11 @@ func (o *OptNilCodeScanningAlertRuleSeverity) SetToNull() {
 	o.Null = true
 	var v CodeScanningAlertRuleSeverity
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAlertRuleSeverity) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49240,6 +49260,11 @@ func (o *OptNilCodeScanningAlertRuleSummarySeverity) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAlertRuleSummarySeverity) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCodeScanningAlertRuleSummarySeverity) Get() (v CodeScanningAlertRuleSummarySeverity, ok bool) {
 	if o.Null {
@@ -49301,6 +49326,11 @@ func (o *OptNilCodeScanningAnalysisToolGUID) SetToNull() {
 	o.Null = true
 	var v CodeScanningAnalysisToolGUID
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAnalysisToolGUID) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49366,6 +49396,11 @@ func (o *OptNilCodeScanningAnalysisToolVersion) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCodeScanningAnalysisToolVersion) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCodeScanningAnalysisToolVersion) Get() (v CodeScanningAnalysisToolVersion, ok bool) {
 	if o.Null {
@@ -49427,6 +49462,11 @@ func (o *OptNilDateTime) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilDateTime) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49492,6 +49532,11 @@ func (o *OptNilFullRepositorySecurityAndAnalysis) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilFullRepositorySecurityAndAnalysis) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilFullRepositorySecurityAndAnalysis) Get() (v FullRepositorySecurityAndAnalysis, ok bool) {
 	if o.Null {
@@ -49553,6 +49598,11 @@ func (o *OptNilGistHistoryArray) SetToNull() {
 	o.Null = true
 	var v []GistHistory
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilGistHistoryArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49618,6 +49668,11 @@ func (o *OptNilGistSimpleForkOf) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilGistSimpleForkOf) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilGistSimpleForkOf) Get() (v GistSimpleForkOf, ok bool) {
 	if o.Null {
@@ -49679,6 +49734,11 @@ func (o *OptNilGistSimpleForksItemArray) SetToNull() {
 	o.Null = true
 	var v []GistSimpleForksItem
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilGistSimpleForksItemArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49744,6 +49804,11 @@ func (o *OptNilInt) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilInt) Get() (v int, ok bool) {
 	if o.Null {
@@ -49805,6 +49870,11 @@ func (o *OptNilIssuesCreateReqMilestone) SetToNull() {
 	o.Null = true
 	var v IssuesCreateReqMilestone
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIssuesCreateReqMilestone) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49870,6 +49940,11 @@ func (o *OptNilIssuesLockReq) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIssuesLockReq) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilIssuesLockReq) Get() (v IssuesLockReq, ok bool) {
 	if o.Null {
@@ -49931,6 +50006,11 @@ func (o *OptNilIssuesUpdateReqMilestone) SetToNull() {
 	o.Null = true
 	var v IssuesUpdateReqMilestone
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIssuesUpdateReqMilestone) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -49996,6 +50076,11 @@ func (o *OptNilIssuesUpdateReqTitle) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIssuesUpdateReqTitle) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilIssuesUpdateReqTitle) Get() (v IssuesUpdateReqTitle, ok bool) {
 	if o.Null {
@@ -50057,6 +50142,11 @@ func (o *OptNilMarketplacePurchaseMarketplacePendingChange) SetToNull() {
 	o.Null = true
 	var v MarketplacePurchaseMarketplacePendingChange
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilMarketplacePurchaseMarketplacePendingChange) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50122,6 +50212,11 @@ func (o *OptNilMigrationsUpdateImportReq) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilMigrationsUpdateImportReq) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilMigrationsUpdateImportReq) Get() (v MigrationsUpdateImportReq, ok bool) {
 	if o.Null {
@@ -50183,6 +50278,11 @@ func (o *OptNilMinimalRepositoryLicense) SetToNull() {
 	o.Null = true
 	var v MinimalRepositoryLicense
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilMinimalRepositoryLicense) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50248,6 +50348,11 @@ func (o *OptNilNullableIntegration) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableIntegration) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilNullableIntegration) Get() (v NullableIntegration, ok bool) {
 	if o.Null {
@@ -50309,6 +50414,11 @@ func (o *OptNilNullableMinimalRepository) SetToNull() {
 	o.Null = true
 	var v NullableMinimalRepository
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableMinimalRepository) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50374,6 +50484,11 @@ func (o *OptNilNullableMinimalRepositoryLicense) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableMinimalRepositoryLicense) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilNullableMinimalRepositoryLicense) Get() (v NullableMinimalRepositoryLicense, ok bool) {
 	if o.Null {
@@ -50435,6 +50550,11 @@ func (o *OptNilNullableRepository) SetToNull() {
 	o.Null = true
 	var v NullableRepository
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableRepository) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50500,6 +50620,11 @@ func (o *OptNilNullableRepositoryTemplateRepository) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableRepositoryTemplateRepository) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilNullableRepositoryTemplateRepository) Get() (v NullableRepositoryTemplateRepository, ok bool) {
 	if o.Null {
@@ -50561,6 +50686,11 @@ func (o *OptNilNullableScopedInstallation) SetToNull() {
 	o.Null = true
 	var v NullableScopedInstallation
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableScopedInstallation) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50626,6 +50756,11 @@ func (o *OptNilNullableSimpleUser) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableSimpleUser) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilNullableSimpleUser) Get() (v NullableSimpleUser, ok bool) {
 	if o.Null {
@@ -50687,6 +50822,11 @@ func (o *OptNilNullableTeamSimple) SetToNull() {
 	o.Null = true
 	var v NullableTeamSimple
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilNullableTeamSimple) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50752,6 +50892,11 @@ func (o *OptNilPageProtectedDomainState) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilPageProtectedDomainState) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilPageProtectedDomainState) Get() (v PageProtectedDomainState, ok bool) {
 	if o.Null {
@@ -50813,6 +50958,11 @@ func (o *OptNilPagesHealthCheckAltDomain) SetToNull() {
 	o.Null = true
 	var v PagesHealthCheckAltDomain
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilPagesHealthCheckAltDomain) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -50878,6 +51028,11 @@ func (o *OptNilProjectsAddCollaboratorReq) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilProjectsAddCollaboratorReq) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilProjectsAddCollaboratorReq) Get() (v ProjectsAddCollaboratorReq, ok bool) {
 	if o.Null {
@@ -50939,6 +51094,11 @@ func (o *OptNilPullRequestReviewCommentStartSide) SetToNull() {
 	o.Null = true
 	var v PullRequestReviewCommentStartSide
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilPullRequestReviewCommentStartSide) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51004,6 +51164,11 @@ func (o *OptNilPullsMergeReq) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilPullsMergeReq) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilPullsMergeReq) Get() (v PullsMergeReq, ok bool) {
 	if o.Null {
@@ -51065,6 +51230,11 @@ func (o *OptNilPullsUpdateBranchReq) SetToNull() {
 	o.Null = true
 	var v PullsUpdateBranchReq
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilPullsUpdateBranchReq) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51130,6 +51300,11 @@ func (o *OptNilReposCreateForkReq) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilReposCreateForkReq) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilReposCreateForkReq) Get() (v ReposCreateForkReq, ok bool) {
 	if o.Null {
@@ -51191,6 +51366,11 @@ func (o *OptNilReposCreateWebhookReq) SetToNull() {
 	o.Null = true
 	var v ReposCreateWebhookReq
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilReposCreateWebhookReq) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51256,6 +51436,11 @@ func (o *OptNilReposUpdateReqSecurityAndAnalysis) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilReposUpdateReqSecurityAndAnalysis) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilReposUpdateReqSecurityAndAnalysis) Get() (v ReposUpdateReqSecurityAndAnalysis, ok bool) {
 	if o.Null {
@@ -51317,6 +51502,11 @@ func (o *OptNilRepositoryTemplateRepository) SetToNull() {
 	o.Null = true
 	var v RepositoryTemplateRepository
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilRepositoryTemplateRepository) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51382,6 +51572,11 @@ func (o *OptNilReviewCommentStartSide) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilReviewCommentStartSide) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilReviewCommentStartSide) Get() (v ReviewCommentStartSide, ok bool) {
 	if o.Null {
@@ -51443,6 +51638,11 @@ func (o *OptNilSecretScanningAlertResolution) SetToNull() {
 	o.Null = true
 	var v SecretScanningAlertResolution
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilSecretScanningAlertResolution) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51508,6 +51708,11 @@ func (o *OptNilSimpleUserArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilSimpleUserArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilSimpleUserArray) Get() (v []SimpleUser, ok bool) {
 	if o.Null {
@@ -51569,6 +51774,11 @@ func (o *OptNilString) SetToNull() {
 	o.Null = true
 	var v string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51634,6 +51844,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringArray) Get() (v []string, ok bool) {
 	if o.Null {
@@ -51695,6 +51910,11 @@ func (o *OptNilTeamArray) SetToNull() {
 	o.Null = true
 	var v []Team
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTeamArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51760,6 +51980,11 @@ func (o *OptNilTeamSimpleArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTeamSimpleArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilTeamSimpleArray) Get() (v []TeamSimple, ok bool) {
 	if o.Null {
@@ -51821,6 +52046,11 @@ func (o *OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq) SetToNull() {
 	o.Null = true
 	var v TeamsAddOrUpdateProjectPermissionsInOrgReq
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTeamsAddOrUpdateProjectPermissionsInOrgReq) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -51886,6 +52116,11 @@ func (o *OptNilTopicSearchResultItemAliasesItemArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTopicSearchResultItemAliasesItemArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilTopicSearchResultItemAliasesItemArray) Get() (v []TopicSearchResultItemAliasesItem, ok bool) {
 	if o.Null {
@@ -51949,6 +52184,11 @@ func (o *OptNilTopicSearchResultItemRelatedItemArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTopicSearchResultItemRelatedItemArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilTopicSearchResultItemRelatedItemArray) Get() (v []TopicSearchResultItemRelatedItem, ok bool) {
 	if o.Null {
@@ -52010,6 +52250,11 @@ func (o *OptNilURI) SetToNull() {
 	o.Null = true
 	var v url.URL
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilURI) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/examples/ex_openai/oas_schemas_gen.go
+++ b/examples/ex_openai/oas_schemas_gen.go
@@ -4589,6 +4589,11 @@ func (o *OptNilAnyArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilAnyArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilAnyArray) Get() (v []jx.Raw, ok bool) {
 	if o.Null {
@@ -4650,6 +4655,11 @@ func (o *OptNilBool) SetToNull() {
 	o.Null = true
 	var v bool
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilBool) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4715,6 +4725,11 @@ func (o *OptNilCreateAnswerRequestStop) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateAnswerRequestStop) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateAnswerRequestStop) Get() (v CreateAnswerRequestStop, ok bool) {
 	if o.Null {
@@ -4776,6 +4791,11 @@ func (o *OptNilCreateChatCompletionRequestStop) SetToNull() {
 	o.Null = true
 	var v CreateChatCompletionRequestStop
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateChatCompletionRequestStop) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4841,6 +4861,11 @@ func (o *OptNilCreateCompletionRequestPrompt) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateCompletionRequestPrompt) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateCompletionRequestPrompt) Get() (v CreateCompletionRequestPrompt, ok bool) {
 	if o.Null {
@@ -4902,6 +4927,11 @@ func (o *OptNilCreateCompletionRequestStop) SetToNull() {
 	o.Null = true
 	var v CreateCompletionRequestStop
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateCompletionRequestStop) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4967,6 +4997,11 @@ func (o *OptNilCreateCompletionResponseChoicesItemLogprobs) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateCompletionResponseChoicesItemLogprobs) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateCompletionResponseChoicesItemLogprobs) Get() (v CreateCompletionResponseChoicesItemLogprobs, ok bool) {
 	if o.Null {
@@ -5028,6 +5063,11 @@ func (o *OptNilCreateEditResponseChoicesItemLogprobs) SetToNull() {
 	o.Null = true
 	var v CreateEditResponseChoicesItemLogprobs
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateEditResponseChoicesItemLogprobs) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5093,6 +5133,11 @@ func (o *OptNilCreateImageEditRequestMultipartResponseFormat) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageEditRequestMultipartResponseFormat) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateImageEditRequestMultipartResponseFormat) Get() (v CreateImageEditRequestMultipartResponseFormat, ok bool) {
 	if o.Null {
@@ -5154,6 +5199,11 @@ func (o *OptNilCreateImageEditRequestMultipartSize) SetToNull() {
 	o.Null = true
 	var v CreateImageEditRequestMultipartSize
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageEditRequestMultipartSize) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5219,6 +5269,11 @@ func (o *OptNilCreateImageRequestResponseFormat) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageRequestResponseFormat) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateImageRequestResponseFormat) Get() (v CreateImageRequestResponseFormat, ok bool) {
 	if o.Null {
@@ -5280,6 +5335,11 @@ func (o *OptNilCreateImageRequestSize) SetToNull() {
 	o.Null = true
 	var v CreateImageRequestSize
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageRequestSize) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5345,6 +5405,11 @@ func (o *OptNilCreateImageVariationRequestMultipartResponseFormat) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageVariationRequestMultipartResponseFormat) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilCreateImageVariationRequestMultipartResponseFormat) Get() (v CreateImageVariationRequestMultipartResponseFormat, ok bool) {
 	if o.Null {
@@ -5406,6 +5471,11 @@ func (o *OptNilCreateImageVariationRequestMultipartSize) SetToNull() {
 	o.Null = true
 	var v CreateImageVariationRequestMultipartSize
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilCreateImageVariationRequestMultipartSize) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5471,6 +5541,11 @@ func (o *OptNilFloat64) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilFloat64) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilFloat64) Get() (v float64, ok bool) {
 	if o.Null {
@@ -5532,6 +5607,11 @@ func (o *OptNilFloat64Array) SetToNull() {
 	o.Null = true
 	var v []float64
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilFloat64Array) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5597,6 +5677,11 @@ func (o *OptNilInt) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilInt) Get() (v int, ok bool) {
 	if o.Null {
@@ -5658,6 +5743,11 @@ func (o *OptNilString) SetToNull() {
 	o.Null = true
 	var v string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5723,6 +5813,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringArray) Get() (v []string, ok bool) {
 	if o.Null {
@@ -5784,6 +5879,11 @@ func (o *OptNilStringArrayArray) SetToNull() {
 	o.Null = true
 	var v [][]string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArrayArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/examples/ex_test_format/oas_schemas_gen.go
+++ b/examples/ex_test_format/oas_schemas_gen.go
@@ -2980,6 +2980,11 @@ func (o *OptNilBool) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilBool) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilBool) Get() (v bool, ok bool) {
 	if o.Null {
@@ -3041,6 +3046,11 @@ func (o *OptNilByte) SetToNull() {
 	o.Null = true
 	var v []byte
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilByte) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3106,6 +3116,11 @@ func (o *OptNilDate) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilDate) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilDate) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -3167,6 +3182,11 @@ func (o *OptNilDateTime) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilDateTime) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3232,6 +3252,11 @@ func (o *OptNilDecimal) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilDecimal) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilDecimal) Get() (v decimal.Decimal, ok bool) {
 	if o.Null {
@@ -3293,6 +3318,11 @@ func (o *OptNilDuration) SetToNull() {
 	o.Null = true
 	var v time.Duration
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilDuration) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3358,6 +3388,11 @@ func (o *OptNilFloat32) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilFloat32) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilFloat32) Get() (v float32, ok bool) {
 	if o.Null {
@@ -3419,6 +3454,11 @@ func (o *OptNilFloat64) SetToNull() {
 	o.Null = true
 	var v float64
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilFloat64) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3484,6 +3524,11 @@ func (o *OptNilHTTPDate) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilHTTPDate) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilHTTPDate) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -3545,6 +3590,11 @@ func (o *OptNilHardwareAddr) SetToNull() {
 	o.Null = true
 	var v net.HardwareAddr
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilHardwareAddr) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3610,6 +3660,11 @@ func (o *OptNilIP) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIP) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilIP) Get() (v netip.Addr, ok bool) {
 	if o.Null {
@@ -3671,6 +3726,11 @@ func (o *OptNilIPv4) SetToNull() {
 	o.Null = true
 	var v netip.Addr
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIPv4) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3736,6 +3796,11 @@ func (o *OptNilIPv6) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilIPv6) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilIPv6) Get() (v netip.Addr, ok bool) {
 	if o.Null {
@@ -3797,6 +3862,11 @@ func (o *OptNilInt) SetToNull() {
 	o.Null = true
 	var v int
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3862,6 +3932,11 @@ func (o *OptNilInt16) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt16) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilInt16) Get() (v int16, ok bool) {
 	if o.Null {
@@ -3923,6 +3998,11 @@ func (o *OptNilInt32) SetToNull() {
 	o.Null = true
 	var v int32
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt32) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -3988,6 +4068,11 @@ func (o *OptNilInt64) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt64) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilInt64) Get() (v int64, ok bool) {
 	if o.Null {
@@ -4049,6 +4134,11 @@ func (o *OptNilInt8) SetToNull() {
 	o.Null = true
 	var v int8
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt8) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4114,6 +4204,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4175,6 +4270,11 @@ func (o *OptNilStringDecimal) SetToNull() {
 	o.Null = true
 	var v decimal.Decimal
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringDecimal) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4240,6 +4340,11 @@ func (o *OptNilStringFloat32) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringFloat32) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringFloat32) Get() (v float32, ok bool) {
 	if o.Null {
@@ -4301,6 +4406,11 @@ func (o *OptNilStringFloat64) SetToNull() {
 	o.Null = true
 	var v float64
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringFloat64) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4366,6 +4476,11 @@ func (o *OptNilStringInt) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringInt) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringInt) Get() (v int, ok bool) {
 	if o.Null {
@@ -4427,6 +4542,11 @@ func (o *OptNilStringInt16) SetToNull() {
 	o.Null = true
 	var v int16
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringInt16) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4492,6 +4612,11 @@ func (o *OptNilStringInt32) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringInt32) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringInt32) Get() (v int32, ok bool) {
 	if o.Null {
@@ -4553,6 +4678,11 @@ func (o *OptNilStringInt64) SetToNull() {
 	o.Null = true
 	var v int64
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringInt64) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4618,6 +4748,11 @@ func (o *OptNilStringInt8) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringInt8) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringInt8) Get() (v int8, ok bool) {
 	if o.Null {
@@ -4679,6 +4814,11 @@ func (o *OptNilStringUint) SetToNull() {
 	o.Null = true
 	var v uint
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUint) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4744,6 +4884,11 @@ func (o *OptNilStringUint16) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUint16) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringUint16) Get() (v uint16, ok bool) {
 	if o.Null {
@@ -4805,6 +4950,11 @@ func (o *OptNilStringUint32) SetToNull() {
 	o.Null = true
 	var v uint32
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUint32) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4870,6 +5020,11 @@ func (o *OptNilStringUint64) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUint64) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringUint64) Get() (v uint64, ok bool) {
 	if o.Null {
@@ -4931,6 +5086,11 @@ func (o *OptNilStringUint8) SetToNull() {
 	o.Null = true
 	var v uint8
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUint8) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -4996,6 +5156,11 @@ func (o *OptNilStringUnixMicro) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUnixMicro) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringUnixMicro) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -5057,6 +5222,11 @@ func (o *OptNilStringUnixMilli) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUnixMilli) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5122,6 +5292,11 @@ func (o *OptNilStringUnixNano) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUnixNano) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilStringUnixNano) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -5183,6 +5358,11 @@ func (o *OptNilStringUnixSeconds) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringUnixSeconds) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5248,6 +5428,11 @@ func (o *OptNilTime) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilTime) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilTime) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -5309,6 +5494,11 @@ func (o *OptNilURI) SetToNull() {
 	o.Null = true
 	var v url.URL
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilURI) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5374,6 +5564,11 @@ func (o *OptNilUUID) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUUID) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilUUID) Get() (v uuid.UUID, ok bool) {
 	if o.Null {
@@ -5435,6 +5630,11 @@ func (o *OptNilUint) SetToNull() {
 	o.Null = true
 	var v uint
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUint) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5500,6 +5700,11 @@ func (o *OptNilUint16) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUint16) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilUint16) Get() (v uint16, ok bool) {
 	if o.Null {
@@ -5561,6 +5766,11 @@ func (o *OptNilUint32) SetToNull() {
 	o.Null = true
 	var v uint32
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUint32) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5626,6 +5836,11 @@ func (o *OptNilUint64) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUint64) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilUint64) Get() (v uint64, ok bool) {
 	if o.Null {
@@ -5687,6 +5902,11 @@ func (o *OptNilUint8) SetToNull() {
 	o.Null = true
 	var v uint8
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUint8) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5752,6 +5972,11 @@ func (o *OptNilUnixMicro) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUnixMicro) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilUnixMicro) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -5813,6 +6038,11 @@ func (o *OptNilUnixMilli) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUnixMilli) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.
@@ -5878,6 +6108,11 @@ func (o *OptNilUnixNano) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUnixNano) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilUnixNano) Get() (v time.Time, ok bool) {
 	if o.Null {
@@ -5939,6 +6174,11 @@ func (o *OptNilUnixSeconds) SetToNull() {
 	o.Null = true
 	var v time.Time
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilUnixSeconds) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/gen/_template/schema/generic.tmpl
+++ b/gen/_template/schema/generic.tmpl
@@ -68,6 +68,13 @@ func (o *{{ $.Name }}) SetToNull() {
 }
 {{ end }}
 
+{{- if and $v.Nullable $v.Optional }}
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o {{ $.ReadOnlyReceiver }}) IsEmpty() bool { 
+    return !o.Set && !o.Null 
+}
+{{- end }}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o {{ $.ReadOnlyReceiver }}) Get() (v {{ $g.Go }}, ok bool) {
 	{{- if $v.Nullable }}

--- a/internal/integration/sample_api/oas_schemas_gen.go
+++ b/internal/integration/sample_api/oas_schemas_gen.go
@@ -4415,6 +4415,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4476,6 +4481,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Null = true
 	var v []string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/internal/integration/sample_api_nc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nc/oas_schemas_gen.go
@@ -4415,6 +4415,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4476,6 +4481,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Null = true
 	var v []string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/internal/integration/sample_api_no_otel/oas_schemas_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_schemas_gen.go
@@ -4415,6 +4415,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4476,6 +4481,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Null = true
 	var v []string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/internal/integration/sample_api_ns/oas_schemas_gen.go
+++ b/internal/integration/sample_api_ns/oas_schemas_gen.go
@@ -4415,6 +4415,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4476,6 +4481,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Null = true
 	var v []string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/internal/integration/sample_api_nsnc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_schemas_gen.go
@@ -4415,6 +4415,11 @@ func (o *OptNilString) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilString) Get() (v string, ok bool) {
 	if o.Null {
@@ -4476,6 +4481,11 @@ func (o *OptNilStringArray) SetToNull() {
 	o.Null = true
 	var v []string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilStringArray) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/internal/integration/test_allof/oas_schemas_gen.go
+++ b/internal/integration/test_allof/oas_schemas_gen.go
@@ -565,6 +565,11 @@ func (o *OptNilLocation) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilLocation) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilLocation) Get() (v Location, ok bool) {
 	if o.Null {

--- a/internal/integration/test_nullable_type_discrimination/oas_schemas_gen.go
+++ b/internal/integration/test_nullable_type_discrimination/oas_schemas_gen.go
@@ -138,6 +138,11 @@ func (o *OptNilInt) SetToNull() {
 	o.Value = v
 }
 
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilInt) IsEmpty() bool {
+	return !o.Set && !o.Null
+}
+
 // Get returns value and boolean that denotes whether value was set.
 func (o OptNilInt) Get() (v int, ok bool) {
 	if o.Null {
@@ -199,6 +204,11 @@ func (o *OptNilString) SetToNull() {
 	o.Null = true
 	var v string
 	o.Value = v
+}
+
+// IsEmpty returns true if the field was omitted from the payload (not Set and not Null).
+func (o OptNilString) IsEmpty() bool {
+	return !o.Set && !o.Null
 }
 
 // Get returns value and boolean that denotes whether value was set.

--- a/uri/cookie_param_encoder.go
+++ b/uri/cookie_param_encoder.go
@@ -13,6 +13,7 @@ type cookieParamEncoder struct {
 }
 
 func (e *cookieParamEncoder) setCookie(val string) {
+	//#nosec G124
 	e.req.AddCookie(&http.Cookie{
 		Name:  e.paramName,
 		Value: escapeCookie(val),


### PR DESCRIPTION
# Summary

When generating schemas with optional, nullable fields, it is often necessary to distinguish between a value being explicitly set to null versus being entirely omitted from the input (e.g., the "Zero" test case in the included examples). 
https://github.com/ogen-go/ogen/blob/f48de28beba3928b5e553ddc07ce5a526a015d11/internal/integration/json_test.go#L84-L104

To simplify this check, this PR introduces the `IsEmpty()` method for `OptNil***` wrappers, providing a clean and efficient way to verify if a field was provided.

# Usage Example

Consider the following struct:
```go
type OrderDto struct {
	OrderUUID uuid.UUID `json:"order_uuid"`
	HullUUID uuid.UUID `json:"hull_uuid"`
	EngineUUID uuid.UUID `json:"engine_uuid"`
	ShieldUUID OptNilUUID `json:"shield_uuid"`
	WeaponUUID OptNilUUID `json:"weapon_uuid"`
	// ...
}
```

## Before

Previously, checking for an omitted value required a more verbose approach:
```go
func OrderCreateRqToModel(orderRq *orderv1.CreateOrderRequest) model.CreateOrderRq {
    // Required fields
	result := model.CreateOrderRq{
		HullUUID:   orderRq.HullUUID.String(),
		EngineUUID: orderRq.EngineUUID.String(),
	}
    // Process optional field if present
	if orderRq.GetShieldUUID().IsSet() && !orderRq.GetShieldUUID().IsNull() {
		val := orderRq.GetShieldUUID().Value.String()
		result.ShieldUUID = &val
	}
    // Handle omitted field
	if !orderRq.GetWeaponUUID().IsSet() && !orderRq.GetWeaponUUID().IsNull() {
		// ...
	}
	return result
}
```

## After
With `IsEmpty()`, the logic is much more concise:
```go
func OrderCreateRqToModel(orderRq *orderv1.CreateOrderRequest) model.CreateOrderRq {
    // Required fields
	result := model.CreateOrderRq{
		HullUUID:   orderRq.HullUUID.String(),
		EngineUUID: orderRq.EngineUUID.String(),
	}
    // Process optional field if present
	if !orderRq.GetShieldUUID().IsEmpty() {
		val := orderRq.GetShieldUUID().Value.String()
		result.ShieldUUID = &val
	}
    // Handle omitted field
	if orderRq.GetWeaponUUID().IsEmpty() {
		// ...
	}
	return result
}
```