### PR TITLE
fix(gen): distinct wrapper types for shared body with differing headers

### DIFF
--- a/_testdata/positive/shared_body_differing_headers.yml
+++ b/_testdata/positive/shared_body_differing_headers.yml
@@ -1,0 +1,43 @@
+openapi: "3.0.3"
+info:
+  title: Shared body with differing response headers
+  version: "0.1.0"
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-ID:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Foo"
+  /bar:
+    post:
+      operationId: createBar
+      responses:
+        "202":
+          description: Accepted
+          headers:
+            Location:
+              schema:
+                type: string
+            X-ID:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Foo"
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        id:
+          type: string

--- a/gen/gen_responses.go
+++ b/gen/gen_responses.go
@@ -373,7 +373,7 @@ func wrapResponseType(
 	}
 
 	if schema := t.Schema; schema != nil && !schema.Ref.IsZero() {
-		if t, ok := ctx.lookupWType(respRef, schema.Ref); ok {
+		if t, ok := ctx.lookupWType(respRef, schema.Ref, headers); ok {
 			return t, nil
 		}
 
@@ -382,7 +382,7 @@ func wrapResponseType(
 				return
 			}
 
-			if err := ctx.saveWType(respRef, schema.Ref, ret); err != nil {
+			if err := ctx.saveWType(respRef, schema.Ref, headers, ret); err != nil {
 				rerr = err
 				ret = nil
 			}
@@ -400,27 +400,34 @@ func wrapResponseType(
 		}()
 	}
 
-	// Prefer response name to schema name in case of wrapping.
-	if (respRef.IsZero() || multipleContents) && t.Name != "" {
-		name = t.Name
-	}
-
-	var (
-		namePostfix string
-		doc         string
-	)
+	var namePostfix string
 	switch {
 	case len(headers) > 0 && withStatusCode:
 		namePostfix = "StatusCodeWithHeaders"
-		doc = fmt.Sprintf("%sStatusCodeWithHeaders wraps %s with status code and response headers.", name, t.Go())
 	case len(headers) > 0:
 		namePostfix = "Headers"
-		doc = fmt.Sprintf("%sHeaders wraps %s with response headers.", name, t.Go())
 	case withStatusCode:
 		namePostfix = "StatusCode"
-		doc = fmt.Sprintf("%sStatusCode wraps %s with StatusCode.", name, t.Go())
 	default:
 		panic("unreachable")
+	}
+
+	// Prefer response name to schema name in case of wrapping, unless that name is
+	// already taken by a wrapper with a different header set.
+	if (respRef.IsZero() || multipleContents) && t.Name != "" {
+		if _, taken := ctx.lookupType(t.Name + namePostfix); !taken {
+			name = t.Name
+		}
+	}
+
+	var doc string
+	switch namePostfix {
+	case "StatusCodeWithHeaders":
+		doc = fmt.Sprintf("%sStatusCodeWithHeaders wraps %s with status code and response headers.", name, t.Go())
+	case "Headers":
+		doc = fmt.Sprintf("%sHeaders wraps %s with response headers.", name, t.Go())
+	case "StatusCode":
+		doc = fmt.Sprintf("%sStatusCode wraps %s with StatusCode.", name, t.Go())
 	}
 
 	wrapper := &ir.Type{

--- a/gen/genctx.go
+++ b/gen/genctx.go
@@ -34,8 +34,8 @@ func (g *genctx) saveResponse(ref jsonschema.Ref, r *ir.Response) error {
 	return g.local.saveResponse(ref, r)
 }
 
-func (g *genctx) saveWType(parent, ref jsonschema.Ref, t *ir.Type) error {
-	return g.local.saveWType(parent, ref, t)
+func (g *genctx) saveWType(parent, ref jsonschema.Ref, headers map[string]*ir.Parameter, t *ir.Type) error {
+	return g.local.saveWType(parent, ref, headers, t)
 }
 
 func (g *genctx) saveParameter(ref jsonschema.Ref, r *ir.Parameter) error {
@@ -52,12 +52,22 @@ func (g *genctx) lookupResponse(ref jsonschema.Ref) (*ir.Response, bool) {
 	return nil, false
 }
 
-func (g *genctx) lookupWType(parent, ref jsonschema.Ref) (*ir.Type, bool) {
-	key := [2]jsonschema.Ref{parent, ref}
+func (g *genctx) lookupWType(parent, ref jsonschema.Ref, headers map[string]*ir.Parameter) (*ir.Type, bool) {
+	key := [3]jsonschema.Ref{parent, ref, headersRef(headers)}
 	if t, ok := g.global.wtypes[key]; ok {
 		return t, true
 	}
 	if t, ok := g.local.wtypes[key]; ok {
+		return t, true
+	}
+	return nil, false
+}
+
+func (g *genctx) lookupType(name string) (*ir.Type, bool) {
+	if t, ok := g.global.types[name]; ok {
+		return t, true
+	}
+	if t, ok := g.local.types[name]; ok {
 		return t, true
 	}
 	return nil, false

--- a/gen/tstorage.go
+++ b/gen/tstorage.go
@@ -1,6 +1,9 @@
 package gen
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/go-faster/errors"
 
 	"github.com/ogen-go/ogen/gen/ir"
@@ -42,7 +45,7 @@ type tstorage struct {
 	//  * [T]StatusCode
 	//  * [T]Headers
 	//  * [T]StatusCodeWithHeaders
-	wtypes map[[2]jsonschema.Ref]*ir.Type // Key: parent ref + ref
+	wtypes map[[3]jsonschema.Ref]*ir.Type // Key: parent ref + ref + headers ref (interned)
 }
 
 func newTStorage() *tstorage {
@@ -51,7 +54,7 @@ func newTStorage() *tstorage {
 		types:      map[string]*ir.Type{},
 		responses:  map[jsonschema.Ref]*ir.Response{},
 		parameters: map[jsonschema.Ref]*ir.Parameter{},
-		wtypes:     map[[2]jsonschema.Ref]*ir.Type{},
+		wtypes:     map[[3]jsonschema.Ref]*ir.Type{},
 	}
 }
 
@@ -109,8 +112,17 @@ func (s *tstorage) saveResponse(ref jsonschema.Ref, r *ir.Response) error {
 	return nil
 }
 
-func (s *tstorage) saveWType(parent, ref jsonschema.Ref, t *ir.Type) error {
-	key := [2]jsonschema.Ref{parent, ref}
+func headersRef(headers map[string]*ir.Parameter) jsonschema.Ref {
+	names := make([]string, 0, len(headers))
+	for k := range headers {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return jsonschema.Ref{Ptr: strings.Join(names, ",")}
+}
+
+func (s *tstorage) saveWType(parent, ref jsonschema.Ref, headers map[string]*ir.Parameter, t *ir.Type) error {
+	key := [3]jsonschema.Ref{parent, ref, headersRef(headers)}
 	if _, ok := s.wtypes[key]; ok {
 		return errors.Errorf("reference conflict: %q", ref)
 	}
@@ -190,7 +202,7 @@ func (s *tstorage) merge(other *tstorage) error {
 
 	for ref := range other.wtypes {
 		if _, ok := s.wtypes[ref]; ok {
-			return errors.Errorf("wrapped type reference conflict: %q", ref)
+			return errors.Errorf("wrapped type reference conflict: %q/%s", ref[1], ref[2].Ptr)
 		}
 	}
 


### PR DESCRIPTION
Widen the `wtypes` cache key to include the response header set so operations sharing a body schema but declaring different headers no longer collapse into one wrapper. When the schema-derived name is already claimed by a wrapper with a different header set, fall back to the operation-specific name to avoid a type-name conflict.

I chose to intern the header keys as a `jsonschema.Ref` vs adding a non-`jsonschema.Ref` value to the key, which would have been a larger change. I can propose a distinct `wtypeKey` type if that's preferable.