### PR TITLE
refactor(gen): rename naming/initialisms to naming/camel_initialisms

### DIFF
--- a/gen/features.go
+++ b/gen/features.go
@@ -141,8 +141,8 @@ var (
 		"debug/example_tests",
 		`Enables example tests generation`,
 	}
-	NamingInitialisms = Feature{
-		"naming/initialisms",
+	NamingCamelInitialisms = Feature{
+		"naming/camel_initialisms",
 		`Applies initialism rules (ID, URL, HTTP, ...) to camelCase identifiers, ` +
 			`e.g. "userId" becomes "UserID". Opt-in, since it changes generated names.`,
 	}
@@ -172,5 +172,5 @@ var AllFeatures = []Feature{
 	OgenOtel,
 	OgenUnimplemented,
 	DebugExampleTests,
-	NamingInitialisms,
+	NamingCamelInitialisms,
 }

--- a/gen/gen_initialisms_test.go
+++ b/gen/gen_initialisms_test.go
@@ -39,7 +39,7 @@ func TestInitialismsFeatureE2E(t *testing.T) {
 	gen := func(t *testing.T, enable bool) map[string]struct{} {
 		opts := Options{}
 		if enable {
-			opts.Generator.Features = &FeatureOptions{Enable: FeatureSet{NamingInitialisms.Name: {}}}
+			opts.Generator.Features = &FeatureOptions{Enable: FeatureSet{NamingCamelInitialisms.Name: {}}}
 		}
 		g, err := NewGenerator(spec, opts)
 		require.NoError(t, err)

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -39,7 +39,7 @@ type Generator struct {
 	equalitySpecs     []*ir.EqualityMethodSpec // Types requiring Equal() methods for uniqueItems validation
 
 	features    FeatureSet // resolved feature set, built once in NewGenerator
-	initialisms bool       // NamingInitialisms feature: apply initialism rules to camelCase identifiers
+	initialisms bool       // NamingCamelInitialisms feature: apply initialism rules to camelCase identifiers
 
 	log *zap.Logger
 }
@@ -127,13 +127,13 @@ func NewGenerator(spec *ogen.Spec, opts Options) (*Generator, error) {
 	}
 
 	// Resolve features once, here, because identifier generation during makeIR
-	// already depends on them (NamingInitialisms); the write stage reuses the
+	// already depends on them (NamingCamelInitialisms); the write stage reuses the
 	// same set via g.features instead of rebuilding it.
 	g.features, err = g.opt.Features.Build()
 	if err != nil {
 		return nil, errors.Wrap(err, "build features")
 	}
-	g.initialisms = g.features.Has(NamingInitialisms)
+	g.initialisms = g.features.Has(NamingCamelInitialisms)
 
 	if err := g.makeIR(api); err != nil {
 		return nil, errors.Wrap(err, "make ir")

--- a/gen/names.go
+++ b/gen/names.go
@@ -179,7 +179,7 @@ func (g *nameGen) checkPart(part string) string {
 //
 // The zero value preserves ogen's historical naming behavior. A namer with
 // initialisms set additionally applies the initialism rules to camelCase input
-// (see nameGen.initialisms and the [NamingInitialisms] feature).
+// (see nameGen.initialisms and the [NamingCamelInitialisms] feature).
 type namer struct {
 	initialisms bool
 }
@@ -241,7 +241,7 @@ func (n namer) camelSpecial(s ...string) (string, error) {
 
 // Package-level helpers (initialisms disabled) for callers without a configured
 // namer: standalone funcs on already-generated names and template helpers.
-// Naming that honors [NamingInitialisms] uses a namer instead (see Generator.namer).
+// Naming that honors [NamingCamelInitialisms] uses a namer instead (see Generator.namer).
 
 func pascal(strs ...string) (string, error) { return namer{}.pascal(strs...) }
 

--- a/gen/names_test.go
+++ b/gen/names_test.go
@@ -24,7 +24,7 @@ func TestNames(t *testing.T) {
 		{"foo+bar", "FooBar", false, false, false},
 		{"+1", "Plus1", true, false, false},
 
-		// NamingInitialisms feature: lower->upper transitions inside a
+		// NamingCamelInitialisms feature: lower->upper transitions inside a
 		// camelCase token are treated as word boundaries, so the initialism
 		// rules fire on camelCase input the same way they do on snake_case.
 		{"userId", "UserID", false, true, false},

--- a/gen/schema_gen.go
+++ b/gen/schema_gen.go
@@ -34,7 +34,7 @@ type schemaGen struct {
 	depthCount int
 
 	request     bool // true if generating for request body
-	initialisms bool // NamingInitialisms feature: apply initialism rules to camelCase identifiers
+	initialisms bool // NamingCamelInitialisms feature: apply initialism rules to camelCase identifiers
 
 	log *zap.Logger
 }

--- a/schemas/ogen.jsonschema.json
+++ b/schemas/ogen.jsonschema.json
@@ -107,7 +107,7 @@
                   "ogen/otel",
                   "ogen/unimplemented",
                   "debug/example_tests",
-                  "naming/initialisms"
+                  "naming/camel_initialisms"
                 ],
                 "enumDescriptions": [
                   "Generate client code for API paths.",
@@ -152,7 +152,7 @@
                   "ogen/otel",
                   "ogen/unimplemented",
                   "debug/example_tests",
-                  "naming/initialisms"
+                  "naming/camel_initialisms"
                 ],
                 "enumDescriptions": [
                   "Disable client code generation for API paths.",

--- a/schemas/ogen.jsonschema.yml
+++ b/schemas/ogen.jsonschema.yml
@@ -115,7 +115,7 @@ properties:
                 - "ogen/otel"
                 - "ogen/unimplemented"
                 - "debug/example_tests"
-                - "naming/initialisms"
+                - "naming/camel_initialisms"
               enumDescriptions:
                 - "Generate client code for API paths."
                 - "Generate server code for API paths."
@@ -158,7 +158,7 @@ properties:
                 - "ogen/otel"
                 - "ogen/unimplemented"
                 - "debug/example_tests"
-                - "naming/initialisms"
+                - "naming/camel_initialisms"
               enumDescriptions:
                 - "Disable client code generation for API paths."
                 - "Disable server code generation for API paths."


### PR DESCRIPTION
## Summary

Follow-up to #1695, where I named this flag `naming/initialisms`. That name didn't accurately capture its scope, so I'm renaming it here — apologies for the churn.

The feature only affects **camelCase** input — delimiter-separated initialisms (`user_id` → `UserID`) already worked by default. The old name implied it toggled initialism handling wholesale, which was misleading. Renamed to `naming/camel_initialisms`, matching the snake_case segment convention of `debug/example_tests`.

## Changes

- Flag string: `naming/initialisms` → `naming/camel_initialisms`
- Go identifier: `NamingInitialisms` → `NamingCamelInitialisms`
- `schemas/ogen.jsonschema.{json,yml}` updated

## Safe to rename

#1695 is **not in any tag yet** (latest release v1.22.0 predates the merge), so no released users depend on the old name. The flag is opt-in and not in `DefaultFeatures`, so default output is unaffected either way.

Note: draft #1700 (configurable initialisms) builds on this area and will need a trivial rebase after this lands.

Refs #1693, #1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)