### PR TITLE
chore(docker): use static-debian13 base to drop libssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 ARG GO_VERSION=latest
-ARG BASE_IMAGE=gcr.io/distroless/base-debian12
+# Use the "static" distroless variant rather than "base". The ogen and
+# jschemagen binaries are built with CGO disabled, so they are fully static
+# and need no glibc. The "base" variant additionally ships libssl3, which we
+# never link against; it showed up in a vulnerability scan (CVE-2026-31789),
+# and "static" omits it entirely, reducing the image's attack surface.
+ARG BASE_IMAGE=gcr.io/distroless/static-debian13
 
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/app


### PR DESCRIPTION
- A vulnerability scan in our infrastructure flagged [CVE-2026-31789](https://security-tracker.debian.org/tracker/CVE-2026-31789) in `libssl3` on ogen v1.20.3 published Docker image. 
- Looking into where `libssl3` comes from: it ships in the `gcr.io/distroless/base-debian12` base image.
- The latest version of base-debian12 no longer contains the CVE, however, `libssl3` does not appear to actually be used by ogen binaries
-  The `ogen` and `jschemagen` binaries are built with `CGO_ENABLED=0`, so they are fully static and never link against `libssl3`

## What

- Switch the base from `gcr.io/distroless/base-debian12` to `gcr.io/distroless/static-debian13`. The `static` variant omits `libssl3` (and glibc) entirely, removing the flagged package and reducing the image's attack surface.
- This includes a bump to the major debian version (12 to 13)

## Verification

Built locally on `static-debian13` and confirmed:

- The image builds.
- `docker run ... --help` runs (the static binary executes on the new base).
- An end-to-end generation against `_testdata/positive/additional_operations.yml` succeeds (exit 0).
- The resulting image contains no `libssl.so` / `libcrypto.so`.

## Notes

- No generated-code changes, so `make generate examples` is not needed here.