### PR TITLE
fix(jsonschema): report real keyword names in min/max conflict errors

### DIFF
--- a/jsonschema/jsonschema_test.go
+++ b/jsonschema/jsonschema_test.go
@@ -51,3 +51,49 @@ func TestNegative(t *testing.T) {
 		t.Logf("\n%s", pretty)
 	})
 }
+
+func TestMinMaxConflictError(t *testing.T) {
+	tests := []struct {
+		file string
+		err  string
+	}{
+		{
+			"_testdata/negative/array/invalid_minItems.json",
+			"at invalid_minItems.json:1:1: " +
+				"- at invalid_minItems.json:4:15: minItems (10) is greater than maxItems (1)\n" +
+				"- at invalid_minItems.json:5:15: \n",
+		},
+		{
+			"_testdata/negative/object/invalid_minProperties.json",
+			"at invalid_minProperties.json:1:1: " +
+				"- at invalid_minProperties.json:4:20: minProperties (10) is greater than maxProperties (1)\n" +
+				"- at invalid_minProperties.json:5:20: \n",
+		},
+		{
+			"_testdata/negative/string/invalid_minLength.json",
+			"at invalid_minLength.json:1:1: " +
+				"- at invalid_minLength.json:4:16: minLength (10) is greater than maxLength (1)\n" +
+				"- at invalid_minLength.json:5:16: \n",
+		},
+	}
+
+	for _, tt := range tests {
+		_, name := path.Split(tt.file)
+
+		t.Run(strings.TrimSuffix(name, ".json"), func(t *testing.T) {
+			a := require.New(t)
+
+			data, err := testdata.ReadFile(tt.file)
+			a.NoError(err)
+
+			var schema jsonschema.RawSchema
+			a.NoError(yaml.Unmarshal(data, &schema))
+
+			p := jsonschema.NewParser(jsonschema.Settings{
+				File: location.NewFile(name, tt.file, data),
+			})
+			_, err = p.Parse(&schema, jsonpointer.NewResolveCtx(&url.URL{Path: "/" + tt.file}, jsonpointer.DefaultDepthLimit))
+			a.EqualError(err, tt.err)
+		})
+	}
+}

--- a/jsonschema/parser.go
+++ b/jsonschema/parser.go
@@ -253,17 +253,17 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 		return p.wrapField(field, p.file(ctx), schema.Common.Locator, err)
 	}
 
-	validateMinMax := func(prop string, minVal *uint64, maxVal *uint64) (rerr error) {
+	validateMinMax := func(minField, maxField string, minVal *uint64, maxVal *uint64) (rerr error) {
 		if minVal == nil || maxVal == nil {
 			return nil
 		}
 		if *minVal > *maxVal {
-			msg := fmt.Sprintf("minVal%s (%d) is greater than maxVal%s (%d)", prop, *minVal, prop, *maxVal)
+			msg := fmt.Sprintf("%s (%d) is greater than %s (%d)", minField, *minVal, maxField, *maxVal)
 			ptr := schema.Common.Pointer(p.file(ctx))
 
 			me := new(location.MultiError)
-			me.ReportPtr(ptr.Field("minVal"+prop), msg)
-			me.ReportPtr(ptr.Field("maxVal"+prop), "")
+			me.ReportPtr(ptr.Field(minField), msg)
+			me.ReportPtr(ptr.Field(maxField), "")
 			return me
 		}
 		return nil
@@ -457,7 +457,8 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 	// Object properties
 	{
 		if err := validateMinMax(
-			"Properties",
+			"minProperties",
+			"maxProperties",
 			schema.MinProperties,
 			schema.MaxProperties,
 		); err != nil {
@@ -537,7 +538,8 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 	// Array properties
 	{
 		if err := validateMinMax(
-			"Items",
+			"minItems",
+			"maxItems",
 			schema.MinItems,
 			schema.MaxItems,
 		); err != nil {
@@ -586,7 +588,8 @@ func (p *Parser) parseSchema(schema *RawSchema, ctx *jsonpointer.ResolveCtx, hoo
 	// String properties
 	{
 		if err := validateMinMax(
-			"Length",
+			"minLength",
+			"maxLength",
 			schema.MinLength,
 			schema.MaxLength,
 		); err != nil {


### PR DESCRIPTION
A schema with `minItems: 10` and `maxItems: 1` is correctly rejected, but the error names a keyword that does not exist and points at the wrong line. On `main`, against `jsonschema/_testdata/negative/array/invalid_minItems.json`:

```
  - invalid_minItems.json:1:1 -> minValItems (10) is greater than maxValItems (1)
	→   1 | {
	    2 |   "$schema": "http://json-schema.org/draft-04/schema#",
	    3 |   "type": "array",
	    4 |   "minItems": 10,
	    5 |   "maxItems": 1
```

`validateMinMax` builds the message and both `ptr.Field(...)` calls from the Go local-variable prefix (`minVal`/`maxVal`) plus `prop`, which is passed as `"Items"`, `"Properties"` or `"Length"`. So the message names `minValItems`, and `ptr.Field("minValItems")` looks up a key that is not in the document — `location.Pointer.Field` returns the receiver unchanged when the key is absent, so both pointers degrade to the enclosing schema node and the caret lands on line 1.

Passing the keyword names in gives, for the same file:

```
  - invalid_minItems.json:4:15 -> minItems (10) is greater than maxItems (1)
	    1 | {
	    2 |   "$schema": "http://json-schema.org/draft-04/schema#",
	    3 |   "type": "array",
	→   4 |   "minItems": 10,
	→   5 |   "maxItems": 1
	    6 | }
	    7 |
```

`minProperties`/`maxProperties` and `minLength`/`maxLength` were affected identically and are fixed by the same change.

`TestMinMaxConflictError` pins the keyword names and the reported positions for all three pairs against the existing negative testdata. I checked it fails with only `jsonschema/parser.go` reverted (`minValItems`, `1:1`) and passes with the fix.

`go test ./...`, `./go.test.sh`, `cd examples && go test ./...` and `golangci-lint run` are clean locally, and `make generate examples` leaves a 0-file diff.
