### PR TITLE
fix(validate): compare multipleOf against the decimal value

### DIFF
--- a/validate/float.go
+++ b/validate/float.go
@@ -91,8 +91,8 @@ func (t Float) validate(v float64) error {
 		return errors.Errorf("value %f greater than %f", v, t.Max)
 	}
 	if t.MultipleOfSet {
-		val := new(big.Rat).SetFloat64(v)
-		if !val.Quo(val, t.MultipleOf).IsInt() {
+		val, ok := new(big.Rat).SetString(strconv.FormatFloat(v, 'g', -1, 64))
+		if !ok || !val.Quo(val, t.MultipleOf).IsInt() {
 			return errors.Errorf("value %f is not multiple of %s", v, t.MultipleOf.RatString())
 		}
 	}

--- a/validate/float_test.go
+++ b/validate/float_test.go
@@ -133,9 +133,90 @@ func TestFloat_Validate(t *testing.T) {
 			Value:     13,
 			Valid:     false,
 		},
+		{
+			Name:      "MultipleOfFractionalOk",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     0.01,
+			Valid:     true,
+		},
+		{
+			Name:      "MultipleOfFractionalPriceOk",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     19.99,
+			Valid:     true,
+		},
+		{
+			Name:      "MultipleOfFractionalLargeOk",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     3765.7,
+			Valid:     true,
+		},
+		{
+			Name:      "MultipleOfFractionalTenthsOk",
+			Validator: Float{MultipleOf: big.NewRat(1, 10), MultipleOfSet: true},
+			Value:     0.3,
+			Valid:     true,
+		},
+		{
+			Name:      "MultipleOfFractionalSmallErr",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     0.005,
+			Valid:     false,
+		},
+		{
+			Name:      "MultipleOfFractionalRemainderErr",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     1.234,
+			Valid:     false,
+		},
+		{
+			Name:      "MultipleOfFractionalNonTerminatingErr",
+			Validator: Float{MultipleOf: big.NewRat(1, 3), MultipleOfSet: true},
+			Value:     0.1,
+			Valid:     false,
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			valid := tc.Validator.Validate(tc.Value) == nil
+			assert.Equal(t, tc.Valid, valid, "%v: %+v",
+				tc.Validator,
+				tc.Value,
+			)
+		})
+	}
+}
+
+func TestFloat_ValidateStringified(t *testing.T) {
+	for _, tc := range []struct {
+		Name      string
+		Validator Float
+		Value     float64
+		Valid     bool
+	}{
+		{Name: "NaN", Value: math.NaN(), Valid: true},
+		{Name: "PosInf", Value: math.Inf(1), Valid: true},
+		{Name: "NegInf", Value: math.Inf(-1), Valid: true},
+		{
+			Name:      "MultipleOfOk",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     19.99,
+			Valid:     true,
+		},
+		{
+			Name:      "NaNMultipleOfErr",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     math.NaN(),
+			Valid:     false,
+		},
+		{
+			Name:      "PosInfMultipleOfErr",
+			Validator: Float{MultipleOf: big.NewRat(1, 100), MultipleOfSet: true},
+			Value:     math.Inf(1),
+			Valid:     false,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			valid := tc.Validator.ValidateStringified(tc.Value) == nil
 			assert.Equal(t, tc.Valid, valid, "%v: %+v",
 				tc.Validator,
 				tc.Value,


### PR DESCRIPTION
Fixes #1158. `multipleOf: 0.01` rejects essentially every value, so a generated client
fails validation on prices it produced itself:
`float: value 3765.700000 is not multiple of 1/100`.

| multipleOf | value  | before | after  |
| ---------- | ------ | ------ | ------ |
| 0.01       | 0.01   | reject | accept |
| 0.01       | 19.99  | reject | accept |
| 0.01       | 3765.7 | reject | accept |
| 0.1        | 0.3    | reject | accept |
| 0.01       | 0.005  | reject | reject |
| 0.01       | 1.234  | reject | reject |
| 1/3        | 0.1    | reject | reject |

## Cause

The two sides of the comparison are built differently. `Validators.SetFloat`
(`gen/ir/validation.go`) parses the spec's `multipleOf` from the raw JSON text with
`big.Rat.UnmarshalText`, so `0.01` becomes exactly `1/100`, and the generated `ratMap`
rebuilds that exactly from `"1/100"`. The value under test, however, went through
`big.Rat.SetFloat64`, which for `0.01` yields the binary approximation
`5764607523034235/576460752303423488`. `1/100` does not divide that, so `IsInt()` is
false no matter what the value is.

## Fix

Parse the shortest round-tripping decimal representation of `v` with `big.Rat.SetString`,
so both operands come from decimal text rather than one of them from a binary
approximation. Two lines in `validate/float.go`; no generator change, so no regenerated
files.

## Behaviour change worth flagging

This narrows one case, and I would rather state it than have it found later. For a
**dyadic** `multipleOf` (1/2, 1/4, 1/8, …) at large magnitudes, a value whose *exact
binary* expansion is a multiple but whose *shortest decimal* representation is not is now
rejected where it used to be accepted:

```
multipleOf 0.25, v = 660852634504614.75  (exact float64)
shortest round-tripping decimal: 6.608526345046148e+14
before: accept    after: reject
```

I measured the size of it with a differential run of the old and new expression, 12
realistic `multipleOf` values x 200 000 seeded pseudorandom values each, magnitudes 10^0
to 10^16, a mix of exact `k x multipleOf` products and arbitrary values:

```
pairs compared            : 2400000
old REJECT -> new ACCEPT  : 310231
old ACCEPT -> new REJECT  : 37567
narrowing by multipleOf   : map[0.0625:20342 0.125:12844 0.25:4381]
smallest narrowing |v| for multipleOf 0.25    : 5.629666836654788e+14
smallest narrowing |v| for multipleOf 0.125   : 7.038144530330212e+13
smallest narrowing |v| for multipleOf 0.0625  : 8.807738074040062e+12
```

Every narrowed case is dyadic; none of `0.01 0.1 0.001 0.05 0.5 1.5 2.5 3 1/3` narrowed at
any magnitude. That sample deliberately over-weights magnitudes above 10^12, so 37 567 is
not a rate you should read across to real traffic — it is an existence proof and a bound on
where the cases live.

Neither answer is unambiguously right, because by the time we see a `float64` the original
number text is gone: the old code answers "is the binary value a multiple", the new code
answers "is the decimal you would have to write a multiple".

**Alternative, if you prefer exactness in both directions:** validate against the original
JSON number text (`jx.Num`) instead of the round-tripped `float64`. That is exact for every
case above, including the dyadic ones, but it needs plumbing at the validation boundary —
the raw number would have to reach the validator instead of a decoded `float64`, which
touches the generated call sites. Happy to switch to that if that is the direction you
want; say so and I will redo it.

I also considered comparing with a tolerance/epsilon and rejected it: any fixed epsilon
starts accepting genuine non-multiples, which is a worse failure than the one being fixed.

## Nil dereference

`SetFloat64` returns nil for non-finite input, and `ValidateStringified` intentionally
permits `NaN` and infinity (d2d85ae4), so the `multipleOf` branch could dereference nil.
`SetString` fails cleanly instead, and the value is rejected with the usual
`value ... is not multiple of ...` error. `TestFloat_ValidateStringified` pins both
directions: non-finite input still passes when no `multipleOf` is set, and is rejected
rather than crashing when one is.

## Tests

`validate/float_test.go`:

- seven cases added to `TestFloat_Validate` — four that must now be accepted (`0.01`,
  `19.99`, `3765.7` against `1/100`; `0.3` against `1/10`) and three that must still be
  rejected (`0.005`, `1.234` against `1/100`; `0.1` against `1/3`).
- `TestFloat_ValidateStringified`, new — `NaN`/`+Inf`/`-Inf` with no validator set, and
  `NaN`/`+Inf` plus a valid `19.99` with `multipleOf: 1/100` set.

Verified they fail without the fix. Restoring only `validate/float.go` from `main` and
keeping the new tests:

```
--- FAIL: TestFloat_Validate (0.00s)
    --- FAIL: TestFloat_Validate/MultipleOfFractionalOk (0.00s)
    --- FAIL: TestFloat_Validate/MultipleOfFractionalPriceOk (0.00s)
    --- FAIL: TestFloat_Validate/MultipleOfFractionalLargeOk (0.00s)
    --- FAIL: TestFloat_Validate/MultipleOfFractionalTenthsOk (0.00s)
--- FAIL: TestFloat_ValidateStringified (0.00s)
    --- FAIL: TestFloat_ValidateStringified/MultipleOfOk (0.00s)
    --- FAIL: TestFloat_ValidateStringified/NaNMultipleOfErr (0.00s)
FAIL	github.com/ogen-go/ogen/validate	0.466s
```

The `NaN` case does not merely fail, it panics on the nil `*big.Rat`. With the fix
restored, `go test -run TestFloat_Validate ./validate/` is `ok`, 25 subtests passing.

## Gates run locally

go1.25.10 darwin/arm64, `CGO_ENABLED=0`, all uncached:

| command | result |
| --- | --- |
| `go test --timeout 15m ./...` | pass, 0 failures (36 `ok`, 50 no-test-files), 42s |
| `./go.test.sh` (race) | pass, 0 races, 95s |
| `golangci-lint run -c .golangci.yml --timeout 5m ./...` | `0 issues.`, v2.12.2, cache cleared first |
| `cd examples && go test ./...` | pass (15 `ok`, 10 no-test-files) |
| `make generate examples && git diff --exit-code` | exit 0, no diff |

`main` is green on all of these before the change, so those are not pre-existing failures.
As a first-time contributor my PR's workflow run needs maintainer approval before CI
reports anything, so the above is the only pre-merge validation available until you click
approve.
