### PR TITLE
fix(jsonschema): infer "boolean" type for boolean default and enum values

### DIFF
--- a/jsonschema/parser_enum.go
+++ b/jsonschema/parser_enum.go
@@ -18,7 +18,7 @@ func inferJSONType(v json.RawMessage) (string, error) {
 	case jx.Number:
 		return "number", nil
 	case jx.Bool:
-		return "bool", nil
+		return "boolean", nil
 	case jx.Null:
 		return "", errors.Errorf("cannot infer type from %q", v)
 	default:

--- a/jsonschema/parser_test.go
+++ b/jsonschema/parser_test.go
@@ -555,3 +555,84 @@ func TestSchemaConst(t *testing.T) {
 		})
 	}
 }
+
+func TestInferJSONType(t *testing.T) {
+	tests := []struct {
+		raw       string
+		expect    string
+		expectErr bool
+	}{
+		{`"foo"`, "string", false},
+		{`10`, "number", false},
+		{`3.14`, "number", false},
+		{`true`, "boolean", false},
+		{`false`, "boolean", false},
+		{`null`, "", true},
+		{`{}`, "", true},
+		{`[]`, "", true},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {
+			typ, err := inferJSONType([]byte(tt.raw))
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, typ)
+		})
+	}
+}
+
+func TestSchemaInferTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    *RawSchema
+		expect *Schema
+	}{
+		{
+			name: "boolean default",
+			raw:  &RawSchema{Default: []byte("true")},
+			expect: &Schema{
+				Type:       Boolean,
+				Default:    true,
+				DefaultSet: true,
+			},
+		},
+		{
+			name: "boolean enum",
+			raw:  &RawSchema{Enum: Enum{[]byte("true"), []byte("false")}},
+			expect: &Schema{
+				Type: Boolean,
+				Enum: []any{true, false},
+			},
+		},
+		{
+			name: "string default",
+			raw:  &RawSchema{Default: []byte(`"foo"`)},
+			expect: &Schema{
+				Type:       String,
+				Default:    "foo",
+				DefaultSet: true,
+			},
+		},
+		{
+			name: "number default",
+			raw:  &RawSchema{Default: []byte("10")},
+			expect: &Schema{
+				Type:       Number,
+				Default:    int64(10),
+				DefaultSet: true,
+			},
+		},
+	}
+
+	parser := NewParser(Settings{InferTypes: true})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := parser.Parse(tt.raw, testCtx())
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, out)
+		})
+	}
+}


### PR DESCRIPTION
With `infer_types` enabled, a schema whose type has to be inferred from a boolean
`default` or `enum` never generates — it fails with an error naming a type the user
never wrote.

```yaml
# spec.yml
paths:
  /probe:
    get:
      operationId: probe
      parameters:
        - name: verbose
          in: query
          schema:
            default: true
```

```console
$ ogen --config cfg.yml --target out --package api spec.yml   # parser.infer_types: true
  - spec.yml:13:13 -> type: unexpected schema type: "bool"
       10 |         - name: verbose
       11 |           in: query
       12 |           schema:
    →  13 |             default: true

generation failed
```

Inference from the other JSON value kinds works, so the failure is specific to booleans:

| schema (no explicit `type`) | inferred type before | after |
|---|---|---|
| `default: true` | error: `unexpected schema type: "bool"` | `boolean` |
| `enum: [true, false]` | error: `unexpected schema type: "bool"` | `boolean` |
| `default: 1` | `number` | `number` |
| `default: "x"` | `string` | `string` |

## Cause

`inferJSONType` (`jsonschema/parser_enum.go`) returns Go's `"bool"` for `jx.Bool`, while
the type table in `parseSchema` (`jsonschema/parser.go`) is keyed with the JSON Schema
names `object/array/string/integer/number/boolean/null`. The lookup misses and
`parseSchema` reports the inferred string back to the user as if they had written it,
which points the error at the wrong thing — the spec says `default: true`, not
`type: bool`.

The neighbouring branches of the same function already return JSON Schema names
(`"string"`, `"number"`), and the sample-based inference in `Infer.Apply`
(`jsonschema/infer.go`) emits `"boolean"`, so `"bool"` is the odd one out.

Present since 69578a9b (2022).

## Fix

One word, `"bool"` → `"boolean"`. With it, the spec above parses as `boolean` and
generates `Verbose OptBool`.

`infer_types` is used by five of ogen's own integration configs (`sample_api`,
`sample_api_nc`, `sample_api_ns`, `sample_api_nsnc`, `sample_api_no_otel`), but none of
the checked-in specs infers a type from a boolean value, so `make generate examples`
produces a **0-file diff** — no regenerated code in this PR.

This does not implement #1529, which asks for enum/const inference without opting into
`infer_types`; this PR only fixes the path that already runs when it is on.

## Tests

`jsonschema/parser_test.go` gains two table tests:

- `TestInferJSONType` — `inferJSONType` maps `true`/`false` to `"boolean"`, alongside the
  existing string/number/null/object/array rows.
- `TestSchemaInferTypes` — under `Settings{InferTypes: true}`, a schema with a boolean
  `default` and one with a boolean `enum` both parse to `Type: Boolean`, with `string`
  and `number` rows pinning the branches that already worked.

I verified both fail without the fix by reverting only `jsonschema/parser_enum.go` to
the base commit and re-running:

```
--- FAIL: TestInferJSONType/Test4 (0.00s)
        Error:      	Not equal:
                    	expected: "boolean"
                    	actual  : "bool"
--- FAIL: TestInferJSONType/Test5 (0.00s)
        Error:      	Not equal:
                    	expected: "boolean"
                    	actual  : "bool"
--- FAIL: TestSchemaInferTypes/boolean_default (0.00s)
        Error:      	Received unexpected error:
                    	type:
                    	  - unexpected schema type: "bool"
--- FAIL: TestSchemaInferTypes/boolean_enum (0.00s)
        Error:      	Received unexpected error:
                    	type:
                    	  - unexpected schema type: "bool"
```

Restoring the one-word change makes all subtests pass.

## Verification

Run locally on macOS/arm64, go1.25.10, `CGO_ENABLED=0`, caches cleared first. `main` @
5c62f50f is green, so these are all comparisons against a clean baseline.

| Gate | Result | Wall |
|---|---|---|
| `go build ./...` | ok | 0.7s |
| `go test --timeout 15m ./...` | PASS, 0 failures | 47s |
| `./go.test.sh` (race) | PASS, 0 races | 2m05s |
| `cd examples && go test ./...` | PASS | 8.3s |
| `golangci-lint v2.12.2 run -c .golangci.yml ./...` | 0 issues | 68s |
| `make generate examples && git diff --exit-code` | exit 0, 0 files changed | 17s |

## Alternative

The other direction is to leave `inferJSONType` alone and add `"bool"` to the type table
in `parseSchema`. That would also accept a literal `type: bool` in a spec, which is not a
valid JSON Schema type, so I went with correcting the inferred string. Happy to switch if
you prefer the other shape.
