### PR TITLE
fix(parser): default explode to false for non-form parameter styles

### DIFF
--- a/openapi/parser/parse_header.go
+++ b/openapi/parser/parse_header.go
@@ -86,6 +86,7 @@ func (p *parser) parseHeader(name string, header *ogen.Header, ctx *jsonpointer.
 		return nil, p.wrapField("content", p.file(ctx), locator, err)
 	}
 
+	style := inferParamStyle(locatedIn, header.Style)
 	op := &openapi.Header{
 		Name:        name,
 		Description: header.Description,
@@ -93,8 +94,8 @@ func (p *parser) parseHeader(name string, header *ogen.Header, ctx *jsonpointer.
 		Schema:      schema,
 		Content:     content,
 		In:          locatedIn,
-		Style:       inferParamStyle(locatedIn, header.Style),
-		Explode:     inferParamExplode(locatedIn, header.Explode),
+		Style:       style,
+		Explode:     inferParamExplode(style, header.Explode),
 		Required:    header.Required,
 		Pointer:     locator.Pointer(p.file(ctx)),
 	}

--- a/openapi/parser/parse_mediatype.go
+++ b/openapi/parser/parse_mediatype.go
@@ -117,11 +117,12 @@ func (p *parser) parseMediaType(ct string, m ogen.Media, ctx *jsonpointer.Resolv
 					rerr = p.wrapLocation(p.file(ctx), locator, rerr)
 				}()
 
+				style := inferParamStyle(openapi.LocationQuery, e.Style)
 				encoding := &openapi.Encoding{
 					ContentType:   e.ContentType,
 					Headers:       map[string]*openapi.Header{},
-					Style:         inferParamStyle(openapi.LocationQuery, e.Style),
-					Explode:       inferParamExplode(openapi.LocationQuery, e.Explode),
+					Style:         style,
+					Explode:       inferParamExplode(style, e.Explode),
 					AllowReserved: e.AllowReserved,
 					Pointer:       locator.Pointer(p.file(ctx)),
 				}

--- a/openapi/parser/parse_parameter.go
+++ b/openapi/parser/parse_parameter.go
@@ -180,6 +180,7 @@ func (p *parser) parseParameter(param *ogen.Parameter, ctx *jsonpointer.ResolveC
 		return nil, p.wrapField("content", p.file(ctx), locator, err)
 	}
 
+	style := inferParamStyle(locatedIn, param.Style)
 	op := &openapi.Parameter{
 		Name:          param.Name,
 		Description:   param.Description,
@@ -187,8 +188,8 @@ func (p *parser) parseParameter(param *ogen.Parameter, ctx *jsonpointer.ResolveC
 		Schema:        schema,
 		Content:       content,
 		In:            locatedIn,
-		Style:         inferParamStyle(locatedIn, param.Style),
-		Explode:       inferParamExplode(locatedIn, param.Explode),
+		Style:         style,
+		Explode:       inferParamExplode(style, param.Explode),
 		Required:      param.Required,
 		AllowReserved: param.AllowReserved,
 		Pointer:       locator.Pointer(p.file(ctx)),
@@ -238,18 +239,22 @@ func inferParamStyle(locatedIn openapi.ParameterLocation, style string) openapi.
 	return openapi.ParameterStyle(style)
 }
 
-func inferParamExplode(locatedIn openapi.ParameterLocation, explode *bool) bool {
+func inferParamExplode(style openapi.ParameterStyle, explode *bool) bool {
 	if explode != nil {
 		return *explode
 	}
 
 	// When style is form, the default value is true.
 	// For all other styles, the default value is false.
-	if locatedIn.Query() || locatedIn.Cookie() {
+	switch style {
+	case openapi.QueryStyleForm:
 		return true
+	case openapi.QueryStyleDeepObject:
+		// ogen supports deepObject only in exploded form.
+		return true
+	default:
+		return false
 	}
-
-	return false
 }
 
 func (p *parser) validateParamStyle(param *openapi.Parameter, file location.File) error {

--- a/openapi/parser/parse_parameter_test.go
+++ b/openapi/parser/parse_parameter_test.go
@@ -131,3 +131,194 @@ func TestNullOnlyParameterRejected(t *testing.T) {
 	a.Error(err)
 	a.Contains(err.Error(), "combination")
 }
+
+func explodePtr(v bool) *bool { return &v }
+
+func stringArraySchema() *ogen.Schema {
+	return &ogen.Schema{
+		Type:  "array",
+		Items: &ogen.Items{Item: &ogen.Schema{Type: "string"}},
+	}
+}
+
+func TestParameterExplodeDefault(t *testing.T) {
+	object := &ogen.Schema{
+		Type:       "object",
+		Properties: []ogen.Property{{Name: "id", Schema: &ogen.Schema{Type: "string"}}},
+	}
+
+	tests := []struct {
+		name    string
+		style   string
+		explode *bool
+		schema  *ogen.Schema
+		want    bool
+	}{
+		{"Unset", "", nil, stringArraySchema(), true},
+		{"Form", "form", nil, stringArraySchema(), true},
+		{"SpaceDelimited", "spaceDelimited", nil, stringArraySchema(), false},
+		{"PipeDelimited", "pipeDelimited", nil, stringArraySchema(), false},
+		{"DeepObject", "deepObject", nil, object, true},
+		{"SpaceDelimitedExplodeTrue", "spaceDelimited", explodePtr(true), stringArraySchema(), true},
+		{"PipeDelimitedExplodeTrue", "pipeDelimited", explodePtr(true), stringArraySchema(), true},
+		{"FormExplodeFalse", "form", explodePtr(false), stringArraySchema(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &ogen.Spec{
+				OpenAPI: "3.0.3",
+				Paths: map[string]*ogen.PathItem{
+					"/items": {
+						Get: &ogen.Operation{
+							OperationID: "listItems",
+							Parameters: []*ogen.Parameter{
+								{
+									Name:    "ids",
+									In:      "query",
+									Style:   tt.style,
+									Explode: tt.explode,
+									Schema:  tt.schema,
+								},
+							},
+							Responses: map[string]*ogen.Response{
+								"200": {Description: "OK"},
+							},
+						},
+					},
+				},
+			}
+
+			a := require.New(t)
+
+			var raw yaml.Node
+			a.NoError(raw.Encode(root))
+			root.Raw = &raw
+
+			spec, err := Parse(root, Settings{
+				RootURL: testRootURL,
+			})
+			a.NoError(err)
+			a.Len(spec.Operations, 1)
+
+			params := spec.Operations[0].Parameters
+			a.Len(params, 1)
+			a.Equal(tt.want, params[0].Explode)
+		})
+	}
+}
+
+func TestEncodingExplodeDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		style   string
+		explode *bool
+		want    bool
+	}{
+		{"Unset", "", nil, true},
+		{"Form", "form", nil, true},
+		{"SpaceDelimited", "spaceDelimited", nil, false},
+		{"PipeDelimited", "pipeDelimited", nil, false},
+		{"PipeDelimitedExplodeTrue", "pipeDelimited", explodePtr(true), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const ct = "application/x-www-form-urlencoded"
+
+			root := &ogen.Spec{
+				OpenAPI: "3.0.3",
+				Paths: map[string]*ogen.PathItem{
+					"/submit": {
+						Post: &ogen.Operation{
+							OperationID: "submit",
+							RequestBody: &ogen.RequestBody{
+								Required: true,
+								Content: map[string]ogen.Media{
+									ct: {
+										Schema: &ogen.Schema{
+											Type:       "object",
+											Properties: []ogen.Property{{Name: "tags", Schema: stringArraySchema()}},
+										},
+										Encoding: map[string]ogen.Encoding{
+											"tags": {Style: tt.style, Explode: tt.explode},
+										},
+									},
+								},
+							},
+							Responses: map[string]*ogen.Response{
+								"200": {Description: "OK"},
+							},
+						},
+					},
+				},
+			}
+
+			a := require.New(t)
+
+			var raw yaml.Node
+			a.NoError(raw.Encode(root))
+			root.Raw = &raw
+
+			spec, err := Parse(root, Settings{
+				RootURL: testRootURL,
+			})
+			a.NoError(err)
+			a.Len(spec.Operations, 1)
+
+			encoding := spec.Operations[0].RequestBody.Content[ct].Encoding
+			a.Contains(encoding, "tags")
+			a.Equal(tt.want, encoding["tags"].Explode)
+		})
+	}
+}
+
+func TestHeaderExplodeDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		explode *bool
+		want    bool
+	}{
+		{"Unset", nil, false},
+		{"ExplodeTrue", explodePtr(true), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &ogen.Spec{
+				OpenAPI: "3.0.3",
+				Paths: map[string]*ogen.PathItem{
+					"/items": {
+						Get: &ogen.Operation{
+							OperationID: "listItems",
+							Responses: map[string]*ogen.Response{
+								"200": {
+									Description: "OK",
+									Headers: map[string]*ogen.Header{
+										"X-Tags": {
+											Explode: tt.explode,
+											Schema:  stringArraySchema(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			a := require.New(t)
+
+			var raw yaml.Node
+			a.NoError(raw.Encode(root))
+			root.Raw = &raw
+
+			spec, err := Parse(root, Settings{
+				RootURL: testRootURL,
+			})
+			a.NoError(err)
+			a.Len(spec.Operations, 1)
+
+			headers := spec.Operations[0].Responses.StatusCode[200].Headers
+			a.Contains(headers, "X-Tags")
+			a.Equal(tt.want, headers["X-Tags"].Explode)
+		})
+	}
+}


### PR DESCRIPTION
A query parameter that declares a non-form `style` but leaves `explode` unset is
serialized as `form`, silently discarding the declared style. Three array parameters,
none of them setting `explode`:

```yaml
parameters:
  - {name: fm, in: query, required: true, style: form,           schema: {type: array, items: {type: string}}}
  - {name: pd, in: query, required: true, style: pipeDelimited,  schema: {type: array, items: {type: string}}}
  - {name: sp, in: query, required: true, style: spaceDelimited, schema: {type: array, items: {type: string}}}
```

Generated client called with `["1","2","3"]` for each, `r.URL.RawQuery` as observed by the
server:

| | RawQuery |
|---|---|
| **before** | `fm=1&fm=2&fm=3&pd=1&pd=2&pd=3&sp=1&sp=2&sp=3` |
| **after** | `fm=1&fm=2&fm=3&pd=1%7C2%7C3&sp=1+2+3` |

`form` is unchanged; `pipeDelimited` and `spaceDelimited` were emitting the form
serialization.

The Encoding Object is affected the same way. For an `application/x-www-form-urlencoded`
body with `encoding: {tags: {style: pipeDelimited}}` over `["a","b","c"]`, the request
body:

| | body |
|---|---|
| **before** | `tags=a&tags=b&tags=c` |
| **after** | `tags=a%7Cb%7Cc` |

Both tables are measured, not derived — generated a client on each side and captured the
request at an `httptest` server.

## Cause

`inferParamExplode` (`openapi/parser/parse_parameter.go:241`) keys the default off the
parameter *location* instead of the style:

```go
// When style is form, the default value is true.
// For all other styles, the default value is false.
if locatedIn.Query() || locatedIn.Cookie() {
	return true
}
```

The comment states the OpenAPI 3.0.3/3.1 rule correctly; the code below it never looks at
the style, so every query and cookie parameter defaults to `explode: true`.

This dates to 6b48c0fea (2022-04-14), which introduced the inference. `pipeDelimited`
arrays were already supported at that commit — `uri/query_encoder.go` implemented the
style and `gen.isSupportedParamStyle` rejected `pipeDelimited` only for objects — so
**`pipeDelimited` has been serialized as `form` since v0.26.0, four years**.
`spaceDelimited` returned `ErrNotImplemented` until #1716 enabled it for arrays,
extending the same defect to a second style.

## Fix

Pass the already-inferred style to `inferParamExplode` instead of the location. The three
call sites — `parse_parameter.go`, `parse_header.go`, `parse_mediatype.go` — hoist their
existing `inferParamStyle(...)` call one line so the value can be reused.

## Blast radius

**`spaceDelimited` has zero released users.**

```console
$ git merge-base --is-ancestor defc9127 v1.23.0; echo $?
1
$ git tag --contains defc9127
$
```

#1716 merged 2026-07-24; `v1.23.0` is dated 2026-07-10 and `main` is `v1.23.0-15`.
Nothing tagged has ever emitted `spaceDelimited`, so that half of the change cannot break
a released user.

**`pipeDelimited` and the Encoding Object do change the wire format for released users on
upgrade.** That is the real compatibility cost of this PR and I would rather state it than
bury it. It is four years of a spec violation rather than a documented behaviour, but a
client whose server was built against the same wrong ogen output will need both sides
upgraded together.

**The escape hatch is one line in the user's own spec.** Adding `explode: true` restores
the previous bytes exactly, with no ogen-version pinning, and that direction is covered by
a test.

**Everything else is provably unchanged.** Defaults by location:

| location | default style | explode before | after |
|---|---|---|---|
| path | `simple` | false | false |
| header | `simple` | false | false |
| query | `form` | true | true |
| cookie | `form` | true | true |

Only an explicitly declared non-form style moves, and only when the spec does not set
`explode` itself. `make generate examples` — 44 integration targets and 22 examples —
produces a **0-file diff**, so no checked-in spec changes shape and there is no
regenerated code in this PR.

## Tests

Three table tests in `openapi/parser/parse_parameter_test.go`, 15 subtests:

- `TestParameterExplodeDefault` — query parameters: unset, `form`, `spaceDelimited`,
  `pipeDelimited`, `deepObject`, plus the override direction (`spaceDelimited` and
  `pipeDelimited` with an explicit `explode: true`, `form` with an explicit
  `explode: false`).
- `TestEncodingExplodeDefault` — the Encoding Object path, which had no coverage.
- `TestHeaderExplodeDefault` — response headers.

I verified they fail without the fix, by reverting only the three source files to the base
commit and keeping the tests:

```
--- FAIL: TestParameterExplodeDefault
    --- FAIL: /SpaceDelimited   Not equal: expected: false, actual: true
    --- FAIL: /PipeDelimited    Not equal: expected: false, actual: true
--- FAIL: TestEncodingExplodeDefault
    --- FAIL: /SpaceDelimited   Not equal: expected: false, actual: true
    --- FAIL: /PipeDelimited    Not equal: expected: false, actual: true
```

Restoring the change makes all 15 pass. To be precise about what that proves: **4 of the
15 subtests catch this bug.** The other 11 pin behaviour that must not move — the explicit
`explode` overrides, `form`, `deepObject`, and the whole of `TestHeaderExplodeDefault`,
which passes both with and without the fix and is a regression guard rather than a
reproduction.

## Verification

Run locally on macOS/arm64, go1.25.10, `CGO_ENABLED=0`, caches cleared first. `main` @
2e755d12 is green on all of these, so these are comparisons against a clean baseline.

| Gate | Result |
|---|---|
| `go test --timeout 15m ./...` | PASS, 0 failures |
| `./go.test.sh` (race) | PASS, 0 races |
| `cd examples && go test ./...` | PASS |
| `golangci-lint v2.12.2 run -c .golangci.yml ./...` | 0 issues |
| `make generate examples && git diff --exit-code` | exit 0, 0 files changed |

If this PR shows no check runs at first, that is the workflow-approval gate rather than a
failure — these local runs are the pre-merge evidence until CI reports.

## Alternative

The strict reading of the spec is `case openapi.QueryStyleForm:` alone — `false` for every
other style, including `deepObject`. I did not take it because `validateParamStyle` accepts
`{deepObject, true}` only, so a bare `style: deepObject` would stop parsing. Three
checked-in specs write it bare, and with the strict variant they fail:

```
--- FAIL: TestGenerate/Positive/parameters/Gen
      - parse parameter "deepObject":
      - invalid style explode combination "deepObject", explode:false
--- FAIL: TestGenerate/Positive/additionalPropertiesPatternProperties/Gen
--- FAIL: TestGenerate/Positive/form/Gen
      - encoding property "deepObject":
```

Keeping `deepObject` on `true` also matches how `uri` implements it —
`query_param_encoder.go:152` panics on non-explode deepObject. If you would rather have
the strict reading and treat `{deepObject, false}` as an error users must fix explicitly,
say so and I will switch: it is a one-line change plus a negative fixture.
