### PR TITLE
feat: support default values for array types

### DIFF
--- a/_testdata/positive/array_defaults.yml
+++ b/_testdata/positive/array_defaults.yml
@@ -1,0 +1,103 @@
+openapi: 3.0.3
+info:
+  title: Array defaults
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: tags
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+            default: [active, featured]
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter'
+components:
+  schemas:
+    Priority:
+      type: string
+      enum: [low, medium, high]
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
+    Filter:
+      type: object
+      properties:
+        strings:
+          type: array
+          items:
+            type: string
+          default: [all]
+        priorities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Priority'
+          default: [medium, high]
+        nested:
+          type: array
+          items:
+            type: array
+            items:
+              type: integer
+          default: [[1, 2], [3]]
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+          default:
+            - name: x
+              count: 5
+        shapes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Shape'
+          default:
+            - kind: circle
+              radius: 5
+        labels:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
+          default:
+            - a: x
+              b: "y"
+    Shape:
+      oneOf:
+        - $ref: '#/components/schemas/Circle'
+        - $ref: '#/components/schemas/Square'
+      discriminator:
+        propertyName: kind
+        mapping:
+          circle: '#/components/schemas/Circle'
+          square: '#/components/schemas/Square'
+    Circle:
+      type: object
+      required: [kind, radius]
+      properties:
+        kind:
+          type: string
+        radius:
+          type: integer
+    Square:
+      type: object
+      required: [kind, side]
+      properties:
+        kind:
+          type: string
+        side:
+          type: integer

--- a/_testdata/positive/sample.json
+++ b/_testdata/positive/sample.json
@@ -647,6 +647,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/defaultQueryParameter"
+          },
+          {
+            "$ref": "#/components/parameters/defaultArrayQueryParameter"
           }
         ],
         "requestBody": {
@@ -1790,6 +1793,61 @@
             "type": "string",
             "format": "byte",
             "default": "aGVsbG8sIHdvcmxkIQ=="
+          },
+          "strings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": ["all"]
+          },
+          "priorities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["low", "medium", "high"]
+            },
+            "default": ["medium", "high"]
+          },
+          "nested": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "default": [[1, 2], [3]]
+          },
+          "objs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "integer"
+                }
+              }
+            },
+            "default": [
+              {
+                "name": "x",
+                "count": 5
+              }
+            ]
+          },
+          "shapes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/DefaultShape" },
+            "default": [ { "kind": "circle", "radius": 5 } ]
+          },
+          "labels": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": { "type": "string" } },
+            "default": [ { "a": "x" } ]
           }
         }
       },
@@ -2069,6 +2127,29 @@
           }
         }
       },
+      "DefaultShape": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/DefaultCircle" },
+          { "$ref": "#/components/schemas/DefaultSquare" }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "circle": "#/components/schemas/DefaultCircle",
+            "square": "#/components/schemas/DefaultSquare"
+          }
+        }
+      },
+      "DefaultCircle": {
+        "type": "object",
+        "required": ["kind", "radius"],
+        "properties": { "kind": { "type": "string" }, "radius": { "type": "integer" } }
+      },
+      "DefaultSquare": {
+        "type": "object",
+        "required": ["kind", "side"],
+        "properties": { "kind": { "type": "string" }, "side": { "type": "integer" } }
+      },
       "Issue1461": {
         "type": "object",
         "properties": {
@@ -2139,6 +2220,17 @@
           "type": "integer",
           "format": "int32",
           "default": 10
+        }
+      },
+      "defaultArrayQueryParameter": {
+        "name": "arrayDefault",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["a", "b"]
         }
       },
       "skipParam": {

--- a/examples/ex_2ch/oas_request_decoders_gen.go
+++ b/examples/ex_2ch/oas_request_decoders_gen.go
@@ -614,6 +614,7 @@ func (s *Server) decodeUserReportPostRequest(r *http.Request) (
 				}
 				if err := q.HasParam(cfg); err == nil {
 					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						optForm.Post = nil
 						return d.DecodeArray(func(d uri.Decoder) error {
 							var optFormDotPostVal int
 							if err := func() error {

--- a/examples/ex_github/oas_defaults_gen.go
+++ b/examples/ex_github/oas_defaults_gen.go
@@ -222,6 +222,17 @@ func (s *OrgsCreateInvitationReq) setDefaults() {
 // setDefaults set default value of fields.
 func (s *OrgsCreateWebhookReq) setDefaults() {
 	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("push")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Events = defaultVal0
+	}
+	{
 		val := bool(true)
 		s.Active.SetTo(val)
 	}
@@ -237,6 +248,17 @@ func (s *OrgsSetMembershipForUserReq) setDefaults() {
 
 // setDefaults set default value of fields.
 func (s *OrgsUpdateWebhookReq) setDefaults() {
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("push")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Events = defaultVal0
+	}
 	{
 		val := bool(true)
 		s.Active.SetTo(val)
@@ -466,6 +488,17 @@ func (s *ReposCreateUsingTemplateReq) setDefaults() {
 // setDefaults set default value of fields.
 func (s *ReposCreateWebhookReq) setDefaults() {
 	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("push")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Events = defaultVal0
+	}
+	{
 		val := bool(true)
 		s.Active.SetTo(val)
 	}
@@ -525,6 +558,17 @@ func (s *ReposUpdateReq) setDefaults() {
 
 // setDefaults set default value of fields.
 func (s *ReposUpdateWebhookReq) setDefaults() {
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("push")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Events = defaultVal0
+	}
 	{
 		val := bool(true)
 		s.Active.SetTo(val)

--- a/examples/ex_github/oas_parameters_gen.go
+++ b/examples/ex_github/oas_parameters_gen.go
@@ -47668,6 +47668,7 @@ func decodeMigrationsGetStatusForAuthenticatedUserParams(args [1]string, argsEsc
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Exclude = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotExcludeVal string
 					if err := func() error {
@@ -47842,6 +47843,7 @@ func decodeMigrationsGetStatusForOrgParams(args [2]string, argsEscaped bool, r *
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Exclude = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotExcludeVal MigrationsGetStatusForOrgExcludeItem
 					if err := func() error {
@@ -48225,6 +48227,7 @@ func decodeMigrationsListForOrgParams(args [1]string, argsEscaped bool, r *http.
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Exclude = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotExcludeVal MigrationsListForOrgExcludeItem
 					if err := func() error {

--- a/examples/ex_oauth2/oas_parameters_gen.go
+++ b/examples/ex_oauth2/oas_parameters_gen.go
@@ -188,6 +188,7 @@ func decodeFindPetsParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Tags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotTagsVal string
 					if err := func() error {

--- a/examples/ex_petstore_expanded/oas_parameters_gen.go
+++ b/examples/ex_petstore_expanded/oas_parameters_gen.go
@@ -188,6 +188,7 @@ func decodeFindPetsParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Tags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotTagsVal string
 					if err := func() error {

--- a/examples/ex_swagger_petstore/oas_parameters_gen.go
+++ b/examples/ex_swagger_petstore/oas_parameters_gen.go
@@ -362,6 +362,7 @@ func decodeFindPetsByTagsParams(args [0]string, argsEscaped bool, r *http.Reques
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Tags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotTagsVal string
 					if err := func() error {

--- a/examples/ex_test_format/oas_parameters_gen.go
+++ b/examples/ex_test_format/oas_parameters_gen.go
@@ -1004,6 +1004,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.BooleanArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotBooleanArrayVal bool
 					if err := func() error {
@@ -1093,6 +1094,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerArrayVal int
 					if err := func() error {
@@ -1182,6 +1184,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerInt16Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerInt16ArrayVal int16
 					if err := func() error {
@@ -1271,6 +1274,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerInt32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerInt32ArrayVal int32
 					if err := func() error {
@@ -1360,6 +1364,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerInt64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerInt64ArrayVal int64
 					if err := func() error {
@@ -1449,6 +1454,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerInt8Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerInt8ArrayVal int8
 					if err := func() error {
@@ -1574,6 +1580,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUint16Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUint16ArrayVal uint16
 					if err := func() error {
@@ -1663,6 +1670,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUint32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUint32ArrayVal uint32
 					if err := func() error {
@@ -1752,6 +1760,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUint64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUint64ArrayVal uint64
 					if err := func() error {
@@ -1841,6 +1850,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUint8Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUint8ArrayVal uint8
 					if err := func() error {
@@ -1894,6 +1904,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUintArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUintArrayVal uint
 					if err := func() error {
@@ -2019,6 +2030,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUnixMicroArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUnixMicroArrayVal time.Time
 					if err := func() error {
@@ -2108,6 +2120,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUnixMilliArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUnixMilliArrayVal time.Time
 					if err := func() error {
@@ -2197,6 +2210,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUnixNanoArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUnixNanoArrayVal time.Time
 					if err := func() error {
@@ -2286,6 +2300,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUnixSecondsArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUnixSecondsArrayVal time.Time
 					if err := func() error {
@@ -2339,6 +2354,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.IntegerUnixArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotIntegerUnixArrayVal time.Time
 					if err := func() error {
@@ -2436,6 +2452,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberArrayVal float64
 					if err := func() error {
@@ -2542,6 +2559,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberDecimalArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberDecimalArrayVal decimal.Decimal
 					if err := func() error {
@@ -2639,6 +2657,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberDoubleArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberDoubleArrayVal float64
 					if err := func() error {
@@ -2753,6 +2772,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberFloatArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberFloatArrayVal float32
 					if err := func() error {
@@ -2859,6 +2879,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberInt32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberInt32ArrayVal int32
 					if err := func() error {
@@ -2948,6 +2969,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.NumberInt64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotNumberInt64ArrayVal int64
 					if err := func() error {
@@ -3037,6 +3059,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringArrayVal string
 					if err := func() error {
@@ -3126,6 +3149,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringBase64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringBase64ArrayVal []byte
 					if err := func() error {
@@ -3215,6 +3239,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringBinaryArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringBinaryArrayVal string
 					if err := func() error {
@@ -3304,6 +3329,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringByteArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringByteArrayVal []byte
 					if err := func() error {
@@ -3429,6 +3455,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringDateTimeArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringDateTimeArrayVal time.Time
 					if err := func() error {
@@ -3482,6 +3509,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringDateArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringDateArrayVal time.Time
 					if err := func() error {
@@ -3571,6 +3599,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringDecimalArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringDecimalArrayVal decimal.Decimal
 					if err := func() error {
@@ -3660,6 +3689,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringDurationArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringDurationArrayVal time.Duration
 					if err := func() error {
@@ -3769,6 +3799,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringEmailArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringEmailArrayVal string
 					if err := func() error {
@@ -3895,6 +3926,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringFloat32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringFloat32ArrayVal float32
 					if err := func() error {
@@ -4009,6 +4041,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringFloat64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringFloat64ArrayVal float64
 					if err := func() error {
@@ -4135,6 +4168,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringHostnameArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringHostnameArrayVal string
 					if err := func() error {
@@ -4253,6 +4287,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringHTTPDateArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringHTTPDateArrayVal time.Time
 					if err := func() error {
@@ -4378,6 +4413,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringInt16Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringInt16ArrayVal int16
 					if err := func() error {
@@ -4467,6 +4503,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringInt32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringInt32ArrayVal int32
 					if err := func() error {
@@ -4556,6 +4593,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringInt64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringInt64ArrayVal int64
 					if err := func() error {
@@ -4645,6 +4683,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringInt8Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringInt8ArrayVal int8
 					if err := func() error {
@@ -4698,6 +4737,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringIntArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringIntArrayVal int
 					if err := func() error {
@@ -4787,6 +4827,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringIPArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringIPArrayVal netip.Addr
 					if err := func() error {
@@ -4876,6 +4917,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringIpv4Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringIpv4ArrayVal netip.Addr
 					if err := func() error {
@@ -4965,6 +5007,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringIpv6Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringIpv6ArrayVal netip.Addr
 					if err := func() error {
@@ -5054,6 +5097,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringMACArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringMACArrayVal net.HardwareAddr
 					if err := func() error {
@@ -5143,6 +5187,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringPasswordArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringPasswordArrayVal string
 					if err := func() error {
@@ -5232,6 +5277,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringTimeArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringTimeArrayVal time.Time
 					if err := func() error {
@@ -5357,6 +5403,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUint16Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUint16ArrayVal uint16
 					if err := func() error {
@@ -5446,6 +5493,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUint32Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUint32ArrayVal uint32
 					if err := func() error {
@@ -5535,6 +5583,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUint64Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUint64ArrayVal uint64
 					if err := func() error {
@@ -5624,6 +5673,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUint8Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUint8ArrayVal uint8
 					if err := func() error {
@@ -5677,6 +5727,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUintArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUintArrayVal uint
 					if err := func() error {
@@ -5802,6 +5853,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUnixMicroArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUnixMicroArrayVal time.Time
 					if err := func() error {
@@ -5891,6 +5943,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUnixMilliArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUnixMilliArrayVal time.Time
 					if err := func() error {
@@ -5980,6 +6033,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUnixNanoArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUnixNanoArrayVal time.Time
 					if err := func() error {
@@ -6069,6 +6123,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUnixSecondsArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUnixSecondsArrayVal time.Time
 					if err := func() error {
@@ -6122,6 +6177,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUnixArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUnixArrayVal time.Time
 					if err := func() error {
@@ -6211,6 +6267,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringURIArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringURIArrayVal url.URL
 					if err := func() error {
@@ -6300,6 +6357,7 @@ func decodeTestQueryParameterParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.StringUUIDArray = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotStringUUIDArrayVal uuid.UUID
 					if err := func() error {

--- a/gen/_template/defaults/set.tmpl
+++ b/gen/_template/defaults/set.tmpl
@@ -6,24 +6,66 @@
 {{- if or $t.IsPrimitive $t.IsEnum -}}
 	{{- template "defaults/val" default_elem $t $.Var $.Default }}
 	{{ $.Var }} = val
-{{- else if $t.IsGeneric -}}{{ $val := $.Default }}
-	{{- if $val.IsNil }}
+{{- else if $t.IsGeneric -}}
+	{{- if $.Default.IsNil }}
 		{{- if $t.GenericVariant.Nullable }}
 		{{ $.Var }}.Null = true
 		{{- end }}
+	{{- else if or $t.GenericOf.IsPrimitive $t.GenericOf.IsEnum -}}
+		{{- template "defaults/val" default_elem $t.GenericOf $.Var $.Default }}
+		{{ $.Var }}.SetTo(val)
 	{{- else if $t.GenericOf.IsAlias -}}
 		{{- template "defaults/val" default_elem $t.GenericOf.AliasTo $.Var $.Default }}
 		{{ $.Var }}.SetTo({{ $t.GenericOf.Go }}(val))
-	{{- else }}
-		{{- template "defaults/val" default_elem $t.GenericOf $.Var $.Default }}
-		{{ $.Var }}.SetTo(val)
+	{{- else -}}
+		var {{ $.LocalVar }} {{ $t.GenericOf.Go }}
+		{{ template "defaults/set" sub_default_elem $t.GenericOf $.LocalVar $.Default.Value $.NextDepth }}
+		{{ $.Var }}.SetTo({{ $.LocalVar }})
 	{{- end }}
 {{- else if $t.IsAlias -}}
 	{{- template "defaults/val" default_elem $t.AliasTo $.Var $.Default }}
 	{{ $.Var }} = {{ $t.Go }}(val)
 {{- else if $t.IsPointer -}}
-	{{- template "defaults/val" default_elem $t.PointerTo $.Var $.Default }}
-	{{ $.Var }} = &val
+	{{- if or $t.PointerTo.IsPrimitive $t.PointerTo.IsEnum -}}
+		{{- template "defaults/val" default_elem $t.PointerTo $.Var $.Default }}
+		{{ $.Var }} = &val
+	{{- else -}}
+		var {{ $.LocalVar }} {{ $t.PointerTo.Go }}
+		{{ template "defaults/set" sub_default_elem $t.PointerTo $.LocalVar $.Default.Value $.NextDepth }}
+		{{ $.Var }} = &{{ $.LocalVar }}
+	{{- end }}
+{{- else if $t.IsArray -}}
+	var {{ $.LocalVar }} {{ $t.Go }}
+	{{- range $v := default_slice $.Default }}
+	{
+		var {{ $.LocalVar }}Elem {{ $t.Item.Go }}
+		{{ template "defaults/set" sub_default_elem $t.Item (printf "%sElem" $.LocalVar) $v $.NextDepth }}
+		{{ $.LocalVar }} = append({{ $.LocalVar }}, {{ $.LocalVar }}Elem)
+	}
+	{{- end }}
+	{{ $.Var }} = {{ $.LocalVar }}
+{{- else if $t.IsStruct -}}
+	var {{ $.LocalVar }} {{ $t.Go }}
+	{{- range $f := default_struct_fields $t $.Default }}
+	{
+		{{ template "defaults/set" sub_default_elem $f.Field.Type (printf "%s.%s" $.LocalVar $f.Field.Name) $f.Value $.NextDepth }}
+	}
+	{{- end }}
+	{{ $.Var }} = {{ $.LocalVar }}
+{{- else if $t.IsMap -}}
+	{{ $.LocalVar }} := make({{ $t.Go }}, {{ len (default_map_entries $.Default) }})
+	{{- range $e := default_map_entries $.Default }}
+	{
+		var {{ $.LocalVar }}Val {{ $t.Item.Go }}
+		{{ template "defaults/set" sub_default_elem $t.Item (printf "%sVal" $.LocalVar) $e.Value $.NextDepth }}
+		{{ $.LocalVar }}[{{ quote $e.Key }}] = {{ $.LocalVar }}Val
+	}
+	{{- end }}
+	{{ $.Var }} = {{ $.LocalVar }}
+{{- else if $t.IsSum -}}
+	// The default is well-formed JSON from the spec; a value that does not match a
+	// variant decodes to the zero value (defaults are not variant-checked at gen time).
+	_ = {{ $.Var }}.Decode(jx.DecodeStr({{ quote (default_json $.Default.Value) }}))
 {{- else -}}
 	{{ errorf "unsupported %#v: %s" $.Default.Value $t }}
 {{- end }}

--- a/gen/_template/uri/decode.tmpl
+++ b/gen/_template/uri/decode.tmpl
@@ -34,6 +34,7 @@
 	{{ $var }} = {{ $t.Go }}(c)
 	return nil
 {{- else if $t.IsArray }}
+	{{ $var }} = nil
 	return d.DecodeArray(func(d uri.Decoder) error {
 		var {{ $tmpVar }} {{ $t.Item.Go }}
 		if err := func() error {

--- a/gen/defaults_render_test.go
+++ b/gen/defaults_render_test.go
@@ -1,0 +1,58 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ogen-go/ogen/gen/ir"
+	"github.com/ogen-go/ogen/jsonschema"
+)
+
+func TestDefaultRenderHelpers(t *testing.T) {
+	t.Run("LocalVarAndDepth", func(t *testing.T) {
+		e := DefaultElem{Depth: 2}
+		require.Equal(t, "defaultVal2", e.LocalVar())
+		require.Equal(t, 3, e.NextDepth())
+	})
+
+	t.Run("Slice", func(t *testing.T) {
+		require.Equal(t, []any{"a", "b"}, defaultSlice(ir.Default{Value: []any{"a", "b"}, Set: true}))
+		require.Nil(t, defaultSlice(ir.Default{Value: "x", Set: true}))
+	})
+
+	t.Run("StructFields", func(t *testing.T) {
+		typ := &ir.Type{
+			Fields: []*ir.Field{
+				{Name: "Name", Type: &ir.Type{}, Spec: &jsonschema.Property{Name: "name"}},
+				{Name: "Count", Type: &ir.Type{}, Spec: &jsonschema.Property{Name: "count"}},
+				{Name: "Extra", Type: &ir.Type{}, Spec: &jsonschema.Property{Name: "extra"}},
+			},
+		}
+		got := defaultStructFields(typ, ir.Default{
+			Value: map[string]any{"name": "x", "count": int64(5)},
+			Set:   true,
+		})
+		require.Len(t, got, 2, "only fields present in the default map are emitted")
+		require.Equal(t, "Name", got[0].Field.Name)
+		require.Equal(t, "x", got[0].Value)
+		require.Equal(t, "Count", got[1].Field.Name)
+		require.Equal(t, int64(5), got[1].Value)
+	})
+
+	t.Run("MapEntriesSorted", func(t *testing.T) {
+		got := defaultMapEntries(ir.Default{
+			Value: map[string]any{"b": 2, "a": 1},
+			Set:   true,
+		})
+		require.Equal(t, []DefaultMapEntry{{Key: "a", Value: 1}, {Key: "b", Value: 2}}, got)
+		require.Empty(t, defaultMapEntries(ir.Default{Value: map[string]any{}, Set: true}))
+		require.Nil(t, defaultMapEntries(ir.Default{Set: false}))
+	})
+
+	t.Run("JSONDeterministic", func(t *testing.T) {
+		s, err := defaultJSON(map[string]any{"type": "foo", "a": 1})
+		require.NoError(t, err)
+		require.Equal(t, `{"a":1,"type":"foo"}`, s, "keys must be sorted for reproducible output")
+	})
+}

--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -216,7 +216,9 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 		case schema.Type == jsonschema.Object:
 			implErr = &ErrNotImplemented{Name: "object defaults"}
 		case schema.Type == jsonschema.Array:
-			implErr = &ErrNotImplemented{Name: "array defaults"}
+			if name := arrayDefaultUnsupported(schema); name != "" {
+				implErr = &ErrNotImplemented{Name: name}
+			}
 		case schema.Type == jsonschema.Empty ||
 			len(schema.AnyOf)+len(schema.OneOf) > 0:
 			implErr = &ErrNotImplemented{Name: "complex defaults"}
@@ -698,12 +700,53 @@ func (g *schemaGen) checkDefaultType(s *jsonschema.Schema, val any) error {
 		return nil
 	}
 
+	// Sum types (oneOf/anyOf) carry no single Go type. Their default is rendered
+	// by decoding the value at runtime (the template emits elem.Decode), and the
+	// spec parser already guaranteed the value is well-formed, so accept it here.
+	if len(s.OneOf)+len(s.AnyOf) > 0 {
+		return nil
+	}
+
 	var ok bool
 	switch s.Type {
 	case jsonschema.Object:
-		_, ok = val.(map[string]any)
+		var m map[string]any
+		m, ok = val.(map[string]any)
+		if ok {
+			for _, p := range s.Properties {
+				pv, has := m[p.Name]
+				if !has {
+					continue
+				}
+				if err := g.checkDefaultType(p.Schema, pv); err != nil {
+					return err
+				}
+			}
+			if s.Item != nil {
+				named := make(map[string]struct{}, len(s.Properties))
+				for _, p := range s.Properties {
+					named[p.Name] = struct{}{}
+				}
+				for k, v := range m {
+					if _, isNamed := named[k]; isNamed {
+						continue
+					}
+					if err := g.checkDefaultType(s.Item, v); err != nil {
+						return err
+					}
+				}
+			}
+		}
 	case jsonschema.Array:
-		_, ok = val.([]any)
+		var arr []any
+		arr, ok = val.([]any)
+		if ok && s.Item != nil {
+			for _, e := range arr {
+				if err := g.checkDefaultType(s.Item, e); err != nil {
+					return err
+				}
+			}
+		}
 	case jsonschema.Integer:
 		_, ok = val.(int64)
 	case jsonschema.Number:
@@ -736,6 +779,30 @@ func (g *schemaGen) checkDefaultType(s *jsonschema.Schema, val any) error {
 	}
 
 	return nil
+}
+
+// arrayDefaultUnsupported returns a non-empty ErrNotImplemented feature name when
+// the array schema's default value cannot be rendered as Go code, or "" otherwise.
+//
+// Renderable element kinds: primitives, enums, objects, maps, nested arrays, and
+// sum types (oneOf/anyOf, rendered via the variant's own Decode). Unsupported:
+// tuple/prefixItems arrays (which generate a struct, not a slice) and free-form
+// (typeless) items.
+func arrayDefaultUnsupported(s *jsonschema.Schema) string {
+	if len(s.Items) > 0 {
+		return "tuple array defaults"
+	}
+	item := s.Item
+	if item == nil {
+		return "array defaults with free-form items"
+	}
+	if item.Type == jsonschema.Array {
+		return arrayDefaultUnsupported(item)
+	}
+	if item.Type == jsonschema.Empty && len(item.OneOf)+len(item.AnyOf) == 0 {
+		return "array defaults with free-form items"
+	}
+	return ""
 }
 
 // nonPrimitiveObjectEnum generates a sum type for object enums.

--- a/gen/schema_gen_test.go
+++ b/gen/schema_gen_test.go
@@ -135,6 +135,45 @@ func TestSchemaGenConst(t *testing.T) {
 	}
 }
 
+func TestCheckDefaultTypeArray(t *testing.T) {
+	g := newSchemaGen(func(ref jsonschema.Ref) (*ir.Type, bool) { return nil, false })
+
+	strItems := &jsonschema.Schema{Type: jsonschema.Array, Item: &jsonschema.Schema{Type: jsonschema.String}}
+	objItems := &jsonschema.Schema{
+		Type: jsonschema.Array,
+		Item: &jsonschema.Schema{
+			Type: jsonschema.Object,
+			Properties: []jsonschema.Property{
+				{Name: "count", Schema: &jsonschema.Schema{Type: jsonschema.Integer}},
+			},
+		},
+	}
+
+	require.NoError(t, g.checkDefaultType(strItems, []any{"a", "b"}))
+	require.Error(t, g.checkDefaultType(strItems, []any{"a", int64(1)}),
+		"element type mismatch must be reported")
+	require.NoError(t, g.checkDefaultType(objItems, []any{map[string]any{"count": int64(5)}}))
+	require.Error(t, g.checkDefaultType(objItems, []any{map[string]any{"count": "no"}}),
+		"object property type mismatch must be reported")
+}
+
+func TestCheckDefaultTypeMapValues(t *testing.T) {
+	g := newSchemaGen(func(ref jsonschema.Ref) (*ir.Type, bool) { return nil, false })
+	// Object with additionalProperties: string (Item set, no named Properties).
+	mapStr := &jsonschema.Schema{Type: jsonschema.Object, Item: &jsonschema.Schema{Type: jsonschema.String}}
+	require.NoError(t, g.checkDefaultType(mapStr, map[string]any{"a": "x", "b": "y"}))
+	require.Error(t, g.checkDefaultType(mapStr, map[string]any{"a": int64(123)}),
+		"additionalProperties value type mismatch must be reported")
+	// Named property is validated by its own schema; extra keys by Item.
+	mixed := &jsonschema.Schema{
+		Type:       jsonschema.Object,
+		Properties: []jsonschema.Property{{Name: "named", Schema: &jsonschema.Schema{Type: jsonschema.Integer}}},
+		Item:       &jsonschema.Schema{Type: jsonschema.String},
+	}
+	require.NoError(t, g.checkDefaultType(mixed, map[string]any{"named": int64(1), "extra": "ok"}))
+	require.Error(t, g.checkDefaultType(mixed, map[string]any{"extra": int64(9)}))
+}
+
 func TestGenerate(t *testing.T) {
 	var loc location.Locator
 	loc.UnmarshalYAML(&yaml.Node{
@@ -296,4 +335,61 @@ func TestGenerate(t *testing.T) {
 			a.Equal(expectedIrType, irType, fmt.Sprintf("\nEXPECTED:\n\n%s\nACTUAL:\n\n%s", expectedIrTypeY, irTypeY))
 		})
 	}
+}
+
+func TestArrayDefaultGate(t *testing.T) {
+	// Supported: array of strings.
+	a := newSchemaGen(func(ref jsonschema.Ref) (*ir.Type, bool) { return nil, false })
+	typ, err := a.generate("StrArr", &jsonschema.Schema{
+		Type:       jsonschema.Array,
+		Item:       &jsonschema.Schema{Type: jsonschema.String},
+		Default:    []any{"x"},
+		DefaultSet: true,
+	}, false)
+	require.NoError(t, err)
+	require.True(t, typ.Schema.DefaultSet, "array-of-string default must survive the gate")
+
+	// Unsupported: tuple (prefixItems) array default → must be reported, not panic.
+	require.Equal(t, "tuple array defaults", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type:  jsonschema.Array,
+		Items: []*jsonschema.Schema{{Type: jsonschema.String}},
+	}))
+	// Unsupported: free-form item default.
+	require.Equal(t, "array defaults with free-form items", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type: jsonschema.Array,
+	}))
+	// Supported shapes return "".
+	require.Equal(t, "", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type: jsonschema.Array, Item: &jsonschema.Schema{Type: jsonschema.String},
+	}))
+
+	// Nested arrays recurse: inner free-form item is rejected.
+	require.Equal(t, "array defaults with free-form items", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type: jsonschema.Array,
+		Item: &jsonschema.Schema{Type: jsonschema.Array},
+	}))
+	// Nested arrays recurse: inner tuple is rejected.
+	require.Equal(t, "tuple array defaults", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type: jsonschema.Array,
+		Item: &jsonschema.Schema{Type: jsonschema.Array, Items: []*jsonschema.Schema{{Type: jsonschema.String}}},
+	}))
+	// Nested arrays recurse: array of array of string is supported.
+	require.Equal(t, "", arrayDefaultUnsupported(&jsonschema.Schema{
+		Type: jsonschema.Array,
+		Item: &jsonschema.Schema{Type: jsonschema.Array, Item: &jsonschema.Schema{Type: jsonschema.String}},
+	}))
+}
+
+func TestCheckDefaultTypeSumType(t *testing.T) {
+	g := newSchemaGen(func(ref jsonschema.Ref) (*ir.Type, bool) { return nil, false })
+	sum := &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{Type: jsonschema.Object},
+			{Type: jsonschema.Object},
+		},
+	}
+	require.NoError(t, g.checkDefaultType(sum, map[string]any{"kind": "circle", "radius": int64(5)}))
+	// Inside an array, the element is the sum schema.
+	arr := &jsonschema.Schema{Type: jsonschema.Array, Item: sum}
+	require.NoError(t, g.checkDefaultType(arr, []any{map[string]any{"kind": "square", "side": int64(2)}}))
 }

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -2,7 +2,9 @@ package gen
 
 import (
 	"embed"
+	stdjson "encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +39,82 @@ type DefaultElem struct {
 	Var string
 	// Default is default value to set.
 	Default ir.Default
+	// Depth is the recursion depth, used to derive unique local variable names
+	// when rendering nested array/struct/map default literals.
+	Depth int
+}
+
+// LocalVar returns a unique local accumulator variable name for this depth.
+func (d DefaultElem) LocalVar() string {
+	return fmt.Sprintf("defaultVal%d", d.Depth)
+}
+
+// NextDepth returns the depth for a nested DefaultElem.
+func (d DefaultElem) NextDepth() int {
+	return d.Depth + 1
+}
+
+// DefaultStructField pairs a struct field with the value present for it in an
+// object default.
+type DefaultStructField struct {
+	Field *ir.Field
+	Value any
+}
+
+// DefaultMapEntry is a single key/value of a map default, in sorted-key order.
+type DefaultMapEntry struct {
+	Key   string
+	Value any
+}
+
+func defaultSlice(d ir.Default) []any {
+	if !d.Set {
+		return nil
+	}
+	s, _ := d.Value.([]any)
+	return s
+}
+
+func defaultStructFields(t *ir.Type, d ir.Default) []DefaultStructField {
+	if !d.Set {
+		return nil
+	}
+	m, _ := d.Value.(map[string]any)
+	var out []DefaultStructField
+	for _, f := range t.Fields {
+		if f.Spec == nil {
+			continue
+		}
+		if v, ok := m[f.Spec.Name]; ok {
+			out = append(out, DefaultStructField{Field: f, Value: v})
+		}
+	}
+	return out
+}
+
+func defaultMapEntries(d ir.Default) []DefaultMapEntry {
+	if !d.Set {
+		return nil
+	}
+	m, _ := d.Value.(map[string]any)
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]DefaultMapEntry, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, DefaultMapEntry{Key: k, Value: m[k]})
+	}
+	return out
+}
+
+func defaultJSON(v any) (string, error) {
+	b, err := stdjson.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // Elem is variable helper for recursive array or object encoding or decoding.
@@ -155,7 +233,7 @@ func templateFunctions() template.FuncMap {
 				Default: value,
 			}
 		},
-		"sub_default_elem": func(t *ir.Type, v string, val any) DefaultElem {
+		"sub_default_elem": func(t *ir.Type, v string, val any, depth int) DefaultElem {
 			return DefaultElem{
 				Type: t,
 				Var:  v,
@@ -163,8 +241,13 @@ func templateFunctions() template.FuncMap {
 					Value: val,
 					Set:   true,
 				},
+				Depth: depth,
 			}
 		},
+		"default_slice":         defaultSlice,
+		"default_struct_fields": defaultStructFields,
+		"default_map_entries":   defaultMapEntries,
+		"default_json":          defaultJSON,
 		"op_elem": func(op *ir.Operation, cfg TemplateConfig) OperationElem {
 			return OperationElem{
 				Operation: op,

--- a/gen_test.go
+++ b/gen_test.go
@@ -179,7 +179,6 @@ func TestGenerate(t *testing.T) {
 				"complex anyOf",
 				"discriminator inference",
 				"sum types with same names",
-				"array defaults",
 				"type-based discrimination with same jxType",
 			},
 			"manga.json":                {},

--- a/internal/integration/defaults_test.go
+++ b/internal/integration/defaults_test.go
@@ -83,6 +83,24 @@ func TestDefault(t *testing.T) {
 				}
 				return b
 			}(),
+			Strings: []string{"all"},
+			Priorities: []api.DefaultTestPrioritiesItem{
+				api.DefaultTestPrioritiesItemMedium,
+				api.DefaultTestPrioritiesItemHigh,
+			},
+			Nested: [][]int{{1, 2}, {3}},
+			Objs: []api.DefaultTestObjsItem{
+				{
+					Name:  api.NewOptString("x"),
+					Count: api.NewOptInt(5),
+				},
+			},
+			Shapes: []api.DefaultShape{
+				api.NewDefaultCircleDefaultShape(api.DefaultCircle{Kind: "circle", Radius: 5}),
+			},
+			Labels: []api.DefaultTestLabelsItem{
+				{"a": "x"},
+			},
 		}
 
 		cb(&defaultValue)

--- a/internal/integration/e2e_test.go
+++ b/internal/integration/e2e_test.go
@@ -64,7 +64,8 @@ func (t techEmpowerServer) JSON(ctx context.Context) (*techempower.HelloWorld, e
 
 type sampleAPIServer struct {
 	api.UnimplementedHandler
-	pet api.Pet
+	pet              api.Pet
+	gotDefaultParams api.DefaultTestParams
 }
 
 func (s sampleAPIServer) DataGetFormat(ctx context.Context, params api.DataGetFormatParams) (string, error) {
@@ -172,7 +173,8 @@ func (s *sampleAPIServer) ErrorGet(ctx context.Context) (*api.ErrorStatusCode, e
 	}, nil
 }
 
-func (s sampleAPIServer) DefaultTest(ctx context.Context, req *api.DefaultTest, params api.DefaultTestParams) (int32, error) {
+func (s *sampleAPIServer) DefaultTest(ctx context.Context, req *api.DefaultTest, params api.DefaultTestParams) (int32, error) {
+	s.gotDefaultParams = params
 	return params.Default.Value, nil
 }
 
@@ -475,6 +477,18 @@ func TestIntegration(t *testing.T) {
 			})
 			a.NoError(err)
 			a.Equal(int32(42), resp)
+
+			// Array parameter default is applied when the parameter is absent.
+			_, err = client.DefaultTest(ctx, &api.DefaultTest{}, api.DefaultTestParams{})
+			a.NoError(err)
+			a.Equal([]string{"a", "b"}, handler.gotDefaultParams.ArrayDefault)
+
+			// An explicit value overrides the default.
+			_, err = client.DefaultTest(ctx, &api.DefaultTest{}, api.DefaultTestParams{
+				ArrayDefault: []string{"z"},
+			})
+			a.NoError(err)
+			a.Equal([]string{"z"}, handler.gotDefaultParams.ArrayDefault)
 		})
 		t.Run("HeaderSecurity", func(t *testing.T) {
 			a := require.New(t)

--- a/internal/integration/sample_api/oas_client_gen.go
+++ b/internal/integration/sample_api/oas_client_gen.go
@@ -480,6 +480,32 @@ func (c *Client) sendDefaultTest(ctx context.Context, request *DefaultTest, para
 			return res, errors.Wrap(err, "encode query")
 		}
 	}
+	{
+		// Encode "arrayDefault" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ArrayDefault != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ArrayDefault {
+						if err := func() error {
+							return e.EncodeValue(conv.StringToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
 	u.RawQuery = q.Values().Encode()
 
 	stage = "EncodeRequest"

--- a/internal/integration/sample_api/oas_defaults_gen.go
+++ b/internal/integration/sample_api/oas_defaults_gen.go
@@ -68,4 +68,118 @@ func (s *DefaultTest) setDefaults() {
 		val, _ := jx.DecodeStr("\"aGVsbG8sIHdvcmxkIQ==\"").Base64()
 		s.Base64 = val
 	}
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("all")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Strings = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestPrioritiesItem
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("medium")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("high")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Priorities = defaultVal0
+	}
+	{
+		var defaultVal0 [][]int
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(1)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			{
+				var defaultVal1Elem int
+
+				val := int(2)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(3)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Nested = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestObjsItem
+		{
+			var defaultVal0Elem DefaultTestObjsItem
+			var defaultVal1 DefaultTestObjsItem
+			{
+
+				val := string("x")
+				defaultVal1.Name.SetTo(val)
+			}
+			{
+
+				val := int(5)
+				defaultVal1.Count.SetTo(val)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Objs = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultShape
+		{
+			var defaultVal0Elem DefaultShape
+			// The default is well-formed JSON from the spec; a value that does not match a
+			// variant decodes to the zero value (defaults are not variant-checked at gen time).
+			_ = defaultVal0Elem.Decode(jx.DecodeStr("{\"kind\":\"circle\",\"radius\":5}"))
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Shapes = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestLabelsItem
+		{
+			var defaultVal0Elem DefaultTestLabelsItem
+			defaultVal1 := make(DefaultTestLabelsItem, 1)
+			{
+				var defaultVal1Val string
+
+				val := string("x")
+				defaultVal1Val = val
+				defaultVal1["a"] = defaultVal1Val
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Labels = defaultVal0
+	}
 }

--- a/internal/integration/sample_api/oas_faker_gen.go
+++ b/internal/integration/sample_api/oas_faker_gen.go
@@ -145,6 +145,44 @@ func (s *DataDescription) SetFake() {
 }
 
 // SetFake set fake values.
+func (s *DefaultCircle) SetFake() {
+	{
+		{
+			s.Kind = "string"
+		}
+	}
+	{
+		{
+			s.Radius = int(0)
+		}
+	}
+}
+
+// SetFake set fake values.
+func (s *DefaultShape) SetFake() {
+	var variant DefaultCircle
+
+	{
+		variant.SetFake()
+	}
+	s.SetDefaultCircle(variant)
+}
+
+// SetFake set fake values.
+func (s *DefaultSquare) SetFake() {
+	{
+		{
+			s.Kind = "string"
+		}
+	}
+	{
+		{
+			s.Side = int(0)
+		}
+	}
+}
+
+// SetFake set fake values.
 func (s *DefaultTest) SetFake() {
 	{
 		{
@@ -221,11 +259,120 @@ func (s *DefaultTest) SetFake() {
 			s.Base64 = []byte("[]byte")
 		}
 	}
+	{
+		{
+			s.Strings = nil
+			for i := 0; i < 0; i++ {
+				var elem string
+				{
+					elem = "string"
+				}
+				s.Strings = append(s.Strings, elem)
+			}
+		}
+	}
+	{
+		{
+			s.Priorities = nil
+			for i := 0; i < 0; i++ {
+				var elem DefaultTestPrioritiesItem
+				{
+					elem.SetFake()
+				}
+				s.Priorities = append(s.Priorities, elem)
+			}
+		}
+	}
+	{
+		{
+			s.Nested = nil
+			for i := 0; i < 0; i++ {
+				var elem []int
+				{
+					elem = nil
+					for i := 0; i < 0; i++ {
+						var elemElem int
+						{
+							elemElem = int(0)
+						}
+						elem = append(elem, elemElem)
+					}
+				}
+				s.Nested = append(s.Nested, elem)
+			}
+		}
+	}
+	{
+		{
+			s.Objs = nil
+			for i := 0; i < 0; i++ {
+				var elem DefaultTestObjsItem
+				{
+					elem.SetFake()
+				}
+				s.Objs = append(s.Objs, elem)
+			}
+		}
+	}
+	{
+		{
+			s.Shapes = nil
+			for i := 0; i < 0; i++ {
+				var elem DefaultShape
+				{
+					elem.SetFake()
+				}
+				s.Shapes = append(s.Shapes, elem)
+			}
+		}
+	}
+	{
+		{
+			s.Labels = nil
+			for i := 0; i < 0; i++ {
+				var elem DefaultTestLabelsItem
+				{
+					elem.SetFake()
+				}
+				s.Labels = append(s.Labels, elem)
+			}
+		}
+	}
 }
 
 // SetFake set fake values.
 func (s *DefaultTestEnum) SetFake() {
 	*s = DefaultTestEnumBig
+}
+
+// SetFake set fake values.
+func (s *DefaultTestLabelsItem) SetFake() {
+	var (
+		elem string
+		m    map[string]string = s.init()
+	)
+	for i := 0; i < 0; i++ {
+		m[fmt.Sprintf("fake%d", i)] = elem
+	}
+}
+
+// SetFake set fake values.
+func (s *DefaultTestObjsItem) SetFake() {
+	{
+		{
+			s.Name.SetFake()
+		}
+	}
+	{
+		{
+			s.Count.SetFake()
+		}
+	}
+}
+
+// SetFake set fake values.
+func (s *DefaultTestPrioritiesItem) SetFake() {
+	*s = DefaultTestPrioritiesItemLow
 }
 
 // SetFake set fake values.

--- a/internal/integration/sample_api/oas_handlers_gen.go
+++ b/internal/integration/sample_api/oas_handlers_gen.go
@@ -308,6 +308,10 @@ func (s *Server) handleDefaultTestRequest(args [0]string, argsEscaped bool, w ht
 					Name: "default",
 					In:   "query",
 				}: params.Default,
+				{
+					Name: "arrayDefault",
+					In:   "query",
+				}: params.ArrayDefault,
 			},
 			Raw: r,
 		}

--- a/internal/integration/sample_api/oas_json_gen.go
+++ b/internal/integration/sample_api/oas_json_gen.go
@@ -690,6 +690,334 @@ func (s *DataDescription) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DefaultCircle) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultCircle) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("radius")
+		e.Int(s.Radius)
+	}
+}
+
+var jsonFieldsNameOfDefaultCircle = [2]string{
+	0: "kind",
+	1: "radius",
+}
+
+// Decode decodes DefaultCircle from json.
+func (s *DefaultCircle) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultCircle to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "radius":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Radius = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"radius\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultCircle")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultCircle) {
+					name = jsonFieldsNameOfDefaultCircle[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultCircle) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultCircle) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultShape as json.
+func (s DefaultShape) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s DefaultShape) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		e.FieldStart("kind")
+		e.Str("circle")
+		{
+			s := s.DefaultCircle
+			{
+				e.FieldStart("radius")
+				e.Int(s.Radius)
+			}
+		}
+	case DefaultSquareDefaultShape:
+		e.FieldStart("kind")
+		e.Str("square")
+		{
+			s := s.DefaultSquare
+			{
+				e.FieldStart("side")
+				e.Int(s.Side)
+			}
+		}
+	}
+}
+
+// Decode decodes DefaultShape from json.
+func (s *DefaultShape) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultShape to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "circle":
+					s.Type = DefaultCircleDefaultShape
+					found = true
+				case "square":
+					s.Type = DefaultSquareDefaultShape
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		if err := s.DefaultCircle.Decode(d); err != nil {
+			return err
+		}
+	case DefaultSquareDefaultShape:
+		if err := s.DefaultSquare.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultShape) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultShape) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultSquare) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultSquare) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("side")
+		e.Int(s.Side)
+	}
+}
+
+var jsonFieldsNameOfDefaultSquare = [2]string{
+	0: "kind",
+	1: "side",
+}
+
+// Decode decodes DefaultSquare from json.
+func (s *DefaultSquare) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultSquare to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "side":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Side = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"side\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultSquare")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultSquare) {
+					name = jsonFieldsNameOfDefaultSquare[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultSquare) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultSquare) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *DefaultTest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -784,9 +1112,73 @@ func (s *DefaultTest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("base64")
 		e.Base64(s.Base64)
 	}
+	{
+		if s.Strings != nil {
+			e.FieldStart("strings")
+			e.ArrStart()
+			for _, elem := range s.Strings {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Priorities != nil {
+			e.FieldStart("priorities")
+			e.ArrStart()
+			for _, elem := range s.Priorities {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Nested != nil {
+			e.FieldStart("nested")
+			e.ArrStart()
+			for _, elem := range s.Nested {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Int(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Objs != nil {
+			e.FieldStart("objs")
+			e.ArrStart()
+			for _, elem := range s.Objs {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Shapes != nil {
+			e.FieldStart("shapes")
+			e.ArrStart()
+			for _, elem := range s.Shapes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Labels != nil {
+			e.FieldStart("labels")
+			e.ArrStart()
+			for _, elem := range s.Labels {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfDefaultTest = [15]string{
+var jsonFieldsNameOfDefaultTest = [21]string{
 	0:  "required",
 	1:  "str",
 	2:  "nullStr",
@@ -802,6 +1194,12 @@ var jsonFieldsNameOfDefaultTest = [15]string{
 	12: "hostname",
 	13: "format",
 	14: "base64",
+	15: "strings",
+	16: "priorities",
+	17: "nested",
+	18: "objs",
+	19: "shapes",
+	20: "labels",
 }
 
 // Decode decodes DefaultTest from json.
@@ -809,7 +1207,7 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode DefaultTest to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -967,6 +1365,120 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"base64\"")
 			}
+		case "strings":
+			if err := func() error {
+				s.Strings = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Strings = append(s.Strings, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"strings\"")
+			}
+		case "priorities":
+			if err := func() error {
+				s.Priorities = make([]DefaultTestPrioritiesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestPrioritiesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Priorities = append(s.Priorities, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"priorities\"")
+			}
+		case "nested":
+			if err := func() error {
+				s.Nested = make([][]int, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []int
+					elem = make([]int, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem int
+						v, err := d.Int()
+						elemElem = int(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Nested = append(s.Nested, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nested\"")
+			}
+		case "objs":
+			if err := func() error {
+				s.Objs = make([]DefaultTestObjsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestObjsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Objs = append(s.Objs, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"objs\"")
+			}
+		case "shapes":
+			if err := func() error {
+				s.Shapes = make([]DefaultShape, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultShape
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Shapes = append(s.Shapes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"shapes\"")
+			}
+		case "labels":
+			if err := func() error {
+				s.Labels = make([]DefaultTestLabelsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestLabelsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Labels = append(s.Labels, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"labels\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -976,8 +1488,9 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b00000001,
+		0b00000000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -1060,6 +1573,184 @@ func (s DefaultTestEnum) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *DefaultTestEnum) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s DefaultTestLabelsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s DefaultTestLabelsItem) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes DefaultTestLabelsItem from json.
+func (s *DefaultTestLabelsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestLabelsItem to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestLabelsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestLabelsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestLabelsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultTestObjsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultTestObjsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Count.Set {
+			e.FieldStart("count")
+			s.Count.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDefaultTestObjsItem = [2]string{
+	0: "name",
+	1: "count",
+}
+
+// Decode decodes DefaultTestObjsItem from json.
+func (s *DefaultTestObjsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestObjsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "count":
+			if err := func() error {
+				s.Count.Reset()
+				if err := s.Count.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestObjsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultTestObjsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestObjsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultTestPrioritiesItem as json.
+func (s DefaultTestPrioritiesItem) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DefaultTestPrioritiesItem from json.
+func (s *DefaultTestPrioritiesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestPrioritiesItem to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DefaultTestPrioritiesItem(v) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
+	default:
+		*s = DefaultTestPrioritiesItem(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestPrioritiesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/sample_api/oas_parameters_gen.go
+++ b/internal/integration/sample_api/oas_parameters_gen.go
@@ -392,7 +392,8 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32 `json:",omitempty,omitzero"`
+	Default      OptInt32 `json:",omitempty,omitzero"`
+	ArrayDefault []string `json:",omitempty"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -403,6 +404,15 @@ func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestPa
 		}
 		if v, ok := packed[key]; ok {
 			params.Default = v.(OptInt32)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "arrayDefault",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ArrayDefault = v.([]string)
 		}
 	}
 	return params
@@ -452,6 +462,69 @@ func decodeDefaultTestParams(args [0]string, argsEscaped bool, r *http.Request) 
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "default",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: arrayDefault.
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("a")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem string
+
+			val := string("b")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		params.ArrayDefault = defaultVal0
+	}
+	// Decode query: arrayDefault.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.ArrayDefault = nil
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotArrayDefaultVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotArrayDefaultVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ArrayDefault = append(params.ArrayDefault, paramsDotArrayDefaultVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "arrayDefault",
 			In:   "query",
 			Err:  err,
 		}
@@ -737,6 +810,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XTags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXTagsVal uuid.UUID
 					if err := func() error {
@@ -788,6 +862,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XScope = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXScopeVal string
 					if err := func() error {

--- a/internal/integration/sample_api/oas_schemas_gen.go
+++ b/internal/integration/sample_api/oas_schemas_gen.go
@@ -286,23 +286,147 @@ func NewDescriptionSimpleDataDescription(v DescriptionSimple) DataDescription {
 	return s
 }
 
+// Ref: #/components/schemas/DefaultCircle
+type DefaultCircle struct {
+	Kind   string `json:"kind"`
+	Radius int    `json:"radius"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultCircle) GetKind() string {
+	return s.Kind
+}
+
+// GetRadius returns the value of Radius.
+func (s *DefaultCircle) GetRadius() int {
+	return s.Radius
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultCircle) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetRadius sets the value of Radius.
+func (s *DefaultCircle) SetRadius(val int) {
+	s.Radius = val
+}
+
+// Ref: #/components/schemas/DefaultShape
+// DefaultShape represents sum type.
+type DefaultShape struct {
+	// Type selects the active sum variant, switch on this field.
+	Type          DefaultShapeType
+	DefaultCircle DefaultCircle
+	DefaultSquare DefaultSquare
+}
+
+// DefaultShapeType is oneOf type of DefaultShape.
+type DefaultShapeType string
+
+// Possible values for DefaultShapeType.
+const (
+	DefaultCircleDefaultShape DefaultShapeType = "circle"
+	DefaultSquareDefaultShape DefaultShapeType = "square"
+)
+
+// IsDefaultCircle reports whether DefaultShape is DefaultCircle.
+func (s DefaultShape) IsDefaultCircle() bool { return s.Type == DefaultCircleDefaultShape }
+
+// IsDefaultSquare reports whether DefaultShape is DefaultSquare.
+func (s DefaultShape) IsDefaultSquare() bool { return s.Type == DefaultSquareDefaultShape }
+
+// SetDefaultCircle sets DefaultShape to DefaultCircle.
+func (s *DefaultShape) SetDefaultCircle(v DefaultCircle) {
+	s.Type = DefaultCircleDefaultShape
+	s.DefaultCircle = v
+}
+
+// GetDefaultCircle returns DefaultCircle and true boolean if DefaultShape is DefaultCircle.
+func (s DefaultShape) GetDefaultCircle() (v DefaultCircle, ok bool) {
+	if !s.IsDefaultCircle() {
+		return v, false
+	}
+	return s.DefaultCircle, true
+}
+
+// NewDefaultCircleDefaultShape returns new DefaultShape from DefaultCircle.
+func NewDefaultCircleDefaultShape(v DefaultCircle) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultCircle(v)
+	return s
+}
+
+// SetDefaultSquare sets DefaultShape to DefaultSquare.
+func (s *DefaultShape) SetDefaultSquare(v DefaultSquare) {
+	s.Type = DefaultSquareDefaultShape
+	s.DefaultSquare = v
+}
+
+// GetDefaultSquare returns DefaultSquare and true boolean if DefaultShape is DefaultSquare.
+func (s DefaultShape) GetDefaultSquare() (v DefaultSquare, ok bool) {
+	if !s.IsDefaultSquare() {
+		return v, false
+	}
+	return s.DefaultSquare, true
+}
+
+// NewDefaultSquareDefaultShape returns new DefaultShape from DefaultSquare.
+func NewDefaultSquareDefaultShape(v DefaultSquare) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultSquare(v)
+	return s
+}
+
+// Ref: #/components/schemas/DefaultSquare
+type DefaultSquare struct {
+	Kind string `json:"kind"`
+	Side int    `json:"side"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultSquare) GetKind() string {
+	return s.Kind
+}
+
+// GetSide returns the value of Side.
+func (s *DefaultSquare) GetSide() int {
+	return s.Side
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultSquare) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetSide sets the value of Side.
+func (s *DefaultSquare) SetSide(val int) {
+	s.Side = val
+}
+
 // Ref: #/components/schemas/DefaultTest
 type DefaultTest struct {
-	Required string             `json:"required"`
-	Str      OptString          `json:"str"`
-	NullStr  OptNilString       `json:"nullStr"`
-	Enum     OptDefaultTestEnum `json:"enum"`
-	UUID     OptUUID            `json:"uuid"`
-	IP       OptIP              `json:"ip"`
-	IPV4     OptIPv4            `json:"ip_v4"`
-	IPV6     OptIPv6            `json:"ip_v6"`
-	URI      OptURI             `json:"uri"`
-	Birthday OptDate            `json:"birthday"`
-	Rate     OptDuration        `json:"rate"`
-	Email    OptString          `json:"email"`
-	Hostname OptString          `json:"hostname"`
-	Format   OptString          `json:"format"`
-	Base64   []byte             `json:"base64"`
+	Required   string                      `json:"required"`
+	Str        OptString                   `json:"str"`
+	NullStr    OptNilString                `json:"nullStr"`
+	Enum       OptDefaultTestEnum          `json:"enum"`
+	UUID       OptUUID                     `json:"uuid"`
+	IP         OptIP                       `json:"ip"`
+	IPV4       OptIPv4                     `json:"ip_v4"`
+	IPV6       OptIPv6                     `json:"ip_v6"`
+	URI        OptURI                      `json:"uri"`
+	Birthday   OptDate                     `json:"birthday"`
+	Rate       OptDuration                 `json:"rate"`
+	Email      OptString                   `json:"email"`
+	Hostname   OptString                   `json:"hostname"`
+	Format     OptString                   `json:"format"`
+	Base64     []byte                      `json:"base64"`
+	Strings    []string                    `json:"strings"`
+	Priorities []DefaultTestPrioritiesItem `json:"priorities"`
+	Nested     [][]int                     `json:"nested"`
+	Objs       []DefaultTestObjsItem       `json:"objs"`
+	Shapes     []DefaultShape              `json:"shapes"`
+	Labels     []DefaultTestLabelsItem     `json:"labels"`
 }
 
 // GetRequired returns the value of Required.
@@ -380,6 +504,36 @@ func (s *DefaultTest) GetBase64() []byte {
 	return s.Base64
 }
 
+// GetStrings returns the value of Strings.
+func (s *DefaultTest) GetStrings() []string {
+	return s.Strings
+}
+
+// GetPriorities returns the value of Priorities.
+func (s *DefaultTest) GetPriorities() []DefaultTestPrioritiesItem {
+	return s.Priorities
+}
+
+// GetNested returns the value of Nested.
+func (s *DefaultTest) GetNested() [][]int {
+	return s.Nested
+}
+
+// GetObjs returns the value of Objs.
+func (s *DefaultTest) GetObjs() []DefaultTestObjsItem {
+	return s.Objs
+}
+
+// GetShapes returns the value of Shapes.
+func (s *DefaultTest) GetShapes() []DefaultShape {
+	return s.Shapes
+}
+
+// GetLabels returns the value of Labels.
+func (s *DefaultTest) GetLabels() []DefaultTestLabelsItem {
+	return s.Labels
+}
+
 // SetRequired sets the value of Required.
 func (s *DefaultTest) SetRequired(val string) {
 	s.Required = val
@@ -455,6 +609,36 @@ func (s *DefaultTest) SetBase64(val []byte) {
 	s.Base64 = val
 }
 
+// SetStrings sets the value of Strings.
+func (s *DefaultTest) SetStrings(val []string) {
+	s.Strings = val
+}
+
+// SetPriorities sets the value of Priorities.
+func (s *DefaultTest) SetPriorities(val []DefaultTestPrioritiesItem) {
+	s.Priorities = val
+}
+
+// SetNested sets the value of Nested.
+func (s *DefaultTest) SetNested(val [][]int) {
+	s.Nested = val
+}
+
+// SetObjs sets the value of Objs.
+func (s *DefaultTest) SetObjs(val []DefaultTestObjsItem) {
+	s.Objs = val
+}
+
+// SetShapes sets the value of Shapes.
+func (s *DefaultTest) SetShapes(val []DefaultShape) {
+	s.Shapes = val
+}
+
+// SetLabels sets the value of Labels.
+func (s *DefaultTest) SetLabels(val []DefaultTestLabelsItem) {
+	s.Labels = val
+}
+
 type DefaultTestEnum string
 
 const (
@@ -490,6 +674,90 @@ func (s *DefaultTestEnum) UnmarshalText(data []byte) error {
 		return nil
 	case DefaultTestEnumSmol:
 		*s = DefaultTestEnumSmol
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type DefaultTestLabelsItem map[string]string
+
+func (s *DefaultTestLabelsItem) init() DefaultTestLabelsItem {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
+	}
+	return m
+}
+
+type DefaultTestObjsItem struct {
+	Name  OptString `json:"name"`
+	Count OptInt    `json:"count"`
+}
+
+// GetName returns the value of Name.
+func (s *DefaultTestObjsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetCount returns the value of Count.
+func (s *DefaultTestObjsItem) GetCount() OptInt {
+	return s.Count
+}
+
+// SetName sets the value of Name.
+func (s *DefaultTestObjsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetCount sets the value of Count.
+func (s *DefaultTestObjsItem) SetCount(val OptInt) {
+	s.Count = val
+}
+
+type DefaultTestPrioritiesItem string
+
+const (
+	DefaultTestPrioritiesItemLow    DefaultTestPrioritiesItem = "low"
+	DefaultTestPrioritiesItemMedium DefaultTestPrioritiesItem = "medium"
+	DefaultTestPrioritiesItemHigh   DefaultTestPrioritiesItem = "high"
+)
+
+// AllValues returns all DefaultTestPrioritiesItem values.
+func (DefaultTestPrioritiesItem) AllValues() []DefaultTestPrioritiesItem {
+	return []DefaultTestPrioritiesItem{
+		DefaultTestPrioritiesItemLow,
+		DefaultTestPrioritiesItemMedium,
+		DefaultTestPrioritiesItemHigh,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DefaultTestPrioritiesItem) MarshalText() ([]byte, error) {
+	switch s {
+	case DefaultTestPrioritiesItemLow:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemMedium:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemHigh:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalText(data []byte) error {
+	switch DefaultTestPrioritiesItem(data) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+		return nil
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+		return nil
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/internal/integration/sample_api/oas_test_examples_gen_test.go
+++ b/internal/integration/sample_api/oas_test_examples_gen_test.go
@@ -73,6 +73,42 @@ func TestDataDescription_EncodeDecode(t *testing.T) {
 	var typ2 DataDescription
 	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
 }
+func TestDefaultCircle_EncodeDecode(t *testing.T) {
+	var typ DefaultCircle
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultCircle
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestDefaultShape_EncodeDecode(t *testing.T) {
+	var typ DefaultShape
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultShape
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestDefaultSquare_EncodeDecode(t *testing.T) {
+	var typ DefaultSquare
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultSquare
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
 func TestDefaultTest_EncodeDecode(t *testing.T) {
 	var typ DefaultTest
 	typ.SetFake()
@@ -95,6 +131,44 @@ func TestDefaultTestEnum_EncodeDecode(t *testing.T) {
 	require.True(t, std.Valid(data), "Encoded: %s", data)
 
 	var typ2 DefaultTestEnum
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestDefaultTestLabelsItem_EncodeDecode(t *testing.T) {
+	var typ DefaultTestLabelsItem
+	typ = make(DefaultTestLabelsItem)
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultTestLabelsItem
+	typ2 = make(DefaultTestLabelsItem)
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestDefaultTestObjsItem_EncodeDecode(t *testing.T) {
+	var typ DefaultTestObjsItem
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultTestObjsItem
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestDefaultTestPrioritiesItem_EncodeDecode(t *testing.T) {
+	var typ DefaultTestPrioritiesItem
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 DefaultTestPrioritiesItem
 	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
 }
 func TestDescriptionDetailed_EncodeDecode(t *testing.T) {

--- a/internal/integration/sample_api/oas_validators_gen.go
+++ b/internal/integration/sample_api/oas_validators_gen.go
@@ -264,6 +264,56 @@ func (s *DefaultTest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Priorities {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "priorities",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Nested {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nested",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -275,6 +325,19 @@ func (s DefaultTestEnum) Validate() error {
 	case "big":
 		return nil
 	case "smol":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s DefaultTestPrioritiesItem) Validate() error {
+	switch s {
+	case "low":
+		return nil
+	case "medium":
+		return nil
+	case "high":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/internal/integration/sample_api_nc/oas_defaults_gen.go
+++ b/internal/integration/sample_api_nc/oas_defaults_gen.go
@@ -68,4 +68,118 @@ func (s *DefaultTest) setDefaults() {
 		val, _ := jx.DecodeStr("\"aGVsbG8sIHdvcmxkIQ==\"").Base64()
 		s.Base64 = val
 	}
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("all")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Strings = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestPrioritiesItem
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("medium")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("high")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Priorities = defaultVal0
+	}
+	{
+		var defaultVal0 [][]int
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(1)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			{
+				var defaultVal1Elem int
+
+				val := int(2)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(3)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Nested = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestObjsItem
+		{
+			var defaultVal0Elem DefaultTestObjsItem
+			var defaultVal1 DefaultTestObjsItem
+			{
+
+				val := string("x")
+				defaultVal1.Name.SetTo(val)
+			}
+			{
+
+				val := int(5)
+				defaultVal1.Count.SetTo(val)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Objs = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultShape
+		{
+			var defaultVal0Elem DefaultShape
+			// The default is well-formed JSON from the spec; a value that does not match a
+			// variant decodes to the zero value (defaults are not variant-checked at gen time).
+			_ = defaultVal0Elem.Decode(jx.DecodeStr("{\"kind\":\"circle\",\"radius\":5}"))
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Shapes = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestLabelsItem
+		{
+			var defaultVal0Elem DefaultTestLabelsItem
+			defaultVal1 := make(DefaultTestLabelsItem, 1)
+			{
+				var defaultVal1Val string
+
+				val := string("x")
+				defaultVal1Val = val
+				defaultVal1["a"] = defaultVal1Val
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Labels = defaultVal0
+	}
 }

--- a/internal/integration/sample_api_nc/oas_handlers_gen.go
+++ b/internal/integration/sample_api_nc/oas_handlers_gen.go
@@ -308,6 +308,10 @@ func (s *Server) handleDefaultTestRequest(args [0]string, argsEscaped bool, w ht
 					Name: "default",
 					In:   "query",
 				}: params.Default,
+				{
+					Name: "arrayDefault",
+					In:   "query",
+				}: params.ArrayDefault,
 			},
 			Raw: r,
 		}

--- a/internal/integration/sample_api_nc/oas_json_gen.go
+++ b/internal/integration/sample_api_nc/oas_json_gen.go
@@ -690,6 +690,334 @@ func (s *DataDescription) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DefaultCircle) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultCircle) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("radius")
+		e.Int(s.Radius)
+	}
+}
+
+var jsonFieldsNameOfDefaultCircle = [2]string{
+	0: "kind",
+	1: "radius",
+}
+
+// Decode decodes DefaultCircle from json.
+func (s *DefaultCircle) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultCircle to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "radius":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Radius = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"radius\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultCircle")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultCircle) {
+					name = jsonFieldsNameOfDefaultCircle[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultCircle) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultCircle) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultShape as json.
+func (s DefaultShape) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s DefaultShape) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		e.FieldStart("kind")
+		e.Str("circle")
+		{
+			s := s.DefaultCircle
+			{
+				e.FieldStart("radius")
+				e.Int(s.Radius)
+			}
+		}
+	case DefaultSquareDefaultShape:
+		e.FieldStart("kind")
+		e.Str("square")
+		{
+			s := s.DefaultSquare
+			{
+				e.FieldStart("side")
+				e.Int(s.Side)
+			}
+		}
+	}
+}
+
+// Decode decodes DefaultShape from json.
+func (s *DefaultShape) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultShape to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "circle":
+					s.Type = DefaultCircleDefaultShape
+					found = true
+				case "square":
+					s.Type = DefaultSquareDefaultShape
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		if err := s.DefaultCircle.Decode(d); err != nil {
+			return err
+		}
+	case DefaultSquareDefaultShape:
+		if err := s.DefaultSquare.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultShape) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultShape) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultSquare) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultSquare) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("side")
+		e.Int(s.Side)
+	}
+}
+
+var jsonFieldsNameOfDefaultSquare = [2]string{
+	0: "kind",
+	1: "side",
+}
+
+// Decode decodes DefaultSquare from json.
+func (s *DefaultSquare) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultSquare to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "side":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Side = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"side\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultSquare")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultSquare) {
+					name = jsonFieldsNameOfDefaultSquare[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultSquare) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultSquare) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *DefaultTest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -784,9 +1112,73 @@ func (s *DefaultTest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("base64")
 		e.Base64(s.Base64)
 	}
+	{
+		if s.Strings != nil {
+			e.FieldStart("strings")
+			e.ArrStart()
+			for _, elem := range s.Strings {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Priorities != nil {
+			e.FieldStart("priorities")
+			e.ArrStart()
+			for _, elem := range s.Priorities {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Nested != nil {
+			e.FieldStart("nested")
+			e.ArrStart()
+			for _, elem := range s.Nested {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Int(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Objs != nil {
+			e.FieldStart("objs")
+			e.ArrStart()
+			for _, elem := range s.Objs {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Shapes != nil {
+			e.FieldStart("shapes")
+			e.ArrStart()
+			for _, elem := range s.Shapes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Labels != nil {
+			e.FieldStart("labels")
+			e.ArrStart()
+			for _, elem := range s.Labels {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfDefaultTest = [15]string{
+var jsonFieldsNameOfDefaultTest = [21]string{
 	0:  "required",
 	1:  "str",
 	2:  "nullStr",
@@ -802,6 +1194,12 @@ var jsonFieldsNameOfDefaultTest = [15]string{
 	12: "hostname",
 	13: "format",
 	14: "base64",
+	15: "strings",
+	16: "priorities",
+	17: "nested",
+	18: "objs",
+	19: "shapes",
+	20: "labels",
 }
 
 // Decode decodes DefaultTest from json.
@@ -809,7 +1207,7 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode DefaultTest to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -967,6 +1365,120 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"base64\"")
 			}
+		case "strings":
+			if err := func() error {
+				s.Strings = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Strings = append(s.Strings, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"strings\"")
+			}
+		case "priorities":
+			if err := func() error {
+				s.Priorities = make([]DefaultTestPrioritiesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestPrioritiesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Priorities = append(s.Priorities, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"priorities\"")
+			}
+		case "nested":
+			if err := func() error {
+				s.Nested = make([][]int, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []int
+					elem = make([]int, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem int
+						v, err := d.Int()
+						elemElem = int(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Nested = append(s.Nested, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nested\"")
+			}
+		case "objs":
+			if err := func() error {
+				s.Objs = make([]DefaultTestObjsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestObjsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Objs = append(s.Objs, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"objs\"")
+			}
+		case "shapes":
+			if err := func() error {
+				s.Shapes = make([]DefaultShape, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultShape
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Shapes = append(s.Shapes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"shapes\"")
+			}
+		case "labels":
+			if err := func() error {
+				s.Labels = make([]DefaultTestLabelsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestLabelsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Labels = append(s.Labels, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"labels\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -976,8 +1488,9 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b00000001,
+		0b00000000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -1060,6 +1573,184 @@ func (s DefaultTestEnum) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *DefaultTestEnum) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s DefaultTestLabelsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s DefaultTestLabelsItem) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes DefaultTestLabelsItem from json.
+func (s *DefaultTestLabelsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestLabelsItem to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestLabelsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestLabelsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestLabelsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultTestObjsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultTestObjsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Count.Set {
+			e.FieldStart("count")
+			s.Count.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDefaultTestObjsItem = [2]string{
+	0: "name",
+	1: "count",
+}
+
+// Decode decodes DefaultTestObjsItem from json.
+func (s *DefaultTestObjsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestObjsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "count":
+			if err := func() error {
+				s.Count.Reset()
+				if err := s.Count.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestObjsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultTestObjsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestObjsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultTestPrioritiesItem as json.
+func (s DefaultTestPrioritiesItem) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DefaultTestPrioritiesItem from json.
+func (s *DefaultTestPrioritiesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestPrioritiesItem to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DefaultTestPrioritiesItem(v) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
+	default:
+		*s = DefaultTestPrioritiesItem(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestPrioritiesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/sample_api_nc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nc/oas_parameters_gen.go
@@ -392,7 +392,8 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32 `json:",omitempty,omitzero"`
+	Default      OptInt32 `json:",omitempty,omitzero"`
+	ArrayDefault []string `json:",omitempty"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -403,6 +404,15 @@ func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestPa
 		}
 		if v, ok := packed[key]; ok {
 			params.Default = v.(OptInt32)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "arrayDefault",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ArrayDefault = v.([]string)
 		}
 	}
 	return params
@@ -452,6 +462,69 @@ func decodeDefaultTestParams(args [0]string, argsEscaped bool, r *http.Request) 
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "default",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: arrayDefault.
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("a")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem string
+
+			val := string("b")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		params.ArrayDefault = defaultVal0
+	}
+	// Decode query: arrayDefault.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.ArrayDefault = nil
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotArrayDefaultVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotArrayDefaultVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ArrayDefault = append(params.ArrayDefault, paramsDotArrayDefaultVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "arrayDefault",
 			In:   "query",
 			Err:  err,
 		}
@@ -737,6 +810,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XTags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXTagsVal uuid.UUID
 					if err := func() error {
@@ -788,6 +862,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XScope = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXScopeVal string
 					if err := func() error {

--- a/internal/integration/sample_api_nc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nc/oas_schemas_gen.go
@@ -286,23 +286,147 @@ func NewDescriptionSimpleDataDescription(v DescriptionSimple) DataDescription {
 	return s
 }
 
+// Ref: #/components/schemas/DefaultCircle
+type DefaultCircle struct {
+	Kind   string `json:"kind"`
+	Radius int    `json:"radius"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultCircle) GetKind() string {
+	return s.Kind
+}
+
+// GetRadius returns the value of Radius.
+func (s *DefaultCircle) GetRadius() int {
+	return s.Radius
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultCircle) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetRadius sets the value of Radius.
+func (s *DefaultCircle) SetRadius(val int) {
+	s.Radius = val
+}
+
+// Ref: #/components/schemas/DefaultShape
+// DefaultShape represents sum type.
+type DefaultShape struct {
+	// Type selects the active sum variant, switch on this field.
+	Type          DefaultShapeType
+	DefaultCircle DefaultCircle
+	DefaultSquare DefaultSquare
+}
+
+// DefaultShapeType is oneOf type of DefaultShape.
+type DefaultShapeType string
+
+// Possible values for DefaultShapeType.
+const (
+	DefaultCircleDefaultShape DefaultShapeType = "circle"
+	DefaultSquareDefaultShape DefaultShapeType = "square"
+)
+
+// IsDefaultCircle reports whether DefaultShape is DefaultCircle.
+func (s DefaultShape) IsDefaultCircle() bool { return s.Type == DefaultCircleDefaultShape }
+
+// IsDefaultSquare reports whether DefaultShape is DefaultSquare.
+func (s DefaultShape) IsDefaultSquare() bool { return s.Type == DefaultSquareDefaultShape }
+
+// SetDefaultCircle sets DefaultShape to DefaultCircle.
+func (s *DefaultShape) SetDefaultCircle(v DefaultCircle) {
+	s.Type = DefaultCircleDefaultShape
+	s.DefaultCircle = v
+}
+
+// GetDefaultCircle returns DefaultCircle and true boolean if DefaultShape is DefaultCircle.
+func (s DefaultShape) GetDefaultCircle() (v DefaultCircle, ok bool) {
+	if !s.IsDefaultCircle() {
+		return v, false
+	}
+	return s.DefaultCircle, true
+}
+
+// NewDefaultCircleDefaultShape returns new DefaultShape from DefaultCircle.
+func NewDefaultCircleDefaultShape(v DefaultCircle) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultCircle(v)
+	return s
+}
+
+// SetDefaultSquare sets DefaultShape to DefaultSquare.
+func (s *DefaultShape) SetDefaultSquare(v DefaultSquare) {
+	s.Type = DefaultSquareDefaultShape
+	s.DefaultSquare = v
+}
+
+// GetDefaultSquare returns DefaultSquare and true boolean if DefaultShape is DefaultSquare.
+func (s DefaultShape) GetDefaultSquare() (v DefaultSquare, ok bool) {
+	if !s.IsDefaultSquare() {
+		return v, false
+	}
+	return s.DefaultSquare, true
+}
+
+// NewDefaultSquareDefaultShape returns new DefaultShape from DefaultSquare.
+func NewDefaultSquareDefaultShape(v DefaultSquare) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultSquare(v)
+	return s
+}
+
+// Ref: #/components/schemas/DefaultSquare
+type DefaultSquare struct {
+	Kind string `json:"kind"`
+	Side int    `json:"side"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultSquare) GetKind() string {
+	return s.Kind
+}
+
+// GetSide returns the value of Side.
+func (s *DefaultSquare) GetSide() int {
+	return s.Side
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultSquare) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetSide sets the value of Side.
+func (s *DefaultSquare) SetSide(val int) {
+	s.Side = val
+}
+
 // Ref: #/components/schemas/DefaultTest
 type DefaultTest struct {
-	Required string             `json:"required"`
-	Str      OptString          `json:"str"`
-	NullStr  OptNilString       `json:"nullStr"`
-	Enum     OptDefaultTestEnum `json:"enum"`
-	UUID     OptUUID            `json:"uuid"`
-	IP       OptIP              `json:"ip"`
-	IPV4     OptIPv4            `json:"ip_v4"`
-	IPV6     OptIPv6            `json:"ip_v6"`
-	URI      OptURI             `json:"uri"`
-	Birthday OptDate            `json:"birthday"`
-	Rate     OptDuration        `json:"rate"`
-	Email    OptString          `json:"email"`
-	Hostname OptString          `json:"hostname"`
-	Format   OptString          `json:"format"`
-	Base64   []byte             `json:"base64"`
+	Required   string                      `json:"required"`
+	Str        OptString                   `json:"str"`
+	NullStr    OptNilString                `json:"nullStr"`
+	Enum       OptDefaultTestEnum          `json:"enum"`
+	UUID       OptUUID                     `json:"uuid"`
+	IP         OptIP                       `json:"ip"`
+	IPV4       OptIPv4                     `json:"ip_v4"`
+	IPV6       OptIPv6                     `json:"ip_v6"`
+	URI        OptURI                      `json:"uri"`
+	Birthday   OptDate                     `json:"birthday"`
+	Rate       OptDuration                 `json:"rate"`
+	Email      OptString                   `json:"email"`
+	Hostname   OptString                   `json:"hostname"`
+	Format     OptString                   `json:"format"`
+	Base64     []byte                      `json:"base64"`
+	Strings    []string                    `json:"strings"`
+	Priorities []DefaultTestPrioritiesItem `json:"priorities"`
+	Nested     [][]int                     `json:"nested"`
+	Objs       []DefaultTestObjsItem       `json:"objs"`
+	Shapes     []DefaultShape              `json:"shapes"`
+	Labels     []DefaultTestLabelsItem     `json:"labels"`
 }
 
 // GetRequired returns the value of Required.
@@ -380,6 +504,36 @@ func (s *DefaultTest) GetBase64() []byte {
 	return s.Base64
 }
 
+// GetStrings returns the value of Strings.
+func (s *DefaultTest) GetStrings() []string {
+	return s.Strings
+}
+
+// GetPriorities returns the value of Priorities.
+func (s *DefaultTest) GetPriorities() []DefaultTestPrioritiesItem {
+	return s.Priorities
+}
+
+// GetNested returns the value of Nested.
+func (s *DefaultTest) GetNested() [][]int {
+	return s.Nested
+}
+
+// GetObjs returns the value of Objs.
+func (s *DefaultTest) GetObjs() []DefaultTestObjsItem {
+	return s.Objs
+}
+
+// GetShapes returns the value of Shapes.
+func (s *DefaultTest) GetShapes() []DefaultShape {
+	return s.Shapes
+}
+
+// GetLabels returns the value of Labels.
+func (s *DefaultTest) GetLabels() []DefaultTestLabelsItem {
+	return s.Labels
+}
+
 // SetRequired sets the value of Required.
 func (s *DefaultTest) SetRequired(val string) {
 	s.Required = val
@@ -455,6 +609,36 @@ func (s *DefaultTest) SetBase64(val []byte) {
 	s.Base64 = val
 }
 
+// SetStrings sets the value of Strings.
+func (s *DefaultTest) SetStrings(val []string) {
+	s.Strings = val
+}
+
+// SetPriorities sets the value of Priorities.
+func (s *DefaultTest) SetPriorities(val []DefaultTestPrioritiesItem) {
+	s.Priorities = val
+}
+
+// SetNested sets the value of Nested.
+func (s *DefaultTest) SetNested(val [][]int) {
+	s.Nested = val
+}
+
+// SetObjs sets the value of Objs.
+func (s *DefaultTest) SetObjs(val []DefaultTestObjsItem) {
+	s.Objs = val
+}
+
+// SetShapes sets the value of Shapes.
+func (s *DefaultTest) SetShapes(val []DefaultShape) {
+	s.Shapes = val
+}
+
+// SetLabels sets the value of Labels.
+func (s *DefaultTest) SetLabels(val []DefaultTestLabelsItem) {
+	s.Labels = val
+}
+
 type DefaultTestEnum string
 
 const (
@@ -490,6 +674,90 @@ func (s *DefaultTestEnum) UnmarshalText(data []byte) error {
 		return nil
 	case DefaultTestEnumSmol:
 		*s = DefaultTestEnumSmol
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type DefaultTestLabelsItem map[string]string
+
+func (s *DefaultTestLabelsItem) init() DefaultTestLabelsItem {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
+	}
+	return m
+}
+
+type DefaultTestObjsItem struct {
+	Name  OptString `json:"name"`
+	Count OptInt    `json:"count"`
+}
+
+// GetName returns the value of Name.
+func (s *DefaultTestObjsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetCount returns the value of Count.
+func (s *DefaultTestObjsItem) GetCount() OptInt {
+	return s.Count
+}
+
+// SetName sets the value of Name.
+func (s *DefaultTestObjsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetCount sets the value of Count.
+func (s *DefaultTestObjsItem) SetCount(val OptInt) {
+	s.Count = val
+}
+
+type DefaultTestPrioritiesItem string
+
+const (
+	DefaultTestPrioritiesItemLow    DefaultTestPrioritiesItem = "low"
+	DefaultTestPrioritiesItemMedium DefaultTestPrioritiesItem = "medium"
+	DefaultTestPrioritiesItemHigh   DefaultTestPrioritiesItem = "high"
+)
+
+// AllValues returns all DefaultTestPrioritiesItem values.
+func (DefaultTestPrioritiesItem) AllValues() []DefaultTestPrioritiesItem {
+	return []DefaultTestPrioritiesItem{
+		DefaultTestPrioritiesItemLow,
+		DefaultTestPrioritiesItemMedium,
+		DefaultTestPrioritiesItemHigh,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DefaultTestPrioritiesItem) MarshalText() ([]byte, error) {
+	switch s {
+	case DefaultTestPrioritiesItemLow:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemMedium:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemHigh:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalText(data []byte) error {
+	switch DefaultTestPrioritiesItem(data) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+		return nil
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+		return nil
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/internal/integration/sample_api_nc/oas_validators_gen.go
+++ b/internal/integration/sample_api_nc/oas_validators_gen.go
@@ -264,6 +264,56 @@ func (s *DefaultTest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Priorities {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "priorities",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Nested {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nested",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -275,6 +325,19 @@ func (s DefaultTestEnum) Validate() error {
 	case "big":
 		return nil
 	case "smol":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s DefaultTestPrioritiesItem) Validate() error {
+	switch s {
+	case "low":
+		return nil
+	case "medium":
+		return nil
+	case "high":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/internal/integration/sample_api_no_otel/oas_client_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_client_gen.go
@@ -391,6 +391,32 @@ func (c *Client) sendDefaultTest(ctx context.Context, request *DefaultTest, para
 			return res, errors.Wrap(err, "encode query")
 		}
 	}
+	{
+		// Encode "arrayDefault" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ArrayDefault != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ArrayDefault {
+						if err := func() error {
+							return e.EncodeValue(conv.StringToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
 	u.RawQuery = q.Values().Encode()
 
 	r, err := ht.NewRequest(ctx, "POST", u)

--- a/internal/integration/sample_api_no_otel/oas_defaults_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_defaults_gen.go
@@ -68,4 +68,118 @@ func (s *DefaultTest) setDefaults() {
 		val, _ := jx.DecodeStr("\"aGVsbG8sIHdvcmxkIQ==\"").Base64()
 		s.Base64 = val
 	}
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("all")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Strings = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestPrioritiesItem
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("medium")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("high")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Priorities = defaultVal0
+	}
+	{
+		var defaultVal0 [][]int
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(1)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			{
+				var defaultVal1Elem int
+
+				val := int(2)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(3)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Nested = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestObjsItem
+		{
+			var defaultVal0Elem DefaultTestObjsItem
+			var defaultVal1 DefaultTestObjsItem
+			{
+
+				val := string("x")
+				defaultVal1.Name.SetTo(val)
+			}
+			{
+
+				val := int(5)
+				defaultVal1.Count.SetTo(val)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Objs = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultShape
+		{
+			var defaultVal0Elem DefaultShape
+			// The default is well-formed JSON from the spec; a value that does not match a
+			// variant decodes to the zero value (defaults are not variant-checked at gen time).
+			_ = defaultVal0Elem.Decode(jx.DecodeStr("{\"kind\":\"circle\",\"radius\":5}"))
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Shapes = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestLabelsItem
+		{
+			var defaultVal0Elem DefaultTestLabelsItem
+			defaultVal1 := make(DefaultTestLabelsItem, 1)
+			{
+				var defaultVal1Val string
+
+				val := string("x")
+				defaultVal1Val = val
+				defaultVal1["a"] = defaultVal1Val
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Labels = defaultVal0
+	}
 }

--- a/internal/integration/sample_api_no_otel/oas_handlers_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_handlers_gen.go
@@ -185,6 +185,10 @@ func (s *Server) handleDefaultTestRequest(args [0]string, argsEscaped bool, w ht
 					Name: "default",
 					In:   "query",
 				}: params.Default,
+				{
+					Name: "arrayDefault",
+					In:   "query",
+				}: params.ArrayDefault,
 			},
 			Raw: r,
 		}

--- a/internal/integration/sample_api_no_otel/oas_json_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_json_gen.go
@@ -690,6 +690,334 @@ func (s *DataDescription) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DefaultCircle) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultCircle) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("radius")
+		e.Int(s.Radius)
+	}
+}
+
+var jsonFieldsNameOfDefaultCircle = [2]string{
+	0: "kind",
+	1: "radius",
+}
+
+// Decode decodes DefaultCircle from json.
+func (s *DefaultCircle) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultCircle to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "radius":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Radius = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"radius\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultCircle")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultCircle) {
+					name = jsonFieldsNameOfDefaultCircle[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultCircle) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultCircle) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultShape as json.
+func (s DefaultShape) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s DefaultShape) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		e.FieldStart("kind")
+		e.Str("circle")
+		{
+			s := s.DefaultCircle
+			{
+				e.FieldStart("radius")
+				e.Int(s.Radius)
+			}
+		}
+	case DefaultSquareDefaultShape:
+		e.FieldStart("kind")
+		e.Str("square")
+		{
+			s := s.DefaultSquare
+			{
+				e.FieldStart("side")
+				e.Int(s.Side)
+			}
+		}
+	}
+}
+
+// Decode decodes DefaultShape from json.
+func (s *DefaultShape) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultShape to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "circle":
+					s.Type = DefaultCircleDefaultShape
+					found = true
+				case "square":
+					s.Type = DefaultSquareDefaultShape
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		if err := s.DefaultCircle.Decode(d); err != nil {
+			return err
+		}
+	case DefaultSquareDefaultShape:
+		if err := s.DefaultSquare.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultShape) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultShape) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultSquare) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultSquare) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("side")
+		e.Int(s.Side)
+	}
+}
+
+var jsonFieldsNameOfDefaultSquare = [2]string{
+	0: "kind",
+	1: "side",
+}
+
+// Decode decodes DefaultSquare from json.
+func (s *DefaultSquare) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultSquare to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "side":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Side = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"side\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultSquare")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultSquare) {
+					name = jsonFieldsNameOfDefaultSquare[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultSquare) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultSquare) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *DefaultTest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -784,9 +1112,73 @@ func (s *DefaultTest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("base64")
 		e.Base64(s.Base64)
 	}
+	{
+		if s.Strings != nil {
+			e.FieldStart("strings")
+			e.ArrStart()
+			for _, elem := range s.Strings {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Priorities != nil {
+			e.FieldStart("priorities")
+			e.ArrStart()
+			for _, elem := range s.Priorities {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Nested != nil {
+			e.FieldStart("nested")
+			e.ArrStart()
+			for _, elem := range s.Nested {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Int(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Objs != nil {
+			e.FieldStart("objs")
+			e.ArrStart()
+			for _, elem := range s.Objs {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Shapes != nil {
+			e.FieldStart("shapes")
+			e.ArrStart()
+			for _, elem := range s.Shapes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Labels != nil {
+			e.FieldStart("labels")
+			e.ArrStart()
+			for _, elem := range s.Labels {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfDefaultTest = [15]string{
+var jsonFieldsNameOfDefaultTest = [21]string{
 	0:  "required",
 	1:  "str",
 	2:  "nullStr",
@@ -802,6 +1194,12 @@ var jsonFieldsNameOfDefaultTest = [15]string{
 	12: "hostname",
 	13: "format",
 	14: "base64",
+	15: "strings",
+	16: "priorities",
+	17: "nested",
+	18: "objs",
+	19: "shapes",
+	20: "labels",
 }
 
 // Decode decodes DefaultTest from json.
@@ -809,7 +1207,7 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode DefaultTest to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -967,6 +1365,120 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"base64\"")
 			}
+		case "strings":
+			if err := func() error {
+				s.Strings = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Strings = append(s.Strings, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"strings\"")
+			}
+		case "priorities":
+			if err := func() error {
+				s.Priorities = make([]DefaultTestPrioritiesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestPrioritiesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Priorities = append(s.Priorities, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"priorities\"")
+			}
+		case "nested":
+			if err := func() error {
+				s.Nested = make([][]int, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []int
+					elem = make([]int, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem int
+						v, err := d.Int()
+						elemElem = int(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Nested = append(s.Nested, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nested\"")
+			}
+		case "objs":
+			if err := func() error {
+				s.Objs = make([]DefaultTestObjsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestObjsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Objs = append(s.Objs, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"objs\"")
+			}
+		case "shapes":
+			if err := func() error {
+				s.Shapes = make([]DefaultShape, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultShape
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Shapes = append(s.Shapes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"shapes\"")
+			}
+		case "labels":
+			if err := func() error {
+				s.Labels = make([]DefaultTestLabelsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestLabelsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Labels = append(s.Labels, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"labels\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -976,8 +1488,9 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b00000001,
+		0b00000000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -1060,6 +1573,184 @@ func (s DefaultTestEnum) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *DefaultTestEnum) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s DefaultTestLabelsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s DefaultTestLabelsItem) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes DefaultTestLabelsItem from json.
+func (s *DefaultTestLabelsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestLabelsItem to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestLabelsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestLabelsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestLabelsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultTestObjsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultTestObjsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Count.Set {
+			e.FieldStart("count")
+			s.Count.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDefaultTestObjsItem = [2]string{
+	0: "name",
+	1: "count",
+}
+
+// Decode decodes DefaultTestObjsItem from json.
+func (s *DefaultTestObjsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestObjsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "count":
+			if err := func() error {
+				s.Count.Reset()
+				if err := s.Count.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestObjsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultTestObjsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestObjsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultTestPrioritiesItem as json.
+func (s DefaultTestPrioritiesItem) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DefaultTestPrioritiesItem from json.
+func (s *DefaultTestPrioritiesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestPrioritiesItem to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DefaultTestPrioritiesItem(v) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
+	default:
+		*s = DefaultTestPrioritiesItem(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestPrioritiesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/sample_api_no_otel/oas_parameters_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_parameters_gen.go
@@ -392,7 +392,8 @@ func decodeDataGetFormatParams(args [5]string, argsEscaped bool, r *http.Request
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32 `json:",omitempty,omitzero"`
+	Default      OptInt32 `json:",omitempty,omitzero"`
+	ArrayDefault []string `json:",omitempty"`
 }
 
 func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestParams) {
@@ -403,6 +404,15 @@ func unpackDefaultTestParams(packed middleware.Parameters) (params DefaultTestPa
 		}
 		if v, ok := packed[key]; ok {
 			params.Default = v.(OptInt32)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "arrayDefault",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ArrayDefault = v.([]string)
 		}
 	}
 	return params
@@ -452,6 +462,69 @@ func decodeDefaultTestParams(args [0]string, argsEscaped bool, r *http.Request) 
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "default",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: arrayDefault.
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("a")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem string
+
+			val := string("b")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		params.ArrayDefault = defaultVal0
+	}
+	// Decode query: arrayDefault.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.ArrayDefault = nil
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotArrayDefaultVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotArrayDefaultVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ArrayDefault = append(params.ArrayDefault, paramsDotArrayDefaultVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "arrayDefault",
 			In:   "query",
 			Err:  err,
 		}
@@ -737,6 +810,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XTags = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXTagsVal uuid.UUID
 					if err := func() error {
@@ -788,6 +862,7 @@ func decodePetGetParams(args [0]string, argsEscaped bool, r *http.Request) (para
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.XScope = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotXScopeVal string
 					if err := func() error {

--- a/internal/integration/sample_api_no_otel/oas_schemas_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_schemas_gen.go
@@ -286,23 +286,147 @@ func NewDescriptionSimpleDataDescription(v DescriptionSimple) DataDescription {
 	return s
 }
 
+// Ref: #/components/schemas/DefaultCircle
+type DefaultCircle struct {
+	Kind   string `json:"kind"`
+	Radius int    `json:"radius"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultCircle) GetKind() string {
+	return s.Kind
+}
+
+// GetRadius returns the value of Radius.
+func (s *DefaultCircle) GetRadius() int {
+	return s.Radius
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultCircle) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetRadius sets the value of Radius.
+func (s *DefaultCircle) SetRadius(val int) {
+	s.Radius = val
+}
+
+// Ref: #/components/schemas/DefaultShape
+// DefaultShape represents sum type.
+type DefaultShape struct {
+	// Type selects the active sum variant, switch on this field.
+	Type          DefaultShapeType
+	DefaultCircle DefaultCircle
+	DefaultSquare DefaultSquare
+}
+
+// DefaultShapeType is oneOf type of DefaultShape.
+type DefaultShapeType string
+
+// Possible values for DefaultShapeType.
+const (
+	DefaultCircleDefaultShape DefaultShapeType = "circle"
+	DefaultSquareDefaultShape DefaultShapeType = "square"
+)
+
+// IsDefaultCircle reports whether DefaultShape is DefaultCircle.
+func (s DefaultShape) IsDefaultCircle() bool { return s.Type == DefaultCircleDefaultShape }
+
+// IsDefaultSquare reports whether DefaultShape is DefaultSquare.
+func (s DefaultShape) IsDefaultSquare() bool { return s.Type == DefaultSquareDefaultShape }
+
+// SetDefaultCircle sets DefaultShape to DefaultCircle.
+func (s *DefaultShape) SetDefaultCircle(v DefaultCircle) {
+	s.Type = DefaultCircleDefaultShape
+	s.DefaultCircle = v
+}
+
+// GetDefaultCircle returns DefaultCircle and true boolean if DefaultShape is DefaultCircle.
+func (s DefaultShape) GetDefaultCircle() (v DefaultCircle, ok bool) {
+	if !s.IsDefaultCircle() {
+		return v, false
+	}
+	return s.DefaultCircle, true
+}
+
+// NewDefaultCircleDefaultShape returns new DefaultShape from DefaultCircle.
+func NewDefaultCircleDefaultShape(v DefaultCircle) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultCircle(v)
+	return s
+}
+
+// SetDefaultSquare sets DefaultShape to DefaultSquare.
+func (s *DefaultShape) SetDefaultSquare(v DefaultSquare) {
+	s.Type = DefaultSquareDefaultShape
+	s.DefaultSquare = v
+}
+
+// GetDefaultSquare returns DefaultSquare and true boolean if DefaultShape is DefaultSquare.
+func (s DefaultShape) GetDefaultSquare() (v DefaultSquare, ok bool) {
+	if !s.IsDefaultSquare() {
+		return v, false
+	}
+	return s.DefaultSquare, true
+}
+
+// NewDefaultSquareDefaultShape returns new DefaultShape from DefaultSquare.
+func NewDefaultSquareDefaultShape(v DefaultSquare) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultSquare(v)
+	return s
+}
+
+// Ref: #/components/schemas/DefaultSquare
+type DefaultSquare struct {
+	Kind string `json:"kind"`
+	Side int    `json:"side"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultSquare) GetKind() string {
+	return s.Kind
+}
+
+// GetSide returns the value of Side.
+func (s *DefaultSquare) GetSide() int {
+	return s.Side
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultSquare) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetSide sets the value of Side.
+func (s *DefaultSquare) SetSide(val int) {
+	s.Side = val
+}
+
 // Ref: #/components/schemas/DefaultTest
 type DefaultTest struct {
-	Required string             `json:"required"`
-	Str      OptString          `json:"str"`
-	NullStr  OptNilString       `json:"nullStr"`
-	Enum     OptDefaultTestEnum `json:"enum"`
-	UUID     OptUUID            `json:"uuid"`
-	IP       OptIP              `json:"ip"`
-	IPV4     OptIPv4            `json:"ip_v4"`
-	IPV6     OptIPv6            `json:"ip_v6"`
-	URI      OptURI             `json:"uri"`
-	Birthday OptDate            `json:"birthday"`
-	Rate     OptDuration        `json:"rate"`
-	Email    OptString          `json:"email"`
-	Hostname OptString          `json:"hostname"`
-	Format   OptString          `json:"format"`
-	Base64   []byte             `json:"base64"`
+	Required   string                      `json:"required"`
+	Str        OptString                   `json:"str"`
+	NullStr    OptNilString                `json:"nullStr"`
+	Enum       OptDefaultTestEnum          `json:"enum"`
+	UUID       OptUUID                     `json:"uuid"`
+	IP         OptIP                       `json:"ip"`
+	IPV4       OptIPv4                     `json:"ip_v4"`
+	IPV6       OptIPv6                     `json:"ip_v6"`
+	URI        OptURI                      `json:"uri"`
+	Birthday   OptDate                     `json:"birthday"`
+	Rate       OptDuration                 `json:"rate"`
+	Email      OptString                   `json:"email"`
+	Hostname   OptString                   `json:"hostname"`
+	Format     OptString                   `json:"format"`
+	Base64     []byte                      `json:"base64"`
+	Strings    []string                    `json:"strings"`
+	Priorities []DefaultTestPrioritiesItem `json:"priorities"`
+	Nested     [][]int                     `json:"nested"`
+	Objs       []DefaultTestObjsItem       `json:"objs"`
+	Shapes     []DefaultShape              `json:"shapes"`
+	Labels     []DefaultTestLabelsItem     `json:"labels"`
 }
 
 // GetRequired returns the value of Required.
@@ -380,6 +504,36 @@ func (s *DefaultTest) GetBase64() []byte {
 	return s.Base64
 }
 
+// GetStrings returns the value of Strings.
+func (s *DefaultTest) GetStrings() []string {
+	return s.Strings
+}
+
+// GetPriorities returns the value of Priorities.
+func (s *DefaultTest) GetPriorities() []DefaultTestPrioritiesItem {
+	return s.Priorities
+}
+
+// GetNested returns the value of Nested.
+func (s *DefaultTest) GetNested() [][]int {
+	return s.Nested
+}
+
+// GetObjs returns the value of Objs.
+func (s *DefaultTest) GetObjs() []DefaultTestObjsItem {
+	return s.Objs
+}
+
+// GetShapes returns the value of Shapes.
+func (s *DefaultTest) GetShapes() []DefaultShape {
+	return s.Shapes
+}
+
+// GetLabels returns the value of Labels.
+func (s *DefaultTest) GetLabels() []DefaultTestLabelsItem {
+	return s.Labels
+}
+
 // SetRequired sets the value of Required.
 func (s *DefaultTest) SetRequired(val string) {
 	s.Required = val
@@ -455,6 +609,36 @@ func (s *DefaultTest) SetBase64(val []byte) {
 	s.Base64 = val
 }
 
+// SetStrings sets the value of Strings.
+func (s *DefaultTest) SetStrings(val []string) {
+	s.Strings = val
+}
+
+// SetPriorities sets the value of Priorities.
+func (s *DefaultTest) SetPriorities(val []DefaultTestPrioritiesItem) {
+	s.Priorities = val
+}
+
+// SetNested sets the value of Nested.
+func (s *DefaultTest) SetNested(val [][]int) {
+	s.Nested = val
+}
+
+// SetObjs sets the value of Objs.
+func (s *DefaultTest) SetObjs(val []DefaultTestObjsItem) {
+	s.Objs = val
+}
+
+// SetShapes sets the value of Shapes.
+func (s *DefaultTest) SetShapes(val []DefaultShape) {
+	s.Shapes = val
+}
+
+// SetLabels sets the value of Labels.
+func (s *DefaultTest) SetLabels(val []DefaultTestLabelsItem) {
+	s.Labels = val
+}
+
 type DefaultTestEnum string
 
 const (
@@ -490,6 +674,90 @@ func (s *DefaultTestEnum) UnmarshalText(data []byte) error {
 		return nil
 	case DefaultTestEnumSmol:
 		*s = DefaultTestEnumSmol
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type DefaultTestLabelsItem map[string]string
+
+func (s *DefaultTestLabelsItem) init() DefaultTestLabelsItem {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
+	}
+	return m
+}
+
+type DefaultTestObjsItem struct {
+	Name  OptString `json:"name"`
+	Count OptInt    `json:"count"`
+}
+
+// GetName returns the value of Name.
+func (s *DefaultTestObjsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetCount returns the value of Count.
+func (s *DefaultTestObjsItem) GetCount() OptInt {
+	return s.Count
+}
+
+// SetName sets the value of Name.
+func (s *DefaultTestObjsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetCount sets the value of Count.
+func (s *DefaultTestObjsItem) SetCount(val OptInt) {
+	s.Count = val
+}
+
+type DefaultTestPrioritiesItem string
+
+const (
+	DefaultTestPrioritiesItemLow    DefaultTestPrioritiesItem = "low"
+	DefaultTestPrioritiesItemMedium DefaultTestPrioritiesItem = "medium"
+	DefaultTestPrioritiesItemHigh   DefaultTestPrioritiesItem = "high"
+)
+
+// AllValues returns all DefaultTestPrioritiesItem values.
+func (DefaultTestPrioritiesItem) AllValues() []DefaultTestPrioritiesItem {
+	return []DefaultTestPrioritiesItem{
+		DefaultTestPrioritiesItemLow,
+		DefaultTestPrioritiesItemMedium,
+		DefaultTestPrioritiesItemHigh,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DefaultTestPrioritiesItem) MarshalText() ([]byte, error) {
+	switch s {
+	case DefaultTestPrioritiesItemLow:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemMedium:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemHigh:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalText(data []byte) error {
+	switch DefaultTestPrioritiesItem(data) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+		return nil
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+		return nil
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/internal/integration/sample_api_no_otel/oas_validators_gen.go
+++ b/internal/integration/sample_api_no_otel/oas_validators_gen.go
@@ -264,6 +264,56 @@ func (s *DefaultTest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Priorities {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "priorities",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Nested {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nested",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -275,6 +325,19 @@ func (s DefaultTestEnum) Validate() error {
 	case "big":
 		return nil
 	case "smol":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s DefaultTestPrioritiesItem) Validate() error {
+	switch s {
+	case "low":
+		return nil
+	case "medium":
+		return nil
+	case "high":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/internal/integration/sample_api_ns/oas_client_gen.go
+++ b/internal/integration/sample_api_ns/oas_client_gen.go
@@ -470,6 +470,32 @@ func (c *Client) sendDefaultTest(ctx context.Context, request *DefaultTest, para
 			return res, errors.Wrap(err, "encode query")
 		}
 	}
+	{
+		// Encode "arrayDefault" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "arrayDefault",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ArrayDefault != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ArrayDefault {
+						if err := func() error {
+							return e.EncodeValue(conv.StringToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
 	u.RawQuery = q.Values().Encode()
 
 	stage = "EncodeRequest"

--- a/internal/integration/sample_api_ns/oas_defaults_gen.go
+++ b/internal/integration/sample_api_ns/oas_defaults_gen.go
@@ -68,4 +68,118 @@ func (s *DefaultTest) setDefaults() {
 		val, _ := jx.DecodeStr("\"aGVsbG8sIHdvcmxkIQ==\"").Base64()
 		s.Base64 = val
 	}
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("all")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Strings = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestPrioritiesItem
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("medium")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("high")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Priorities = defaultVal0
+	}
+	{
+		var defaultVal0 [][]int
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(1)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			{
+				var defaultVal1Elem int
+
+				val := int(2)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(3)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Nested = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestObjsItem
+		{
+			var defaultVal0Elem DefaultTestObjsItem
+			var defaultVal1 DefaultTestObjsItem
+			{
+
+				val := string("x")
+				defaultVal1.Name.SetTo(val)
+			}
+			{
+
+				val := int(5)
+				defaultVal1.Count.SetTo(val)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Objs = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultShape
+		{
+			var defaultVal0Elem DefaultShape
+			// The default is well-formed JSON from the spec; a value that does not match a
+			// variant decodes to the zero value (defaults are not variant-checked at gen time).
+			_ = defaultVal0Elem.Decode(jx.DecodeStr("{\"kind\":\"circle\",\"radius\":5}"))
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Shapes = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestLabelsItem
+		{
+			var defaultVal0Elem DefaultTestLabelsItem
+			defaultVal1 := make(DefaultTestLabelsItem, 1)
+			{
+				var defaultVal1Val string
+
+				val := string("x")
+				defaultVal1Val = val
+				defaultVal1["a"] = defaultVal1Val
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Labels = defaultVal0
+	}
 }

--- a/internal/integration/sample_api_ns/oas_json_gen.go
+++ b/internal/integration/sample_api_ns/oas_json_gen.go
@@ -690,6 +690,334 @@ func (s *DataDescription) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DefaultCircle) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultCircle) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("radius")
+		e.Int(s.Radius)
+	}
+}
+
+var jsonFieldsNameOfDefaultCircle = [2]string{
+	0: "kind",
+	1: "radius",
+}
+
+// Decode decodes DefaultCircle from json.
+func (s *DefaultCircle) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultCircle to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "radius":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Radius = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"radius\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultCircle")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultCircle) {
+					name = jsonFieldsNameOfDefaultCircle[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultCircle) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultCircle) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultShape as json.
+func (s DefaultShape) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s DefaultShape) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		e.FieldStart("kind")
+		e.Str("circle")
+		{
+			s := s.DefaultCircle
+			{
+				e.FieldStart("radius")
+				e.Int(s.Radius)
+			}
+		}
+	case DefaultSquareDefaultShape:
+		e.FieldStart("kind")
+		e.Str("square")
+		{
+			s := s.DefaultSquare
+			{
+				e.FieldStart("side")
+				e.Int(s.Side)
+			}
+		}
+	}
+}
+
+// Decode decodes DefaultShape from json.
+func (s *DefaultShape) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultShape to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "circle":
+					s.Type = DefaultCircleDefaultShape
+					found = true
+				case "square":
+					s.Type = DefaultSquareDefaultShape
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		if err := s.DefaultCircle.Decode(d); err != nil {
+			return err
+		}
+	case DefaultSquareDefaultShape:
+		if err := s.DefaultSquare.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultShape) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultShape) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultSquare) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultSquare) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("side")
+		e.Int(s.Side)
+	}
+}
+
+var jsonFieldsNameOfDefaultSquare = [2]string{
+	0: "kind",
+	1: "side",
+}
+
+// Decode decodes DefaultSquare from json.
+func (s *DefaultSquare) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultSquare to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "side":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Side = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"side\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultSquare")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultSquare) {
+					name = jsonFieldsNameOfDefaultSquare[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultSquare) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultSquare) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *DefaultTest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -784,9 +1112,73 @@ func (s *DefaultTest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("base64")
 		e.Base64(s.Base64)
 	}
+	{
+		if s.Strings != nil {
+			e.FieldStart("strings")
+			e.ArrStart()
+			for _, elem := range s.Strings {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Priorities != nil {
+			e.FieldStart("priorities")
+			e.ArrStart()
+			for _, elem := range s.Priorities {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Nested != nil {
+			e.FieldStart("nested")
+			e.ArrStart()
+			for _, elem := range s.Nested {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Int(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Objs != nil {
+			e.FieldStart("objs")
+			e.ArrStart()
+			for _, elem := range s.Objs {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Shapes != nil {
+			e.FieldStart("shapes")
+			e.ArrStart()
+			for _, elem := range s.Shapes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Labels != nil {
+			e.FieldStart("labels")
+			e.ArrStart()
+			for _, elem := range s.Labels {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfDefaultTest = [15]string{
+var jsonFieldsNameOfDefaultTest = [21]string{
 	0:  "required",
 	1:  "str",
 	2:  "nullStr",
@@ -802,6 +1194,12 @@ var jsonFieldsNameOfDefaultTest = [15]string{
 	12: "hostname",
 	13: "format",
 	14: "base64",
+	15: "strings",
+	16: "priorities",
+	17: "nested",
+	18: "objs",
+	19: "shapes",
+	20: "labels",
 }
 
 // Decode decodes DefaultTest from json.
@@ -809,7 +1207,7 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode DefaultTest to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -967,6 +1365,120 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"base64\"")
 			}
+		case "strings":
+			if err := func() error {
+				s.Strings = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Strings = append(s.Strings, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"strings\"")
+			}
+		case "priorities":
+			if err := func() error {
+				s.Priorities = make([]DefaultTestPrioritiesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestPrioritiesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Priorities = append(s.Priorities, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"priorities\"")
+			}
+		case "nested":
+			if err := func() error {
+				s.Nested = make([][]int, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []int
+					elem = make([]int, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem int
+						v, err := d.Int()
+						elemElem = int(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Nested = append(s.Nested, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nested\"")
+			}
+		case "objs":
+			if err := func() error {
+				s.Objs = make([]DefaultTestObjsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestObjsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Objs = append(s.Objs, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"objs\"")
+			}
+		case "shapes":
+			if err := func() error {
+				s.Shapes = make([]DefaultShape, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultShape
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Shapes = append(s.Shapes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"shapes\"")
+			}
+		case "labels":
+			if err := func() error {
+				s.Labels = make([]DefaultTestLabelsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestLabelsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Labels = append(s.Labels, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"labels\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -976,8 +1488,9 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b00000001,
+		0b00000000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -1060,6 +1573,184 @@ func (s DefaultTestEnum) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *DefaultTestEnum) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s DefaultTestLabelsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s DefaultTestLabelsItem) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes DefaultTestLabelsItem from json.
+func (s *DefaultTestLabelsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestLabelsItem to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestLabelsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestLabelsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestLabelsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultTestObjsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultTestObjsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Count.Set {
+			e.FieldStart("count")
+			s.Count.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDefaultTestObjsItem = [2]string{
+	0: "name",
+	1: "count",
+}
+
+// Decode decodes DefaultTestObjsItem from json.
+func (s *DefaultTestObjsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestObjsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "count":
+			if err := func() error {
+				s.Count.Reset()
+				if err := s.Count.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestObjsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultTestObjsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestObjsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultTestPrioritiesItem as json.
+func (s DefaultTestPrioritiesItem) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DefaultTestPrioritiesItem from json.
+func (s *DefaultTestPrioritiesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestPrioritiesItem to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DefaultTestPrioritiesItem(v) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
+	default:
+		*s = DefaultTestPrioritiesItem(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestPrioritiesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/sample_api_ns/oas_parameters_gen.go
+++ b/internal/integration/sample_api_ns/oas_parameters_gen.go
@@ -17,7 +17,8 @@ type DataGetFormatParams struct {
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32 `json:",omitempty,omitzero"`
+	Default      OptInt32 `json:",omitempty,omitzero"`
+	ArrayDefault []string `json:",omitempty"`
 }
 
 // FoobarGetParams is parameters of foobarGet operation.

--- a/internal/integration/sample_api_ns/oas_schemas_gen.go
+++ b/internal/integration/sample_api_ns/oas_schemas_gen.go
@@ -286,23 +286,147 @@ func NewDescriptionSimpleDataDescription(v DescriptionSimple) DataDescription {
 	return s
 }
 
+// Ref: #/components/schemas/DefaultCircle
+type DefaultCircle struct {
+	Kind   string `json:"kind"`
+	Radius int    `json:"radius"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultCircle) GetKind() string {
+	return s.Kind
+}
+
+// GetRadius returns the value of Radius.
+func (s *DefaultCircle) GetRadius() int {
+	return s.Radius
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultCircle) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetRadius sets the value of Radius.
+func (s *DefaultCircle) SetRadius(val int) {
+	s.Radius = val
+}
+
+// Ref: #/components/schemas/DefaultShape
+// DefaultShape represents sum type.
+type DefaultShape struct {
+	// Type selects the active sum variant, switch on this field.
+	Type          DefaultShapeType
+	DefaultCircle DefaultCircle
+	DefaultSquare DefaultSquare
+}
+
+// DefaultShapeType is oneOf type of DefaultShape.
+type DefaultShapeType string
+
+// Possible values for DefaultShapeType.
+const (
+	DefaultCircleDefaultShape DefaultShapeType = "circle"
+	DefaultSquareDefaultShape DefaultShapeType = "square"
+)
+
+// IsDefaultCircle reports whether DefaultShape is DefaultCircle.
+func (s DefaultShape) IsDefaultCircle() bool { return s.Type == DefaultCircleDefaultShape }
+
+// IsDefaultSquare reports whether DefaultShape is DefaultSquare.
+func (s DefaultShape) IsDefaultSquare() bool { return s.Type == DefaultSquareDefaultShape }
+
+// SetDefaultCircle sets DefaultShape to DefaultCircle.
+func (s *DefaultShape) SetDefaultCircle(v DefaultCircle) {
+	s.Type = DefaultCircleDefaultShape
+	s.DefaultCircle = v
+}
+
+// GetDefaultCircle returns DefaultCircle and true boolean if DefaultShape is DefaultCircle.
+func (s DefaultShape) GetDefaultCircle() (v DefaultCircle, ok bool) {
+	if !s.IsDefaultCircle() {
+		return v, false
+	}
+	return s.DefaultCircle, true
+}
+
+// NewDefaultCircleDefaultShape returns new DefaultShape from DefaultCircle.
+func NewDefaultCircleDefaultShape(v DefaultCircle) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultCircle(v)
+	return s
+}
+
+// SetDefaultSquare sets DefaultShape to DefaultSquare.
+func (s *DefaultShape) SetDefaultSquare(v DefaultSquare) {
+	s.Type = DefaultSquareDefaultShape
+	s.DefaultSquare = v
+}
+
+// GetDefaultSquare returns DefaultSquare and true boolean if DefaultShape is DefaultSquare.
+func (s DefaultShape) GetDefaultSquare() (v DefaultSquare, ok bool) {
+	if !s.IsDefaultSquare() {
+		return v, false
+	}
+	return s.DefaultSquare, true
+}
+
+// NewDefaultSquareDefaultShape returns new DefaultShape from DefaultSquare.
+func NewDefaultSquareDefaultShape(v DefaultSquare) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultSquare(v)
+	return s
+}
+
+// Ref: #/components/schemas/DefaultSquare
+type DefaultSquare struct {
+	Kind string `json:"kind"`
+	Side int    `json:"side"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultSquare) GetKind() string {
+	return s.Kind
+}
+
+// GetSide returns the value of Side.
+func (s *DefaultSquare) GetSide() int {
+	return s.Side
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultSquare) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetSide sets the value of Side.
+func (s *DefaultSquare) SetSide(val int) {
+	s.Side = val
+}
+
 // Ref: #/components/schemas/DefaultTest
 type DefaultTest struct {
-	Required string             `json:"required"`
-	Str      OptString          `json:"str"`
-	NullStr  OptNilString       `json:"nullStr"`
-	Enum     OptDefaultTestEnum `json:"enum"`
-	UUID     OptUUID            `json:"uuid"`
-	IP       OptIP              `json:"ip"`
-	IPV4     OptIPv4            `json:"ip_v4"`
-	IPV6     OptIPv6            `json:"ip_v6"`
-	URI      OptURI             `json:"uri"`
-	Birthday OptDate            `json:"birthday"`
-	Rate     OptDuration        `json:"rate"`
-	Email    OptString          `json:"email"`
-	Hostname OptString          `json:"hostname"`
-	Format   OptString          `json:"format"`
-	Base64   []byte             `json:"base64"`
+	Required   string                      `json:"required"`
+	Str        OptString                   `json:"str"`
+	NullStr    OptNilString                `json:"nullStr"`
+	Enum       OptDefaultTestEnum          `json:"enum"`
+	UUID       OptUUID                     `json:"uuid"`
+	IP         OptIP                       `json:"ip"`
+	IPV4       OptIPv4                     `json:"ip_v4"`
+	IPV6       OptIPv6                     `json:"ip_v6"`
+	URI        OptURI                      `json:"uri"`
+	Birthday   OptDate                     `json:"birthday"`
+	Rate       OptDuration                 `json:"rate"`
+	Email      OptString                   `json:"email"`
+	Hostname   OptString                   `json:"hostname"`
+	Format     OptString                   `json:"format"`
+	Base64     []byte                      `json:"base64"`
+	Strings    []string                    `json:"strings"`
+	Priorities []DefaultTestPrioritiesItem `json:"priorities"`
+	Nested     [][]int                     `json:"nested"`
+	Objs       []DefaultTestObjsItem       `json:"objs"`
+	Shapes     []DefaultShape              `json:"shapes"`
+	Labels     []DefaultTestLabelsItem     `json:"labels"`
 }
 
 // GetRequired returns the value of Required.
@@ -380,6 +504,36 @@ func (s *DefaultTest) GetBase64() []byte {
 	return s.Base64
 }
 
+// GetStrings returns the value of Strings.
+func (s *DefaultTest) GetStrings() []string {
+	return s.Strings
+}
+
+// GetPriorities returns the value of Priorities.
+func (s *DefaultTest) GetPriorities() []DefaultTestPrioritiesItem {
+	return s.Priorities
+}
+
+// GetNested returns the value of Nested.
+func (s *DefaultTest) GetNested() [][]int {
+	return s.Nested
+}
+
+// GetObjs returns the value of Objs.
+func (s *DefaultTest) GetObjs() []DefaultTestObjsItem {
+	return s.Objs
+}
+
+// GetShapes returns the value of Shapes.
+func (s *DefaultTest) GetShapes() []DefaultShape {
+	return s.Shapes
+}
+
+// GetLabels returns the value of Labels.
+func (s *DefaultTest) GetLabels() []DefaultTestLabelsItem {
+	return s.Labels
+}
+
 // SetRequired sets the value of Required.
 func (s *DefaultTest) SetRequired(val string) {
 	s.Required = val
@@ -455,6 +609,36 @@ func (s *DefaultTest) SetBase64(val []byte) {
 	s.Base64 = val
 }
 
+// SetStrings sets the value of Strings.
+func (s *DefaultTest) SetStrings(val []string) {
+	s.Strings = val
+}
+
+// SetPriorities sets the value of Priorities.
+func (s *DefaultTest) SetPriorities(val []DefaultTestPrioritiesItem) {
+	s.Priorities = val
+}
+
+// SetNested sets the value of Nested.
+func (s *DefaultTest) SetNested(val [][]int) {
+	s.Nested = val
+}
+
+// SetObjs sets the value of Objs.
+func (s *DefaultTest) SetObjs(val []DefaultTestObjsItem) {
+	s.Objs = val
+}
+
+// SetShapes sets the value of Shapes.
+func (s *DefaultTest) SetShapes(val []DefaultShape) {
+	s.Shapes = val
+}
+
+// SetLabels sets the value of Labels.
+func (s *DefaultTest) SetLabels(val []DefaultTestLabelsItem) {
+	s.Labels = val
+}
+
 type DefaultTestEnum string
 
 const (
@@ -490,6 +674,90 @@ func (s *DefaultTestEnum) UnmarshalText(data []byte) error {
 		return nil
 	case DefaultTestEnumSmol:
 		*s = DefaultTestEnumSmol
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type DefaultTestLabelsItem map[string]string
+
+func (s *DefaultTestLabelsItem) init() DefaultTestLabelsItem {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
+	}
+	return m
+}
+
+type DefaultTestObjsItem struct {
+	Name  OptString `json:"name"`
+	Count OptInt    `json:"count"`
+}
+
+// GetName returns the value of Name.
+func (s *DefaultTestObjsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetCount returns the value of Count.
+func (s *DefaultTestObjsItem) GetCount() OptInt {
+	return s.Count
+}
+
+// SetName sets the value of Name.
+func (s *DefaultTestObjsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetCount sets the value of Count.
+func (s *DefaultTestObjsItem) SetCount(val OptInt) {
+	s.Count = val
+}
+
+type DefaultTestPrioritiesItem string
+
+const (
+	DefaultTestPrioritiesItemLow    DefaultTestPrioritiesItem = "low"
+	DefaultTestPrioritiesItemMedium DefaultTestPrioritiesItem = "medium"
+	DefaultTestPrioritiesItemHigh   DefaultTestPrioritiesItem = "high"
+)
+
+// AllValues returns all DefaultTestPrioritiesItem values.
+func (DefaultTestPrioritiesItem) AllValues() []DefaultTestPrioritiesItem {
+	return []DefaultTestPrioritiesItem{
+		DefaultTestPrioritiesItemLow,
+		DefaultTestPrioritiesItemMedium,
+		DefaultTestPrioritiesItemHigh,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DefaultTestPrioritiesItem) MarshalText() ([]byte, error) {
+	switch s {
+	case DefaultTestPrioritiesItemLow:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemMedium:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemHigh:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalText(data []byte) error {
+	switch DefaultTestPrioritiesItem(data) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+		return nil
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+		return nil
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/internal/integration/sample_api_ns/oas_validators_gen.go
+++ b/internal/integration/sample_api_ns/oas_validators_gen.go
@@ -264,6 +264,56 @@ func (s *DefaultTest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Priorities {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "priorities",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Nested {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nested",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -275,6 +325,19 @@ func (s DefaultTestEnum) Validate() error {
 	case "big":
 		return nil
 	case "smol":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s DefaultTestPrioritiesItem) Validate() error {
+	switch s {
+	case "low":
+		return nil
+	case "medium":
+		return nil
+	case "high":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/internal/integration/sample_api_nsnc/oas_defaults_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_defaults_gen.go
@@ -68,4 +68,118 @@ func (s *DefaultTest) setDefaults() {
 		val, _ := jx.DecodeStr("\"aGVsbG8sIHdvcmxkIQ==\"").Base64()
 		s.Base64 = val
 	}
+	{
+		var defaultVal0 []string
+		{
+			var defaultVal0Elem string
+
+			val := string("all")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Strings = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestPrioritiesItem
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("medium")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem DefaultTestPrioritiesItem
+
+			val := DefaultTestPrioritiesItem("high")
+			defaultVal0Elem = val
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Priorities = defaultVal0
+	}
+	{
+		var defaultVal0 [][]int
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(1)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			{
+				var defaultVal1Elem int
+
+				val := int(2)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		{
+			var defaultVal0Elem []int
+			var defaultVal1 []int
+			{
+				var defaultVal1Elem int
+
+				val := int(3)
+				defaultVal1Elem = val
+				defaultVal1 = append(defaultVal1, defaultVal1Elem)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Nested = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestObjsItem
+		{
+			var defaultVal0Elem DefaultTestObjsItem
+			var defaultVal1 DefaultTestObjsItem
+			{
+
+				val := string("x")
+				defaultVal1.Name.SetTo(val)
+			}
+			{
+
+				val := int(5)
+				defaultVal1.Count.SetTo(val)
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Objs = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultShape
+		{
+			var defaultVal0Elem DefaultShape
+			// The default is well-formed JSON from the spec; a value that does not match a
+			// variant decodes to the zero value (defaults are not variant-checked at gen time).
+			_ = defaultVal0Elem.Decode(jx.DecodeStr("{\"kind\":\"circle\",\"radius\":5}"))
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Shapes = defaultVal0
+	}
+	{
+		var defaultVal0 []DefaultTestLabelsItem
+		{
+			var defaultVal0Elem DefaultTestLabelsItem
+			defaultVal1 := make(DefaultTestLabelsItem, 1)
+			{
+				var defaultVal1Val string
+
+				val := string("x")
+				defaultVal1Val = val
+				defaultVal1["a"] = defaultVal1Val
+			}
+			defaultVal0Elem = defaultVal1
+			defaultVal0 = append(defaultVal0, defaultVal0Elem)
+		}
+		s.Labels = defaultVal0
+	}
 }

--- a/internal/integration/sample_api_nsnc/oas_json_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_json_gen.go
@@ -690,6 +690,334 @@ func (s *DataDescription) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DefaultCircle) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultCircle) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("radius")
+		e.Int(s.Radius)
+	}
+}
+
+var jsonFieldsNameOfDefaultCircle = [2]string{
+	0: "kind",
+	1: "radius",
+}
+
+// Decode decodes DefaultCircle from json.
+func (s *DefaultCircle) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultCircle to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "radius":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Radius = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"radius\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultCircle")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultCircle) {
+					name = jsonFieldsNameOfDefaultCircle[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultCircle) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultCircle) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultShape as json.
+func (s DefaultShape) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s DefaultShape) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		e.FieldStart("kind")
+		e.Str("circle")
+		{
+			s := s.DefaultCircle
+			{
+				e.FieldStart("radius")
+				e.Int(s.Radius)
+			}
+		}
+	case DefaultSquareDefaultShape:
+		e.FieldStart("kind")
+		e.Str("square")
+		{
+			s := s.DefaultSquare
+			{
+				e.FieldStart("side")
+				e.Int(s.Side)
+			}
+		}
+	}
+}
+
+// Decode decodes DefaultShape from json.
+func (s *DefaultShape) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultShape to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "circle":
+					s.Type = DefaultCircleDefaultShape
+					found = true
+				case "square":
+					s.Type = DefaultSquareDefaultShape
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case DefaultCircleDefaultShape:
+		if err := s.DefaultCircle.Decode(d); err != nil {
+			return err
+		}
+	case DefaultSquareDefaultShape:
+		if err := s.DefaultSquare.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultShape) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultShape) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultSquare) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultSquare) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("kind")
+		e.Str(s.Kind)
+	}
+	{
+		e.FieldStart("side")
+		e.Int(s.Side)
+	}
+}
+
+var jsonFieldsNameOfDefaultSquare = [2]string{
+	0: "kind",
+	1: "side",
+}
+
+// Decode decodes DefaultSquare from json.
+func (s *DefaultSquare) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultSquare to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "kind":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Kind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "side":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Side = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"side\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultSquare")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDefaultSquare) {
+					name = jsonFieldsNameOfDefaultSquare[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultSquare) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultSquare) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *DefaultTest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -784,9 +1112,73 @@ func (s *DefaultTest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("base64")
 		e.Base64(s.Base64)
 	}
+	{
+		if s.Strings != nil {
+			e.FieldStart("strings")
+			e.ArrStart()
+			for _, elem := range s.Strings {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Priorities != nil {
+			e.FieldStart("priorities")
+			e.ArrStart()
+			for _, elem := range s.Priorities {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Nested != nil {
+			e.FieldStart("nested")
+			e.ArrStart()
+			for _, elem := range s.Nested {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Int(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Objs != nil {
+			e.FieldStart("objs")
+			e.ArrStart()
+			for _, elem := range s.Objs {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Shapes != nil {
+			e.FieldStart("shapes")
+			e.ArrStart()
+			for _, elem := range s.Shapes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Labels != nil {
+			e.FieldStart("labels")
+			e.ArrStart()
+			for _, elem := range s.Labels {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfDefaultTest = [15]string{
+var jsonFieldsNameOfDefaultTest = [21]string{
 	0:  "required",
 	1:  "str",
 	2:  "nullStr",
@@ -802,6 +1194,12 @@ var jsonFieldsNameOfDefaultTest = [15]string{
 	12: "hostname",
 	13: "format",
 	14: "base64",
+	15: "strings",
+	16: "priorities",
+	17: "nested",
+	18: "objs",
+	19: "shapes",
+	20: "labels",
 }
 
 // Decode decodes DefaultTest from json.
@@ -809,7 +1207,7 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode DefaultTest to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -967,6 +1365,120 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"base64\"")
 			}
+		case "strings":
+			if err := func() error {
+				s.Strings = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Strings = append(s.Strings, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"strings\"")
+			}
+		case "priorities":
+			if err := func() error {
+				s.Priorities = make([]DefaultTestPrioritiesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestPrioritiesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Priorities = append(s.Priorities, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"priorities\"")
+			}
+		case "nested":
+			if err := func() error {
+				s.Nested = make([][]int, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []int
+					elem = make([]int, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem int
+						v, err := d.Int()
+						elemElem = int(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Nested = append(s.Nested, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nested\"")
+			}
+		case "objs":
+			if err := func() error {
+				s.Objs = make([]DefaultTestObjsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestObjsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Objs = append(s.Objs, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"objs\"")
+			}
+		case "shapes":
+			if err := func() error {
+				s.Shapes = make([]DefaultShape, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultShape
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Shapes = append(s.Shapes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"shapes\"")
+			}
+		case "labels":
+			if err := func() error {
+				s.Labels = make([]DefaultTestLabelsItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem DefaultTestLabelsItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Labels = append(s.Labels, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"labels\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -976,8 +1488,9 @@ func (s *DefaultTest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b00000001,
+		0b00000000,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -1060,6 +1573,184 @@ func (s DefaultTestEnum) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *DefaultTestEnum) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s DefaultTestLabelsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s DefaultTestLabelsItem) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes DefaultTestLabelsItem from json.
+func (s *DefaultTestLabelsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestLabelsItem to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestLabelsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestLabelsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestLabelsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DefaultTestObjsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DefaultTestObjsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Count.Set {
+			e.FieldStart("count")
+			s.Count.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDefaultTestObjsItem = [2]string{
+	0: "name",
+	1: "count",
+}
+
+// Decode decodes DefaultTestObjsItem from json.
+func (s *DefaultTestObjsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestObjsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "count":
+			if err := func() error {
+				s.Count.Reset()
+				if err := s.Count.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DefaultTestObjsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DefaultTestObjsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestObjsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DefaultTestPrioritiesItem as json.
+func (s DefaultTestPrioritiesItem) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DefaultTestPrioritiesItem from json.
+func (s *DefaultTestPrioritiesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DefaultTestPrioritiesItem to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DefaultTestPrioritiesItem(v) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
+	default:
+		*s = DefaultTestPrioritiesItem(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DefaultTestPrioritiesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/sample_api_nsnc/oas_parameters_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_parameters_gen.go
@@ -17,7 +17,8 @@ type DataGetFormatParams struct {
 
 // DefaultTestParams is parameters of defaultTest operation.
 type DefaultTestParams struct {
-	Default OptInt32 `json:",omitempty,omitzero"`
+	Default      OptInt32 `json:",omitempty,omitzero"`
+	ArrayDefault []string `json:",omitempty"`
 }
 
 // FoobarGetParams is parameters of foobarGet operation.

--- a/internal/integration/sample_api_nsnc/oas_schemas_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_schemas_gen.go
@@ -286,23 +286,147 @@ func NewDescriptionSimpleDataDescription(v DescriptionSimple) DataDescription {
 	return s
 }
 
+// Ref: #/components/schemas/DefaultCircle
+type DefaultCircle struct {
+	Kind   string `json:"kind"`
+	Radius int    `json:"radius"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultCircle) GetKind() string {
+	return s.Kind
+}
+
+// GetRadius returns the value of Radius.
+func (s *DefaultCircle) GetRadius() int {
+	return s.Radius
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultCircle) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetRadius sets the value of Radius.
+func (s *DefaultCircle) SetRadius(val int) {
+	s.Radius = val
+}
+
+// Ref: #/components/schemas/DefaultShape
+// DefaultShape represents sum type.
+type DefaultShape struct {
+	// Type selects the active sum variant, switch on this field.
+	Type          DefaultShapeType
+	DefaultCircle DefaultCircle
+	DefaultSquare DefaultSquare
+}
+
+// DefaultShapeType is oneOf type of DefaultShape.
+type DefaultShapeType string
+
+// Possible values for DefaultShapeType.
+const (
+	DefaultCircleDefaultShape DefaultShapeType = "circle"
+	DefaultSquareDefaultShape DefaultShapeType = "square"
+)
+
+// IsDefaultCircle reports whether DefaultShape is DefaultCircle.
+func (s DefaultShape) IsDefaultCircle() bool { return s.Type == DefaultCircleDefaultShape }
+
+// IsDefaultSquare reports whether DefaultShape is DefaultSquare.
+func (s DefaultShape) IsDefaultSquare() bool { return s.Type == DefaultSquareDefaultShape }
+
+// SetDefaultCircle sets DefaultShape to DefaultCircle.
+func (s *DefaultShape) SetDefaultCircle(v DefaultCircle) {
+	s.Type = DefaultCircleDefaultShape
+	s.DefaultCircle = v
+}
+
+// GetDefaultCircle returns DefaultCircle and true boolean if DefaultShape is DefaultCircle.
+func (s DefaultShape) GetDefaultCircle() (v DefaultCircle, ok bool) {
+	if !s.IsDefaultCircle() {
+		return v, false
+	}
+	return s.DefaultCircle, true
+}
+
+// NewDefaultCircleDefaultShape returns new DefaultShape from DefaultCircle.
+func NewDefaultCircleDefaultShape(v DefaultCircle) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultCircle(v)
+	return s
+}
+
+// SetDefaultSquare sets DefaultShape to DefaultSquare.
+func (s *DefaultShape) SetDefaultSquare(v DefaultSquare) {
+	s.Type = DefaultSquareDefaultShape
+	s.DefaultSquare = v
+}
+
+// GetDefaultSquare returns DefaultSquare and true boolean if DefaultShape is DefaultSquare.
+func (s DefaultShape) GetDefaultSquare() (v DefaultSquare, ok bool) {
+	if !s.IsDefaultSquare() {
+		return v, false
+	}
+	return s.DefaultSquare, true
+}
+
+// NewDefaultSquareDefaultShape returns new DefaultShape from DefaultSquare.
+func NewDefaultSquareDefaultShape(v DefaultSquare) DefaultShape {
+	var s DefaultShape
+	s.SetDefaultSquare(v)
+	return s
+}
+
+// Ref: #/components/schemas/DefaultSquare
+type DefaultSquare struct {
+	Kind string `json:"kind"`
+	Side int    `json:"side"`
+}
+
+// GetKind returns the value of Kind.
+func (s *DefaultSquare) GetKind() string {
+	return s.Kind
+}
+
+// GetSide returns the value of Side.
+func (s *DefaultSquare) GetSide() int {
+	return s.Side
+}
+
+// SetKind sets the value of Kind.
+func (s *DefaultSquare) SetKind(val string) {
+	s.Kind = val
+}
+
+// SetSide sets the value of Side.
+func (s *DefaultSquare) SetSide(val int) {
+	s.Side = val
+}
+
 // Ref: #/components/schemas/DefaultTest
 type DefaultTest struct {
-	Required string             `json:"required"`
-	Str      OptString          `json:"str"`
-	NullStr  OptNilString       `json:"nullStr"`
-	Enum     OptDefaultTestEnum `json:"enum"`
-	UUID     OptUUID            `json:"uuid"`
-	IP       OptIP              `json:"ip"`
-	IPV4     OptIPv4            `json:"ip_v4"`
-	IPV6     OptIPv6            `json:"ip_v6"`
-	URI      OptURI             `json:"uri"`
-	Birthday OptDate            `json:"birthday"`
-	Rate     OptDuration        `json:"rate"`
-	Email    OptString          `json:"email"`
-	Hostname OptString          `json:"hostname"`
-	Format   OptString          `json:"format"`
-	Base64   []byte             `json:"base64"`
+	Required   string                      `json:"required"`
+	Str        OptString                   `json:"str"`
+	NullStr    OptNilString                `json:"nullStr"`
+	Enum       OptDefaultTestEnum          `json:"enum"`
+	UUID       OptUUID                     `json:"uuid"`
+	IP         OptIP                       `json:"ip"`
+	IPV4       OptIPv4                     `json:"ip_v4"`
+	IPV6       OptIPv6                     `json:"ip_v6"`
+	URI        OptURI                      `json:"uri"`
+	Birthday   OptDate                     `json:"birthday"`
+	Rate       OptDuration                 `json:"rate"`
+	Email      OptString                   `json:"email"`
+	Hostname   OptString                   `json:"hostname"`
+	Format     OptString                   `json:"format"`
+	Base64     []byte                      `json:"base64"`
+	Strings    []string                    `json:"strings"`
+	Priorities []DefaultTestPrioritiesItem `json:"priorities"`
+	Nested     [][]int                     `json:"nested"`
+	Objs       []DefaultTestObjsItem       `json:"objs"`
+	Shapes     []DefaultShape              `json:"shapes"`
+	Labels     []DefaultTestLabelsItem     `json:"labels"`
 }
 
 // GetRequired returns the value of Required.
@@ -380,6 +504,36 @@ func (s *DefaultTest) GetBase64() []byte {
 	return s.Base64
 }
 
+// GetStrings returns the value of Strings.
+func (s *DefaultTest) GetStrings() []string {
+	return s.Strings
+}
+
+// GetPriorities returns the value of Priorities.
+func (s *DefaultTest) GetPriorities() []DefaultTestPrioritiesItem {
+	return s.Priorities
+}
+
+// GetNested returns the value of Nested.
+func (s *DefaultTest) GetNested() [][]int {
+	return s.Nested
+}
+
+// GetObjs returns the value of Objs.
+func (s *DefaultTest) GetObjs() []DefaultTestObjsItem {
+	return s.Objs
+}
+
+// GetShapes returns the value of Shapes.
+func (s *DefaultTest) GetShapes() []DefaultShape {
+	return s.Shapes
+}
+
+// GetLabels returns the value of Labels.
+func (s *DefaultTest) GetLabels() []DefaultTestLabelsItem {
+	return s.Labels
+}
+
 // SetRequired sets the value of Required.
 func (s *DefaultTest) SetRequired(val string) {
 	s.Required = val
@@ -455,6 +609,36 @@ func (s *DefaultTest) SetBase64(val []byte) {
 	s.Base64 = val
 }
 
+// SetStrings sets the value of Strings.
+func (s *DefaultTest) SetStrings(val []string) {
+	s.Strings = val
+}
+
+// SetPriorities sets the value of Priorities.
+func (s *DefaultTest) SetPriorities(val []DefaultTestPrioritiesItem) {
+	s.Priorities = val
+}
+
+// SetNested sets the value of Nested.
+func (s *DefaultTest) SetNested(val [][]int) {
+	s.Nested = val
+}
+
+// SetObjs sets the value of Objs.
+func (s *DefaultTest) SetObjs(val []DefaultTestObjsItem) {
+	s.Objs = val
+}
+
+// SetShapes sets the value of Shapes.
+func (s *DefaultTest) SetShapes(val []DefaultShape) {
+	s.Shapes = val
+}
+
+// SetLabels sets the value of Labels.
+func (s *DefaultTest) SetLabels(val []DefaultTestLabelsItem) {
+	s.Labels = val
+}
+
 type DefaultTestEnum string
 
 const (
@@ -490,6 +674,90 @@ func (s *DefaultTestEnum) UnmarshalText(data []byte) error {
 		return nil
 	case DefaultTestEnumSmol:
 		*s = DefaultTestEnumSmol
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type DefaultTestLabelsItem map[string]string
+
+func (s *DefaultTestLabelsItem) init() DefaultTestLabelsItem {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
+	}
+	return m
+}
+
+type DefaultTestObjsItem struct {
+	Name  OptString `json:"name"`
+	Count OptInt    `json:"count"`
+}
+
+// GetName returns the value of Name.
+func (s *DefaultTestObjsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetCount returns the value of Count.
+func (s *DefaultTestObjsItem) GetCount() OptInt {
+	return s.Count
+}
+
+// SetName sets the value of Name.
+func (s *DefaultTestObjsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetCount sets the value of Count.
+func (s *DefaultTestObjsItem) SetCount(val OptInt) {
+	s.Count = val
+}
+
+type DefaultTestPrioritiesItem string
+
+const (
+	DefaultTestPrioritiesItemLow    DefaultTestPrioritiesItem = "low"
+	DefaultTestPrioritiesItemMedium DefaultTestPrioritiesItem = "medium"
+	DefaultTestPrioritiesItemHigh   DefaultTestPrioritiesItem = "high"
+)
+
+// AllValues returns all DefaultTestPrioritiesItem values.
+func (DefaultTestPrioritiesItem) AllValues() []DefaultTestPrioritiesItem {
+	return []DefaultTestPrioritiesItem{
+		DefaultTestPrioritiesItemLow,
+		DefaultTestPrioritiesItemMedium,
+		DefaultTestPrioritiesItemHigh,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DefaultTestPrioritiesItem) MarshalText() ([]byte, error) {
+	switch s {
+	case DefaultTestPrioritiesItemLow:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemMedium:
+		return []byte(s), nil
+	case DefaultTestPrioritiesItemHigh:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DefaultTestPrioritiesItem) UnmarshalText(data []byte) error {
+	switch DefaultTestPrioritiesItem(data) {
+	case DefaultTestPrioritiesItemLow:
+		*s = DefaultTestPrioritiesItemLow
+		return nil
+	case DefaultTestPrioritiesItemMedium:
+		*s = DefaultTestPrioritiesItemMedium
+		return nil
+	case DefaultTestPrioritiesItemHigh:
+		*s = DefaultTestPrioritiesItemHigh
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/internal/integration/sample_api_nsnc/oas_validators_gen.go
+++ b/internal/integration/sample_api_nsnc/oas_validators_gen.go
@@ -264,6 +264,56 @@ func (s *DefaultTest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Priorities {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "priorities",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Nested {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nested",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -275,6 +325,19 @@ func (s DefaultTestEnum) Validate() error {
 	case "big":
 		return nil
 	case "smol":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s DefaultTestPrioritiesItem) Validate() error {
+	switch s {
+	case "low":
+		return nil
+	case "medium":
+		return nil
+	case "high":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/internal/integration/test_form/oas_request_decoders_gen.go
+++ b/internal/integration/test_form/oas_request_decoders_gen.go
@@ -425,6 +425,7 @@ func (s *Server) decodeTestFormURLEncodedRequest(r *http.Request) (
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+					request.Array = nil
 					return d.DecodeArray(func(d uri.Decoder) error {
 						var requestDotArrayVal string
 						if err := func() error {
@@ -644,6 +645,7 @@ func (s *Server) decodeTestMultipartRequest(r *http.Request) (
 			}
 			if err := q.HasParam(cfg); err == nil {
 				if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+					request.Array = nil
 					return d.DecodeArray(func(d uri.Decoder) error {
 						var requestDotArrayVal string
 						if err := func() error {

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -771,6 +771,7 @@ func decodeOptionalArrayParameterParams(args [0]string, argsEscaped bool, r *htt
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Query = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotQueryVal string
 					if err := func() error {
@@ -812,6 +813,7 @@ func decodeOptionalArrayParameterParams(args [0]string, argsEscaped bool, r *htt
 		}
 		if err := h.HasParam(cfg); err == nil {
 			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Header = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotHeaderVal string
 					if err := func() error {
@@ -1123,6 +1125,7 @@ func decodeOptionalParametersParams(args [0]string, argsEscaped bool, r *http.Re
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotArrayVal string
 					if err := func() error {

--- a/internal/integration/test_type_extension/oas_parameters_gen.go
+++ b/internal/integration/test_type_extension/oas_parameters_gen.go
@@ -787,6 +787,7 @@ func decodeOptionalParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotArrayVal testtypes.StringJSON
 					if err := func() error {
@@ -1447,6 +1448,7 @@ func decodeRequiredParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 
 		if err := q.HasParam(cfg); err == nil {
 			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Array = nil
 				return d.DecodeArray(func(d uri.Decoder) error {
 					var paramsDotArrayVal testtypes.StringJSON
 					if err := func() error {


### PR DESCRIPTION
  ## Summary

  Implements `default` values for array-typed schemas and parameters (closes #1674).
  Previously ogen failed generation with `Feature "array defaults" is not implemented
  yet`, forcing users to either drop the `default` (losing documentation) or set
  `ignore_not_implemented: ["array defaults"]` (which silently skips applying it).

  ogen now generates code that applies an array default when the value is unset — in
  `setDefaults()` for schema properties and during parameter decoding — consistent with
  how scalar defaults already work.

  ## Supported element types

  Defaults are rendered for arrays whose items are, recursively:

  - primitives and formatted primitives (string, int, bool, date, uuid, ip, duration,
    byte/base64, …)
  - enums
  - objects (structs, built field-by-field, including optional fields)
  - maps (`additionalProperties`)
  - nested arrays
  - sum types (`oneOf`/`anyOf`) — constructed via the variant's own generated `Decode`

  ## Not supported (graceful degradation)

  Two shapes are still reported as not-implemented (so `ignore_not_implemented` keeps
  working), since they cannot be rendered as a value literal:

  - tuple / `prefixItems` arrays — `"tuple array defaults"`
  - free-form / typeless items — `"array defaults with free-form items"`

  The sibling `object defaults` and `complex defaults` gates are left unchanged.

  ## Implementation notes

  - `gen/schema_gen.go`: replace the blanket `array defaults` gate with
    `arrayDefaultUnsupported` (rejects only the two shapes above); make
    `checkDefaultType` validate array elements, object properties and
    `additionalProperties` values recursively, and accept `oneOf`/`anyOf` defaults
    (validated at runtime via decode).
  - `gen/templates.go`: render helpers (`defaultSlice`, `defaultStructFields`,
    `defaultMapEntries`, `defaultJSON`) plus depth-based local variable names on
    `DefaultElem` to avoid shadowing in nested literals.
  - `gen/_template/defaults/set.tmpl`: new array/struct/map/sum and
    generic/pointer-complex branches.
  - `gen/_template/uri/decode.tmpl`: reset an array parameter before `DecodeArray` so an
    explicit request value replaces the default instead of appending to it.

  ## Behavior change to note

  Array parameters are now reset to `nil` before decoding. For arrays without a default
  this is a no-op (they already started nil); for arrays with a default it ensures an
  explicit request value *replaces* the default rather than accumulating on top of it.
  This path was previously unreachable because array parameters could not carry defaults.

  ## Tests

  - Unit tests for the gate, the recursive `checkDefaultType`, and the render helpers.
  - A positive fixture (`_testdata/positive/array_defaults.yml`) exercising every element
    kind through generation.
  - Integration tests on `sample_api`: schema-property defaults applied on decode, and a
    query-parameter default applied when absent / overridden when provided, via a real
    client↔server round-trip.
  - `go test ./...`, `go vet ./...` and `golangci-lint run` all pass.

  ## AI disclosure

  This change was produced with the assistance of a coding AI (Claude Code). The design,
  implementation and tests were AI-generated, then reviewed and verified: the full test
  suite and linters pass, and the generated output was inspected for correctness. Please
  review accordingly.
