### PR TITLE
fix(gen): deterministic order of unique validators (#1655)

### DIFF
--- a/gen/gen_equality_detect.go
+++ b/gen/gen_equality_detect.go
@@ -1,6 +1,10 @@
 package gen
 
-import "github.com/ogen-go/ogen/gen/ir"
+import (
+	"sort"
+
+	"github.com/ogen-go/ogen/gen/ir"
+)
 
 const (
 	prefixOpt  = "Opt"
@@ -11,10 +15,16 @@ const (
 // collectEqualitySpecs identifies types that require Equal() and Hash() methods
 // for complex uniqueItems validation.
 func (g *Generator) collectEqualitySpecs() {
-	// Iterate through all types to find arrays with complex uniqueItems
+	// Iterate through all types to find arrays with complex uniqueItems.
+	// Sort by name to ensure deterministic order of generated functions (#1655).
 	visited := make(map[string]bool)
-	for _, t := range g.tstorage.types {
-		g.collectFromType(t, visited)
+	names := make([]string, 0, len(g.tstorage.types))
+	for name := range g.tstorage.types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		g.collectFromType(g.tstorage.types[name], visited)
 	}
 }
 

--- a/gen/gen_equality_test.go
+++ b/gen/gen_equality_test.go
@@ -1,12 +1,14 @@
 package gen
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ogen-go/ogen/gen/ir"
+	"github.com/ogen-go/ogen/jsonschema"
 )
 
 func TestCreateEqualityMethodSpec_ArrayDetection(t *testing.T) {
@@ -410,5 +412,55 @@ func TestWriteFieldComparison_NullableArray(t *testing.T) {
 					"output should NOT contain: %s", notExpected)
 			}
 		})
+	}
+}
+
+// TestCollectEqualitySpecs_Deterministic is a regression test for #1655:
+// collectEqualitySpecs ranged over the tstorage.types map directly, producing
+// equalitySpecs (and thus generated validateUnique* functions) in a
+// non-deterministic order across runs. The types are now visited in sorted
+// order, so the resulting specs must be deterministic and sorted by TypeName.
+func TestCollectEqualitySpecs_Deterministic(t *testing.T) {
+	newArrayOfStruct := func(name string) *ir.Type {
+		return &ir.Type{
+			Name:   name + "List",
+			Kind:   ir.KindArray,
+			Schema: &jsonschema.Schema{UniqueItems: true},
+			Item: &ir.Type{
+				Name: name,
+				Kind: ir.KindStruct,
+				Fields: []*ir.Field{
+					{Name: "ID", Type: &ir.Type{Kind: ir.KindPrimitive, Primitive: ir.Int}},
+				},
+			},
+		}
+	}
+
+	names := []string{"Pet", "User", "Order", "Account", "Zebra"}
+
+	var first []string
+	for run := range 20 {
+		g := &Generator{tstorage: newTStorage()}
+		for _, n := range names {
+			arr := newArrayOfStruct(n)
+			g.tstorage.types[arr.Name] = arr
+		}
+
+		g.collectEqualitySpecs()
+
+		got := make([]string, 0, len(g.equalitySpecs))
+		for _, spec := range g.equalitySpecs {
+			got = append(got, spec.TypeName)
+		}
+
+		require.True(t, sort.StringsAreSorted(got),
+			"equality specs must be emitted in sorted order, got %v", got)
+
+		if run == 0 {
+			first = got
+			continue
+		}
+		require.Equal(t, first, got,
+			"equality specs order must be deterministic across runs")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1655.

`collectEqualitySpecs` in `gen/gen_equality_detect.go` ranged directly over `g.tstorage.types` (a `map[string]*ir.Type`). Go randomizes map iteration order, so the `equalitySpecs` slice — and thus the order of `validateUnique*` functions emitted into `*_validators_unique_gen.go` — varied between runs given the same input spec. In CI pipelines that auto-format/auto-generate and commit the result, this caused infinite "autofix" commit loops (each run reorders the file → new commit → another reorder → …).

This is the same class of bug as #486 (`generateContents` non-determinism), in a different part of the generator.

## Fix

Collect the type names, sort them, and iterate in sorted order so spec collection — and the generated function order — is deterministic and alphabetically stable.

## Verification

- Reproduced the issue's spec and generated it 8 times: output is now byte-identical across all runs, with `validateUnique*` functions sorted (`Order`, `Pet`, `User`).
- Added `TestCollectEqualitySpecs_Deterministic`, which asserts sorted + deterministic ordering across 20 runs. Confirmed it **fails** without the fix (`got [Order Account Zebra Pet User]`) and **passes** with it.
- `go build ./...`, the full `gen` test suite, and the `test_complex_uniqueitems` integration tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)