### PR TITLE
feat(gen): space delimited query style

### DIFF
--- a/_testdata/positive/parameters.json
+++ b/_testdata/positive/parameters.json
@@ -128,6 +128,70 @@
         }
       }
     },
+    "/spaceDelimitedParameter": {
+      "get": {
+        "operationId": "spaceDelimitedParameter",
+        "summary": "Test for spaceDelimited style query array parameters",
+        "parameters": [
+          {
+            "name": "exploded",
+            "in": "query",
+            "required": true,
+            "style": "spaceDelimited",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "joined",
+            "in": "query",
+            "required": true,
+            "style": "spaceDelimited",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "exploded",
+                    "joined"
+                  ],
+                  "properties": {
+                    "exploded": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "joined": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/objectQueryParameter": {
       "get": {
         "operationId": "objectQueryParameter",

--- a/gen/gen_parameters.go
+++ b/gen/gen_parameters.go
@@ -274,7 +274,9 @@ func isParamAllowed(t *ir.Type, root bool, visited map[*ir.Type]struct{}) error 
 func isSupportedParamStyle(param *openapi.Parameter) error {
 	switch param.Style {
 	case openapi.QueryStyleSpaceDelimited:
-		return &ErrNotImplemented{Name: "spaceDelimited parameter style"}
+		if s := param.Schema; s != nil && s.Type == jsonschema.Object {
+			return &ErrNotImplemented{Name: "spaceDelimited style for object parameters"}
+		}
 
 	case openapi.QueryStylePipeDelimited:
 		if s := param.Schema; s != nil && s.Type == jsonschema.Object {

--- a/internal/integration/parameters_test.go
+++ b/internal/integration/parameters_test.go
@@ -90,6 +90,13 @@ func (s *testParameters) SimilarNames(ctx context.Context, params api.SimilarNam
 	panic("implement me")
 }
 
+func (s *testParameters) SpaceDelimitedParameter(ctx context.Context, params api.SpaceDelimitedParameterParams) (*api.SpaceDelimitedParameterOK, error) {
+	return &api.SpaceDelimitedParameterOK{
+		Exploded: params.Exploded,
+		Joined:   params.Joined,
+	}, nil
+}
+
 func TestParameters(t *testing.T) {
 	ctx := context.Background()
 
@@ -130,6 +137,18 @@ func TestParameters(t *testing.T) {
 		resp, err := client.ObjectCookieParameter(ctx, api.ObjectCookieParameterParams{Value: oneLevel})
 		require.NoError(t, err)
 		require.Equal(t, oneLevel, *resp)
+	})
+
+	t.Run("SpaceDelimitedParameter", func(t *testing.T) {
+		exploded := []string{"a", "b", "c"}
+		joined := []string{"1", "2", "3"}
+		resp, err := client.SpaceDelimitedParameter(ctx, api.SpaceDelimitedParameterParams{
+			Exploded: exploded,
+			Joined:   joined,
+		})
+		require.NoError(t, err)
+		require.Equal(t, exploded, resp.Exploded)
+		require.Equal(t, joined, resp.Joined)
 	})
 
 	const plainParam = "`\"';,./<>?[]{}\\|~!@#$%^&*()_+-="

--- a/internal/integration/test_parameters/oas_client_gen.go
+++ b/internal/integration/test_parameters/oas_client_gen.go
@@ -83,6 +83,12 @@ type Invoker interface {
 	//
 	// GET /similarNames
 	SimilarNames(ctx context.Context, params SimilarNamesParams) error
+	// SpaceDelimitedParameter invokes spaceDelimitedParameter operation.
+	//
+	// Test for spaceDelimited style query array parameters.
+	//
+	// GET /spaceDelimitedParameter
+	SpaceDelimitedParameter(ctx context.Context, params SpaceDelimitedParameterParams) (*SpaceDelimitedParameterOK, error)
 }
 
 // Client implements OAS client.
@@ -1481,6 +1487,136 @@ func (c *Client) sendSimilarNames(ctx context.Context, params SimilarNamesParams
 
 	stage = "DecodeResponse"
 	result, err := decodeSimilarNamesResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// SpaceDelimitedParameter invokes spaceDelimitedParameter operation.
+//
+// Test for spaceDelimited style query array parameters.
+//
+// GET /spaceDelimitedParameter
+func (c *Client) SpaceDelimitedParameter(ctx context.Context, params SpaceDelimitedParameterParams) (*SpaceDelimitedParameterOK, error) {
+	res, err := c.sendSpaceDelimitedParameter(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendSpaceDelimitedParameter(ctx context.Context, params SpaceDelimitedParameterParams) (res *SpaceDelimitedParameterOK, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("spaceDelimitedParameter"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/spaceDelimitedParameter"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, SpaceDelimitedParameterOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/spaceDelimitedParameter"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeQueryParams"
+	q := uri.NewQueryEncoder()
+	{
+		// Encode "exploded" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "exploded",
+			Style:   uri.QueryStyleSpaceDelimited,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeArray(func(e uri.Encoder) error {
+				for i, item := range params.Exploded {
+					if err := func() error {
+						return e.EncodeValue(conv.StringToString(item))
+					}(); err != nil {
+						return errors.Wrapf(err, "[%d]", i)
+					}
+				}
+				return nil
+			})
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "joined" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "joined",
+			Style:   uri.QueryStyleSpaceDelimited,
+			Explode: false,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeArray(func(e uri.Encoder) error {
+				for i, item := range params.Joined {
+					if err := func() error {
+						return e.EncodeValue(conv.StringToString(item))
+					}(); err != nil {
+						return errors.Wrapf(err, "[%d]", i)
+					}
+				}
+				return nil
+			})
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	u.RawQuery = q.Values().Encode()
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeSpaceDelimitedParameterResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/integration/test_parameters/oas_handlers_gen.go
+++ b/internal/integration/test_parameters/oas_handlers_gen.go
@@ -1656,3 +1656,150 @@ func (s *Server) handleSimilarNamesRequest(args [0]string, argsEscaped bool, w h
 		return
 	}
 }
+
+// handleSpaceDelimitedParameterRequest handles spaceDelimitedParameter operation.
+//
+// Test for spaceDelimited style query array parameters.
+//
+// GET /spaceDelimitedParameter
+func (s *Server) handleSpaceDelimitedParameterRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("spaceDelimitedParameter"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/spaceDelimitedParameter"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), SpaceDelimitedParameterOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: SpaceDelimitedParameterOperation,
+			ID:   "spaceDelimitedParameter",
+		}
+	)
+	params, err := decodeSpaceDelimitedParameterParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response *SpaceDelimitedParameterOK
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    SpaceDelimitedParameterOperation,
+			OperationSummary: "Test for spaceDelimited style query array parameters",
+			OperationID:      "spaceDelimitedParameter",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "exploded",
+					In:   "query",
+				}: params.Exploded,
+				{
+					Name: "joined",
+					In:   "query",
+				}: params.Joined,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = SpaceDelimitedParameterParams
+			Response = *SpaceDelimitedParameterOK
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackSpaceDelimitedParameterParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.SpaceDelimitedParameter(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.SpaceDelimitedParameter(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeSpaceDelimitedParameterResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}

--- a/internal/integration/test_parameters/oas_json_gen.go
+++ b/internal/integration/test_parameters/oas_json_gen.go
@@ -824,6 +824,143 @@ func (s *OptionalQueryParametersResponseObject) UnmarshalJSON(data []byte) error
 }
 
 // Encode implements json.Marshaler.
+func (s *SpaceDelimitedParameterOK) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *SpaceDelimitedParameterOK) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("exploded")
+		e.ArrStart()
+		for _, elem := range s.Exploded {
+			e.Str(elem)
+		}
+		e.ArrEnd()
+	}
+	{
+		e.FieldStart("joined")
+		e.ArrStart()
+		for _, elem := range s.Joined {
+			e.Str(elem)
+		}
+		e.ArrEnd()
+	}
+}
+
+var jsonFieldsNameOfSpaceDelimitedParameterOK = [2]string{
+	0: "exploded",
+	1: "joined",
+}
+
+// Decode decodes SpaceDelimitedParameterOK from json.
+func (s *SpaceDelimitedParameterOK) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SpaceDelimitedParameterOK to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "exploded":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				s.Exploded = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Exploded = append(s.Exploded, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"exploded\"")
+			}
+		case "joined":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				s.Joined = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Joined = append(s.Joined, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"joined\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode SpaceDelimitedParameterOK")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfSpaceDelimitedParameterOK) {
+					name = jsonFieldsNameOfSpaceDelimitedParameterOK[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SpaceDelimitedParameterOK) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SpaceDelimitedParameterOK) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *User) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/internal/integration/test_parameters/oas_operations_gen.go
+++ b/internal/integration/test_parameters/oas_operations_gen.go
@@ -17,4 +17,5 @@ const (
 	PathParameterOperation               OperationName = "PathParameter"
 	SameNameOperation                    OperationName = "SameName"
 	SimilarNamesOperation                OperationName = "SimilarNames"
+	SpaceDelimitedParameterOperation     OperationName = "SpaceDelimitedParameter"
 )

--- a/internal/integration/test_parameters/oas_parameters_gen.go
+++ b/internal/integration/test_parameters/oas_parameters_gen.go
@@ -1436,3 +1436,140 @@ func decodeSimilarNamesParams(args [0]string, argsEscaped bool, r *http.Request)
 	}
 	return params, nil
 }
+
+// SpaceDelimitedParameterParams is parameters of spaceDelimitedParameter operation.
+type SpaceDelimitedParameterParams struct {
+	Exploded []string `json:",omitempty"`
+	Joined   []string `json:",omitempty"`
+}
+
+func unpackSpaceDelimitedParameterParams(packed middleware.Parameters) (params SpaceDelimitedParameterParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "exploded",
+			In:   "query",
+		}
+		params.Exploded = packed[key].([]string)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "joined",
+			In:   "query",
+		}
+		params.Joined = packed[key].([]string)
+	}
+	return params
+}
+
+func decodeSpaceDelimitedParameterParams(args [0]string, argsEscaped bool, r *http.Request) (params SpaceDelimitedParameterParams, _ error) {
+	q := uri.NewQueryDecoder(r.URL.Query())
+	// Decode query: exploded.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "exploded",
+			Style:   uri.QueryStyleSpaceDelimited,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Exploded = nil
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotExplodedVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotExplodedVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.Exploded = append(params.Exploded, paramsDotExplodedVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if params.Exploded == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "exploded",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: joined.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "joined",
+			Style:   uri.QueryStyleSpaceDelimited,
+			Explode: false,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				params.Joined = nil
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotJoinedVal string
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotJoinedVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.Joined = append(params.Joined, paramsDotJoinedVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if params.Joined == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "joined",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	return params, nil
+}

--- a/internal/integration/test_parameters/oas_response_decoders_gen.go
+++ b/internal/integration/test_parameters/oas_response_decoders_gen.go
@@ -378,3 +378,53 @@ func decodeSimilarNamesResponse(resp *http.Response) (res *SimilarNamesOK, _ err
 	}
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
+
+func decodeSpaceDelimitedParameterResponse(resp *http.Response) (res *SpaceDelimitedParameterOK, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response SpaceDelimitedParameterOK
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}

--- a/internal/integration/test_parameters/oas_response_encoders_gen.go
+++ b/internal/integration/test_parameters/oas_response_encoders_gen.go
@@ -131,3 +131,16 @@ func encodeSimilarNamesResponse(response *SimilarNamesOK, w http.ResponseWriter,
 
 	return nil
 }
+
+func encodeSpaceDelimitedParameterResponse(response *SpaceDelimitedParameterOK, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}

--- a/internal/integration/test_parameters/oas_router_gen.go
+++ b/internal/integration/test_parameters/oas_router_gen.go
@@ -452,6 +452,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
+				case 'p': // Prefix: "paceDelimitedParameter"
+
+					if l := len("paceDelimitedParameter"); len(elem) >= l && elem[0:l] == "paceDelimitedParameter" {
+						elem = elem[l:]
+					} else {
+						break
+					}
+
+					if len(elem) == 0 {
+						// Leaf node.
+						switch r.Method {
+						case "GET":
+							s.handleSpaceDelimitedParameterRequest([0]string{}, elemIsEscaped, w, r)
+						default:
+							s.notAllowed(w, r, notAllowedParams{
+								allowedMethods: "GET",
+								allowedHeaders: nil,
+								acceptPost:     "",
+								acceptPatch:    "",
+							})
+						}
+
+						return
+					}
+
 				}
 
 			}
@@ -916,6 +941,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							r.operationID = "similarNames"
 							r.operationGroup = ""
 							r.pathPattern = "/similarNames"
+							r.args = args
+							r.count = 0
+							return r, true
+						default:
+							return
+						}
+					}
+
+				case 'p': // Prefix: "paceDelimitedParameter"
+
+					if l := len("paceDelimitedParameter"); len(elem) >= l && elem[0:l] == "paceDelimitedParameter" {
+						elem = elem[l:]
+					} else {
+						break
+					}
+
+					if len(elem) == 0 {
+						// Leaf node.
+						switch method {
+						case "GET":
+							r.name = SpaceDelimitedParameterOperation
+							r.summary = "Test for spaceDelimited style query array parameters"
+							r.operationID = "spaceDelimitedParameter"
+							r.operationGroup = ""
+							r.pathPattern = "/spaceDelimitedParameter"
 							r.args = args
 							r.count = 0
 							return r, true

--- a/internal/integration/test_parameters/oas_schemas_gen.go
+++ b/internal/integration/test_parameters/oas_schemas_gen.go
@@ -546,6 +546,31 @@ type SameNameOK struct{}
 // SimilarNamesOK is response for SimilarNames operation.
 type SimilarNamesOK struct{}
 
+type SpaceDelimitedParameterOK struct {
+	Exploded []string `json:"exploded"`
+	Joined   []string `json:"joined"`
+}
+
+// GetExploded returns the value of Exploded.
+func (s *SpaceDelimitedParameterOK) GetExploded() []string {
+	return s.Exploded
+}
+
+// GetJoined returns the value of Joined.
+func (s *SpaceDelimitedParameterOK) GetJoined() []string {
+	return s.Joined
+}
+
+// SetExploded sets the value of Exploded.
+func (s *SpaceDelimitedParameterOK) SetExploded(val []string) {
+	s.Exploded = val
+}
+
+// SetJoined sets the value of Joined.
+func (s *SpaceDelimitedParameterOK) SetJoined(val []string) {
+	s.Joined = val
+}
+
 // Ref: #/components/schemas/User
 type User struct {
 	ID       int      `json:"id"`

--- a/internal/integration/test_parameters/oas_server_gen.go
+++ b/internal/integration/test_parameters/oas_server_gen.go
@@ -62,6 +62,12 @@ type Handler interface {
 	//
 	// GET /similarNames
 	SimilarNames(ctx context.Context, params SimilarNamesParams) error
+	// SpaceDelimitedParameter implements spaceDelimitedParameter operation.
+	//
+	// Test for spaceDelimited style query array parameters.
+	//
+	// GET /spaceDelimitedParameter
+	SpaceDelimitedParameter(ctx context.Context, params SpaceDelimitedParameterParams) (*SpaceDelimitedParameterOK, error)
 }
 
 // Server implements http server based on OpenAPI v3 specification and

--- a/internal/integration/test_parameters/oas_unimplemented_gen.go
+++ b/internal/integration/test_parameters/oas_unimplemented_gen.go
@@ -99,3 +99,12 @@ func (UnimplementedHandler) SameName(ctx context.Context, params SameNameParams)
 func (UnimplementedHandler) SimilarNames(ctx context.Context, params SimilarNamesParams) error {
 	return ht.ErrNotImplemented
 }
+
+// SpaceDelimitedParameter implements spaceDelimitedParameter operation.
+//
+// Test for spaceDelimited style query array parameters.
+//
+// GET /spaceDelimitedParameter
+func (UnimplementedHandler) SpaceDelimitedParameter(ctx context.Context, params SpaceDelimitedParameterParams) (r *SpaceDelimitedParameterOK, _ error) {
+	return r, ht.ErrNotImplemented
+}

--- a/internal/integration/test_parameters/oas_validators_gen.go
+++ b/internal/integration/test_parameters/oas_validators_gen.go
@@ -65,6 +65,40 @@ func (s *ContentParameters) Validate() error {
 	return nil
 }
 
+func (s *SpaceDelimitedParameterOK) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if s.Exploded == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "exploded",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.Joined == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "joined",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *User) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/uri/query_param_decoder.go
+++ b/uri/query_param_decoder.go
@@ -86,7 +86,18 @@ func (d *queryParamDecoder) DecodeArray(f func(d Decoder) error) error {
 			return errors.New("invalid value")
 		}
 
-		return errors.New("spaceDelimited with explode: false not supported")
+		// do not decode `?param=` as `[""]` and leave the parameter as whatever zero value it has
+		if values[0] == "" {
+			return nil
+		}
+
+		for _, item := range strings.Split(values[0], " ") {
+			if err := f(&constval{item}); err != nil {
+				return err
+			}
+		}
+
+		return nil
 
 	case QueryStylePipeDelimited:
 		if d.explode {

--- a/uri/query_param_decoder_test.go
+++ b/uri/query_param_decoder_test.go
@@ -92,12 +92,20 @@ func TestQueryParamDecoder(t *testing.T) {
 				Style:   QueryStyleSpaceDelimited,
 				Explode: true,
 			},
-			// {
-			// 	Input:   []string{"a%20b%20c"},
-			// 	Expect:  []string{"a", "b", "c"},
-			// 	Style:   QueryStyleSpaceDelimited,
-			// 	Explode: false,
-			// },
+			{
+				Param:   "id",
+				Input:   "id=a%20b%20c",
+				Expect:  []string{"a", "b", "c"},
+				Style:   QueryStyleSpaceDelimited,
+				Explode: false,
+			},
+			{
+				Param:   "id",
+				Input:   "id=a+b+c",
+				Expect:  []string{"a", "b", "c"},
+				Style:   QueryStyleSpaceDelimited,
+				Explode: false,
+			},
 			{
 				Param:   "id",
 				Input:   "id=3&id=4&id=5",

--- a/uri/query_param_encoder.go
+++ b/uri/query_param_encoder.go
@@ -76,7 +76,14 @@ func (e *queryParamEncoder) encodeArray() error {
 			return nil
 		}
 
-		panic("spaceDelimited with explode: false not supported")
+		const sep = " "
+		for _, v := range e.items {
+			if err := checkNotContains(v, sep); err != nil {
+				return err
+			}
+		}
+		e.values[e.paramName] = []string{strings.Join(e.items, sep)}
+		return nil
 
 	case QueryStylePipeDelimited:
 		if e.explode {

--- a/uri/query_param_encoder_test.go
+++ b/uri/query_param_encoder_test.go
@@ -90,12 +90,13 @@ func TestQueryParamEncoder(t *testing.T) {
 				Style:   QueryStyleSpaceDelimited,
 				Explode: true,
 			},
-			// {
-			// 	Input:   []string{"a", "b", "c"},
-			// 	Expect:  []string{"a%20b%20c"},
-			// 	Style:   QueryStyleSpaceDelimited,
-			// 	Explode: false,
-			// },
+			{
+				Param:   "id",
+				Input:   []string{"a", "b", "c"},
+				Expect:  "id=a+b+c",
+				Style:   QueryStyleSpaceDelimited,
+				Explode: false,
+			},
 			{
 				Param:   "id",
 				Input:   []string{"3", "4", "5"},


### PR DESCRIPTION
## Summary

Enables the `spaceDelimited` query parameter style, which was previously rejected by the generator with `ErrNotImplemented`.

It was originally disabled because the old implementation joined items on the literal string `"%20"` and then ran that through `url.Values.Encode()`, which double-encoded the `%` (producing `%2520`). This takes the same approach as the existing `pipeDelimited` support: join array items with a real space and let `url.Values.Encode()` handle the encoding.

## Details

- `explode: true` already behaved like `form` (repeated keys); this fills in the `explode: false` case for arrays.
- On the wire, spaces are encoded as `+` (the `application/x-www-form-urlencoded` form). Decoding accepts both `+` and `%20`, so round-trips are stable.
- Objects still aren't allowed for this style, matching the spec (spaceDelimited is array-only).

## Tests

- Re-enabled the previously commented-out `spaceDelimited` encoder/decoder unit tests, plus a `%20` decode case.
- Added an end-to-end `spaceDelimited` operation to the parameters integration test.
- Regenerated code committed separately.