### PR TITLE
fix(gen): report unimplemented SSE server response encoding at IR time

### DIFF
--- a/_testdata/positive/issue1710.yml
+++ b/_testdata/positive/issue1710.yml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: SSE server response encoding regression (issue 1710)
+  version: 1.0.0
+paths:
+  /events:
+    get:
+      operationId: getEvents
+      responses:
+        "200":
+          description: Event stream.
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/EventOut'
+components:
+  schemas:
+    EventOut:
+      type: object
+      properties:
+        id:
+          type: string
+        data:
+          type: string
+      required: [id, data]

--- a/_testdata/positive/issue1710_stream.yml
+++ b/_testdata/positive/issue1710_stream.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Binary stream SSE response generates without SSE mode (issue 1710)
+  version: 1.0.0
+paths:
+  /events:
+    get:
+      operationId: getEvents
+      responses:
+        "200":
+          description: Raw event stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                format: binary

--- a/gen/gen_operation.go
+++ b/gen/gen_operation.go
@@ -62,6 +62,20 @@ func (g *Generator) generateOperation(ctx *genctx, webhookName string, spec *ope
 		return nil, errors.Wrap(err, "responses")
 	}
 
+	// Report unimplemented SSE server response encoding here, during IR
+	// generation, so that `ignore_not_implemented` skips the operation
+	// cleanly and the error is raised before the target directory is
+	// cleaned, instead of failing at template execution time.
+	if op.HasSSEStreamResponse() {
+		serverEnabled := g.features.Has(PathsServer)
+		if webhookName != "" {
+			serverEnabled = g.features.Has(WebhooksServer)
+		}
+		if serverEnabled {
+			return nil, errors.Wrap(&ErrNotImplemented{Name: "sse server response encoding"}, "responses")
+		}
+	}
+
 	op.Security, err = g.generateSecurities(ctx, opName, spec.Security)
 	if err != nil {
 		return nil, errors.Wrap(err, "security")

--- a/gen_test.go
+++ b/gen_test.go
@@ -142,6 +142,9 @@ func TestGenerate(t *testing.T) {
 			"content_header_response.json": {
 				"parameter content encoding",
 			},
+			"issue1710.yml": {
+				"sse server response encoding",
+			},
 		}))
 
 	t.Run("Examples", runPositive("_testdata/examples",

--- a/openapi/parser/parse_mediatype.go
+++ b/openapi/parser/parse_mediatype.go
@@ -248,22 +248,22 @@ func (p *parser) parseMediaType(ct string, m ogen.Media, ctx *jsonpointer.Resolv
 // isBinaryStreamSchema reports whether s describes a raw byte stream that
 // the generator lowers to io.Reader rather than a structured type.
 //
-// Keep in sync with gen.isStream.
+// This is intentionally narrower than gen.isStream: schemas without an
+// explicit type (e.g. oneOf sums) stay in SSE mode, since typed events are
+// the primary SSE use case, while only schema-less media and explicit
+// string/binary schemas keep the legacy io.Reader behavior.
 func isBinaryStreamSchema(s *jsonschema.Schema) bool {
 	if s == nil {
 		return true
 	}
-
-	switch s.Type {
-	case jsonschema.Empty, jsonschema.String:
-	default:
+	if s.Type != jsonschema.String {
 		return false
 	}
 
 	switch s.Format {
 	case "", "binary", "byte", "base64":
+		return true
 	default:
 		return false
 	}
-	return true
 }

--- a/openapi/parser/parse_mediatype.go
+++ b/openapi/parser/parse_mediatype.go
@@ -225,7 +225,10 @@ func (p *parser) parseMediaType(ct string, m ogen.Media, ctx *jsonpointer.Resolv
 				err := errors.Errorf("unknown SSE event shape %q", value)
 				return nil, p.wrapField(extensionName, p.file(ctx), locator, err)
 			}
-		} else if ct == "text/event-stream" && !rawResponse {
+		} else if ct == "text/event-stream" && !rawResponse && !isBinaryStreamSchema(s) {
+			// Do not auto-enable SSE for raw byte stream schemas: the
+			// generator lowers them to io.Reader, which was the only way
+			// to describe an SSE response before typed SSE support.
 			sseShape = openapi.SSEEventShapeDataOnly
 		}
 	}
@@ -240,4 +243,27 @@ func (p *parser) parseMediaType(ct string, m ogen.Media, ctx *jsonpointer.Resolv
 		XOgenSSEEventShape: sseShape,
 		Pointer:            locator.Pointer(p.file(ctx)),
 	}, nil
+}
+
+// isBinaryStreamSchema reports whether s describes a raw byte stream that
+// the generator lowers to io.Reader rather than a structured type.
+//
+// Keep in sync with gen.isStream.
+func isBinaryStreamSchema(s *jsonschema.Schema) bool {
+	if s == nil {
+		return true
+	}
+
+	switch s.Type {
+	case jsonschema.Empty, jsonschema.String:
+	default:
+		return false
+	}
+
+	switch s.Format {
+	case "", "binary", "byte", "base64":
+	default:
+		return false
+	}
+	return true
 }

--- a/openapi/parser/parse_mediatype_test.go
+++ b/openapi/parser/parse_mediatype_test.go
@@ -74,6 +74,22 @@ func TestParseMediaTypeSSEShapeBinaryStreamDefault(t *testing.T) {
 	}
 }
 
+func TestParseMediaTypeSSEShapeSumDefault(t *testing.T) {
+	// Schemas without an explicit type, e.g. oneOf sums, must stay in SSE mode.
+	api, err := parser.Parse(sseSpec(ogen.Media{
+		Schema: &ogen.Schema{
+			OneOf: []*ogen.Schema{
+				{Type: "object"},
+				{Type: "string"},
+			},
+		},
+	}), parser.Settings{})
+	require.NoError(t, err)
+
+	media := api.Operations[0].Responses.StatusCode[200].Content["text/event-stream"]
+	require.Equal(t, openapi.SSEEventShapeDataOnly, media.XOgenSSEEventShape)
+}
+
 func TestParseMediaTypeSSEShapeBinaryStreamExplicit(t *testing.T) {
 	api, err := parser.Parse(sseSpec(ogen.Media{
 		Schema: &ogen.Schema{Type: "string"},

--- a/openapi/parser/parse_mediatype_test.go
+++ b/openapi/parser/parse_mediatype_test.go
@@ -56,6 +56,39 @@ func TestParseMediaTypeSSEShapeDefault(t *testing.T) {
 	require.Equal(t, openapi.SSEEventShapeDataOnly, media.XOgenSSEEventShape)
 }
 
+func TestParseMediaTypeSSEShapeBinaryStreamDefault(t *testing.T) {
+	for name, schema := range map[string]*ogen.Schema{
+		"no schema":     nil,
+		"string":        {Type: "string"},
+		"binary string": {Type: "string", Format: "binary"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			api, err := parser.Parse(sseSpec(ogen.Media{
+				Schema: schema,
+			}), parser.Settings{})
+			require.NoError(t, err)
+
+			media := api.Operations[0].Responses.StatusCode[200].Content["text/event-stream"]
+			require.Equal(t, openapi.SSEEventShapeNone, media.XOgenSSEEventShape)
+		})
+	}
+}
+
+func TestParseMediaTypeSSEShapeBinaryStreamExplicit(t *testing.T) {
+	api, err := parser.Parse(sseSpec(ogen.Media{
+		Schema: &ogen.Schema{Type: "string"},
+		Common: ogen.OpenAPICommon{
+			Extensions: ogen.Extensions{
+				"x-ogen-sse-event-shape": extensionString("data-only"),
+			},
+		},
+	}), parser.Settings{})
+	require.NoError(t, err)
+
+	media := api.Operations[0].Responses.StatusCode[200].Content["text/event-stream"]
+	require.Equal(t, openapi.SSEEventShapeDataOnly, media.XOgenSSEEventShape)
+}
+
 func TestParseMediaTypeSSEShapeFull(t *testing.T) {
 	api, err := parser.Parse(sseSpec(ogen.Media{
 		Schema: &ogen.Schema{Type: "object"},


### PR DESCRIPTION
## What

Two fixes for the v1.22.0 SSE regression:

1. **`openapi/parser`**: only auto-enable SSE mode for `text/event-stream` media when the schema is *not* a raw byte stream (`type: string` / `format: binary` / no schema, mirroring `gen.isStream`). Such schemas fall back to the pre-v1.22 `io.Reader` path and generate a working `Content-Type: text/event-stream` + `io.Copy` response encoder again — verified byte-for-byte equivalent behavior against a real v1.20.3 checkout. An explicit `x-ogen-sse-event-shape` extension is still honored regardless of the schema.
2. **`gen`**: for typed (structured-schema) SSE responses, which server generation genuinely does not support yet, raise `ErrNotImplemented("sse server response encoding")` during IR generation (only when `paths/server` / `webhooks/server` is enabled) instead of failing inside `WriteSource` at template-execution time.

Fixes #1710

## Why

Since v1.22.0 the parser auto-treats **every** `text/event-stream` response as typed SSE:

- Raw-stream schemas that generated a functional encoder in v1.20.3 (binary passthrough) now route to the unimplemented SSE server encoder and hard-fail — a true regression, restored by fix 1.
- The unimplemented-feature error fired inside `WriteSource`, i.e. **after** `--clean` wiped the target directory and **outside** the `fail()`/`trySkip` machinery, so `--clean` destroyed working projects, and `ignore_not_implemented: ["sse server response encoding"]` did not suppress the error — fixed by 2.

Note: structured (non-stream) schemas under `text/event-stream`, such as the object schema in the issue's minimal repro, did **not** generate in v1.20.3 either (`Content type "text/event-stream" is unsupported`); with this PR they fail cleanly and skippably until server-side typed SSE encoding is implemented. Client-only generation of typed SSE (server features disabled) is unaffected.

## After this change

- `text/event-stream` + binary/raw-stream schema: generates a working `io.Reader`-based server encoder, as in v1.20.3.
- `text/event-stream` + structured schema, server enabled: error surfaces during IR building, **before** `--clean` runs; `ignore_not_implemented` skips the operation via `trySkip` and the generated package compiles.
- Client-only typed SSE: unchanged.

## Testing

- `_testdata/positive/issue1710_stream.yml` — binary-stream SSE spec generating with no ignore rules.
- `_testdata/positive/issue1710.yml` — the issue's object-schema repro with the `sse server response encoding` skip rule; the harness asserts the rule is genuinely exercised. Fails without the `gen` fix, passes with it.
- Parser unit tests: no auto-SSE for nil/string/binary schemas; explicit extension still honored.
- End-to-end: default run fails before writing/cleaning anything; with the ignore config output compiles; binary-schema output compiles and matches v1.20.3's file set.
- `go test . ./gen/... ./openapi/... ./cmd/...` green (includes wikimedia/openai SSE example specs).