### PR TITLE
fix(uri): check escape sequence bounds on NormalizeEscapedPath slow path

### DIFF
--- a/uri/normalize.go
+++ b/uri/normalize.go
@@ -94,6 +94,10 @@ slow:
 	for i := 0; i < len(s); {
 		switch s[i] {
 		case '%':
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				// Invalid escape sequence.
+				return "", false
+			}
 			// Unescape character.
 			a, b := s[i+1], s[i+2]
 			ch := unhex(a)<<4 | unhex(b)

--- a/uri/normalize_test.go
+++ b/uri/normalize_test.go
@@ -30,11 +30,17 @@ func TestNormalizeEscapedPath(t *testing.T) {
 		// Lowercase hex digits.
 		{"/foo%3fbar", "/foo%3Fbar", true},
 		{"/foo%3fbar", "/foo%3Fbar", true},
+		{"/foo%3f", "/foo%3F", true},
 
 		// Invalid.
 		{"/foo%", "", false},
 		{"/foo%3", "", false},
 		{"/foo%zz", "", false},
+		// Invalid, slow path.
+		{"/foo%3fbar%", "", false},
+		{"/foo%3fbar%3", "", false},
+		{"/foo%3fbar%zz", "", false},
+		{"/user/ern%61do%", "", false},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {


### PR DESCRIPTION
A spec whose path key has an escape typo crashes `ogen` with a raw Go stack trace — but only when an earlier escape in the same path is lowercase or redundant.

`"/report%"` (no earlier escape) is reported the way a user expects:

```
  - spec2.json:5:5 -> parse path "/report%": parse "/report%": invalid URL escape "%"
```

`"/caf%e9/100%"` — the same trailing `%`, with a lowercase escape in front of it — instead prints:

```
panic: runtime error: index out of range [12] with length 12
```

with `uri.NormalizeEscapedPath` at `uri/normalize.go:98` on top, called from `openapi/parser/parser.go:243`.

`NormalizeEscapedPath` documents that it "returns empty string and false" for an invalid escape sequence, and the fast loop does check for one. But once a lowercase hex digit or a redundant escape triggers `goto slow`, the slow loop reads `s[i+1], s[i+2]` with no bounds or hex check. `openapi/parser/parser.go:243` passes raw spec path keys to it with no `url.Parse` in front, so the panic reaches the CLI.

The same gap also makes the function return `true` for input it should reject: on `main`, `NormalizeEscapedPath("/foo%3fbar%zz")` returns `("/foo%3Fbar%zz", true)`.

The fix checks bounds and hex digits before indexing, mirroring the fast loop. With it, `"/caf%e9/100%"` produces the same located parse error `"/report%"` already did.

Four rows added to the `TestNormalizeEscapedPath` table reach the slow path, which the three existing invalid rows do not. I checked they fail with only `uri/normalize.go` reverted — the truncated ones panic, the `%zz` one fails on `Should be false` — and pass with the fix.

`go test ./...`, `./go.test.sh`, `cd examples && go test ./...` and `golangci-lint run` are clean locally, and `make generate examples` leaves a 0-file diff.
