### PR TITLE
fix(gen): apply x-ogen-name to external types (x-ogen-type)

### DIFF
--- a/_testdata/positive/type_extension_name.yml
+++ b/_testdata/positive/type_extension_name.yml
@@ -38,6 +38,24 @@ paths:
                     x-ogen-name: Decimal2
                     default: 1.23
 
+  /component:
+    get:
+      operationId: component
+      responses:
+        '200':
+          description: Test
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - amount
+                properties:
+                  amount:
+                    $ref: '#/components/schemas/usdAmount'
+                  optionalAmount:
+                    $ref: '#/components/schemas/usdAmount'
+
   /required:
     get:
       operationId: required
@@ -73,3 +91,11 @@ paths:
                     type: number
                     x-ogen-type: github.com/ogen-go/ogen/_testdata/testtypes/bar/decimal.Decimal
                     x-ogen-name: Decimal2
+
+components:
+  schemas:
+    # x-ogen-name must override the component key: type is USDAmount, not UsdAmount.
+    usdAmount:
+      type: string
+      x-ogen-type: github.com/ogen-go/ogen/_testdata/testtypes/foo/decimal.Decimal
+      x-ogen-name: USDAmount

--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -179,6 +179,15 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 		}
 	}
 
+	// Resolve the final type name before any branch that may return early
+	// (e.g. external types via x-ogen-type), so x-ogen-name is always honored.
+	// The DefaultSet and UniqueItems checks below do not depend on name.
+	if n := schema.XOgenName; n != "" {
+		name = n
+	} else if len(name) > 0 && name[0] >= '0' && name[0] <= '9' {
+		name = "R" + name
+	}
+
 	if schema.XOgenType != "" {
 		t, err := ir.External(schema)
 		if err != nil {
@@ -241,12 +250,6 @@ func (g *schemaGen) generate2(name string, schema *jsonschema.Schema) (ret *ir.T
 		if item == nil || item.Type == "" {
 			return nil, &ErrNotImplemented{Name: "empty uniqueItems"}
 		}
-	}
-
-	if n := schema.XOgenName; n != "" {
-		name = n
-	} else if len(name) > 0 && name[0] >= '0' && name[0] <= '9' {
-		name = "R" + name
 	}
 
 	var (

--- a/internal/integration/test_type_extension_name/oas_client_gen.go
+++ b/internal/integration/test_type_extension_name/oas_client_gen.go
@@ -28,6 +28,10 @@ func trimTrailingSlashes(u *url.URL) {
 
 // Invoker invokes operations described by OpenAPI v3 specification.
 type Invoker interface {
+	// Component invokes component operation.
+	//
+	// GET /component
+	Component(ctx context.Context) (*ComponentOK, error)
 	// Optional invokes optional operation.
 	//
 	// GET /optional
@@ -75,6 +79,84 @@ func (c *Client) requestURL(ctx context.Context) *url.URL {
 		return c.serverURL
 	}
 	return u
+}
+
+// Component invokes component operation.
+//
+// GET /component
+func (c *Client) Component(ctx context.Context) (*ComponentOK, error) {
+	res, err := c.sendComponent(ctx)
+	return res, err
+}
+
+func (c *Client) sendComponent(ctx context.Context) (res *ComponentOK, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("component"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/component"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, ComponentOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/component"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeComponentResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
 }
 
 // Optional invokes optional operation.

--- a/internal/integration/test_type_extension_name/oas_handlers_gen.go
+++ b/internal/integration/test_type_extension_name/oas_handlers_gen.go
@@ -33,6 +33,128 @@ func (c *codeRecorder) Unwrap() http.ResponseWriter {
 	return c.ResponseWriter
 }
 
+// handleComponentRequest handles component operation.
+//
+// GET /component
+func (s *Server) handleComponentRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("component"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/component"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), ComponentOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err error
+	)
+
+	var rawBody []byte
+
+	var response *ComponentOK
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    ComponentOperation,
+			OperationSummary: "",
+			OperationID:      "component",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = struct{}
+			Response = *ComponentOK
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.Component(ctx)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.Component(ctx)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeComponentResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleOptionalRequest handles optional operation.
 //
 // GET /optional

--- a/internal/integration/test_type_extension_name/oas_json_gen.go
+++ b/internal/integration/test_type_extension_name/oas_json_gen.go
@@ -14,6 +14,117 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
+// Encode implements json.Marshaler.
+func (s *ComponentOK) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ComponentOK) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("amount")
+		s.Amount.Encode(e)
+	}
+	{
+		if s.OptionalAmount.Set {
+			e.FieldStart("optionalAmount")
+			s.OptionalAmount.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfComponentOK = [2]string{
+	0: "amount",
+	1: "optionalAmount",
+}
+
+// Decode decodes ComponentOK from json.
+func (s *ComponentOK) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ComponentOK to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "amount":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.Amount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"amount\"")
+			}
+		case "optionalAmount":
+			if err := func() error {
+				s.OptionalAmount.Reset()
+				if err := s.OptionalAmount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"optionalAmount\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ComponentOK")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfComponentOK) {
+					name = jsonFieldsNameOfComponentOK[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ComponentOK) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ComponentOK) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes decimal2.Decimal as json.
 func (o OptDecimal) Encode(e *jx.Encoder, format func(*jx.Encoder, decimal2.Decimal)) {
 	if !o.Set {
@@ -82,6 +193,39 @@ func (s OptDecimal2) MarshalJSON() ([]byte, error) {
 func (s *OptDecimal2) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d, json.DecodeExternal[decimal3.Decimal])
+}
+
+// Encode encodes USDAmount as json.
+func (o OptUSDAmount) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes USDAmount from json.
+func (o *OptUSDAmount) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptUSDAmount to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptUSDAmount) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptUSDAmount) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
 }
 
 // Encode implements json.Marshaler.
@@ -274,6 +418,46 @@ func (s *RequiredOK) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *RequiredOK) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes USDAmount as json.
+func (s USDAmount) Encode(e *jx.Encoder) {
+	unwrapped := decimal2.Decimal(s)
+
+	json.EncodeExternal(e, unwrapped)
+}
+
+// Decode decodes USDAmount from json.
+func (s *USDAmount) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode USDAmount to nil")
+	}
+	var unwrapped decimal2.Decimal
+	if err := func() error {
+		v, err := json.DecodeExternal[decimal2.Decimal](d)
+		unwrapped = v
+		if err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = USDAmount(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s USDAmount) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *USDAmount) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/integration/test_type_extension_name/oas_operations_gen.go
+++ b/internal/integration/test_type_extension_name/oas_operations_gen.go
@@ -6,6 +6,7 @@ package api
 type OperationName = string
 
 const (
-	OptionalOperation OperationName = "Optional"
-	RequiredOperation OperationName = "Required"
+	ComponentOperation OperationName = "Component"
+	OptionalOperation  OperationName = "Optional"
+	RequiredOperation  OperationName = "Required"
 )

--- a/internal/integration/test_type_extension_name/oas_response_decoders_gen.go
+++ b/internal/integration/test_type_extension_name/oas_response_decoders_gen.go
@@ -13,6 +13,47 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
+func decodeComponentResponse(resp *http.Response) (res *ComponentOK, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ComponentOK
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeOptionalResponse(resp *http.Response) (res *OptionalOK, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/integration/test_type_extension_name/oas_response_encoders_gen.go
+++ b/internal/integration/test_type_extension_name/oas_response_encoders_gen.go
@@ -10,6 +10,19 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func encodeComponentResponse(response *ComponentOK, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
 func encodeOptionalResponse(response *OptionalOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)

--- a/internal/integration/test_type_extension_name/oas_router_gen.go
+++ b/internal/integration/test_type_extension_name/oas_router_gen.go
@@ -60,6 +60,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 			switch elem[0] {
+			case 'c': // Prefix: "component"
+
+				if l := len("component"); len(elem) >= l && elem[0:l] == "component" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch r.Method {
+					case "GET":
+						s.handleComponentRequest([0]string{}, elemIsEscaped, w, r)
+					default:
+						s.notAllowed(w, r, notAllowedParams{
+							allowedMethods: "GET",
+							allowedHeaders: nil,
+							acceptPost:     "",
+							acceptPatch:    "",
+						})
+					}
+
+					return
+				}
+
 			case 'o': // Prefix: "optional"
 
 				if l := len("optional"); len(elem) >= l && elem[0:l] == "optional" {
@@ -210,6 +235,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				break
 			}
 			switch elem[0] {
+			case 'c': // Prefix: "component"
+
+				if l := len("component"); len(elem) >= l && elem[0:l] == "component" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch method {
+					case "GET":
+						r.name = ComponentOperation
+						r.summary = ""
+						r.operationID = "component"
+						r.operationGroup = ""
+						r.pathPattern = "/component"
+						r.args = args
+						r.count = 0
+						return r, true
+					default:
+						return
+					}
+				}
+
 			case 'o': // Prefix: "optional"
 
 				if l := len("optional"); len(elem) >= l && elem[0:l] == "optional" {

--- a/internal/integration/test_type_extension_name/oas_schemas_gen.go
+++ b/internal/integration/test_type_extension_name/oas_schemas_gen.go
@@ -7,6 +7,31 @@ import (
 	decimal2 "github.com/ogen-go/ogen/_testdata/testtypes/foo/decimal"
 )
 
+type ComponentOK struct {
+	Amount         USDAmount    `json:"amount"`
+	OptionalAmount OptUSDAmount `json:"optionalAmount"`
+}
+
+// GetAmount returns the value of Amount.
+func (s *ComponentOK) GetAmount() USDAmount {
+	return s.Amount
+}
+
+// GetOptionalAmount returns the value of OptionalAmount.
+func (s *ComponentOK) GetOptionalAmount() OptUSDAmount {
+	return s.OptionalAmount
+}
+
+// SetAmount sets the value of Amount.
+func (s *ComponentOK) SetAmount(val USDAmount) {
+	s.Amount = val
+}
+
+// SetOptionalAmount sets the value of OptionalAmount.
+func (s *ComponentOK) SetOptionalAmount(val OptUSDAmount) {
+	s.OptionalAmount = val
+}
+
 // NewOptDecimal returns new OptDecimal with value set to v.
 func NewOptDecimal(v decimal2.Decimal) OptDecimal {
 	return OptDecimal{
@@ -99,6 +124,52 @@ func (o OptDecimal2) Or(d decimal3.Decimal) decimal3.Decimal {
 	return d
 }
 
+// NewOptUSDAmount returns new OptUSDAmount with value set to v.
+func NewOptUSDAmount(v USDAmount) OptUSDAmount {
+	return OptUSDAmount{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptUSDAmount is optional USDAmount.
+type OptUSDAmount struct {
+	Value USDAmount
+	Set   bool
+}
+
+// IsSet returns true if OptUSDAmount was set.
+func (o OptUSDAmount) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptUSDAmount) Reset() {
+	var v USDAmount
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptUSDAmount) SetTo(v USDAmount) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptUSDAmount) Get() (v USDAmount, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptUSDAmount) Or(d USDAmount) USDAmount {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 type OptionalOK struct {
 	Foo OptDecimal  `json:"foo"`
 	Bar OptDecimal2 `json:"bar"`
@@ -148,3 +219,5 @@ func (s *RequiredOK) SetFoo(val decimal2.Decimal) {
 func (s *RequiredOK) SetBar(val decimal3.Decimal) {
 	s.Bar = val
 }
+
+type USDAmount decimal2.Decimal

--- a/internal/integration/test_type_extension_name/oas_server_gen.go
+++ b/internal/integration/test_type_extension_name/oas_server_gen.go
@@ -8,6 +8,10 @@ import (
 
 // Handler handles operations described by OpenAPI v3 specification.
 type Handler interface {
+	// Component implements component operation.
+	//
+	// GET /component
+	Component(ctx context.Context) (*ComponentOK, error)
 	// Optional implements optional operation.
 	//
 	// GET /optional

--- a/internal/integration/test_type_extension_name/oas_unimplemented_gen.go
+++ b/internal/integration/test_type_extension_name/oas_unimplemented_gen.go
@@ -13,6 +13,13 @@ type UnimplementedHandler struct{}
 
 var _ Handler = UnimplementedHandler{}
 
+// Component implements component operation.
+//
+// GET /component
+func (UnimplementedHandler) Component(ctx context.Context) (r *ComponentOK, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // Optional implements optional operation.
 //
 // GET /optional

--- a/internal/integration/type_extension_name_test.go
+++ b/internal/integration/type_extension_name_test.go
@@ -28,6 +28,10 @@ func (h *testTypeNameHandler) Required(ctx context.Context, params api.RequiredP
 	return nil, assert.AnError
 }
 
+func (h *testTypeNameHandler) Component(ctx context.Context) (*api.ComponentOK, error) {
+	return nil, assert.AnError
+}
+
 type testTypeNameClient struct {
 	request *http.Request
 }
@@ -138,5 +142,25 @@ func TestTypeExtensionName_JSON(t *testing.T) {
 		var p api.OptionalOK
 		a.NoError(p.Decode(jx.DecodeStr(`{}`)))
 		a.Equal(expected, p)
+	})
+
+	// Component schema with x-ogen-type + x-ogen-name: the type must be named
+	// USDAmount (from x-ogen-name), not UsdAmount (from the "usdAmount" key).
+	t.Run("Component", func(t *testing.T) {
+		input := `{ "amount": "0.1", "optionalAmount": "0.2" }`
+
+		expected := api.ComponentOK{
+			Amount:         api.USDAmount("0.1"),
+			OptionalAmount: api.NewOptUSDAmount(api.USDAmount("0.2")),
+		}
+
+		a := require.New(t)
+		var p api.ComponentOK
+		a.NoError(p.Decode(jx.DecodeStr(input)))
+		a.Equal(expected, p)
+
+		out, err := p.MarshalJSON()
+		a.NoError(err)
+		a.JSONEq(input, string(out))
 	})
 }


### PR DESCRIPTION
## Problem

A component schema combining `x-ogen-type` (external Go type mapping) and `x-ogen-name` (type name override) ignores `x-ogen-name`. The generated type is named after the component key instead of the override.

```yaml
components:
  schemas:
    usdAmount:
      type: string
      x-ogen-type: github.com/me/money.Decimal
      x-ogen-name: USDAmount
```

- Expected: `type USDAmount money.Decimal`
- Actual: `type UsdAmount money.Decimal` (PascalCase of the key `usdAmount`; `x-ogen-name` ignored)

`x-ogen-name` works for plain (non-external) schemas — only external types were affected.

## Cause

In `schemaGen.generate2` (`gen/schema_gen.go`), the `x-ogen-type` branch builds the external type and returns early, *before* the name-override block below it is reached. So the name stays the component-key-derived one.

## Fix

Move the name resolution above the `x-ogen-type` branch so it always applies. The intervening `DefaultSet` and `UniqueItems` checks do not depend on `name`, so behavior for all other schemas is unchanged.

A side effect: external types now also get the `R` prefix for digit-leading names (previously skipped via the early return) — this only turns a previously-invalid Go identifier into a valid one.

## Tests

- Added a component-schema case (`x-ogen-type` + `x-ogen-name`) to `_testdata/positive/type_extension_name.yml`. The schema key `usdAmount` PascalCases to `UsdAmount`, while `x-ogen-name: USDAmount` is the Go-idiomatic spelling; the test reuses an existing testdata external type to avoid adding a dependency.
- Regenerated the golden package and added a regression test (`TestTypeExtensionName_JSON/Component`).
- `go generate ./...` changes only the `test_type_extension_name` package; no other golden output is affected.

### Before / after (generated)

```go
// before — name derived from the "usdAmount" component key
type UsdAmount decimal.Decimal   // OptUsdAmount, NewOptUsdAmount, ...
// after — name from x-ogen-name
type USDAmount decimal.Decimal   // OptUSDAmount, NewOptUSDAmount, ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)