### PR TITLE
fix(gen): coerce enum values to string when type is string

### DIFF
--- a/_testdata/positive/enum_number_coerce.yml
+++ b/_testdata/positive/enum_number_coerce.yml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: title
+  version: v0.1.0
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumWithNumber'
+components:
+  schemas:
+    StringEnumWithNumber:
+      type: string
+      enum: ["wasd", 2, true]

--- a/gen/schema_gen_primitive.go
+++ b/gen/schema_gen_primitive.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-faster/errors"
+	"go.uber.org/zap"
 
 	"github.com/ogen-go/ogen/gen/ir"
 	"github.com/ogen-go/ogen/jsonschema"
@@ -113,7 +114,22 @@ func (g *schemaGen) validateEnumValues(s *jsonschema.Schema) error {
 		return nil
 	case jsonschema.String:
 		for idx, val := range s.Enum {
-			if _, ok := val.(string); !ok {
+			switch v := val.(type) {
+			case string:
+			case int64, float64, bool:
+				coerced := fmt.Sprint(v)
+
+				fields := []zap.Field{
+					zap.Any("value", v),
+					zap.String("coerced_to", coerced),
+				}
+				if pos, ok := s.Pointer.Field("enum").Index(idx).Position(); ok {
+					fields = append(fields, zap.String("at", pos.WithFilename(s.File().Name)))
+				}
+				g.log.Warn("Enum value type does not match declared string type, coercing to string", fields...)
+
+				s.Enum[idx] = coerced
+			default:
 				return reportErr(idx, errors.Errorf("enum value should be a string, got %T", val))
 			}
 		}


### PR DESCRIPTION
Sometimes we encounter cases where string values in the spec are not wrapped in quotes because they use specific values. Unfortunately, ogen cannot handle this, although we would very much like it to. Such cases sometimes occur in OpenAPI specs of third-party services that we would rather not touch and that are pulled directly from the documentation site, as in the example below.

```
  - openapi.yaml:2397:15 -> enum value should be a string, got int64
          2394 |           rate:
          2395 |             type: "string"
          2396 |             enum:
        → 2397 |             - 5
          2398 |             - 7
          2399 |             - 10
          2400 |             - 20
          2401 |             - 22
```

Now int64/float64/bool values in a string enum get coerced to their string form via `fmt.Sprint` instead of failing generation, and a warning is logged so you can tell it happened (and fix the spec if you can).